### PR TITLE
fix: Consistent light/dark theming via CSS variables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ gethostname = { version = "1.1.0", optional = true }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 js-sys = "0.3"
-web-sys = { version = "0.3", features = ["Window", "Storage", "Request", "RequestInit", "Response", "Headers", "EventSource", "MessageEvent"] }
+web-sys = { version = "0.3", features = ["Window", "Document", "Element", "DomTokenList", "Storage", "Request", "RequestInit", "Response", "Headers", "EventSource", "MessageEvent"] }
 serde-wasm-bindgen = "0.6"
 # getrandom needs js feature for WASM (used by rand)
 getrandom = { version = "0.2", features = ["js"] }

--- a/public/dx-components-theme.css
+++ b/public/dx-components-theme.css
@@ -40,13 +40,10 @@ body {
   --light: ;
 }
 
+/* OLED black: pure black surfaces for AMOLED screens */
 :root.theme-oled {
   --dark: initial;
   --light: ;
-}
-
-/* OLED black: pure black surfaces for AMOLED screens */
-:root.theme-oled {
   --primary-color-1: #000;
   --primary-color-2: #000;
   --primary-color-3: #000;

--- a/public/dx-components-theme.css
+++ b/public/dx-components-theme.css
@@ -62,6 +62,25 @@ body {
     var(--light, var(--primary-color));
   --secondary-info-color: var(--dark, var(--primary-color-7))
     var(--light, var(--secondary-color-3));
+
+  /* Semantic text colors */
+  --text-primary: var(--secondary-color-1);
+  --text-secondary: var(--secondary-color-4);
+  --text-muted: var(--secondary-color-5);
+  --text-disabled: var(--secondary-color-6);
+
+  /* Semantic surface colors */
+  --surface-base: var(--primary-color);
+  --surface-elevated: var(--primary-color-5);
+  --surface-hover: var(--primary-color-7);
+
+  /* Semantic border colors */
+  --border-default: var(--primary-color-6);
+  --border-subtle: var(--primary-color-7);
+
+  /* Accent color (links, primary buttons) */
+  --accent-color: var(--focused-border-color);
+  --accent-hover: var(--dark, #3d8fff) var(--light, #1a6fef);
 }
 
 /* Modern browsers with `scrollbar-*` support */

--- a/public/dx-components-theme.css
+++ b/public/dx-components-theme.css
@@ -14,6 +14,7 @@ body {
   font-weight: 400;
 }
 
+/* Default: follow system preference */
 @media (prefers-color-scheme: dark) {
   :root {
     --dark: initial;
@@ -26,6 +27,33 @@ body {
     --dark: ;
     --light: initial;
   }
+}
+
+/* Manual theme overrides via class on <html> */
+:root.theme-light {
+  --dark: ;
+  --light: initial;
+}
+
+:root.theme-dark {
+  --dark: initial;
+  --light: ;
+}
+
+:root.theme-oled {
+  --dark: initial;
+  --light: ;
+}
+
+/* OLED black: pure black surfaces for AMOLED screens */
+:root.theme-oled {
+  --primary-color-1: #000;
+  --primary-color-2: #000;
+  --primary-color-3: #000;
+  --primary-color-4: #0a0a0a;
+  --primary-color-5: #0a0a0a;
+  --primary-color-6: #1a1a1a;
+  --primary-color-7: #2a2a2a;
 }
 
 :root {

--- a/public/tailwind.css
+++ b/public/tailwind.css
@@ -301,9 +301,6 @@
   .inline {
     display: inline;
   }
-  .inline-flex {
-    display: inline-flex;
-  }
   .table {
     display: table;
   }
@@ -407,9 +404,6 @@
   .rounded-lg {
     border-radius: var(--radius-lg);
   }
-  .rounded-md {
-    border-radius: var(--radius-md);
-  }
   .border {
     border-style: var(--tw-border-style);
     border-width: 1px;
@@ -430,9 +424,6 @@
   }
   .object-cover {
     object-fit: cover;
-  }
-  .p-2 {
-    padding: calc(var(--spacing) * 2);
   }
   .p-4 {
     padding: calc(var(--spacing) * 4);
@@ -521,12 +512,6 @@
       @media (hover: hover) {
         color: var(--color-white);
       }
-    }
-  }
-  .focus\:outline-none {
-    &:focus {
-      --tw-outline-style: none;
-      outline-style: none;
     }
   }
   .sm\:px-6 {
@@ -660,7 +645,22 @@
     gap: calc(var(--spacing) * 1);
     padding-block: calc(var(--spacing) * 2);
   }
-  .nav-link {
+  .nav-mobile-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--radius-md);
+    padding: calc(var(--spacing) * 2);
+    color: var(--text-muted);
+  }
+  .nav-mobile-toggle:hover {
+    color: var(--text-primary);
+    background: var(--surface-hover);
+  }
+  .nav-mobile-toggle:focus {
+    outline: none;
+  }
+  .nav-link, .nav-link-active {
     display: block;
     border-radius: var(--radius-md);
     padding-inline: calc(var(--spacing) * 3);
@@ -669,6 +669,8 @@
     line-height: var(--tw-leading, var(--text-sm--line-height));
     --tw-font-weight: var(--font-weight-medium);
     font-weight: var(--font-weight-medium);
+  }
+  .nav-link {
     color: var(--text-secondary);
   }
   .nav-link:hover {
@@ -676,14 +678,6 @@
     background: var(--surface-hover);
   }
   .nav-link-active {
-    display: block;
-    border-radius: var(--radius-md);
-    padding-inline: calc(var(--spacing) * 3);
-    padding-block: calc(var(--spacing) * 2);
-    font-size: var(--text-sm);
-    line-height: var(--tw-leading, var(--text-sm--line-height));
-    --tw-font-weight: var(--font-weight-medium);
-    font-weight: var(--font-weight-medium);
     background: var(--surface-hover);
     color: var(--text-primary);
   }

--- a/public/tailwind.css
+++ b/public/tailwind.css
@@ -14,7 +14,6 @@
     --color-indigo-500: oklch(58.5% 0.233 277.117);
     --color-indigo-600: oklch(51.1% 0.262 276.966);
     --color-indigo-700: oklch(45.7% 0.24 277.023);
-    --color-gray-100: oklch(96.7% 0.003 264.542);
     --color-gray-300: oklch(87.2% 0.01 258.338);
     --color-gray-400: oklch(70.7% 0.022 261.325);
     --color-gray-500: oklch(55.1% 0.027 264.364);
@@ -247,11 +246,17 @@
       max-width: 96rem;
     }
   }
