### PR TITLE
fix: Show HQPlayer controls for linked zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ services:
     image: muness/unified-hifi-control:latest
     network_mode: host  # Required for Roon mDNS discovery
     volumes:
-      - ./data:/data
-      - ./firmware:/app/firmware
+      - ./data:/data  # Config, settings, and firmware stored here
     environment:
       - PORT=8088
       - CONFIG_DIR=/data

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -102,6 +102,41 @@ if (Array.isArray(data)) {
 - Keep CHANGELOG.md current
 - Document breaking changes prominently
 
+## Code Review
+
+### Automated Reviewers
+
+All PRs should be reviewed by both automated reviewers:
+
+1. **CodeRabbit** (`@coderabbitai`) - AI code review bot on GitHub
+   - Comment `@coderabbitai review` on the PR
+   - Provides line-by-line feedback, security checks, best practices
+   - Address feedback or explain why you're not
+
+2. **Superego** (`sg review pr`) - Local metacognitive review
+   - Run before creating PR or after significant changes
+   - Evaluates proportionality, scope creep, architectural fit
+   - Paste non-trivial feedback as PR comment for transparency
+
+### Review Workflow
+
+```bash
+# Before PR: run superego locally
+sg review pr
+
+# After PR created: request coderabbit
+gh pr comment <number> --body "@coderabbitai review"
+
+# If superego has substantive feedback, paste it to PR
+gh pr comment <number> --body "**Superego Review:**
+<paste feedback here>"
+```
+
+### When to Paste Superego Reviews
+
+- **Always paste:** Observations about architectural decisions, timing concerns, error handling gaps
+- **Skip pasting:** Simple "ship it" approvals with no substantive observations
+
 ## CI Pipeline
 
 All PRs must pass:


### PR DESCRIPTION
## Summary

- Fix HQPlayer controls not showing for linked zones on /zone page
- Fetch zone links from `/hqp/zones/links` instead of checking `output_name`
- Linked zones (roon:*, lms:*) don't have 'hqplayer' in output_name

## Root Cause

The zone page checked `output_name.includes('hqplayer')` to decide whether to show HQP controls. But linked zones are regular zones that are *linked* to HQPlayer via `hqpService` - they don't have 'hqplayer' in their output name.

## Changes

| Line | Before | After |
|------|--------|-------|
| 737 | - | `let hqpZoneLinks = [];` |
| 797 | `output_name.includes('hqplayer')` | `hqpZoneLinks.some(link => link.zone_id === selectedZone)` |
| 815-822 | fetch status only | fetch status + links in parallel |

## Test plan

- [x] Lint passes
- [x] Tests pass (16/16)
- [ ] Manual: verify HQP controls show for linked zone on /zone page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HQPlayer visibility and linkage detection; HQPlayer status now loads more reliably with concurrent fetching and better error recovery.

* **Documentation**
  * Simplified example docker-compose volume for runtime data/firmware storage.
  * Added a "Code Review" best-practices section with automated reviewer guidance and CI workflow notes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->