### PR TITLE
docs: Clarify HQPlayer Embedded (not Desktop)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A source-agnostic hi-fi control bridge that connects music sources and audio pip
 Hi-fi software assumes you're at a computer or using vendor-specific apps. This bridge fills the gap:
 
 - **Music Sources:** Roon (now), Music Assistant, Tidal Connect, Qobuz Connect (future)
-- **Audio Pipeline:** HQPlayer profiles + DSP settings, receiver control (future)
+- **Audio Pipeline:** HQPlayer Embedded (web UI control), receiver control (future)
 - **Surfaces:** ESP32 hardware (roon-knob), Web UI, Home Assistant via MQTT
 
 ## Status
@@ -21,6 +21,7 @@ Hi-fi software assumes you're at a computer or using vendor-specific apps. This 
 │            Unified Hi-Fi Control Bridge              │
 │  ┌──────────┐  ┌──────────────┐                     │
 │  │   Roon   │  │  HQPlayer    │   (+ future sources)│
+│  │          │  │  Embedded    │                     │
 │  └──────────┘  └──────────────┘                     │
 │                                                      │
 │  HTTP API + optional MQTT                            │


### PR DESCRIPTION
Clarifies that the HQPlayer integration is for HQPlayer Embedded (web UI), not HQPlayer Desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Audio Pipeline documentation to reflect HQPlayer Embedded with web UI control capabilities.
  * Enhanced system architecture diagram with HQPlayer Embedded entry for improved clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->