### PR TITLE
fix: Add graceful shutdown with cancellation tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4183,6 +4183,7 @@ dependencies = [
  "serial_test",
  "sha2",
  "ssdp-client",
+ "syn",
  "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
@@ -4194,6 +4195,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "urlencoding",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,8 @@ path = "src/bin/protocol_checker.rs"
 [dev-dependencies]
 tokio-test = "0.4"
 serial_test = "3"
+syn = { version = "2", features = ["full", "parsing", "visit"] }
+walkdir = "2"
 
 [profile.release]
 lto = true

--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -224,7 +224,11 @@ impl RoonAdapter {
             }
         });
 
-        Ok(Self { state, bus, shutdown })
+        Ok(Self {
+            state,
+            bus,
+            shutdown,
+        })
     }
 
     /// Get connection status

--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -15,6 +15,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::{oneshot, RwLock};
+use tokio_util::sync::CancellationToken;
 
 use crate::bus::{BusEvent, SharedBus};
 use crate::config::get_data_dir;
@@ -141,10 +142,12 @@ struct RoonState {
 }
 
 /// Roon adapter
+#[derive(Clone)]
 pub struct RoonAdapter {
     state: Arc<RwLock<RoonState>>,
     #[allow(dead_code)]
     bus: SharedBus,
+    shutdown: CancellationToken,
 }
 
 /// Initial reconnection delay
@@ -160,7 +163,14 @@ impl RoonAdapter {
         Self {
             state: Arc::new(RwLock::new(RoonState::default())),
             bus,
+            shutdown: CancellationToken::new(),
         }
+    }
+
+    /// Stop the Roon adapter
+    pub fn stop(&self) {
+        self.shutdown.cancel();
+        tracing::info!("Roon adapter stopped");
     }
 
     /// Create and start Roon adapter
@@ -170,6 +180,8 @@ impl RoonAdapter {
         let state = Arc::new(RwLock::new(RoonState::default()));
         let state_clone = state.clone();
         let bus_clone = bus.clone();
+        let shutdown = CancellationToken::new();
+        let shutdown_clone = shutdown.clone();
 
         // Spawn Roon event loop with reconnection logic
         tokio::spawn(async move {
@@ -197,14 +209,22 @@ impl RoonAdapter {
                 }
 
                 tracing::info!("Roon loop exited, reconnecting in {:?}...", retry_delay);
-                tokio::time::sleep(retry_delay).await;
 
-                // Exponential backoff up to max
-                retry_delay = (retry_delay * 2).min(MAX_RETRY_DELAY);
+                // Check for shutdown before sleeping
+                tokio::select! {
+                    _ = shutdown_clone.cancelled() => {
+                        tracing::info!("Roon adapter shutdown requested");
+                        break;
+                    }
+                    _ = tokio::time::sleep(retry_delay) => {
+                        // Exponential backoff up to max
+                        retry_delay = (retry_delay * 2).min(MAX_RETRY_DELAY);
+                    }
+                }
             }
         });
 
-        Ok(Self { state, bus })
+        Ok(Self { state, bus, shutdown })
     }
 
     /// Get connection status

--- a/tests/mock_servers/hqplayer.rs
+++ b/tests/mock_servers/hqplayer.rs
@@ -2,7 +2,6 @@
 //!
 //! Simulates the TCP/XML protocol on port 4321
 
-use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};

--- a/tests/protocol_schema.rs
+++ b/tests/protocol_schema.rs
@@ -4,7 +4,7 @@
 //! This serves as an executable contract test for clients consuming the API.
 
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::json;
 
 /// StatusResponse schema - GET /status
 #[derive(Debug, Deserialize)]

