### PR TITLE
fix: Add zones_sha for zone list change detection

### DIFF
--- a/src/knobs/routes.js
+++ b/src/knobs/routes.js
@@ -73,8 +73,9 @@ function createKnobRoutes({ bus, roon, knobs, adapterFactory, logger }) {
     const image_url = `/now_playing/image?zone_id=${encodeURIComponent(zoneId)}`;
     const config_sha = knob?.id ? knobs.getConfigSha(knob.id) : null;
     const zones = bus ? bus.getZones() : roon.getZones();
+    const zones_sha = bus ? bus.getZonesSha() : null;
 
-    res.json({ ...data, image_url, zones, config_sha });
+    res.json({ ...data, image_url, zones, config_sha, zones_sha });
   });
 
   // GET /now_playing/image - Get album artwork


### PR DESCRIPTION
## Summary

Enables knobs to detect when the zone list changes without requiring a reboot.

- Add `getZonesSha()` to bus that computes SHA from sorted zone IDs
- Include `zones_sha` in `/now_playing` response
- Invalidate cached SHA in `refreshZones()` and `unregisterBackend()`

## How It Works

The knob polls `/now_playing` every 2-5 seconds. When `zones_sha` changes, it re-fetches `/zones` to pick up new/removed zones.

## Related

- Fixes: muness/roon-knob#79
- Companion PR in roon-knob repo will add knob-side detection

## Test plan

- [ ] Start bridge, verify `/now_playing` response includes `zones_sha`
- [ ] Add/remove a zone, verify `zones_sha` changes
- [ ] Verify knob picks up new zones without reboot

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized zone configuration tracking with enhanced performance caching.
  * API responses now include improved zone state identification information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->