### PR TITLE
feat: Add FIRMWARE_AUTO_UPDATE opt-out for automatic updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,11 @@ services:
       # - LMS_PORT=9000
       # - LMS_USERNAME=admin
       # - LMS_PASSWORD=secret
-      # Optional: Firmware polling interval (default: 6 hours)
-      # - FIRMWARE_POLL_INTERVAL_MS=21600000
+      # Optional: Firmware auto-update (default: true)
+      # - FIRMWARE_AUTO_UPDATE=false
+      # Optional: Firmware polling interval when auto-update enabled
+      # - FIRMWARE_POLL_INTERVAL_MINUTES=360  # 6 hours (default)
+      # - FIRMWARE_POLL_INTERVAL_MINUTES=1440 # 24 hours
     restart: unless-stopped
 ```
 
@@ -162,7 +165,12 @@ Ask Claude: "What's playing right now?" or "Turn the volume down a bit" or "Swit
 
 The bridge automatically polls GitHub for new [roon-knob](https://github.com/muness/roon-knob) firmware releases every 6 hours (default, configurable) and downloads updates when available. Knobs check `/firmware/version` on startup and can OTA update from the bridge.
 
-Configure the poll interval via `FIRMWARE_POLL_INTERVAL_MS` environment variable (in milliseconds).
+**Opt-out:** Set `FIRMWARE_AUTO_UPDATE=false` to disable automatic polling and downloading. The bridge will not check GitHub for updates, but the `/firmware/version` and `/firmware/download` endpoints remain available for manual firmware management.
+
+**Configuration:**
+- `FIRMWARE_AUTO_UPDATE` - Enable/disable automatic updates (default: `true`)
+- `FIRMWARE_POLL_INTERVAL_MINUTES` - Poll interval in minutes when auto-update enabled (default: `360` minutes / 6 hours)
+- `FIRMWARE_POLL_INTERVAL_MS` - Legacy: Poll interval in milliseconds (prefer `_MINUTES` above)
 
 If MQTT is enabled, firmware version is published to `unified-hifi/firmware/version` for Home Assistant monitoring.
 

--- a/src/index.js
+++ b/src/index.js
@@ -257,6 +257,9 @@ const mqttService = createMqttService({
   logger: createLogger('MQTT'),
 });
 
+// Check if firmware auto-update is enabled (default: true)
+const FIRMWARE_AUTO_UPDATE = process.env.FIRMWARE_AUTO_UPDATE !== 'false';
+
 // Create HTTP server
 const app = createApp({
   bus,
@@ -273,7 +276,14 @@ const app = createApp({
 // Start services
 bus.start();  // Starts all registered backends (including roon)
 mqttService.connect();
-firmwareService.start();  // Start polling for firmware updates
+
+// Start firmware polling only if enabled
+if (FIRMWARE_AUTO_UPDATE) {
+  firmwareService.start();  // Start polling for firmware updates
+  log.info('Firmware auto-update enabled');
+} else {
+  log.info('Firmware auto-update disabled (set FIRMWARE_AUTO_UPDATE=true to enable)');
+}
 
 let mdnsService;
 


### PR DESCRIPTION
## Summary

Improves firmware configuration with two changes:

1. **Opt-out from auto-updates:** Add `FIRMWARE_AUTO_UPDATE` environment variable to disable automatic firmware polling/downloading
2. **Minutes-based poll interval:** Change from milliseconds to minutes for more intuitive configuration

Closes #29

## Changes

### Opt-out Feature
- Added `FIRMWARE_AUTO_UPDATE` environment variable (default: `true` for backward compatibility)
- Conditionally start firmware service based on the flag
- Firmware HTTP endpoints remain available for manual management
- MQTT firmware monitoring continues to work (reads local version.json)

### Poll Interval Improvement  
- Changed poll interval from `FIRMWARE_POLL_INTERVAL_MS` (milliseconds) to `FIRMWARE_POLL_INTERVAL_MINUTES` (minutes)
- Default: 360 minutes (6 hours)
- Maintains backward compatibility with `_MS` variable (legacy)
- Updated log output to show "N minutes" instead of hours

### Documentation
- Updated README with clear configuration examples
- Docker Compose example shows both new variables
- Documented legacy `_MS` support for backward compatibility

## User Benefits

- Users with bandwidth constraints can disable automatic updates
- Manual firmware management still supported via HTTP endpoints  
- More intuitive poll interval configuration (360 vs 21600000)
- Control over when/how firmware updates occur

## Testing

- ✅ Syntax validated (`node -c src/firmware/index.js src/index.js`)
- ✅ Superego review passed
- ✅ Verified MQTT firmware monitoring works independently of auto-update flag
- ✅ Backward compatibility maintained for `FIRMWARE_POLL_INTERVAL_MS`
- ✅ Documentation updated with clear explanation of behavior

## Backward Compatibility

- Default behavior unchanged - firmware auto-update enabled by default
- Legacy `FIRMWARE_POLL_INTERVAL_MS` still supported
- Config precedence: explicit param > `_MINUTES` > `_MS` (legacy) > default

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced FIRMWARE_AUTO_UPDATE (default: enabled) to toggle automatic firmware checks; when disabled, manual firmware endpoints remain available.
  * Poll interval configurable in minutes (FIRMWARE_POLL_INTERVAL_MINUTES, default 360) while legacy millisecond setting remains supported.

* **Documentation**
  * Updated Quick Start and Firmware Updates to explain the auto-update toggle, minute-based interval, defaults, examples, and opt-out behavior.

* **Other**
  * Startup/status logs now show a human-friendly poll interval and report auto-update status.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->