### PR TITLE
fix: Use shared-key for cross build cache isolation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,8 +100,9 @@ jobs:
         with:
           # Cross builds need all crates cached, not just dependencies
           cache-all-crates: true
-          # Use target as key to avoid cache collisions between architectures
-          key: cross-${{ matrix.target }}
+          # shared-key replaces automatic job-based key entirely, ensuring each target
+          # gets a completely separate cache (key only adds a suffix to shared prefix)
+          shared-key: cross-${{ matrix.target }}
 
       - name: Cache cross
         id: cache-cross

--- a/docs/gh-release.md
+++ b/docs/gh-release.md
@@ -44,8 +44,11 @@ Proc-macros (serde_derive, dioxus, thiserror, etc.) can't be cached by sccache d
 - name: Cache Rust (cross builds)
   uses: Swatinem/rust-cache@v2
   with:
-    cache-directories: target/${{ matrix.target }}
+    cache-all-crates: true
+    shared-key: cross-${{ matrix.target }}
 ```
+
+**Why `shared-key` instead of `key`:** The `key` parameter only adds a suffix to the automatic job-based cache key. Since all Linux matrix jobs run on the same OS/arch runner, they can collide and restore each other's caches. Using `shared-key` completely replaces the automatic key, ensuring each target triple gets a completely separate cache.
 
 **Why this works:** Cross mounts the host's `target/` directory into the container, so rust-cache's directory-based caching is effective here.
 


### PR DESCRIPTION
## Summary
- Fixed cross-build cache collision that caused all Linux matrix jobs to share the same ~1.8MB cache
- Changed `key` to `shared-key` in rust-cache config to ensure each target gets a separate cache

## Problem
The `key` parameter only adds a suffix to the automatic job-based cache key. Since all Linux matrix jobs (x86_64, aarch64, armv7) run on the same OS/arch runner, they were all matching the same cache prefix and restoring from whichever was saved first.

Evidence from [run #21118465779](https://github.com/open-horizon-labs/unified-hifi-control/actions/runs/21118465779):
- Linux cache: ~1.8 MB (just registry metadata)
- macOS cache: ~330 MB (full compiled artifacts)

## Fix
Using `shared-key` completely replaces the automatic key, giving each target its own cache:
- `v0-rust-cross-x86_64-unknown-linux-musl-{hash}`
- `v0-rust-cross-aarch64-unknown-linux-musl-{hash}` 
- `v0-rust-cross-armv7-unknown-linux-musleabihf-{hash}`

## Test plan
- [ ] Merge and trigger workflow dispatch
- [ ] Verify each Linux target gets its own cache key in logs
- [ ] On second run, verify cache hits with larger sizes (~100MB+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized caching strategy for Rust cross-platform builds in CI/CD workflows.

* **Documentation**
  * Updated build documentation with caching configuration details and explanation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->