### PR TITLE
v3/LMS: Implement a subscription to player state changes in LMS

### DIFF
--- a/lms-plugin/Helper.pm
+++ b/lms-plugin/Helper.pm
@@ -476,6 +476,17 @@ sub writeKnobConfig {
     }
 }
 
+# Notify helper of playback state change
+sub notifyPlaybackStateChange {
+    my ($class, $client) = @_;
+    return unless running() && $client;
+
+    my $zoneId = 'lms:' . $client->id;
+    # TODO: Implement notification logic (e.g., HTTP request to helper API)
+
+    $log->debug("Notified helper of playback state change for zone $zoneId");
+}
+
 # Get knob status from running helper (if available)
 sub knobStatus {
     my $class = shift;

--- a/lms-plugin/Plugin.pm
+++ b/lms-plugin/Plugin.pm
@@ -43,6 +43,8 @@ sub initPlugin {
         Plugins::UnifiedHiFi::Helper->start;
     }
 
+    Slim::Control::Request::subscribe(\&_onPlaylistEvent, [['power', 'pause', 'stop', 'mixer', 'playlist'], ['newsong', 'pause', 'stop', 'play', 'volume']]);
+
     $log->info("Unified Hi-Fi Control plugin initialized");
 }
 
@@ -56,6 +58,14 @@ sub getDisplayName {
 }
 
 sub playerMenu { }
+
+sub _onPlaylistEvent {
+    my $request = shift;
+
+    my $client = $request->client() || return;
+
+    Plugins::UnifiedHiFi::Helper->notifyPlaybackStateChange($client);
+}
 
 1;
 


### PR DESCRIPTION
In LMS we can listen to events happening to a player. This change would listen for playback state changes.

This PR is to start the discussion. If you implemented an endpoint in the bridge which the plugin could call to trigger a metadata update, I could take care of the LMS side of things.