### PR TITLE
fix: Docker improvements for v1.0 release

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -6,11 +6,10 @@
 ```yaml
 services:
   unified-hifi-control:
-    image: ghcr.io/cloud-atlas-ai/unified-hifi-control:{{VERSION}}
+    image: muness/unified-hifi-control:{{VERSION}}
     network_mode: host  # Required for Roon mDNS discovery
     volumes:
-      - ./data:/data
-      - ./firmware:/app/firmware
+      - ./data:/data  # Config + firmware stored here
     environment:
       - PORT=8088
       - CONFIG_DIR=/data

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -74,7 +74,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/src/knobs/routes.js
+++ b/src/knobs/routes.js
@@ -898,7 +898,8 @@ loadStatus();
   const fs = require('fs');
   const path = require('path');
   const https = require('https');
-  const FIRMWARE_DIR = process.env.FIRMWARE_DIR || path.join(__dirname, '..', '..', 'firmware');
+  const CONFIG_DIR = process.env.CONFIG_DIR || path.join(__dirname, '..', '..', 'data');
+  const FIRMWARE_DIR = process.env.FIRMWARE_DIR || path.join(CONFIG_DIR, 'firmware');
   const GITHUB_REPO = process.env.FIRMWARE_REPO || 'muness/roon-knob';
 
   // POST /admin/fetch-firmware - Download latest firmware from GitHub releases


### PR DESCRIPTION
## Summary

Docker improvements for v1.0 release:

1. **Firmware path fix**: Store in `/data/firmware` instead of `/app/firmware`
   - Fixes EACCES permission errors in Docker
   - Works locally too (`<project>/data/firmware`)

2. **Docker Hub image**: Use `muness/unified-hifi-control` in docs (not GHCR)

3. **ARM support**: Add `linux/arm/v7` platform for 32-bit ARM devices
   - Now builds: amd64, arm64, arm/v7
   - Each tag (including `latest`) is a multi-arch manifest

## Test plan

- [ ] Docker build succeeds for all 3 platforms
- [ ] Firmware fetch works in Docker container

🤖 Generated with [Claude Code](https://claude.com/claude-code)