### PR TITLE
fix: Support PORT and LOG_LEVEL env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ services:
       - ./data:/data
     environment:
       - CONFIG_DIR=/data
+      # - UHC_PORT=8088       # Bridge port (default: 8088)
+      # - RUST_LOG=info       # Log level: trace, debug, info, warn, error
     restart: unless-stopped
 ```
 
@@ -69,6 +71,18 @@ services:
 docker compose up -d
 # Access http://localhost:8088
 ```
+
+### Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `UHC_PORT` | Bridge HTTP port | `8088` |
+| `CONFIG_DIR` | Directory for config/state files | `/data` |
+| `RUST_LOG` | Log filter (e.g., `info`, `debug`, `unified_hifi_control=debug`) | `debug` |
+| `LMS_HOST` | Auto-configure LMS backend (used by LMS plugin) | — |
+| `LMS_PORT` | LMS server port | `9000` |
+
+Legacy aliases: `PORT` (→ `UHC_PORT`), `LOG_LEVEL` (→ `RUST_LOG`)
 
 **Note:** Port 8088 is also HQPlayer's default. If running both on the same host, change one.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,12 +65,13 @@ mod server {
 
     pub async fn run() -> Result<()> {
         // Initialize logging
+        // Priority: RUST_LOG > LOG_LEVEL (legacy) > default
+        let log_filter = std::env::var("RUST_LOG")
+            .or_else(|_| std::env::var("LOG_LEVEL"))
+            .unwrap_or_else(|_| "unified_hifi_control=debug,tower_http=debug,roon_api=info".into());
+
         tracing_subscriber::registry()
-            .with(
-                tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-                    "unified_hifi_control=debug,tower_http=debug,roon_api=info".into()
-                }),
-            )
+            .with(tracing_subscriber::EnvFilter::new(&log_filter))
             .with(tracing_subscriber::fmt::layer())
             .init();
 


### PR DESCRIPTION
## Summary
- Add legacy `PORT` env var support (falls back from `UHC_PORT`)
- Add legacy `LOG_LEVEL` env var support (falls back from `RUST_LOG`)
- Document environment variables in README

Fixes #75

## Environment Variable Priority

| Setting | Priority |
|---------|----------|
| Port | `UHC_PORT` > `PORT` > config > `8088` |
| Logging | `RUST_LOG` > `LOG_LEVEL` > default |

## Test plan
- [x] `cargo test` passes
- [ ] Manual: `PORT=9000 cargo run` uses port 9000
- [ ] Manual: `LOG_LEVEL=warn cargo run` shows only warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README with comprehensive environment variables reference, including port, logging, and LMS configuration options
  * Documented legacy environment variable aliases to support existing configurations
  * Added Docker Compose quickstart examples with environment variable samples and note about default port conflicts

* **Improvements**
  * Clarified environment variable precedence for port handling and added safer logging configuration handling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->