### PR TITLE
fix: Simplify LMS play/pause commands

### DIFF
--- a/tests/adapter_integration.rs
+++ b/tests/adapter_integration.rs
@@ -532,9 +532,9 @@ mod mock_server_tests {
 
     /// Tests that the LMS adapter's "play" command correctly resumes from pause.
     ///
-    /// This is a regression test for issue #68: the LMS "play" command doesn't
-    /// resume from pause (it only starts playback from stopped). The adapter
-    /// must use "pause 0" (unpause) to resume playback.
+    /// Per real-world testing (issue #68), the LMS "play" command handles both
+    /// starting from stopped AND resuming from pause. The adapter can simply
+    /// send "play" without checking cached state.
     #[tokio::test]
     async fn lms_adapter_play_resumes_from_pause() {
         // Start mock server with player in paused state
@@ -562,7 +562,6 @@ mod mock_server_tests {
         assert_eq!(player.mode, "pause", "Player should start paused");
 
         // Send "play" command through the adapter
-        // The adapter should translate this to "pause 0" (unpause)
         adapter.control(player_id, "play", None).await.unwrap();
 
         // Give the adapter a moment to update its cache


### PR DESCRIPTION
## Summary
- Simplify LMS play/pause to use direct commands without state checking
- Add debug logging for LMS requests/responses
- Use distinct request ID (217) for easier LMS log debugging

Fixes #68

## Root Cause
The previous implementation checked cached player state to decide between `play` vs `pause 0` for resume. This cache could become stale, causing incorrect commands to be sent.

## Solution
Per @mherger's real-world testing:
- `play` → send `["play"]` (LMS handles both start and resume)
- `pause` → send `["pause"]` (toggle without explicit arg)

This simpler approach works because LMS's commands already handle the state transitions internally.

## Test plan
- [x] `cargo test` passes (41 adapter integration tests)
- [ ] Manual testing with LMS plugin by @mherger

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The play command now resumes playback from a paused state, in addition to starting from stopped. This makes playback control behavior more intuitive and consistent.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->