### PR TITLE
fix: Real-time UI updates and volume type display

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ gethostname = { version = "1.1.0", optional = true }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 js-sys = "0.3"
-web-sys = { version = "0.3", features = ["Window", "Storage", "Request", "RequestInit", "Response", "Headers"] }
+web-sys = { version = "0.3", features = ["Window", "Storage", "Request", "RequestInit", "Response", "Headers", "EventSource", "MessageEvent"] }
 serde-wasm-bindgen = "0.6"
 # getrandom needs js feature for WASM (used by rand)
 getrandom = { version = "0.2", features = ["js"] }

--- a/README.md
+++ b/README.md
@@ -247,9 +247,16 @@ dx build --release --platform web
 ### Run
 
 ```bash
-# Run from dx output directory (contains required wasm assets)
-./target/dx/unified-hifi-control/release/web/unified-hifi-control
+# Recommended: Use dx serve for development (builds + runs + hot reload)
+PORT=8088 dx serve --release --platform web --features web --port 8088
 
+# Access at http://127.0.0.1:8088
+```
+
+For production deployment, run the binary directly from the dx output directory:
+
+```bash
+./target/dx/unified-hifi-control/release/web/unified-hifi-control
 # Access at http://127.0.0.1:8088
 ```
 

--- a/public/tailwind.css
+++ b/public/tailwind.css
@@ -7,6 +7,8 @@
     'Noto Color Emoji';
     --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
     monospace;
+    --color-red-500: oklch(63.7% 0.237 25.331);
+    --color-green-500: oklch(72.3% 0.219 149.579);
     --color-indigo-300: oklch(78.5% 0.115 274.713);
     --color-indigo-400: oklch(67.3% 0.182 276.935);
     --color-indigo-500: oklch(58.5% 0.233 277.117);
@@ -44,9 +46,6 @@
     --default-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     --default-font-family: var(--font-sans);
     --default-mono-font-family: var(--font-mono);
