### PR TITLE
v3/LMS: Get rid of some of the redundancy evaluating the binary to be used

### DIFF
--- a/lms-plugin/Settings.pm
+++ b/lms-plugin/Settings.pm
@@ -106,7 +106,9 @@ sub beforeRender {
     # Add template variables
     $params->{'running'}    = Plugins::UnifiedHiFi::Helper->running();
     $params->{'webUrl'}     = Plugins::UnifiedHiFi::Helper->webUrl();
-    $params->{'binaries'}   = [Plugins::UnifiedHiFi::Helper->binaries()];
+    # Single binary per platform now - dropdown only shows if size > 1 (never)
+    my $platformBinary = Plugins::UnifiedHiFi::Helper::BINARY_MAP->{Plugins::UnifiedHiFi::Helper->detectPlatform()};
+    $params->{'binaries'}   = $platformBinary ? [$platformBinary] : [];
     $params->{'loglevels'}  = ['error', 'warn', 'info', 'debug'];
     $params->{'rotations'}  = [0, 90, 180, 270];
 


### PR DESCRIPTION
There were multiple implementations to try to figure out the platform, and what binary to use on each platform. Resulting in broken support for eg. `linux-armv7l`. Consolidate all evaluation in one place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Linux ARMv7l systems

* **Improvements**
  * Enhanced platform detection and binary selection for improved reliability across different architectures
  * Better logging and debugging capabilities for troubleshooting binary-related issues

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->