### PR TITLE
fix: Update web UI to use unified API protocol

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1040,9 +1040,9 @@ pub async fn zone_page(State(_state): State<AppState>) -> impl IntoResponse {
             <p id="zone-album" style="margin:0;color:var(--pico-muted-color);"><small>—</small></p>
             <hr>
             <div style="display:flex;gap:0.5rem;align-items:center;margin:1rem 0;">
-                <button id="btn-prev" style="width:3rem;">◀◀</button>
-                <button id="btn-play" style="width:3rem;">⏯</button>
-                <button id="btn-next" style="width:3rem;">▶▶</button>
+                <button id="btn-prev">◀◀</button>
+                <button id="btn-play">⏯</button>
+                <button id="btn-next">▶▶</button>
                 <span style="margin-left:1rem;">Volume: <strong id="zone-volume">—</strong></span>
                 <button id="btn-vol-down" style="width:2.5rem;" title="Volume Down">−</button>
                 <button id="btn-vol-up" style="width:2.5rem;" title="Volume Up">+</button>

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1056,7 +1056,9 @@ function updateZoneDisplay(zone, np) {
         document.getElementById('zone-artist').innerHTML = '<small>' + esc(np.line2 || '') + '</small>';
         document.getElementById('zone-album').innerHTML = '<small>' + esc(np.line3 || '') + '</small>';
         if (np.image_url) {
-            document.getElementById('zone-art').src = np.image_url + '&width=200&height=200&t=' + Date.now();
+            const url = np.image_url;
+            const sep = url.includes('?') ? (url.endsWith('?') || url.endsWith('&') ? '' : '&') : '?';
+            document.getElementById('zone-art').src = url + sep + 'width=200&height=200&t=' + Date.now();
         } else {
             document.getElementById('zone-art').src = '';
         }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -281,7 +281,7 @@ async function loadZones() {
         }
 
         section.innerHTML = '<div class="zone-grid">' + zones.map(zone => {
-            const playIcon = zone.state === 'playing' ? '⏸' : '▶';
+            const playIcon = zone.state === 'playing' ? '⏸︎' : '▶';
             const hqpLink = hqpZoneLinks[zone.zone_id];
             const hqpBadge = hqpLink ? `<mark style="font-size:0.7em;padding:0.1em 0.3em;margin-left:0.5em;">HQP</mark>` : '';
             const sourceBadge = zone.source ? `<mark style="font-size:0.7em;padding:0.1em 0.3em;margin-left:0.5em;background:var(--pico-muted-background);">${esc(zone.source)}</mark>` : '';
@@ -1197,7 +1197,7 @@ function updateZoneDisplay(zone, np) {
     const isPlaying = np?.is_playing || false;
     document.getElementById('btn-prev').disabled = !np?.is_previous_allowed;
     document.getElementById('btn-next').disabled = !np?.is_next_allowed;
-    document.getElementById('btn-play').textContent = isPlaying ? '⏸' : '▶';
+    document.getElementById('btn-play').textContent = isPlaying ? '⏸︎' : '▶';
 
     // Show/hide HQP section based on zone link
     const hqpInstance = zoneLinkMap[zone.zone_id];

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1041,7 +1041,7 @@ pub async fn zone_page(State(_state): State<AppState>) -> impl IntoResponse {
             <hr>
             <div style="display:flex;gap:0.5rem;align-items:center;margin:1rem 0;">
                 <button id="btn-prev">◀◀</button>
-                <button id="btn-play">⏯</button>
+                <button id="btn-play">▶</button>
                 <button id="btn-next">▶▶</button>
                 <span style="margin-left:1rem;">Volume: <strong id="zone-volume">—</strong></span>
                 <button id="btn-vol-down" style="width:2.5rem;" title="Volume Down">−</button>


### PR DESCRIPTION
## Summary
- Updated web UI pages to use the unified API protocol that the roon-knob ESP32 client uses
- The API was correct (verified by working knob), but web pages were using legacy Roon-specific endpoints
- All pages now use `/zones`, `/control`, and `/now_playing` instead of `/roon/zones`, `/roon/control`

## Changes
- **Zones page** (`/ui/zones`): Uses `/zones` and `/control`, shows source badge for each zone
- **Zone control page** (`/zone`): Uses `/zones`, `/now_playing`, `/control` with vol_up/vol_down
- **Knobs page** (`/knobs`): Uses `/zones` for zone name lookup
- **HQPlayer zone links** (`/hqplayer`): Uses `zone_name` instead of `display_name`

## API Protocol
The unified API provides:
- `GET /zones` → `{zones: [{zone_id, zone_name, source, state}]}`
- `POST /control` → Routes by zone_id prefix (`roon:`, `lms:`, `openhome:`, `upnp:`)
- `GET /now_playing?zone_id=...` → `{line1, line2, line3, is_playing, volume, ...}`

## Test plan
- [ ] Verify zones page loads and shows zones from all enabled adapters
- [ ] Verify zone control page shows now playing info and controls work
- [ ] Verify knobs page shows correct zone names
- [ ] Verify HQPlayer zone links page shows correct zone names
- [ ] Test with multiple adapter types if available (Roon, LMS, OpenHome, UPnP)

Fixes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added source information display to zone headers

* **Improvements**
  * Streamlined zone display with more compact now-playing rendering
  * Updated messaging to guide users toward checking adapter connections when zones are unavailable
  * Simplified playback controls interface

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->