### PR TITLE
v3/LMS: Use the server's IP address rather than localhost to access the bridge

### DIFF
--- a/lms-plugin/Helper.pm
+++ b/lms-plugin/Helper.pm
@@ -382,7 +382,7 @@ sub running {
 sub webUrl {
     my $class = shift;
     my $port = $prefs->get('port') || 8088;
-    return "http://localhost:$port";
+    return sprintf('http://%s:%d', Slim::Utils::Network::serverAddr(), $port);
 }
 
 # Health check timer callback


### PR DESCRIPTION
Many LMS users run LMS on a headless machine, access it remotely in a browser on some other host. In those cases we need the real IP address.