+  .m-0 {
+    margin: calc(var(--spacing) * 0);
+  }
   .mx-4 {
     margin-inline: calc(var(--spacing) * 4);
   }
   .mx-auto {
     margin-inline: auto;
+  }
+  .my-2 {
+    margin-block: calc(var(--spacing) * 2);
   }
   .my-4 {
     margin-block: calc(var(--spacing) * 4);
@@ -286,6 +291,9 @@
   .mb-8 {
     margin-bottom: calc(var(--spacing) * 8);
   }
+  .ml-4 {
+    margin-left: calc(var(--spacing) * 4);
+  }
   .ml-auto {
     margin-left: auto;
   }
@@ -316,14 +324,20 @@
   .h-6 {
     height: calc(var(--spacing) * 6);
   }
-  .h-16 {
-    height: calc(var(--spacing) * 16);
+  .h-\[200px\] {
+    height: 200px;
   }
   .min-h-\[40px\] {
     min-height: 40px;
   }
   .w-6 {
     width: calc(var(--spacing) * 6);
+  }
+  .w-10 {
+    width: calc(var(--spacing) * 10);
+  }
+  .w-\[200px\] {
+    width: 200px;
   }
   .w-full {
     width: 100%;
@@ -337,11 +351,20 @@
   .min-w-\[3\.5rem\] {
     min-width: 3.5rem;
   }
+  .min-w-\[200px\] {
+    min-width: 200px;
+  }
+  .flex-1 {
+    flex: 1;
+  }
   .flex-wrap {
     flex-wrap: wrap;
   }
   .items-center {
     align-items: center;
+  }
+  .items-start {
+    align-items: flex-start;
   }
   .justify-between {
     justify-content: space-between;
@@ -392,6 +415,9 @@
   .rounded {
     border-radius: 0.25rem;
   }
+  .rounded-lg {
+    border-radius: var(--radius-lg);
+  }
   .rounded-md {
     border-radius: var(--radius-md);
   }
@@ -407,23 +433,14 @@
     border-bottom-style: var(--tw-border-style);
     border-bottom-width: 1px;
   }
-  .border-gray-700 {
-    border-color: var(--color-gray-700);
-  }
-  .border-gray-800 {
-    border-color: var(--color-gray-800);
-  }
   .bg-black\/50 {
     background-color: color-mix(in srgb, #000 50%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
       background-color: color-mix(in oklab, var(--color-black) 50%, transparent);
     }
   }
-  .bg-gray-800 {
-    background-color: var(--color-gray-800);
-  }
-  .bg-gray-900 {
-    background-color: var(--color-gray-900);
+  .object-cover {
+    object-fit: cover;
   }
   .p-2 {
     padding: calc(var(--spacing) * 2);
@@ -496,21 +513,6 @@
     --tw-font-weight: var(--font-weight-semibold);
     font-weight: var(--font-weight-semibold);
   }
-  .text-gray-300 {
-    color: var(--color-gray-300);
-  }
-  .text-gray-400 {
-    color: var(--color-gray-400);
-  }
-  .text-gray-500 {
-    color: var(--color-gray-500);
-  }
-  .text-indigo-400 {
-    color: var(--color-indigo-400);
-  }
-  .text-white {
-    color: var(--color-white);
-  }
   .lowercase {
     text-transform: lowercase;
   }
@@ -524,20 +526,6 @@
   }
   .filter {
     filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
-  }
-  .hover\:bg-gray-700 {
-    &:hover {
-      @media (hover: hover) {
-        background-color: var(--color-gray-700);
-      }
-    }
-  }
-  .hover\:text-indigo-300 {
-    &:hover {
-      @media (hover: hover) {
-        color: var(--color-indigo-300);
-      }
-    }
   }
   .hover\:text-white {
     &:hover {
@@ -581,13 +569,53 @@
 }
 @layer components {
   .status-ok {
-    color: var(--color-green-500);
+    color: var(--secondary-success-color);
   }
   .status-err {
-    color: var(--color-red-500);
+    color: var(--primary-error-color);
   }
   .status-disabled {
-    color: var(--color-gray-500);
+    color: var(--text-disabled);
+  }
+  .text-primary {
+    color: var(--text-primary);
+  }
+  .text-secondary {
+    color: var(--text-secondary);
+  }
+  .text-muted {
+    color: var(--text-muted);
+  }
+  .bg-elevated {
+    background: var(--surface-elevated);
+  }
+  .bg-hover {
+    background: var(--surface-hover);
+  }
+  .border-default {
+    border-color: var(--border-default);
+  }
+  .border-subtle {
+    border-color: var(--border-subtle);
+  }
+  .link {
+    color: var(--accent-color);
+    text-decoration: none;
+  }
+  .link:hover {
+    color: var(--accent-hover);
+  }
+  .code {
+    border-radius: 0.25rem;
+    padding-inline: calc(var(--spacing) * 1);
+    font-size: var(--text-xs);
+    line-height: var(--tw-leading, var(--text-xs--line-height));
+    background: var(--surface-elevated);
+  }
+  .table-row {
+    border-bottom-style: var(--tw-border-style);
+    border-bottom-width: 1px;
+    border-color: var(--border-default);
   }
   .zone-grid {
     display: grid;
@@ -603,7 +631,7 @@
     margin: calc(var(--spacing) * 0);
   }
   .nav-container {
-    background: var(--primary-color-5);
+    background: var(--surface-elevated);
   }
   .nav-inner {
     margin-inline: auto;
@@ -619,11 +647,11 @@
     line-height: var(--tw-leading, var(--text-xl--line-height));
     --tw-font-weight: var(--font-weight-bold);
     font-weight: var(--font-weight-bold);
-    color: var(--secondary-color-1);
+    color: var(--text-primary);
     text-decoration: none;
   }
   .nav-brand:hover {
-    color: var(--secondary-color-2);
+    color: var(--text-secondary);
   }
   .nav-desktop {
     display: none;
@@ -643,14 +671,37 @@
     gap: calc(var(--spacing) * 1);
     padding-block: calc(var(--spacing) * 2);
   }
-  .navbar-item-active {
-    background: var(--primary-color-7);
-    color: var(--secondary-color-1);
+  .nav-link {
+    display: block;
+    border-radius: var(--radius-md);
+    padding-inline: calc(var(--spacing) * 3);
+    padding-block: calc(var(--spacing) * 2);
+    font-size: var(--text-sm);
+    line-height: var(--tw-leading, var(--text-sm--line-height));
+    --tw-font-weight: var(--font-weight-medium);
+    font-weight: var(--font-weight-medium);
+    color: var(--text-secondary);
+  }
+  .nav-link:hover {
+    color: var(--text-primary);
+    background: var(--surface-hover);
+  }
+  .nav-link-active {
+    display: block;
+    border-radius: var(--radius-md);
+    padding-inline: calc(var(--spacing) * 3);
+    padding-block: calc(var(--spacing) * 2);
+    font-size: var(--text-sm);
+    line-height: var(--tw-leading, var(--text-sm--line-height));
+    --tw-font-weight: var(--font-weight-medium);
+    font-weight: var(--font-weight-medium);
+    background: var(--surface-hover);
+    color: var(--text-primary);
   }
   .card {
     border-radius: var(--radius-lg);
-    background: var(--primary-color-5);
-    border: 1px solid var(--primary-color-6);
+    background: var(--surface-elevated);
+    border: 1px solid var(--border-default);
   }
   .badge {
     display: inline-flex;
@@ -664,26 +715,24 @@
     font-weight: var(--font-weight-medium);
   }
   .badge-primary {
-    background-color: var(--color-indigo-600);
-    color: var(--color-white);
+    background: var(--accent-color);
+    color: var(--surface-base);
   }
   .badge-secondary {
-    background: var(--primary-color-7);
-    color: var(--secondary-color-3);
+    background: var(--surface-hover);
+    color: var(--text-secondary);
   }
   .checkbox {
     height: calc(var(--spacing) * 4);
     width: calc(var(--spacing) * 4);
     border-radius: 0.25rem;
-    border-color: var(--color-gray-600);
-    background-color: var(--color-gray-700);
-    color: var(--color-indigo-600);
-    &:focus {
-      --tw-ring-color: var(--color-indigo-500);
-    }
-    &:focus {
-      --tw-ring-offset-color: var(--color-gray-800);
-    }
+    border-color: var(--border-default);
+    background: var(--surface-elevated);
+    accent-color: var(--accent-color);
+  }
+  .checkbox:focus {
+    outline: 2px solid var(--accent-color);
+    outline-offset: 2px;
   }
   .input {
     display: block;
@@ -691,28 +740,12 @@
     border-radius: var(--radius-md);
     border-style: var(--tw-border-style);
     border-width: 0px;
-    background-color: var(--color-gray-700);
     padding-inline: calc(var(--spacing) * 3);
     padding-block: calc(var(--spacing) * 1.5);
-    color: var(--color-white);
     --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
     --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
-    --tw-ring-color: var(--color-gray-600);
     --tw-ring-inset: inset;
-    &::placeholder {
-      color: var(--color-gray-400);
-    }
-    &:focus {
-      --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
-      box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
-    }
-    &:focus {
-      --tw-ring-color: var(--color-indigo-500);
-    }
-    &:focus {
-      --tw-ring-inset: inset;
-    }
     @media (width >= 40rem) {
       font-size: var(--text-sm);
       line-height: var(--tw-leading, var(--text-sm--line-height));
@@ -721,6 +754,18 @@
       --tw-leading: calc(var(--spacing) * 6);
       line-height: calc(var(--spacing) * 6);
     }
+    background: var(--surface-elevated);
+    color: var(--text-primary);
+    --tw-ring-color: var(--border-default);
+  }
+  .input::placeholder {
+    color: var(--text-muted);
+  }
+  .input:focus {
+    --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+    --tw-ring-inset: inset;
+    --tw-ring-color: var(--accent-color);
   }
   .form-grid {
     display: grid;
@@ -753,59 +798,35 @@
       --tw-ring-offset-shadow: var(--tw-ring-inset,) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
     }
     &:focus {
-      --tw-ring-offset-color: var(--color-gray-900);
-    }
-    &:focus {
       --tw-outline-style: none;
       outline-style: none;
     }
+    --tw-ring-offset-color: var(--surface-base);
   }
   .btn-primary {
-    background-color: var(--color-indigo-600);
-    color: var(--color-white);
-    &:hover {
-      @media (hover: hover) {
-        background-color: var(--color-indigo-700);
-      }
-    }
-    &:focus {
-      --tw-ring-color: var(--color-indigo-500);
-    }
+    background: var(--accent-color);
+    color: var(--surface-base);
+    --tw-ring-color: var(--accent-color);
+  }
+  .btn-primary:hover {
+    background: var(--accent-hover);
   }
   .btn-ghost {
-    color: var(--color-gray-300);
-    &:hover {
-      @media (hover: hover) {
-        background-color: var(--color-gray-700);
-      }
-    }
-    &:hover {
-      @media (hover: hover) {
-        color: var(--color-white);
-      }
-    }
-    &:focus {
-      --tw-ring-color: var(--color-gray-500);
-    }
+    color: var(--text-secondary);
+    --tw-ring-color: var(--border-default);
+  }
+  .btn-ghost:hover {
+    color: var(--text-primary);
+    background: var(--surface-hover);
   }
   .btn-outline {
-    border-style: var(--tw-border-style);
-    border-width: 1px;
-    border-color: var(--color-gray-600);
-    color: var(--color-gray-300);
-    &:hover {
-      @media (hover: hover) {
-        background-color: var(--color-gray-700);
-      }
-    }
-    &:hover {
-      @media (hover: hover) {
-        color: var(--color-white);
-      }
-    }
-    &:focus {
-      --tw-ring-color: var(--color-gray-500);
-    }
+    border: 1px solid var(--border-default);
+    color: var(--text-secondary);
+    --tw-ring-color: var(--border-default);
+  }
+  .btn-outline:hover {
+    color: var(--text-primary);
+    background: var(--surface-hover);
   }
   .btn-sm {
     padding-inline: calc(var(--spacing) * 2);

--- a/public/tailwind.css
+++ b/public/tailwind.css
@@ -7,20 +7,6 @@
     'Noto Color Emoji';
     --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
     monospace;
-    --color-red-500: oklch(63.7% 0.237 25.331);
-    --color-green-500: oklch(72.3% 0.219 149.579);
-    --color-indigo-300: oklch(78.5% 0.115 274.713);
-    --color-indigo-400: oklch(67.3% 0.182 276.935);
-    --color-indigo-500: oklch(58.5% 0.233 277.117);
-    --color-indigo-600: oklch(51.1% 0.262 276.966);
-    --color-indigo-700: oklch(45.7% 0.24 277.023);
-    --color-gray-300: oklch(87.2% 0.01 258.338);
-    --color-gray-400: oklch(70.7% 0.022 261.325);
-    --color-gray-500: oklch(55.1% 0.027 264.364);
-    --color-gray-600: oklch(44.6% 0.03 256.802);
-    --color-gray-700: oklch(37.3% 0.034 259.733);
-    --color-gray-800: oklch(27.8% 0.033 256.848);
-    --color-gray-900: oklch(21% 0.034 264.665);
     --color-black: #000;
     --color-white: #fff;
     --spacing: 0.25rem;
@@ -380,6 +366,9 @@
   }
   .gap-2 {
     gap: calc(var(--spacing) * 2);
+  }
+  .gap-3 {
+    gap: calc(var(--spacing) * 3);
   }
   .gap-4 {
     gap: calc(var(--spacing) * 4);

--- a/src/app/components/nav.rs
+++ b/src/app/components/nav.rs
@@ -1,5 +1,6 @@
 //! Navigation component using Tailwind CSS.
 
+use crate::app::Route;
 use dioxus::prelude::*;
 
 #[derive(Props, Clone, PartialEq)]
@@ -41,24 +42,24 @@ pub fn Nav(props: NavProps) -> Element {
             div { class: "nav-inner",
                 // Logo / Brand
                 div { class: "flex items-center",
-                    a { class: "nav-brand", href: "/", "Hi-Fi Control" }
+                    Link { class: "nav-brand", to: Route::Dashboard {}, "Hi-Fi Control" }
                 }
 
-                // Desktop navigation
+                // Desktop navigation - use Link for client-side routing (no page reload)
                 div { class: "hidden lg:flex items-center space-x-4",
-                    a { class: nav_link_class("dashboard"), href: "/", "Dashboard" }
-                    a { class: nav_link_class("zones"), href: "/ui/zones", "Zones" }
-                    a { class: nav_link_class("zone"), href: "/zone", "Zone" }
+                    Link { class: nav_link_class("dashboard"), to: Route::Dashboard {}, "Dashboard" }
+                    Link { class: nav_link_class("zones"), to: Route::Zones {}, "Zones" }
+                    Link { class: nav_link_class("zone"), to: Route::Zone {}, "Zone" }
                     if !props.hide_hqp {
-                        a { class: nav_link_class("hqplayer"), href: "/hqplayer", "HQPlayer" }
+                        Link { class: nav_link_class("hqplayer"), to: Route::HqPlayer {}, "HQPlayer" }
                     }
                     if !props.hide_lms {
-                        a { class: nav_link_class("lms"), href: "/lms", "LMS" }
+                        Link { class: nav_link_class("lms"), to: Route::Lms {}, "LMS" }
                     }
                     if !props.hide_knobs {
-                        a { class: nav_link_class("knobs"), href: "/knobs", "Knobs" }
+                        Link { class: nav_link_class("knobs"), to: Route::Knobs {}, "Knobs" }
                     }
-                    a { class: nav_link_class("settings"), href: "/settings", "Settings" }
+                    Link { class: nav_link_class("settings"), to: Route::Settings {}, "Settings" }
                 }
 
                 // Mobile menu button
@@ -83,22 +84,22 @@ pub fn Nav(props: NavProps) -> Element {
                 }
             }
 
-            // Mobile menu
+            // Mobile menu - use Link for client-side routing
             div { class: "{mobile_menu_class}", id: "mobile-menu",
                 div { class: "px-2 pt-2 pb-3 space-y-1",
-                    a { class: nav_link_class("dashboard"), href: "/", onclick: move |_| menu_open.set(false), "Dashboard" }
-                    a { class: nav_link_class("zones"), href: "/ui/zones", onclick: move |_| menu_open.set(false), "Zones" }
-                    a { class: nav_link_class("zone"), href: "/zone", onclick: move |_| menu_open.set(false), "Zone" }
+                    Link { class: nav_link_class("dashboard"), to: Route::Dashboard {}, onclick: move |_| menu_open.set(false), "Dashboard" }
+                    Link { class: nav_link_class("zones"), to: Route::Zones {}, onclick: move |_| menu_open.set(false), "Zones" }
+                    Link { class: nav_link_class("zone"), to: Route::Zone {}, onclick: move |_| menu_open.set(false), "Zone" }
                     if !props.hide_hqp {
-                        a { class: nav_link_class("hqplayer"), href: "/hqplayer", onclick: move |_| menu_open.set(false), "HQPlayer" }
+                        Link { class: nav_link_class("hqplayer"), to: Route::HqPlayer {}, onclick: move |_| menu_open.set(false), "HQPlayer" }
                     }
                     if !props.hide_lms {
-                        a { class: nav_link_class("lms"), href: "/lms", onclick: move |_| menu_open.set(false), "LMS" }
+                        Link { class: nav_link_class("lms"), to: Route::Lms {}, onclick: move |_| menu_open.set(false), "LMS" }
                     }
                     if !props.hide_knobs {
-                        a { class: nav_link_class("knobs"), href: "/knobs", onclick: move |_| menu_open.set(false), "Knobs" }
+                        Link { class: nav_link_class("knobs"), to: Route::Knobs {}, onclick: move |_| menu_open.set(false), "Knobs" }
                     }
-                    a { class: nav_link_class("settings"), href: "/settings", onclick: move |_| menu_open.set(false), "Settings" }
+                    Link { class: nav_link_class("settings"), to: Route::Settings {}, onclick: move |_| menu_open.set(false), "Settings" }
                 }
             }
         }

--- a/src/app/components/nav.rs
+++ b/src/app/components/nav.rs
@@ -24,9 +24,9 @@ pub fn Nav(props: NavProps) -> Element {
 
     let nav_link_class = |page: &str| {
         if props.active == page {
-            "block px-3 py-2 rounded-md text-sm font-medium text-white bg-gray-900"
+            "nav-link-active"
         } else {
-            "block px-3 py-2 rounded-md text-sm font-medium text-gray-300 hover:text-white hover:bg-gray-700"
+            "nav-link"
         }
     };
 
@@ -37,48 +37,46 @@ pub fn Nav(props: NavProps) -> Element {
     };
 
     rsx! {
-        nav { class: "bg-gray-800",
-            div { class: "max-w-7xl mx-auto px-4 sm:px-6 lg:px-8",
-                div { class: "flex items-center justify-between h-16",
-                    // Logo / Brand
-                    div { class: "flex items-center",
-                        a { class: "text-white font-bold text-xl", href: "/", "Hi-Fi Control" }
-                    }
+        nav { class: "nav-container",
+            div { class: "nav-inner",
+                // Logo / Brand
+                div { class: "flex items-center",
+                    a { class: "nav-brand", href: "/", "Hi-Fi Control" }
+                }
 
-                    // Desktop navigation
-                    div { class: "hidden lg:flex items-center space-x-4",
-                        a { class: nav_link_class("dashboard"), href: "/", "Dashboard" }
-                        a { class: nav_link_class("zones"), href: "/ui/zones", "Zones" }
-                        a { class: nav_link_class("zone"), href: "/zone", "Zone" }
-                        if !props.hide_hqp {
-                            a { class: nav_link_class("hqplayer"), href: "/hqplayer", "HQPlayer" }
-                        }
-                        if !props.hide_lms {
-                            a { class: nav_link_class("lms"), href: "/lms", "LMS" }
-                        }
-                        if !props.hide_knobs {
-                            a { class: nav_link_class("knobs"), href: "/knobs", "Knobs" }
-                        }
-                        a { class: nav_link_class("settings"), href: "/settings", "Settings" }
+                // Desktop navigation
+                div { class: "hidden lg:flex items-center space-x-4",
+                    a { class: nav_link_class("dashboard"), href: "/", "Dashboard" }
+                    a { class: nav_link_class("zones"), href: "/ui/zones", "Zones" }
+                    a { class: nav_link_class("zone"), href: "/zone", "Zone" }
+                    if !props.hide_hqp {
+                        a { class: nav_link_class("hqplayer"), href: "/hqplayer", "HQPlayer" }
                     }
+                    if !props.hide_lms {
+                        a { class: nav_link_class("lms"), href: "/lms", "LMS" }
+                    }
+                    if !props.hide_knobs {
+                        a { class: nav_link_class("knobs"), href: "/knobs", "Knobs" }
+                    }
+                    a { class: nav_link_class("settings"), href: "/settings", "Settings" }
+                }
 
-                    // Mobile menu button
-                    div { class: "lg:hidden",
-                        button {
-                            class: "inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-white hover:bg-gray-700 focus:outline-none",
-                            r#type: "button",
-                            onclick: move |_| menu_open.toggle(),
-                            span { class: "sr-only", "Toggle menu" }
-                            if menu_open() {
-                                // X icon
-                                svg { class: "h-6 w-6", fill: "none", view_box: "0 0 24 24", stroke: "currentColor", "stroke-width": "2",
-                                    path { "stroke-linecap": "round", "stroke-linejoin": "round", d: "M6 18L18 6M6 6l12 12" }
-                                }
-                            } else {
-                                // Hamburger icon
-                                svg { class: "h-6 w-6", fill: "none", view_box: "0 0 24 24", stroke: "currentColor", "stroke-width": "2",
-                                    path { "stroke-linecap": "round", "stroke-linejoin": "round", d: "M4 6h16M4 12h16M4 18h16" }
-                                }
+                // Mobile menu button
+                div { class: "lg:hidden",
+                    button {
+                        class: "inline-flex items-center justify-center p-2 rounded-md text-muted hover:text-primary hover:bg-hover focus:outline-none",
+                        r#type: "button",
+                        onclick: move |_| menu_open.toggle(),
+                        span { class: "sr-only", "Toggle menu" }
+                        if menu_open() {
+                            // X icon
+                            svg { class: "h-6 w-6", fill: "none", view_box: "0 0 24 24", stroke: "currentColor", "stroke-width": "2",
+                                path { "stroke-linecap": "round", "stroke-linejoin": "round", d: "M6 18L18 6M6 6l12 12" }
+                            }
+                        } else {
+                            // Hamburger icon
+                            svg { class: "h-6 w-6", fill: "none", view_box: "0 0 24 24", stroke: "currentColor", "stroke-width": "2",
+                                path { "stroke-linecap": "round", "stroke-linejoin": "round", d: "M4 6h16M4 12h16M4 18h16" }
                             }
                         }
                     }

--- a/src/app/components/nav.rs
+++ b/src/app/components/nav.rs
@@ -65,7 +65,7 @@ pub fn Nav(props: NavProps) -> Element {
                 // Mobile menu button
                 div { class: "lg:hidden",
                     button {
-                        class: "inline-flex items-center justify-center p-2 rounded-md text-muted hover:text-primary hover:bg-hover focus:outline-none",
+                        class: "nav-mobile-toggle",
                         r#type: "button",
                         onclick: move |_| menu_open.toggle(),
                         span { class: "sr-only", "Toggle menu" }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -9,15 +9,20 @@ pub mod api;
 pub mod components;
 pub mod pages;
 pub mod sse;
+pub mod theme;
 
 use pages::{Dashboard, HqPlayer, Knobs, Lms, Settings, Zone, Zones};
 use sse::use_sse_provider;
+use theme::use_theme_provider;
 
 /// Root app component with routing
 #[component]
 pub fn App() -> Element {
     // Initialize SSE context at app root (single EventSource for all pages)
     use_sse_provider();
+
+    // Initialize theme context at app root (handles localStorage + DOM class)
+    use_theme_provider();
 
     rsx! {
         Router::<Route> {}

--- a/src/app/pages/dashboard.rs
+++ b/src/app/pages/dashboard.rs
@@ -65,10 +65,10 @@ pub fn Dashboard() -> Element {
                     p { span { class: "font-semibold", "Uptime:" } " {app_status.uptime_secs}s" }
                     p { span { class: "font-semibold", "Event Bus Subscribers:" } " {app_status.bus_subscribers}" }
                 }
-                div { class: "border-t border-gray-700 my-4" }
+                div { class: "border-t border-default my-4" }
                 table { class: "w-full",
                     thead {
-                        tr { class: "border-b border-gray-700",
+                        tr { class: "border-b border-default",
                             th { class: "text-left py-2 px-3 font-semibold", "Adapter" }
                             th { class: "text-left py-2 px-3 font-semibold", "Status" }
                             th { class: "text-left py-2 px-3 font-semibold", "Details" }
@@ -76,7 +76,7 @@ pub fn Dashboard() -> Element {
                     }
                     tbody {
                         // Roon row
-                        tr { class: "border-b border-gray-800",
+                        tr { class: "border-b border-default",
                             td { class: "py-2 px-3", "Roon" }
                             td { class: "py-2 px-3",
                                 span {
@@ -84,7 +84,7 @@ pub fn Dashboard() -> Element {
                                     if roon_status.connected { "✓ Connected" } else { "✗ Disconnected" }
                                 }
                             }
-                            td { class: "py-2 px-3 text-sm text-gray-400",
+                            td { class: "py-2 px-3 text-sm text-muted",
                                 if let Some(name) = &roon_status.core_name {
                                     "{name} "
                                 }
@@ -94,7 +94,7 @@ pub fn Dashboard() -> Element {
                             }
                         }
                         // HQPlayer row
-                        tr { class: "border-b border-gray-800",
+                        tr { class: "border-b border-default",
                             td { class: "py-2 px-3", "HQPlayer" }
                             td { class: "py-2 px-3",
                                 span {
@@ -102,7 +102,7 @@ pub fn Dashboard() -> Element {
                                     if hqp_status.connected { "✓ Connected" } else { "✗ Disconnected" }
                                 }
                             }
-                            td { class: "py-2 px-3 text-sm text-gray-400",
+                            td { class: "py-2 px-3 text-sm text-muted",
                                 if let Some(host) = &hqp_status.host {
                                     "{host}"
                                 }
@@ -117,7 +117,7 @@ pub fn Dashboard() -> Element {
                                     if lms_status.connected { "✓ Connected" } else { "✗ Disconnected" }
                                 }
                             }
-                            td { class: "py-2 px-3 text-sm text-gray-400",
+                            td { class: "py-2 px-3 text-sm text-muted",
                                 if let (Some(host), Some(port)) = (&lms_status.host, lms_status.port) {
                                     "{host}:{port}"
                                 }
@@ -139,7 +139,7 @@ pub fn Dashboard() -> Element {
             section { id: "status",
                 div { class: "mb-4",
                     h2 { class: "text-xl font-semibold", "Service Status" }
-                    p { class: "text-gray-400 text-sm", "Connection status for all adapters" }
+                    p { class: "text-muted text-sm", "Connection status for all adapters" }
                 }
                 {status_content}
             }

--- a/src/app/pages/hqplayer.rs
+++ b/src/app/pages/hqplayer.rs
@@ -222,7 +222,7 @@ pub fn HqPlayer() -> Element {
             section { id: "hqp-config", class: "mb-8",
                 div { class: "mb-4",
                     h2 { class: "text-xl font-semibold", "Configuration" }
-                    p { class: "text-gray-400 text-sm", "HQPlayer connection settings" }
+                    p { class: "text-muted text-sm", "HQPlayer connection settings" }
                 }
                 div { class: "card p-6",
                     div { class: "mb-4",
@@ -265,7 +265,7 @@ pub fn HqPlayer() -> Element {
                                     }
                                 }
                             }
-                            p { class: "text-gray-500 text-xs mt-1", "For profile loading (HQPlayer Embedded)" }
+                            p { class: "text-muted text-xs mt-1", "For profile loading (HQPlayer Embedded)" }
                         }
                     }
                     div { class: "form-grid mb-4",
@@ -290,7 +290,7 @@ pub fn HqPlayer() -> Element {
                             }
                         }
                     }
-                    p { class: "text-gray-500 text-xs mb-4", "Web credentials enable profile switching via HQPlayer's web UI" }
+                    p { class: "text-muted text-xs mb-4", "Web credentials enable profile switching via HQPlayer's web UI" }
                     div { class: "flex items-center gap-4",
                         button { class: "btn btn-primary", onclick: save_config, "Save Configuration" }
                         if let Some(ref status_msg) = config_status() {
@@ -299,7 +299,7 @@ pub fn HqPlayer() -> Element {
                             } else if status_msg.starts_with("Error") {
                                 span { class: "status-err", "{status_msg}" }
                             } else {
-                                span { class: "text-gray-400", "{status_msg}" }
+                                span { class: "text-muted", "{status_msg}" }
                             }
                         }
                     }
@@ -310,7 +310,7 @@ pub fn HqPlayer() -> Element {
             section { id: "hqp-status", class: "mb-8",
                 div { class: "mb-4",
                     h2 { class: "text-xl font-semibold", "Connection Status" }
-                    p { class: "text-gray-400 text-sm", "HQPlayer DSP engine connection" }
+                    p { class: "text-muted text-sm", "HQPlayer DSP engine connection" }
                 }
                 div { class: "card p-6",
                     if let Some(ref s) = current_status {
@@ -333,7 +333,7 @@ pub fn HqPlayer() -> Element {
             section { id: "hqp-pipeline", class: "mb-8",
                 div { class: "mb-4",
                     h2 { class: "text-xl font-semibold", "Pipeline Settings" }
-                    p { class: "text-gray-400 text-sm", "Current DSP configuration" }
+                    p { class: "text-muted text-sm", "Current DSP configuration" }
                 }
                 div { class: "card p-6",
                     if let Some(ref pipe) = current_pipeline {
@@ -350,22 +350,22 @@ pub fn HqPlayer() -> Element {
             section { id: "hqp-profiles", class: "mb-8",
                 div { class: "mb-4",
                     h2 { class: "text-xl font-semibold", "Profiles" }
-                    p { class: "text-gray-400 text-sm", "Saved configurations (requires web credentials)" }
+                    p { class: "text-muted text-sm", "Saved configurations (requires web credentials)" }
                 }
                 div { class: "card p-6",
                     if profiles_list.is_empty() {
-                        p { class: "text-gray-400", "No profiles available" }
+                        p { class: "text-muted", "No profiles available" }
                     } else {
                         table { class: "w-full",
                             thead {
-                                tr { class: "border-b border-gray-700",
+                                tr { class: "border-b border-default",
                                     th { class: "text-left py-2", "Profile" }
                                     th { class: "text-left py-2", "Action" }
                                 }
                             }
                             tbody {
                                 for profile in profiles_list {
-                                    tr { class: "border-b border-gray-700",
+                                    tr { class: "border-b border-default",
                                         td { class: "py-2", "{profile.title.as_deref().or(profile.name.as_deref()).unwrap_or(\"Unknown\")}" }
                                         td { class: "py-2",
                                             button { class: "btn btn-outline btn-sm", "Load" }
@@ -382,7 +382,7 @@ pub fn HqPlayer() -> Element {
             section { id: "hqp-zone-links", class: "mb-8",
                 div { class: "mb-4",
                     h2 { class: "text-xl font-semibold", "Zone Linking" }
-                    p { class: "text-gray-400 text-sm", "Link audio zones to HQPlayer for DSP processing" }
+                    p { class: "text-muted text-sm", "Link audio zones to HQPlayer for DSP processing" }
                 }
                 div { class: "card p-6",
                     ZoneLinkTable {
@@ -415,20 +415,20 @@ fn PipelineDisplay(pipeline: HqpPipeline) -> Element {
     rsx! {
         table { class: "w-full",
             tbody {
-                tr { class: "border-b border-gray-700",
-                    td { class: "py-2 text-gray-400", "Mode" }
+                tr { class: "border-b border-default",
+                    td { class: "py-2 text-muted", "Mode" }
                     td { class: "py-2", "{status.and_then(|s| s.active_mode.as_deref()).unwrap_or(\"N/A\")}" }
                 }
-                tr { class: "border-b border-gray-700",
-                    td { class: "py-2 text-gray-400", "Filter" }
+                tr { class: "border-b border-default",
+                    td { class: "py-2 text-muted", "Filter" }
                     td { class: "py-2", "{status.and_then(|s| s.active_filter.as_deref()).unwrap_or(\"N/A\")}" }
                 }
-                tr { class: "border-b border-gray-700",
-                    td { class: "py-2 text-gray-400", "Shaper" }
+                tr { class: "border-b border-default",
+                    td { class: "py-2 text-muted", "Shaper" }
                     td { class: "py-2", "{status.and_then(|s| s.active_shaper.as_deref()).unwrap_or(\"N/A\")}" }
                 }
-                tr { class: "border-b border-gray-700",
-                    td { class: "py-2 text-gray-400", "Sample Rate" }
+                tr { class: "border-b border-default",
+                    td { class: "py-2 text-muted", "Sample Rate" }
                     td { class: "py-2",
                         if let Some(rate) = status.and_then(|s| s.active_rate) {
                             "{format_rate(rate)}"
@@ -438,7 +438,7 @@ fn PipelineDisplay(pipeline: HqpPipeline) -> Element {
                     }
                 }
                 tr {
-                    td { class: "py-2 text-gray-400", "Volume" }
+                    td { class: "py-2 text-muted", "Volume" }
                     td { class: "py-2",
                         if let Some(v) = volume.and_then(|vol| vol.value) {
                             "{v} dB"
@@ -466,7 +466,7 @@ fn ZoneLinkTable(
 ) -> Element {
     if zones.is_empty() {
         return rsx! {
-            p { class: "text-gray-400", "No audio zones available. Check that adapters are connected." }
+            p { class: "text-muted", "No audio zones available. Check that adapters are connected." }
         };
     }
 
@@ -491,7 +491,7 @@ fn ZoneLinkTable(
     rsx! {
         table { class: "w-full",
             thead {
-                tr { class: "border-b border-gray-700",
+                tr { class: "border-b border-default",
                     th { class: "text-left py-2", "Zone" }
                     th { class: "text-left py-2", "Source" }
                     th { class: "text-left py-2", "HQPlayer Instance" }
@@ -508,9 +508,9 @@ fn ZoneLinkTable(
                         let backend = get_backend(&zone_id);
 
                         rsx! {
-                            tr { class: "border-b border-gray-700",
+                            tr { class: "border-b border-default",
                                 td { class: "py-2", "{zone.zone_name}" }
-                                td { class: "py-2", span { class: "text-sm text-gray-400", "{backend}" } }
+                                td { class: "py-2", span { class: "text-sm text-muted", "{backend}" } }
                                 td { class: "py-2",
                                     if let Some(ref inst) = linked {
                                         span { class: "font-semibold", "{inst}" }

--- a/src/app/pages/knobs.rs
+++ b/src/app/pages/knobs.rs
@@ -163,9 +163,9 @@ pub fn Knobs() -> Element {
 
             h1 { class: "text-2xl font-bold mb-6", "Knob Devices" }
 
-            p { class: "mb-6 text-gray-400",
+            p { class: "mb-6 text-muted",
                 a {
-                    class: "text-indigo-400 hover:text-indigo-300",
+                    class: "link",
                     href: "https://community.roonlabs.com/t/50-esp32-s3-knob-roon-controller/311363",
                     target: "_blank",
                     rel: "noopener",
@@ -179,12 +179,12 @@ pub fn Knobs() -> Element {
                 if is_loading {
                     div { class: "card p-6", aria_busy: "true", "Loading knobs..." }
                 } else if knobs_list.is_empty() {
-                    div { class: "card p-6 text-gray-400", "No knobs registered. Connect a knob to see it here." }
+                    div { class: "card p-6 text-muted", "No knobs registered. Connect a knob to see it here." }
                 } else {
                     div { class: "card p-6 overflow-x-auto",
                         table { class: "w-full",
                             thead {
-                                tr { class: "border-b border-gray-700",
+                                tr { class: "border-b border-default",
                                     th { class: "text-left py-2 text-sm", "ID" }
                                     th { class: "text-left py-2 text-sm", "Name" }
                                     th { class: "text-left py-2 text-sm", "Version" }
@@ -213,7 +213,7 @@ pub fn Knobs() -> Element {
             section { id: "firmware-section", class: "mb-8",
                 div { class: "mb-4",
                     h2 { class: "text-xl font-semibold", "Firmware" }
-                    p { class: "text-gray-400 text-sm", "Manage knob firmware updates" }
+                    p { class: "text-muted text-sm", "Manage knob firmware updates" }
                 }
                 div { class: "card p-6",
                     p { class: "mb-4",
@@ -235,7 +235,7 @@ pub fn Knobs() -> Element {
                             onclick: fetch_firmware,
                             "Fetch Latest from GitHub"
                         }
-                        a { class: "text-indigo-400 hover:text-indigo-300", href: "/knobs/flash", "Flash a new knob" }
+                        a { class: "link", href: "/knobs/flash", "Flash a new knob" }
                         if let Some((is_err, ref msg)) = fw_message() {
                             if is_err {
                                 span { class: "status-err", "{msg}" }
@@ -359,14 +359,14 @@ fn KnobRow(knob: KnobDevice, zones: Vec<Zone>, on_config: EventHandler<String>) 
     let last_seen = format_ago(knob.last_seen.as_deref());
 
     rsx! {
-        tr { class: "border-b border-gray-700",
-            td { class: "py-2", code { class: "text-xs bg-gray-800 px-1 rounded", "{knob.knob_id}" } }
-            td { class: "py-2 text-sm text-gray-400", "{display_name}" }
+        tr { class: "border-b border-default",
+            td { class: "py-2", code { class: "text-xs bg-elevated px-1 rounded", "{knob.knob_id}" } }
+            td { class: "py-2 text-sm text-muted", "{display_name}" }
             td { class: "py-2", "{version}" }
             td { class: "py-2", "{ip}" }
             td { class: "py-2", "{zone_name}" }
             td { class: "py-2", "{battery}" }
-            td { class: "py-2 text-sm text-gray-400", "{last_seen}" }
+            td { class: "py-2 text-sm text-muted", "{last_seen}" }
             td { class: "py-2",
                 button {
                     class: "btn btn-outline btn-sm",
@@ -405,7 +405,7 @@ fn ConfigModal(
                 div { class: "flex items-center justify-between mb-6",
                     h2 { class: "text-xl font-semibold", "Knob Configuration" }
                     button {
-                        class: "text-gray-400 hover:text-white text-xl",
+                        class: "text-muted hover:text-white text-xl",
                         aria_label: "Close",
                         onclick: move |_| on_close.call(()),
                         "×"
@@ -413,7 +413,7 @@ fn ConfigModal(
                 }
 
                 if loading {
-                    p { class: "text-gray-400", aria_busy: "true", "Loading configuration..." }
+                    p { class: "text-muted", aria_busy: "true", "Loading configuration..." }
                 } else {
                     form {
                         onsubmit: move |e| {
@@ -436,7 +436,7 @@ fn ConfigModal(
                             legend { class: "text-sm font-medium mb-2", "Display Rotation" }
                             div { class: "form-grid",
                                 div {
-                                    label { class: "block text-sm text-gray-400 mb-1", "Charging" }
+                                    label { class: "block text-sm text-muted mb-1", "Charging" }
                                     select {
                                         class: "input",
                                         value: "{rotation_charging}",
@@ -450,7 +450,7 @@ fn ConfigModal(
                                     }
                                 }
                                 div {
-                                    label { class: "block text-sm text-gray-400 mb-1", "Battery" }
+                                    label { class: "block text-sm text-muted mb-1", "Battery" }
                                     select {
                                         class: "input",
                                         value: "{rotation_not_charging}",
@@ -472,7 +472,7 @@ fn ConfigModal(
                                     if status.starts_with("Error") {
                                         span { class: "status-err", "{status}" }
                                     } else {
-                                        span { class: "text-gray-400", "{status}" }
+                                        span { class: "text-muted", "{status}" }
                                     }
                                 }
                             }

--- a/src/app/pages/lms.rs
+++ b/src/app/pages/lms.rs
@@ -143,7 +143,7 @@ pub fn Lms() -> Element {
             section { id: "lms-config", class: "mb-8",
                 div { class: "mb-4",
                     h2 { class: "text-xl font-semibold", "Server Configuration" }
-                    p { class: "text-gray-400 text-sm", "Configure connection to your Squeezebox server" }
+                    p { class: "text-muted text-sm", "Configure connection to your Squeezebox server" }
                 }
                 div { class: "card p-6",
                     // Status line
@@ -158,10 +158,10 @@ pub fn Lms() -> Element {
                                     "✗ Configured but not connected ({c.host.as_deref().unwrap_or(\"\")}:{c.port.unwrap_or(9000)})"
                                 }
                             } else {
-                                span { class: "text-gray-400", "Not configured" }
+                                span { class: "text-muted", "Not configured" }
                             }
                         } else {
-                            span { class: "text-gray-400", "Checking..." }
+                            span { class: "text-muted", "Checking..." }
                         }
                     }
 
@@ -225,7 +225,7 @@ pub fn Lms() -> Element {
                                     } else if status.contains("Connected") {
                                         span { class: "status-ok", "✓ {status}" }
                                     } else {
-                                        span { class: "text-gray-400", "{status}" }
+                                        span { class: "text-muted", "{status}" }
                                     }
                                 }
                             }
@@ -247,16 +247,16 @@ pub fn Lms() -> Element {
             section { id: "lms-players", class: "mb-8",
                 div { class: "mb-4",
                     h2 { class: "text-xl font-semibold", "Players" }
-                    p { class: "text-gray-400 text-sm", "Connected Squeezebox players" }
+                    p { class: "text-muted text-sm", "Connected Squeezebox players" }
                 }
 
                 if settings_loading {
                     div { class: "card p-6", aria_busy: "true", "Loading settings..." }
                 } else if matches!(lms_enabled, Some(false)) {
                     div { class: "card p-6",
-                        p { class: "text-gray-400",
+                        p { class: "text-muted",
                             "LMS adapter is disabled. "
-                            a { class: "text-indigo-400 hover:text-indigo-300", href: "/settings", "Enable it in Settings" }
+                            a { class: "link", href: "/settings", "Enable it in Settings" }
                             " to discover players."
                         }
                     }
@@ -264,7 +264,7 @@ pub fn Lms() -> Element {
                     div { class: "card p-6", aria_busy: "true", "Loading..." }
                 } else if players_list.is_empty() {
                     div { class: "card p-6",
-                        p { class: "text-gray-400", "No players found. Make sure your Squeezebox server is configured and reachable." }
+                        p { class: "text-muted", "No players found. Make sure your Squeezebox server is configured and reachable." }
                     }
                 } else {
                     div { class: "zone-grid",
@@ -308,10 +308,10 @@ fn PlayerCard(player: LmsPlayer, on_control: EventHandler<(String, String)>) -> 
                 if let Some(ref title) = player.current_title {
                     p { class: "font-medium text-sm truncate", "{title}" }
                     if let Some(ref artist) = player.artist {
-                        p { class: "text-sm text-gray-400 truncate", "{artist}" }
+                        p { class: "text-sm text-muted truncate", "{artist}" }
                     }
                 } else {
-                    p { class: "text-sm text-gray-500", "Nothing playing" }
+                    p { class: "text-sm text-muted", "Nothing playing" }
                 }
             }
 
@@ -332,7 +332,7 @@ fn PlayerCard(player: LmsPlayer, on_control: EventHandler<(String, String)>) -> 
                     onclick: move |_| on_control.call((player_id_next.clone(), "next".to_string())),
                     "▶▶"
                 }
-                span { class: "ml-auto text-sm text-gray-400", "Volume: {player.volume}%" }
+                span { class: "ml-auto text-sm text-muted", "Volume: {player.volume}%" }
             }
         }
     }

--- a/src/app/pages/settings.rs
+++ b/src/app/pages/settings.rs
@@ -106,7 +106,7 @@ pub fn Settings() -> Element {
             section { class: "mb-8",
                 div { class: "mb-4",
                     h2 { class: "text-xl font-semibold", "Adapter Settings" }
-                    p { class: "text-gray-400 text-sm", "Enable or disable zone sources" }
+                    p { class: "text-muted text-sm", "Enable or disable zone sources" }
                 }
 
                 div { class: "card p-6",
@@ -160,7 +160,7 @@ pub fn Settings() -> Element {
                             "UPnP/DLNA"
                         }
                     }
-                    p { class: "mt-3 text-sm text-gray-400",
+                    p { class: "mt-3 text-sm text-muted",
                         "Changes take effect immediately. Disabled adapters won't contribute zones."
                     }
                 }
@@ -170,13 +170,13 @@ pub fn Settings() -> Element {
             section {
                 div { class: "mb-4",
                     h2 { class: "text-xl font-semibold", "Auto-Discovery" }
-                    p { class: "text-gray-400 text-sm", "Devices found via SSDP (no configuration needed)" }
+                    p { class: "text-muted text-sm", "Devices found via SSDP (no configuration needed)" }
                 }
 
                 div { class: "card p-6",
                     table { class: "w-full", id: "discovery-table",
                         thead {
-                            tr { class: "border-b border-gray-700",
+                            tr { class: "border-b border-default",
                                 th { class: "text-left py-2 px-3 font-semibold", "Protocol" }
                                 th { class: "text-left py-2 px-3 font-semibold", "Status" }
                                 th { class: "text-left py-2 px-3 font-semibold", "Devices" }
@@ -184,7 +184,7 @@ pub fn Settings() -> Element {
                         }
                         tbody {
                             // Roon row
-                            tr { class: "border-b border-gray-800",
+                            tr { class: "border-b border-default",
                                 td { class: "py-2 px-3", "Roon" }
                                 td { class: "py-2 px-3",
                                     if !roon_enabled() {
@@ -199,7 +199,7 @@ pub fn Settings() -> Element {
                                         "Loading..."
                                     }
                                 }
-                                td { class: "py-2 px-3 text-gray-400",
+                                td { class: "py-2 px-3 text-muted",
                                     if !roon_enabled() {
                                         "-"
                                     } else if let Some(ref status) = roon_st {
@@ -218,7 +218,7 @@ pub fn Settings() -> Element {
                                 }
                             }
                             // OpenHome row
-                            tr { class: "border-b border-gray-800",
+                            tr { class: "border-b border-default",
                                 td { class: "py-2 px-3", "OpenHome" }
                                 td { class: "py-2 px-3",
                                     if !openhome_enabled() {
@@ -233,7 +233,7 @@ pub fn Settings() -> Element {
                                         "Loading..."
                                     }
                                 }
-                                td { class: "py-2 px-3 text-gray-400",
+                                td { class: "py-2 px-3 text-muted",
                                     if !openhome_enabled() {
                                         "-"
                                     } else if let Some(ref status) = openhome_st {
@@ -259,7 +259,7 @@ pub fn Settings() -> Element {
                                         "Loading..."
                                     }
                                 }
-                                td { class: "py-2 px-3 text-gray-400",
+                                td { class: "py-2 px-3 text-muted",
                                     if !upnp_enabled() {
                                         "-"
                                     } else if let Some(ref status) = upnp_st {

--- a/src/app/pages/settings.rs
+++ b/src/app/pages/settings.rs
@@ -7,6 +7,7 @@ use dioxus::prelude::*;
 use crate::app::api::{AdapterSettings, AppSettings, RoonStatus};
 use crate::app::components::Layout;
 use crate::app::sse::use_sse;
+use crate::app::theme::{use_theme, Theme};
 
 /// OpenHome status response
 #[derive(Clone, Debug, Default, serde::Deserialize, PartialEq)]
@@ -24,6 +25,7 @@ struct UpnpStatus {
 #[component]
 pub fn Settings() -> Element {
     let sse = use_sse();
+    let theme_ctx = use_theme();
 
     // Adapter toggle signals
     let mut roon_enabled = use_signal(|| true);
@@ -162,6 +164,34 @@ pub fn Settings() -> Element {
                     }
                     p { class: "mt-3 text-sm text-muted",
                         "Changes take effect immediately. Disabled adapters won't contribute zones."
+                    }
+                }
+            }
+
+            // Theme Settings section
+            section { class: "mb-8",
+                div { class: "mb-4",
+                    h2 { class: "text-xl font-semibold", "Appearance" }
+                    p { class: "text-muted text-sm", "Choose your preferred color theme" }
+                }
+
+                div { class: "card p-6",
+                    div { class: "flex flex-wrap gap-3",
+                        for theme in [Theme::System, Theme::Light, Theme::Dark, Theme::Oled] {
+                            button {
+                                class: if theme_ctx.get() == theme { "btn-primary" } else { "btn-outline" },
+                                onclick: move |_| theme_ctx.set(theme),
+                                "{theme.label()}"
+                            }
+                        }
+                    }
+                    p { class: "mt-3 text-sm text-muted",
+                        match theme_ctx.get() {
+                            Theme::System => "Using your system's color scheme preference.",
+                            Theme::Light => "Light theme for bright environments.",
+                            Theme::Dark => "Dark theme for low-light environments.",
+                            Theme::Oled => "Pure black theme for AMOLED displays.",
+                        }
                     }
                 }
             }

--- a/src/app/pages/zone.rs
+++ b/src/app/pages/zone.rs
@@ -287,20 +287,20 @@ fn ZoneDisplay(
 
     rsx! {
         article { id: "zone-display",
-            div { style: "display:flex;gap:1.5rem;align-items:flex-start;flex-wrap:wrap;",
+            div { class: "flex gap-6 items-start flex-wrap",
                 img {
                     id: "zone-art",
                     src: "{image_url}",
                     alt: "Album art",
-                    style: "width:200px;height:200px;object-fit:cover;border-radius:8px;background:#222;"
+                    class: "w-[200px] h-[200px] object-cover rounded-lg bg-elevated"
                 }
-                div { style: "flex:1;min-width:200px;",
-                    h2 { id: "zone-name", style: "margin-bottom:0.25rem;", "{zone.zone_name}" }
-                    p { style: "margin:0;",
+                div { class: "flex-1 min-w-[200px]",
+                    h2 { id: "zone-name", class: "mb-1", "{zone.zone_name}" }
+                    p { class: "m-0",
                         small { if is_playing { "playing" } else { "stopped" } }
                     }
                     hr {}
-                    p { style: "margin:0.5rem 0;",
+                    p { class: "my-2",
                         if !track.is_empty() {
                             strong { "{track}" }
                         } else {
@@ -308,13 +308,13 @@ fn ZoneDisplay(
                         }
                     }
                     if !artist.is_empty() {
-                        p { style: "margin:0;", small { "{artist}" } }
+                        p { class: "m-0", small { "{artist}" } }
                     }
                     if !album.is_empty() {
-                        p { class: "text-gray-500", style: "margin:0;", small { "{album}" } }
+                        p { class: "text-muted m-0", small { "{album}" } }
                     }
                     hr {}
-                    div { style: "display:flex;gap:0.5rem;align-items:center;margin:1rem 0;",
+                    div { class: "flex gap-2 items-center my-4",
                         button {
                             disabled: !can_prev,
                             onclick: move |_| on_control.call(("previous", None)),
@@ -332,17 +332,17 @@ fn ZoneDisplay(
                         // Volume controls (hidden for fixed volume outputs)
                         if has_volume || is_incremental {
                             if !is_incremental {
-                                span { style: "margin-left:1rem;", "Volume: ", strong { "{volume_display}" } }
+                                span { class: "ml-4", "Volume: ", strong { "{volume_display}" } }
                             } else {
-                                span { style: "margin-left:1rem;", "Volume:" }
+                                span { class: "ml-4", "Volume:" }
                             }
                             button {
-                                style: "width:2.5rem;",
+                                class: "w-10",
                                 onclick: move |_| on_control.call(("vol_down", Some(2))),
                                 "−"
                             }
                             button {
-                                style: "width:2.5rem;",
+                                class: "w-10",
                                 onclick: move |_| on_control.call(("vol_up", Some(2))),
                                 "+"
                             }

--- a/src/app/pages/zones.rs
+++ b/src/app/pages/zones.rs
@@ -219,9 +219,9 @@ fn ZoneCard(
             div { class: "min-h-[40px] overflow-hidden mb-4",
                 if !track.is_empty() {
                     p { class: "font-medium text-sm truncate", "{track}" }
-                    p { class: "text-sm text-gray-400 truncate", "{artist}" }
+                    p { class: "text-sm text-muted truncate", "{artist}" }
                 } else {
-                    p { class: "text-sm text-gray-500", "Nothing playing" }
+                    p { class: "text-sm text-muted", "Nothing playing" }
                 }
             }
 

--- a/src/app/theme.rs
+++ b/src/app/theme.rs
@@ -81,7 +81,8 @@ impl ThemeContext {
 
 /// Initialize theme context provider - call once at app root
 pub fn use_theme_provider() {
-    let current = use_signal(|| Theme::System);
+    #[allow(unused_mut)] // mut needed for WASM target
+    let mut current = use_signal(|| Theme::System);
 
     let ctx = ThemeContext { current };
     use_context_provider(|| ctx);

--- a/src/app/theme.rs
+++ b/src/app/theme.rs
@@ -1,0 +1,146 @@
+//! Theme management with localStorage persistence.
+//!
+//! Provides a theme context for managing light/dark/OLED theme preferences.
+
+use dioxus::prelude::*;
+
+/// Theme options
+#[derive(Clone, Copy, Debug, PartialEq, Default)]
+pub enum Theme {
+    #[default]
+    System,
+    Light,
+    Dark,
+    Oled,
+}
+
+impl Theme {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Theme::System => "system",
+            Theme::Light => "light",
+            Theme::Dark => "dark",
+            Theme::Oled => "oled",
+        }
+    }
+
+    pub fn parse(s: &str) -> Self {
+        match s {
+            "light" => Theme::Light,
+            "dark" => Theme::Dark,
+            "oled" => Theme::Oled,
+            _ => Theme::System,
+        }
+    }
+
+    pub fn label(&self) -> &'static str {
+        match self {
+            Theme::System => "System",
+            Theme::Light => "Light",
+            Theme::Dark => "Dark",
+            Theme::Oled => "OLED Black",
+        }
+    }
+
+    /// CSS class to apply to :root (empty for system)
+    pub fn css_class(&self) -> &'static str {
+        match self {
+            Theme::System => "",
+            Theme::Light => "theme-light",
+            Theme::Dark => "theme-dark",
+            Theme::Oled => "theme-oled",
+        }
+    }
+}
+
+/// Global theme state shared via context
+#[derive(Clone, Copy)]
+pub struct ThemeContext {
+    pub current: Signal<Theme>,
+}
+
+impl ThemeContext {
+    /// Get current theme
+    pub fn get(&self) -> Theme {
+        (self.current)()
+    }
+
+    /// Set and persist theme
+    pub fn set(&self, theme: Theme) {
+        let mut current = self.current;
+        current.set(theme);
+
+        // Apply to DOM and save to localStorage
+        #[cfg(target_arch = "wasm32")]
+        {
+            apply_theme_to_dom(theme);
+            save_theme_to_storage(theme);
+        }
+    }
+}
+
+/// Initialize theme context provider - call once at app root
+pub fn use_theme_provider() {
+    let current = use_signal(|| Theme::System);
+
+    let ctx = ThemeContext { current };
+    use_context_provider(|| ctx);
+
+    // Client-side only: load from localStorage and apply
+    #[cfg(target_arch = "wasm32")]
+    {
+        use_effect(move || {
+            let saved = load_theme_from_storage();
+            current.set(saved);
+            apply_theme_to_dom(saved);
+        });
+    }
+}
+
+/// Get theme context - use in any component
+pub fn use_theme() -> ThemeContext {
+    use_context::<ThemeContext>()
+}
+
+// ============ WASM-only helpers ============
+
+#[cfg(target_arch = "wasm32")]
+fn load_theme_from_storage() -> Theme {
+    if let Some(window) = web_sys::window() {
+        if let Ok(Some(storage)) = window.local_storage() {
+            if let Ok(Some(value)) = storage.get_item("hifi-theme") {
+                return Theme::parse(&value);
+            }
+        }
+    }
+    Theme::System
+}
+
+#[cfg(target_arch = "wasm32")]
+fn save_theme_to_storage(theme: Theme) {
+    if let Some(window) = web_sys::window() {
+        if let Ok(Some(storage)) = window.local_storage() {
+            let _ = storage.set_item("hifi-theme", theme.as_str());
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn apply_theme_to_dom(theme: Theme) {
+    if let Some(window) = web_sys::window() {
+        if let Some(document) = window.document() {
+            if let Some(root) = document.document_element() {
+                // Remove all theme classes
+                let _ = root
+                    .class_list()
+                    .remove_3("theme-light", "theme-dark", "theme-oled");
+
+                // Add the selected theme class (if not system)
+                let class = theme.css_class();
+                if !class.is_empty() {
+                    let _ = root.class_list().add_1(class);
+                }
+            }
+        }
+    }
+}

--- a/src/input.css
+++ b/src/input.css
@@ -126,9 +126,26 @@
     @apply flex flex-col gap-1 py-2;
   }
 
-  /* Nav link styling */
-  .nav-link {
+  /* Mobile menu toggle button */
+  .nav-mobile-toggle {
+    @apply inline-flex items-center justify-center p-2 rounded-md;
+    color: var(--text-muted);
+  }
+  .nav-mobile-toggle:hover {
+    color: var(--text-primary);
+    background: var(--surface-hover);
+  }
+  .nav-mobile-toggle:focus {
+    outline: none;
+  }
+
+  /* Nav link base styling */
+  .nav-link,
+  .nav-link-active {
     @apply block px-3 py-2 rounded-md text-sm font-medium;
+  }
+
+  .nav-link {
     color: var(--text-secondary);
   }
   .nav-link:hover {
@@ -138,7 +155,6 @@
 
   /* Active nav item styling */
   .nav-link-active {
-    @apply block px-3 py-2 rounded-md text-sm font-medium;
     background: var(--surface-hover);
     color: var(--text-primary);
   }

--- a/src/input.css
+++ b/src/input.css
@@ -7,6 +7,7 @@
  * Theme: Uses dioxus-primitives CSS variables from dx-components-theme.css
  * --primary-color-* : background shades (dark theme: darker = lower number)
  * --secondary-color-* : text/foreground shades (dark theme: lighter = lower number)
+ * --text-*, --surface-*, --border-*, --accent-* : semantic aliases
  */
 
 /* Base styles - integrate with dioxus-primitives theme */
@@ -19,15 +20,63 @@
 
 /* Custom utility classes for the app */
 @layer components {
-  /* Status indicators - using standard Tailwind colors */
+  /* Status indicators - using theme success/error colors */
   .status-ok {
-    @apply text-green-500;
+    color: var(--secondary-success-color);
   }
   .status-err {
-    @apply text-red-500;
+    color: var(--primary-error-color);
   }
   .status-disabled {
-    @apply text-gray-500;
+    color: var(--text-disabled);
+  }
+
+  /* Semantic text utilities */
+  .text-primary {
+    color: var(--text-primary);
+  }
+  .text-secondary {
+    color: var(--text-secondary);
+  }
+  .text-muted {
+    color: var(--text-muted);
+  }
+
+  /* Surface utilities */
+  .bg-elevated {
+    background: var(--surface-elevated);
+  }
+  .bg-hover {
+    background: var(--surface-hover);
+  }
+
+  /* Border utilities */
+  .border-default {
+    border-color: var(--border-default);
+  }
+  .border-subtle {
+    border-color: var(--border-subtle);
+  }
+
+  /* Link styling */
+  .link {
+    color: var(--accent-color);
+    text-decoration: none;
+  }
+  .link:hover {
+    color: var(--accent-hover);
+  }
+
+  /* Code/monospace styling */
+  .code {
+    @apply text-xs px-1 rounded;
+    background: var(--surface-elevated);
+  }
+
+  /* Table row with border */
+  .table-row {
+    @apply border-b;
+    border-color: var(--border-default);
   }
 
   /* Zone grid layout */
@@ -46,7 +95,7 @@
 
   /* Navigation container */
   .nav-container {
-    background: var(--primary-color-5);
+    background: var(--surface-elevated);
   }
 
   .nav-inner {
@@ -55,12 +104,12 @@
 
   .nav-brand {
     @apply text-xl font-bold;
-    color: var(--secondary-color-1);
+    color: var(--text-primary);
     text-decoration: none;
   }
 
   .nav-brand:hover {
-    color: var(--secondary-color-2);
+    color: var(--text-secondary);
   }
 
   /* Desktop nav - hidden on mobile */
@@ -77,17 +126,28 @@
     @apply flex flex-col gap-1 py-2;
   }
 
+  /* Nav link styling */
+  .nav-link {
+    @apply block px-3 py-2 rounded-md text-sm font-medium;
+    color: var(--text-secondary);
+  }
+  .nav-link:hover {
+    color: var(--text-primary);
+    background: var(--surface-hover);
+  }
+
   /* Active nav item styling */
-  .navbar-item-active {
-    background: var(--primary-color-7);
-    color: var(--secondary-color-1);
+  .nav-link-active {
+    @apply block px-3 py-2 rounded-md text-sm font-medium;
+    background: var(--surface-hover);
+    color: var(--text-primary);
   }
 
   /* Card component */
   .card {
     @apply rounded-lg;
-    background: var(--primary-color-5);
-    border: 1px solid var(--primary-color-6);
+    background: var(--surface-elevated);
+    border: 1px solid var(--border-default);
   }
 
   /* Badge components */
@@ -96,22 +156,40 @@
   }
 
   .badge-primary {
-    @apply bg-indigo-600 text-white;
+    background: var(--accent-color);
+    color: var(--surface-base);
   }
 
   .badge-secondary {
-    background: var(--primary-color-7);
-    color: var(--secondary-color-3);
+    background: var(--surface-hover);
+    color: var(--text-secondary);
   }
 
   /* Checkbox styling */
   .checkbox {
-    @apply w-4 h-4 rounded border-gray-600 bg-gray-700 text-indigo-600 focus:ring-indigo-500 focus:ring-offset-gray-800;
+    @apply w-4 h-4 rounded;
+    border-color: var(--border-default);
+    background: var(--surface-elevated);
+    accent-color: var(--accent-color);
+  }
+  .checkbox:focus {
+    outline: 2px solid var(--accent-color);
+    outline-offset: 2px;
   }
 
   /* Form input styling */
   .input {
-    @apply block w-full rounded-md border-0 py-1.5 px-3 bg-gray-700 text-white shadow-sm ring-1 ring-inset ring-gray-600 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-500 sm:text-sm sm:leading-6;
+    @apply block w-full rounded-md border-0 py-1.5 px-3 shadow-sm ring-1 ring-inset sm:text-sm sm:leading-6;
+    background: var(--surface-elevated);
+    color: var(--text-primary);
+    --tw-ring-color: var(--border-default);
+  }
+  .input::placeholder {
+    color: var(--text-muted);
+  }
+  .input:focus {
+    @apply ring-2 ring-inset;
+    --tw-ring-color: var(--accent-color);
   }
 
   /* Form grid */
@@ -121,19 +199,36 @@
 
   /* Button styles */
   .btn {
-    @apply inline-flex items-center justify-center px-4 py-2 rounded-md text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-900;
+    @apply inline-flex items-center justify-center px-4 py-2 rounded-md text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2;
+    --tw-ring-offset-color: var(--surface-base);
   }
 
   .btn-primary {
-    @apply bg-indigo-600 text-white hover:bg-indigo-700 focus:ring-indigo-500;
+    background: var(--accent-color);
+    color: var(--surface-base);
+    --tw-ring-color: var(--accent-color);
+  }
+  .btn-primary:hover {
+    background: var(--accent-hover);
   }
 
   .btn-ghost {
-    @apply text-gray-300 hover:text-white hover:bg-gray-700 focus:ring-gray-500;
+    color: var(--text-secondary);
+    --tw-ring-color: var(--border-default);
+  }
+  .btn-ghost:hover {
+    color: var(--text-primary);
+    background: var(--surface-hover);
   }
 
   .btn-outline {
-    @apply border border-gray-600 text-gray-300 hover:text-white hover:bg-gray-700 focus:ring-gray-500;
+    border: 1px solid var(--border-default);
+    color: var(--text-secondary);
+    --tw-ring-color: var(--border-default);
+  }
+  .btn-outline:hover {
+    color: var(--text-primary);
+    background: var(--surface-hover);
   }
 
   .btn-sm {


### PR DESCRIPTION
Fixes #96

## Summary
- Add semantic CSS variables to `dx-components-theme.css` for theming
- Refactor all custom utilities in `input.css` to use CSS vars
- Replace all hardcoded Tailwind colors in Rust components with semantic classes
- Remove inline styles from `zone.rs` in favor of Tailwind utilities

## Changes

### CSS Foundation
- New semantic variables: `--text-primary/secondary/muted`, `--surface-elevated/hover`, `--border-default`, `--accent-color`
- New utility classes: `.text-muted`, `.bg-elevated`, `.link`, `.code`, `.table-row`, `.nav-link`, `.nav-link-active`
- All buttons, forms, badges, status indicators now use CSS vars

### Components Updated
- `nav.rs` - Uses `nav-link` / `nav-link-active` classes
- `zone.rs` - Inline styles replaced with Tailwind utilities
- All pages - `text-gray-*`, `border-gray-*`, `bg-gray-*` → semantic classes

## Test plan
- [x] View UI in dark mode (default OS setting)
- [x] View UI in light mode (change OS setting)
- [x] All pages render correctly in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App-wide theming (System/Light/Dark/OLED) with persistent preference and system color-scheme support.

* **Style**
  * Unified semantic color tokens and OLED-specific blacks; refreshed navigation, cards, forms, buttons, tables, badges, and muted/text/surface contrasts for consistent appearance.

* **Refactor**
  * Migration to token-driven utility classes and class-based layout utilities for more consistent and maintainable styling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->