### PR TITLE
feat: Unified adapter lifecycle with dynamic enable/disable (Fixes #81)

### DIFF
--- a/src/adapters/lms.rs
+++ b/src/adapters/lms.rs
@@ -464,8 +464,8 @@ impl LmsAdapter {
         self.rpc.get_player_status(player_id).await
     }
 
-    /// Start polling for player updates
-    pub async fn start(&self) -> Result<()> {
+    /// Start polling for player updates (internal - use Startable trait)
+    async fn start_polling(&self) -> Result<()> {
         if !self.is_configured().await {
             return Err(anyhow!("LMS not configured"));
         }
@@ -521,8 +521,8 @@ impl LmsAdapter {
         update_players_internal(&self.rpc, &self.state, &self.bus).await
     }
 
-    /// Stop polling
-    pub async fn stop(&self) {
+    /// Stop polling (internal - use Startable trait)
+    async fn stop_polling(&self) {
         // Cancel background tasks first
         self.shutdown.cancel();
 
@@ -801,11 +801,11 @@ impl Startable for LmsAdapter {
     }
 
     async fn start(&self) -> Result<()> {
-        LmsAdapter::start(self).await
+        self.start_polling().await
     }
 
     async fn stop(&self) {
-        LmsAdapter::stop(self).await
+        self.stop_polling().await
     }
 
     async fn can_start(&self) -> bool {

--- a/src/adapters/lms.rs
+++ b/src/adapters/lms.rs
@@ -15,8 +15,10 @@ use tokio::sync::RwLock;
 use tokio::time::interval;
 use tokio_util::sync::CancellationToken;
 
+use crate::adapters::traits::Startable;
 use crate::bus::{BusEvent, PlaybackState, SharedBus, VolumeControl, Zone};
 use crate::config::get_config_dir;
+use async_trait::async_trait;
 
 const LMS_CONFIG_FILE: &str = "lms-config.json";
 
@@ -786,4 +788,27 @@ async fn update_players_internal(
     }
 
     Ok(())
+}
+
+// =============================================================================
+// Startable trait implementation
+// =============================================================================
+
+#[async_trait]
+impl Startable for LmsAdapter {
+    fn name(&self) -> &'static str {
+        "lms"
+    }
+
+    async fn start(&self) -> Result<()> {
+        LmsAdapter::start(self).await
+    }
+
+    async fn stop(&self) {
+        LmsAdapter::stop(self).await
+    }
+
+    async fn can_start(&self) -> bool {
+        self.is_configured().await
+    }
 }

--- a/src/adapters/lms.rs
+++ b/src/adapters/lms.rs
@@ -480,8 +480,12 @@ impl LmsAdapter {
             state.running = true;
         }
 
-        // Initial update
-        self.update_players().await?;
+        // Initial update - reset running flag on failure so we can retry
+        if let Err(e) = self.update_players().await {
+            let mut state = self.state.write().await;
+            state.running = false;
+            return Err(e);
+        }
 
         {
             let mut state = self.state.write().await;

--- a/src/adapters/lms.rs
+++ b/src/adapters/lms.rs
@@ -308,6 +308,7 @@ struct LmsState {
     username: Option<String>,
     password: Option<String>,
     connected: bool,
+    running: bool,
     players: HashMap<String, LmsPlayer>,
 }
 
@@ -319,6 +320,7 @@ impl Default for LmsState {
             username: None,
             password: None,
             connected: false,
+            running: false,
             players: HashMap::new(),
         }
     }
@@ -469,6 +471,15 @@ impl LmsAdapter {
             return Err(anyhow!("LMS not configured"));
         }
 
+        // Check if already running to prevent double-start
+        {
+            let mut state = self.state.write().await;
+            if state.running {
+                return Ok(());
+            }
+            state.running = true;
+        }
+
         // Initial update
         self.update_players().await?;
 
@@ -534,6 +545,7 @@ impl LmsAdapter {
         let host = {
             let mut state = self.state.write().await;
             state.connected = false;
+            state.running = false;
             state.host.clone()
         };
 

--- a/src/adapters/openhome.rs
+++ b/src/adapters/openhome.rs
@@ -4,7 +4,10 @@
 //! OpenHome is an extension of UPnP that provides richer metadata and more
 //! control actions (next/previous track, playlists, etc.)
 
+use crate::adapters::traits::Startable;
 use crate::bus::{BusEvent, PlaybackState, SharedBus, VolumeControl as BusVolumeControl, Zone};
+use anyhow::Result;
+use async_trait::async_trait;
 use futures::StreamExt;
 use quick_xml::de::from_str as xml_from_str;
 use reqwest::Client;
@@ -925,5 +928,24 @@ fn openhome_device_to_zone(device: &OpenHomeDevice) -> Zone {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_millis() as u64,
+    }
+}
+
+// =============================================================================
+// Startable trait implementation
+// =============================================================================
+
+#[async_trait]
+impl Startable for OpenHomeAdapter {
+    fn name(&self) -> &'static str {
+        "openhome"
+    }
+
+    async fn start(&self) -> Result<()> {
+        OpenHomeAdapter::start(self).await
+    }
+
+    async fn stop(&self) {
+        OpenHomeAdapter::stop(self).await
     }
 }

--- a/src/adapters/openhome.rs
+++ b/src/adapters/openhome.rs
@@ -144,8 +144,8 @@ impl OpenHomeAdapter {
         }
     }
 
-    /// Start SSDP discovery
-    pub async fn start(&self) -> anyhow::Result<()> {
+    /// Start SSDP discovery (internal - use Startable trait)
+    async fn start_discovery(&self) -> anyhow::Result<()> {
         {
             let mut state = self.state.write().await;
             if state.running {
@@ -621,8 +621,8 @@ impl OpenHomeAdapter {
         })
     }
 
-    /// Stop discovery
-    pub async fn stop(&self) {
+    /// Stop discovery (internal - use Startable trait)
+    async fn stop_discovery(&self) {
         // Cancel background tasks first
         self.shutdown.cancel();
 
@@ -942,10 +942,10 @@ impl Startable for OpenHomeAdapter {
     }
 
     async fn start(&self) -> Result<()> {
-        OpenHomeAdapter::start(self).await
+        self.start_discovery().await
     }
 
     async fn stop(&self) {
-        OpenHomeAdapter::stop(self).await
+        self.stop_discovery().await
     }
 }

--- a/src/adapters/openhome.rs
+++ b/src/adapters/openhome.rs
@@ -4,10 +4,7 @@
 //! OpenHome is an extension of UPnP that provides richer metadata and more
 //! control actions (next/previous track, playlists, etc.)
 
-use crate::adapters::traits::Startable;
 use crate::bus::{BusEvent, PlaybackState, SharedBus, VolumeControl as BusVolumeControl, Zone};
-use anyhow::Result;
-use async_trait::async_trait;
 use futures::StreamExt;
 use quick_xml::de::from_str as xml_from_str;
 use reqwest::Client;
@@ -145,7 +142,7 @@ impl OpenHomeAdapter {
     }
 
     /// Start SSDP discovery (internal - use Startable trait)
-    async fn start_discovery(&self) -> anyhow::Result<()> {
+    async fn start_internal(&self) -> anyhow::Result<()> {
         {
             let mut state = self.state.write().await;
             if state.running {
@@ -622,7 +619,7 @@ impl OpenHomeAdapter {
     }
 
     /// Stop discovery (internal - use Startable trait)
-    async fn stop_discovery(&self) {
+    async fn stop_internal(&self) {
         // Cancel background tasks first
         self.shutdown.cancel();
 
@@ -931,21 +928,5 @@ fn openhome_device_to_zone(device: &OpenHomeDevice) -> Zone {
     }
 }
 
-// =============================================================================
-// Startable trait implementation
-// =============================================================================
-
-#[async_trait]
-impl Startable for OpenHomeAdapter {
-    fn name(&self) -> &'static str {
-        "openhome"
-    }
-
-    async fn start(&self) -> Result<()> {
-        self.start_discovery().await
-    }
-
-    async fn stop(&self) {
-        self.stop_discovery().await
-    }
-}
+// Startable trait implementation via macro
+crate::impl_startable!(OpenHomeAdapter, "openhome");

--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -197,8 +197,8 @@ impl RoonAdapter {
         Ok(adapter)
     }
 
-    /// Start the Roon event loop
-    pub async fn start_roon(&self) -> Result<()> {
+    /// Start the Roon event loop (internal - use Startable trait)
+    async fn start_roon(&self) -> Result<()> {
         use std::sync::atomic::Ordering;
 
         // Check if already started
@@ -260,8 +260,8 @@ impl RoonAdapter {
         Ok(())
     }
 
-    /// Stop the Roon adapter
-    pub fn stop(&self) {
+    /// Stop the Roon adapter (internal - use Startable trait)
+    fn stop_adapter(&self) {
         self.shutdown.cancel();
         tracing::info!("Roon adapter stopped");
     }
@@ -799,7 +799,7 @@ impl Startable for RoonAdapter {
     }
 
     async fn stop(&self) {
-        RoonAdapter::stop(self)
+        self.stop_adapter()
     }
 
     async fn can_start(&self) -> bool {

--- a/src/adapters/traits.rs
+++ b/src/adapters/traits.rs
@@ -4,6 +4,30 @@ use tokio_util::sync::CancellationToken;
 
 use crate::bus::SharedBus;
 
+// =============================================================================
+// Startable - Uniform adapter lifecycle trait
+// =============================================================================
+
+/// Trait for adapters that can be started/stopped uniformly.
+/// This enables the coordinator to manage all adapters through a single codepath.
+#[async_trait]
+pub trait Startable: Send + Sync {
+    /// Adapter name/prefix (e.g., "lms", "openhome")
+    fn name(&self) -> &'static str;
+
+    /// Start the adapter. No-op if already running or can't start.
+    async fn start(&self) -> Result<()>;
+
+    /// Stop the adapter gracefully.
+    async fn stop(&self);
+
+    /// Whether this adapter can be started (e.g., has required config).
+    /// Default: true (most adapters can always start).
+    async fn can_start(&self) -> bool {
+        true
+    }
+}
+
 /// Context passed to adapter logic during execution
 pub struct AdapterContext {
     /// Event bus for publishing events

--- a/src/adapters/upnp.rs
+++ b/src/adapters/upnp.rs
@@ -4,7 +4,10 @@
 //! Pure UPnP/DLNA has limited metadata support compared to OpenHome.
 //! Specifically, next/previous track are NOT supported by pure UPnP.
 
+use crate::adapters::traits::Startable;
 use crate::bus::{BusEvent, PlaybackState, SharedBus, VolumeControl as BusVolumeControl, Zone};
+use anyhow::Result;
+use async_trait::async_trait;
 use futures::StreamExt;
 use quick_xml::de::from_str as xml_from_str;
 use regex::Regex;
@@ -885,5 +888,24 @@ fn upnp_renderer_to_zone(renderer: &UPnPRenderer) -> Zone {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_millis() as u64,
+    }
+}
+
+// =============================================================================
+// Startable trait implementation
+// =============================================================================
+
+#[async_trait]
+impl Startable for UPnPAdapter {
+    fn name(&self) -> &'static str {
+        "upnp"
+    }
+
+    async fn start(&self) -> Result<()> {
+        UPnPAdapter::start(self).await
+    }
+
+    async fn stop(&self) {
+        UPnPAdapter::stop(self).await
     }
 }

--- a/src/adapters/upnp.rs
+++ b/src/adapters/upnp.rs
@@ -133,8 +133,8 @@ impl UPnPAdapter {
         }
     }
 
-    /// Start SSDP discovery
-    pub async fn start(&self) -> anyhow::Result<()> {
+    /// Start SSDP discovery (internal - use Startable trait)
+    async fn start_discovery(&self) -> anyhow::Result<()> {
         {
             let mut state = self.state.write().await;
             if state.running {
@@ -575,8 +575,8 @@ impl UPnPAdapter {
             .map(|m| m.as_str().to_string())
     }
 
-    /// Stop discovery
-    pub async fn stop(&self) {
+    /// Stop discovery (internal - use Startable trait)
+    async fn stop_discovery(&self) {
         // Cancel background tasks first
         self.shutdown.cancel();
 
@@ -902,10 +902,10 @@ impl Startable for UPnPAdapter {
     }
 
     async fn start(&self) -> Result<()> {
-        UPnPAdapter::start(self).await
+        self.start_discovery().await
     }
 
     async fn stop(&self) {
-        UPnPAdapter::stop(self).await
+        self.stop_discovery().await
     }
 }

--- a/src/adapters/upnp.rs
+++ b/src/adapters/upnp.rs
@@ -4,10 +4,7 @@
 //! Pure UPnP/DLNA has limited metadata support compared to OpenHome.
 //! Specifically, next/previous track are NOT supported by pure UPnP.
 
-use crate::adapters::traits::Startable;
 use crate::bus::{BusEvent, PlaybackState, SharedBus, VolumeControl as BusVolumeControl, Zone};
-use anyhow::Result;
-use async_trait::async_trait;
 use futures::StreamExt;
 use quick_xml::de::from_str as xml_from_str;
 use regex::Regex;
@@ -134,7 +131,7 @@ impl UPnPAdapter {
     }
 
     /// Start SSDP discovery (internal - use Startable trait)
-    async fn start_discovery(&self) -> anyhow::Result<()> {
+    async fn start_internal(&self) -> anyhow::Result<()> {
         {
             let mut state = self.state.write().await;
             if state.running {
@@ -576,7 +573,7 @@ impl UPnPAdapter {
     }
 
     /// Stop discovery (internal - use Startable trait)
-    async fn stop_discovery(&self) {
+    async fn stop_internal(&self) {
         // Cancel background tasks first
         self.shutdown.cancel();
 
@@ -891,21 +888,5 @@ fn upnp_renderer_to_zone(renderer: &UPnPRenderer) -> Zone {
     }
 }
 
-// =============================================================================
-// Startable trait implementation
-// =============================================================================
-
-#[async_trait]
-impl Startable for UPnPAdapter {
-    fn name(&self) -> &'static str {
-        "upnp"
-    }
-
-    async fn start(&self) -> Result<()> {
-        self.start_discovery().await
-    }
-
-    async fn stop(&self) {
-        self.stop_discovery().await
-    }
-}
+// Startable trait implementation via macro
+crate::impl_startable!(UPnPAdapter, "upnp");

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,9 @@ use unified_hifi_control::{
     adapters, aggregator, api, bus, config, coordinator, firmware, knobs, mdns, ui,
 };
 
+// Import Startable trait for adapter lifecycle methods
+use adapters::Startable;
+
 // Import load_app_settings for checking adapter enabled state
 use api::load_app_settings;
 
@@ -382,7 +385,7 @@ async fn main() -> Result<()> {
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
     // Stop adapters
-    roon_for_shutdown.stop();
+    roon_for_shutdown.stop().await;
     if let Some(ref fw) = firmware_service {
         fw.stop();
     }

--- a/tests/adapter_integration.rs
+++ b/tests/adapter_integration.rs
@@ -16,6 +16,7 @@ use tokio::time::timeout;
 
 use unified_hifi_control::adapters::hqplayer::HqpAdapter;
 use unified_hifi_control::adapters::lms::LmsAdapter;
+use unified_hifi_control::adapters::Startable;
 use unified_hifi_control::bus::{create_bus, BusEvent, SharedBus};
 
 // =============================================================================

--- a/tests/protocol_integration.rs
+++ b/tests/protocol_integration.rs
@@ -21,9 +21,11 @@ use unified_hifi_control::adapters::lms::LmsAdapter;
 use unified_hifi_control::adapters::openhome::OpenHomeAdapter;
 use unified_hifi_control::adapters::roon::RoonAdapter;
 use unified_hifi_control::adapters::upnp::UPnPAdapter;
+use unified_hifi_control::adapters::Startable;
 use unified_hifi_control::aggregator::ZoneAggregator;
 use unified_hifi_control::api::AppState;
 use unified_hifi_control::bus::create_bus;
+use unified_hifi_control::coordinator::AdapterCoordinator;
 use unified_hifi_control::knobs::{self, KnobStore};
 use unified_hifi_control::{api, ui};
 
@@ -31,8 +33,11 @@ use unified_hifi_control::{api, ui};
 async fn create_test_app() -> Router {
     let bus = create_bus();
 
+    // Create coordinator (tests don't need real lifecycle management)
+    let coordinator = Arc::new(AdapterCoordinator::new(bus.clone()));
+
     // Create disconnected adapters
-    let roon = RoonAdapter::new_disconnected(bus.clone());
+    let roon = Arc::new(RoonAdapter::new_disconnected(bus.clone()));
     let hqp_instances = Arc::new(HqpInstanceManager::new(bus.clone()));
     let hqplayer = hqp_instances.get_default().await;
     let hqp_zone_links = Arc::new(HqpZoneLinkService::new(hqp_instances.clone()));
@@ -40,6 +45,10 @@ async fn create_test_app() -> Router {
     let openhome = Arc::new(OpenHomeAdapter::new(bus.clone()));
     let upnp = Arc::new(UPnPAdapter::new(bus.clone()));
     let knob_store = KnobStore::new(std::env::temp_dir());
+
+    // Build startable adapters list
+    let startable_adapters: Vec<Arc<dyn Startable>> =
+        vec![roon.clone(), lms.clone(), openhome.clone(), upnp.clone()];
 
     let aggregator = Arc::new(ZoneAggregator::new(bus.clone()));
     let state = AppState::new(
@@ -53,6 +62,8 @@ async fn create_test_app() -> Router {
         knob_store,
         bus,
         aggregator,
+        coordinator,
+        startable_adapters,
     );
 
     // Build router with all routes (same as main.rs)


### PR DESCRIPTION
## Summary
- Fixed issue where Settings showed adapters as "searching" even when disabled
- **All adapters** (Roon, LMS, OpenHome, UPnP) now implement `Startable` trait
- Single codepath for starting all adapters through coordinator
- **Dynamic enable/disable**: Toggling adapters in settings takes effect immediately - no restart required

## Architecture Changes
- `Startable` trait in `adapters/traits.rs` - uniform interface for adapter lifecycle
- All adapters (`RoonAdapter`, `LmsAdapter`, `OpenHomeAdapter`, `UPnPAdapter`) implement `Startable`
- `AdapterCoordinator` has `start_all_enabled()` and `stop_all()` methods
- `AVAILABLE_ADAPTERS` constant defines all adapters in the system
- Coordinator is the single source of truth for adapter enabled state
- `AppState` now holds coordinator and startable_adapters for dynamic control

## API Changes
- `POST /api/settings` now dynamically starts/stops adapters when their enabled state changes
- No restart required when toggling adapters

## UI Changes
- Settings page shows "Disabled" instead of "Searching..." for disabled adapters
- Toggling adapters immediately starts/stops them and updates the status display

## Test plan
- [x] With adapters disabled: Settings shows "Disabled"
- [x] With adapters enabled: Shows "Searching..." or "✓ Active/Connected"
- [x] Toggling the checkbox immediately starts/stops the adapter
- [x] All 189 tests pass

Fixes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized adapter lifecycle coordinator with a uniform start/stop interface and restartable adapters.
  * Runtime-driven adapter enable/disable applied immediately via settings.

* **Settings / UI**
  * Adapter toggles persisted and reflected in discovery/status UI; disabled adapters show "Disabled" and suppress active status.

* **Behavior / Refactor**
  * Adapters are instantiated up-front and managed through a unified, settings-driven lifecycle.

* **Tests**
  * Test harnesses updated to exercise the coordinator-driven lifecycle.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->