### PR TITLE
feat: Add admin UI with firmware fetch from GitHub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ data/
 *.log
 .DS_Store
 .env
+
+# Downloaded firmware (fetched at runtime)
+firmware/*.bin
+firmware/version.json


### PR DESCRIPTION
## Summary

- New `/admin` dashboard showing current firmware version and bridge status
- **Fetch Latest from GitHub** button downloads latest `roon_knob.bin` from GitHub releases
- Creates `version.json` with version, timestamp, and release URL
- Firmware files gitignored (fetched at runtime)

## Usage

1. Go to `http://localhost:8088/admin`
2. Click "Fetch Latest from GitHub" to download firmware
3. Knobs can now OTA update from the bridge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added over-the-air (OTA) firmware update capability to the admin interface.
  * Enhanced admin dashboard with firmware status, version display, and "Fetch Latest from GitHub" button for retrieving the latest firmware releases.
  * Implemented automatic firmware download and version tracking from GitHub repository.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->