### PR TITLE
fix: Enable mDNS address auto-discovery

### DIFF
--- a/src/mdns.rs
+++ b/src/mdns.rs
@@ -32,10 +32,11 @@ pub fn advertise(port: u16, name: &str, base_url: &str) -> anyhow::Result<Servic
         service_type,
         name,
         &hostname,
-        (), // All local addresses
+        (), // Will be filled by enable_addr_auto()
         port,
         Some(txt),
-    )?;
+    )?
+    .enable_addr_auto();
 
     tracing::info!(
         "mDNS: Publishing service '{}' on port {} (type: {})",


### PR DESCRIPTION
## Summary
- Added `.enable_addr_auto()` to mDNS service registration
- Without this, the service was registered but with no addresses, making it invisible on the network

## Problem
mDNS service wasn't being discovered by clients (issue #74). The service registration appeared to succeed in logs but `dns-sd -B _roonknob._tcp local.` showed nothing.

## Root Cause
The `mdns_sd` crate requires `.enable_addr_auto()` to be called on `ServiceInfo` for the daemon to discover and broadcast the service addresses automatically.

Fixes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced mDNS service configuration with automatic local address population. Local addresses are now automatically populated during service initialization instead of requiring manual placeholder handling, simplifying setup and improving service discovery reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->