--- a/tests/spawn_cancellation_lint.rs
+++ b/tests/spawn_cancellation_lint.rs
@@ -49,7 +49,12 @@ impl SpawnLoopVisitor {
     fn is_tokio_spawn_call(&self, call: &ExprCall) -> bool {
         // Check for tokio::spawn(...) pattern
         if let Expr::Path(path) = &*call.func {
-            let segments: Vec<_> = path.path.segments.iter().map(|s| s.ident.to_string()).collect();
+            let segments: Vec<_> = path
+                .path
+                .segments
+                .iter()
+                .map(|s| s.ident.to_string())
+                .collect();
             return segments == vec!["tokio", "spawn"];
         }
         false
@@ -57,7 +62,10 @@ impl SpawnLoopVisitor {
 
     fn is_select_macro_path(&self, mac: &Macro) -> bool {
         // Check for tokio::select! or select! pattern
-        let path_str: String = mac.path.segments.iter()
+        let path_str: String = mac
+            .path
+            .segments
+            .iter()
             .map(|s| s.ident.to_string())
             .collect::<Vec<_>>()
             .join("::");
@@ -88,7 +96,8 @@ impl<'ast> Visit<'ast> for SpawnLoopVisitor {
             self.has_select_in_loop = false;
 
             // Try to get some context about this loop
-            self.loop_context = loop_expr.label
+            self.loop_context = loop_expr
+                .label
                 .as_ref()
                 .map(|l| format!("'{}", l.name.ident))
                 .unwrap_or_else(|| "loop".to_string());
@@ -100,7 +109,10 @@ impl<'ast> Visit<'ast> for SpawnLoopVisitor {
             if !self.has_select_in_loop {
                 self.violations.push((
                     self.current_file.clone(),
-                    format!("Spawned {} without cancellation handling", self.loop_context),
+                    format!(
+                        "Spawned {} without cancellation handling",
+                        self.loop_context
+                    ),
                 ));
             }
 

--- a/tests/spawn_cancellation_lint.rs
+++ b/tests/spawn_cancellation_lint.rs
@@ -1,0 +1,187 @@
+//! AST-level test to ensure all tokio::spawn loops have proper cancellation handling.
+//!
+//! This test parses Rust source files and finds patterns like:
+//! ```ignore
+//! tokio::spawn(async move {
+//!     loop {
+//!         // ... must have tokio::select! with cancellation check
+//!     }
+//! });
+//! ```
+//!
+//! Any spawned infinite loop without a cancellation mechanism will cause the process
+//! to hang on shutdown (Ctrl+C won't work properly).
+
+use std::fs;
+use std::path::Path;
+use syn::visit::Visit;
+use syn::{Expr, ExprCall, ExprLoop, ExprMacro, File, Macro, StmtMacro};
+use walkdir::WalkDir;
+
+/// Tracks spawned async blocks and whether they contain uncancellable loops
+struct SpawnLoopVisitor {
+    /// Current file being analyzed
+    current_file: String,
+    /// Stack tracking if we're inside a tokio::spawn
+    in_spawn_depth: usize,
+    /// Stack tracking if we're inside a loop within a spawn
+    in_loop_depth: usize,
+    /// Whether we've seen a select! macro in the current loop
+    has_select_in_loop: bool,
+    /// Violations found: (file, approximate context)
+    violations: Vec<(String, String)>,
+    /// Track loop starts to give better error context
+    loop_context: String,
+}
+
+impl SpawnLoopVisitor {
+    fn new(file: String) -> Self {
+        Self {
+            current_file: file,
+            in_spawn_depth: 0,
+            in_loop_depth: 0,
+            has_select_in_loop: false,
+            violations: Vec::new(),
+            loop_context: String::new(),
+        }
+    }
+
+    fn is_tokio_spawn_call(&self, call: &ExprCall) -> bool {
+        // Check for tokio::spawn(...) pattern
+        if let Expr::Path(path) = &*call.func {
+            let segments: Vec<_> = path.path.segments.iter().map(|s| s.ident.to_string()).collect();
+            return segments == vec!["tokio", "spawn"];
+        }
+        false
+    }
+
+    fn is_select_macro_path(&self, mac: &Macro) -> bool {
+        // Check for tokio::select! or select! pattern
+        let path_str: String = mac.path.segments.iter()
+            .map(|s| s.ident.to_string())
+            .collect::<Vec<_>>()
+            .join("::");
+        path_str == "tokio::select" || path_str == "select"
+    }
+}
+
+impl<'ast> Visit<'ast> for SpawnLoopVisitor {
+    fn visit_expr_call(&mut self, call: &'ast ExprCall) {
+        if self.is_tokio_spawn_call(call) {
+            self.in_spawn_depth += 1;
+            // Visit the arguments (the async block)
+            for arg in &call.args {
+                self.visit_expr(arg);
+            }
+            self.in_spawn_depth -= 1;
+        } else {
+            // Continue visiting normally
+            syn::visit::visit_expr_call(self, call);
+        }
+    }
+
+    fn visit_expr_loop(&mut self, loop_expr: &'ast ExprLoop) {
+        if self.in_spawn_depth > 0 {
+            // We're in a spawned task and found a loop
+            self.in_loop_depth += 1;
+            let old_has_select = self.has_select_in_loop;
+            self.has_select_in_loop = false;
+
+            // Try to get some context about this loop
+            self.loop_context = loop_expr.label
+                .as_ref()
+                .map(|l| format!("'{}", l.name.ident))
+                .unwrap_or_else(|| "loop".to_string());
+
+            // Visit the loop body
+            syn::visit::visit_expr_loop(self, loop_expr);
+
+            // After visiting, check if we found a select!
+            if !self.has_select_in_loop {
+                self.violations.push((
+                    self.current_file.clone(),
+                    format!("Spawned {} without cancellation handling", self.loop_context),
+                ));
+            }
+
+            self.has_select_in_loop = old_has_select;
+            self.in_loop_depth -= 1;
+        } else {
+            syn::visit::visit_expr_loop(self, loop_expr);
+        }
+    }
+
+    fn visit_expr_macro(&mut self, mac: &'ast ExprMacro) {
+        if self.in_loop_depth > 0 && self.is_select_macro_path(&mac.mac) {
+            // Found a select! inside a loop - this is good
+            self.has_select_in_loop = true;
+        }
+        syn::visit::visit_expr_macro(self, mac);
+    }
+
+    fn visit_stmt_macro(&mut self, mac: &'ast StmtMacro) {
+        if self.in_loop_depth > 0 && self.is_select_macro_path(&mac.mac) {
+            // Found a select! inside a loop - this is good
+            self.has_select_in_loop = true;
+        }
+        syn::visit::visit_stmt_macro(self, mac);
+    }
+}
+
+fn analyze_file(path: &Path) -> Vec<(String, String)> {
+    let content = match fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(_) => return vec![],
+    };
+
+    let syntax: File = match syn::parse_file(&content) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("Warning: Failed to parse {}: {}", path.display(), e);
+            return vec![];
+        }
+    };
+
+    let mut visitor = SpawnLoopVisitor::new(path.display().to_string());
+    visitor.visit_file(&syntax);
+    visitor.violations
+}
+
+#[test]
+fn spawned_loops_must_have_cancellation() {
+    let src_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+
+    let mut all_violations = Vec::new();
+
+    for entry in WalkDir::new(&src_dir)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().map_or(false, |ext| ext == "rs"))
+    {
+        let violations = analyze_file(entry.path());
+        all_violations.extend(violations);
+    }
+
+    if !all_violations.is_empty() {
+        let mut error_msg = String::from(
+            "\n\nFound spawned loops without cancellation handling!\n\
+             These will prevent graceful shutdown (Ctrl+C will hang).\n\n\
+             Fix by adding tokio::select! with a cancellation token:\n\
+             ```rust\n\
+             loop {\n\
+                 tokio::select! {\n\
+                     _ = shutdown.cancelled() => break,\n\
+                     _ = ticker.tick() => { /* work */ }\n\
+                 }\n\
+             }\n\
+             ```\n\n\
+             Violations:\n",
+        );
+
+        for (file, context) in &all_violations {
+            error_msg.push_str(&format!("  - {}: {}\n", file, context));
+        }
+
+        panic!("{}", error_msg);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #61 - Ctrl+C now properly terminates the process on macOS (and other platforms).

**Root cause:** Spawned tasks with infinite loops weren't responding to shutdown signals because they lacked cancellation mechanisms.

**Changes:**
- `firmware.rs`: Add `CancellationToken` to polling loop
- `roon.rs`: Add `CancellationToken` to reconnection loop, derive `Clone`
- `main.rs`: Call `stop()` on roon and firmware services during shutdown
- Add AST-level lint test to catch future violations

## Test plan

- [x] All 172 tests pass
- [x] New `spawn_cancellation_lint` test validates all spawned loops have cancellation
- [x] Manual test: run bridge, Ctrl+C should exit cleanly

## AST Lint Test

The new `spawn_cancellation_lint.rs` test parses all source files and fails if any `tokio::spawn` contains a `loop` without `tokio::select!` for cancellation handling. This prevents regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented graceful shutdown mechanism for the Roon adapter enabling clean service termination
  * Added controlled shutdown capability for firmware polling service

* **Tests**
  * Added automated lint test to enforce cancellation handling in spawned async tasks

* **Chores**
  * Cleaned up unused imports from test modules

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->