### PR TITLE
fix: SSE graceful shutdown + documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,18 +247,20 @@ dx build --release --platform web
 ### Run
 
 ```bash
-# Recommended: Use dx serve for development (builds + runs + hot reload)
-PORT=8088 dx serve --release --platform web --features web --port 8088
+# Run the server (from dx build output directory)
+cd target/dx/unified-hifi-control/release/web
+PORT=8088 ./unified-hifi-control
 
 # Access at http://127.0.0.1:8088
 ```
 
-For production deployment, run the binary directly from the dx output directory:
+For development with hot reload:
 
 ```bash
-./target/dx/unified-hifi-control/release/web/unified-hifi-control
-# Access at http://127.0.0.1:8088
+PORT=8088 dx serve --release --platform web --features web --port 8088
 ```
+
+**Note:** `dx serve` runs a dev server proxy which may cause issues with Roon discovery (wrong port advertised). For testing with Roon, run the binary directly.
 
 **Important:** The server must be run from the `dx build` output directory where the `public/wasm/` folder exists. Running the binary from elsewhere will cause a panic or non-functional UI.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -59,6 +59,44 @@ A source-agnostic hi-fi control platform where **complexity is absorbed by the b
 - Flushes zones on `AdapterStopping`
 - API calls this, never adapters directly
 
+### SSE (Server-Sent Events)
+Real-time event streaming for clients via `/events` endpoint.
+
+**Endpoint:** `GET /events`
+
+**Event Types:**
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `RoonConnected` | — | Roon core discovered |
+| `RoonDisconnected` | — | Roon core lost |
+| `ZoneUpdated` | `{ zone_id }` | Zone state changed |
+| `ZoneRemoved` | `{ zone_id }` | Zone no longer available |
+| `NowPlayingChanged` | `{ zone_id }` | Track/playback changed |
+| `VolumeChanged` | `{ zone_id }` | Volume level changed |
+| `SeekPositionChanged` | `{ zone_id }` | Playback position changed |
+| `HqpConnected` | — | HQPlayer connected |
+| `HqpDisconnected` | — | HQPlayer disconnected |
+| `HqpStateChanged` | — | HQPlayer state changed |
+| `HqpPipelineChanged` | — | HQPlayer DSP pipeline changed |
+| `LmsConnected` | — | LMS server connected |
+| `LmsDisconnected` | — | LMS server disconnected |
+| `LmsPlayerStateChanged` | `{ player_id }` | LMS player state changed |
+| `OpenHomeDeviceFound` | — | OpenHome device discovered |
+| `OpenHomeDeviceLost` | — | OpenHome device lost |
+| `UpnpRendererFound` | — | UPnP renderer discovered |
+| `UpnpRendererLost` | — | UPnP renderer lost |
+
+**Message Format:**
+```json
+{"type":"NowPlayingChanged","payload":{"zone_id":"roon:1234567890"}}
+```
+
+**Usage:**
+- Web UI uses EventSource API for reactive updates
+- Any HTTP client can subscribe (curl, ESP32, etc.)
+- Auto-reconnects on connection loss (EventSource spec)
+- Closes gracefully on server shutdown
+
 ## Principles
 
 1. **Disabled adapter = not started = nothing to show**


### PR DESCRIPTION
## Summary
- Fix server hanging on Ctrl+C with active SSE clients
- Update README with correct run instructions
- Document SSE support in ARCHITECTURE.md

## Changes
- `src/api/mod.rs`: Replace `stream::pending()` with `.map()` to capture guard lifetime properly
- `README.md`: Note that `dx serve` proxy may confuse Roon discovery
- `docs/ARCHITECTURE.md`: Add SSE event type reference table

## Test plan
- [ ] Start server, connect SSE client, Ctrl+C should exit cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development setup instructions with guidance on running from build output and hot reload development options
  * Added Server-Sent Events architecture documentation including real-time event streaming details, event types, and usage examples

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->