### PR TITLE
fix: Handle zones_added event for late-joining Roon zones

### DIFF
--- a/src/roon/client.js
+++ b/src/roon/client.js
@@ -156,6 +156,10 @@ function createRoonClient(opts = {}) {
           });
           try { onZonesChanged(); } catch (e) { log.warn('onZonesChanged error:', e); }
         }
+        if (Array.isArray(data?.zones_added)) {
+          data.zones_added.forEach(updateZone);
+          try { onZonesChanged(); } catch (e) { log.warn('onZonesChanged error:', e); }
+        }
         if (Array.isArray(data?.zones_changed)) {
           data.zones_changed.forEach(updateZone);
           try { onZonesChanged(); } catch (e) { log.warn('onZonesChanged error:', e); }


### PR DESCRIPTION
## Summary

- Fixes Roon zones not appearing when powered on after the hub/bridge is running
- Adds handling for `zones_added` event in `subscribe_zones` callback

## Problem

When a Roon zone is powered on after the hub (which runs 24/7), it was not discovered. Users couldn't select the zone on the knob or see it in the web UI. The only workaround was rebooting the hub.

## Root Cause

The Roon transport API sends three types of zone events:
- `zones_removed` - when zones disappear (was handled)
- `zones_changed` - when existing zones change state (was handled)
- `zones_added` - when NEW zones appear (was **not** handled)

We were missing the `zones_added` handler, so late-joining zones were never added to the zone list.

## Fix

Added handling for `data.zones_added` in the `subscribe_zones` callback, matching the existing pattern for `zones_removed` and `zones_changed`.

## Test plan

- [x] Power off a Roon zone
- [x] Start the bridge (or leave it running)
- [x] Power on the zone
- [x] Verify zone appears in web UI and on knob without hub reboot

Fixes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved zone subscription handling to properly initialize and track newly added zones during real-time updates, ensuring they are correctly reflected and managed alongside existing zones in the system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->