-    --color-success: #22c55e;
-    --color-danger: #ef4444;
-    --color-muted: #9ca3af;
   }
 }
 @layer base {
@@ -509,9 +508,6 @@
   .text-indigo-400 {
     color: var(--color-indigo-400);
   }
-  .text-muted {
-    color: var(--color-muted);
-  }
   .text-white {
     color: var(--color-white);
   }
@@ -579,21 +575,19 @@
 }
 @layer base {
   body {
-    background-color: var(--color-gray-900);
-    color: var(--color-gray-100);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }
 }
 @layer components {
   .status-ok {
-    color: var(--color-success);
+    color: var(--color-green-500);
   }
   .status-err {
-    color: var(--color-danger);
+    color: var(--color-red-500);
   }
   .status-disabled {
-    color: var(--color-muted);
+    color: var(--color-gray-500);
   }
   .zone-grid {
     display: grid;

--- a/src/app/components/mod.rs
+++ b/src/app/components/mod.rs
@@ -2,6 +2,8 @@
 
 pub mod layout;
 pub mod nav;
+pub mod volume;
 
 pub use layout::Layout;
 pub use nav::Nav;
+pub use volume::{VolumeControlsCompact, VolumeControlsFull};

--- a/src/app/components/volume.rs
+++ b/src/app/components/volume.rs
@@ -25,6 +25,9 @@ impl VolumeType {
     /// Parse volume type from API response
     pub fn from_api(volume: Option<f32>, volume_type: Option<&str>) -> Self {
         match (volume, volume_type) {
+            // Explicit "fixed" type from API
+            (_, Some("fixed")) => VolumeType::Fixed,
+            // Legacy: no volume means fixed
             (None, _) => VolumeType::Fixed,
             (Some(_), Some("db")) => VolumeType::Db,
             (Some(_), Some("incremental")) => VolumeType::Incremental,

--- a/src/app/components/volume.rs
+++ b/src/app/components/volume.rs
@@ -1,0 +1,124 @@
+//! Volume control component with support for different volume types.
+//!
+//! Handles:
+//! - "db": dB scale with suffix
+//! - "number": 0-100 numeric scale
+//! - "incremental": blind control (+/- only, no value)
+//! - Fixed volume: hides controls entirely
+
+use dioxus::prelude::*;
+
+/// Volume type enum for cleaner pattern matching
+#[derive(Clone, Copy, PartialEq)]
+pub enum VolumeType {
+    /// dB scale (typically negative values, 0 is max)
+    Db,
+    /// Numeric scale (typically 0-100)
+    Number,
+    /// Incremental/blind control (no absolute value)
+    Incremental,
+    /// Fixed volume (no control available)
+    Fixed,
+}
+
+impl VolumeType {
+    /// Parse volume type from API response
+    pub fn from_api(volume: Option<f32>, volume_type: Option<&str>) -> Self {
+        match (volume, volume_type) {
+            (None, _) => VolumeType::Fixed,
+            (Some(_), Some("db")) => VolumeType::Db,
+            (Some(_), Some("incremental")) => VolumeType::Incremental,
+            (Some(_), _) => VolumeType::Number, // Default to number for "number" or unknown
+        }
+    }
+}
+
+/// Compact volume controls for zone cards
+#[component]
+pub fn VolumeControlsCompact(
+    volume: Option<f32>,
+    volume_type: Option<String>,
+    on_vol_down: EventHandler<()>,
+    on_vol_up: EventHandler<()>,
+) -> Element {
+    let vol_type = VolumeType::from_api(volume, volume_type.as_deref());
+
+    // Don't render anything for fixed volume
+    if vol_type == VolumeType::Fixed {
+        return rsx! {};
+    }
+
+    let volume_display = match vol_type {
+        VolumeType::Db => volume
+            .map(|v| format!("{} dB", v.round() as i32))
+            .unwrap_or_default(),
+        VolumeType::Number => volume
+            .map(|v| format!("{}", v.round() as i32))
+            .unwrap_or_default(),
+        VolumeType::Incremental | VolumeType::Fixed => String::new(),
+    };
+
+    rsx! {
+        div { class: "ml-auto flex items-center gap-1",
+            button {
+                class: "btn btn-outline btn-sm",
+                onclick: move |_| on_vol_down.call(()),
+                "−"
+            }
+            if vol_type != VolumeType::Incremental {
+                span { class: "min-w-[3.5rem] text-center text-sm",
+                    "{volume_display}"
+                }
+            }
+            button {
+                class: "btn btn-outline btn-sm",
+                onclick: move |_| on_vol_up.call(()),
+                "+"
+            }
+        }
+    }
+}
+
+/// Full volume controls with label for zone detail view
+#[component]
+pub fn VolumeControlsFull(
+    volume: Option<f32>,
+    volume_type: Option<String>,
+    on_vol_down: EventHandler<()>,
+    on_vol_up: EventHandler<()>,
+) -> Element {
+    let vol_type = VolumeType::from_api(volume, volume_type.as_deref());
+
+    // Don't render anything for fixed volume
+    if vol_type == VolumeType::Fixed {
+        return rsx! {};
+    }
+
+    let volume_display = match vol_type {
+        VolumeType::Db => volume
+            .map(|v| format!("{} dB", v.round() as i32))
+            .unwrap_or_default(),
+        VolumeType::Number => volume
+            .map(|v| format!("{}", v.round() as i32))
+            .unwrap_or_default(),
+        VolumeType::Incremental | VolumeType::Fixed => String::new(),
+    };
+
+    rsx! {
+        if vol_type != VolumeType::Incremental {
+            span { style: "margin-left:1rem;", "Volume: ", strong { "{volume_display}" } }
+        } else {
+            span { style: "margin-left:1rem;", "Volume:" }
+        }
+        button {
+            style: "width:2.5rem;",
+            onclick: move |_| on_vol_down.call(()),
+            "−"
+        }
+        button {
+            style: "width:2.5rem;",
+            onclick: move |_| on_vol_up.call(()),
+            "+"
+        }
+    }
+}

--- a/src/input.css
+++ b/src/input.css
@@ -3,46 +3,31 @@
 /* Source scanning for Dioxus .rs files */
 @source "../src/**/*.rs";
 
-/* Custom theme for Hi-Fi Control */
-@theme {
-  /* Primary colors - dark theme optimized for hi-fi aesthetic */
-  --color-primary: #6366f1;
-  --color-primary-hover: #818cf8;
-  --color-primary-active: #4f46e5;
+/*
+ * Theme: Uses dioxus-primitives CSS variables from dx-components-theme.css
+ * --primary-color-* : background shades (dark theme: darker = lower number)
+ * --secondary-color-* : text/foreground shades (dark theme: lighter = lower number)
+ */
 
-  /* Status colors */
-  --color-success: #22c55e;
-  --color-danger: #ef4444;
-  --color-warning: #f59e0b;
-  --color-muted: #9ca3af;
-
-  /* Dark theme base */
-  --color-bg-dark: #111827;
-  --color-bg-card: #1f2937;
-  --color-bg-elevated: #374151;
-  --color-text-primary: #f9fafb;
-  --color-text-secondary: #d1d5db;
-  --color-border: #374151;
-}
-
-/* Base styles */
+/* Base styles - integrate with dioxus-primitives theme */
 @layer base {
   body {
-    @apply bg-gray-900 text-gray-100 antialiased;
+    @apply antialiased;
+    /* Let dx-components-theme.css handle body bg/color via CSS vars */
   }
 }
 
 /* Custom utility classes for the app */
 @layer components {
-  /* Status indicators */
+  /* Status indicators - using standard Tailwind colors */
   .status-ok {
-    @apply text-success;
+    @apply text-green-500;
   }
   .status-err {
-    @apply text-danger;
+    @apply text-red-500;
   }
   .status-disabled {
-    @apply text-muted;
+    @apply text-gray-500;
   }
 
   /* Zone grid layout */

--- a/src/knobs/routes.rs
+++ b/src/knobs/routes.rs
@@ -364,9 +364,21 @@ pub async fn knob_now_playing_handler(
             }),
             is_playing,
             volume: np.as_ref().and_then(|n| n.volume.map(|v| v as f64)),
-            volume_type: Some("number".to_string()),
-            volume_min: np.as_ref().map(|n| n.volume_min as f64),
-            volume_max: np.as_ref().map(|n| n.volume_max as f64),
+            volume_type: Some(if np.as_ref().and_then(|n| n.volume).is_some() {
+                "number".to_string()
+            } else {
+                "fixed".to_string()
+            }),
+            volume_min: if np.as_ref().and_then(|n| n.volume).is_some() {
+                np.as_ref().map(|n| n.volume_min as f64)
+            } else {
+                Some(0.0)
+            },
+            volume_max: if np.as_ref().and_then(|n| n.volume).is_some() {
+                np.as_ref().map(|n| n.volume_max as f64)
+            } else {
+                Some(0.0)
+            },
             volume_step: Some(1.0),
             image_url: Some(image_url),
             image_key: np.as_ref().and_then(|n| n.image_key.clone()),
@@ -416,9 +428,21 @@ pub async fn knob_now_playing_handler(
             }),
             is_playing,
             volume: np.as_ref().and_then(|n| n.volume.map(|v| v as f64)),
-            volume_type: Some("number".to_string()),
-            volume_min: np.as_ref().map(|n| n.volume_min as f64),
-            volume_max: np.as_ref().map(|n| n.volume_max as f64),
+            volume_type: Some(if np.as_ref().and_then(|n| n.volume).is_some() {
+                "number".to_string()
+            } else {
+                "fixed".to_string()
+            }),
+            volume_min: if np.as_ref().and_then(|n| n.volume).is_some() {
+                np.as_ref().map(|n| n.volume_min as f64)
+            } else {
+                Some(0.0)
+            },
+            volume_max: if np.as_ref().and_then(|n| n.volume).is_some() {
+                np.as_ref().map(|n| n.volume_max as f64)
+            } else {
+                Some(0.0)
+            },
             volume_step: Some(1.0),
             image_url: Some(image_url),
             image_key: np.as_ref().and_then(|n| n.image_key.clone()),
@@ -480,9 +504,21 @@ pub async fn knob_now_playing_handler(
             line3,
             is_playing,
             volume: vol.and_then(|v| v.value.map(|x| x as f64)),
-            volume_type: vol.map(|_| "db".to_string()),
-            volume_min: vol.and_then(|v| v.min.map(|x| x as f64)),
-            volume_max: vol.and_then(|v| v.max.map(|x| x as f64)),
+            volume_type: Some(if vol.is_some() {
+                "db".to_string()
+            } else {
+                "fixed".to_string()
+            }),
+            volume_min: if vol.is_some() {
+                vol.and_then(|v| v.min.map(|x| x as f64))
+            } else {
+                Some(0.0)
+            },
+            volume_max: if vol.is_some() {
+                vol.and_then(|v| v.max.map(|x| x as f64))
+            } else {
+                Some(0.0)
+            },
             volume_step: Some(1.0),
             image_url: Some(image_url),
             image_key: np.as_ref().and_then(|n| n.image_key.clone()),


### PR DESCRIPTION
## Summary
- Fix real-time UI updates for track changes and volume (#93)
- Fix volume display for different volume types (#85)

Fixes #85, #93

## Changes

### #93 - Real-time updates
- `now_playing` data now refreshes on `NowPlayingChanged`, `VolumeChanged`, `LmsPlayerStateChanged` SSE events
- Previously only zone list changes triggered refresh

### #85 - Volume type handling
Added `VolumeControlsCompact` component:
| Type | Display |
|------|---------|
| `db` | `-20 dB` |
| `number` | `50` |
| `incremental` | `[ - ] [ + ]` (no value) |
| Fixed (None) | Hidden |

## Follow-ups (separate PRs)
- [ ] Unified zone card component for /zones and /zone pages
- [ ] Profile/matrix selector for DSP-linked zones

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` passes
- [ ] Manual: Volume changes appear without refresh
- [ ] Manual: Track changes appear without refresh
- [ ] Manual: Fixed volume zones hide volume controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added compact and full volume controls with context-aware displays for dB, numeric, incremental, or fixed modes.
  * Zone pages now conditionally show volume values and controls based on volume mode.
  * Now-playing data is fetched in bulk and SSE-driven updates refresh all zones for more consistent playback/volume state.

* **Documentation**
  * Updated README with improved development and production run instructions.

* **Style**
  * Updated theme and utility CSS (status color tokens and global theme handling).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->