### PR TITLE
feat: add event-driven LMS updates via HTTP callbacks (#77)

### DIFF
--- a/lms-plugin/Plugin.pm
+++ b/lms-plugin/Plugin.pm
@@ -2,6 +2,7 @@ package Plugins::UnifiedHiFi::Plugin;
 
 # Unified Hi-Fi Control - LMS Plugin
 # Manages the unified-hifi-control bridge as a helper process
+# and pushes player state changes via HTTP callbacks (#77)
 
 use strict;
 use warnings;
@@ -11,6 +12,9 @@ use base qw(Slim::Plugin::Base);
 use Slim::Utils::Prefs;
 use Slim::Utils::Log;
 use Slim::Utils::Strings qw(string);
+use Slim::Control::Request;
+use Slim::Networking::SimpleAsyncHTTP;
+use JSON::XS;
 
 use Plugins::UnifiedHiFi::Helper;
 
@@ -45,10 +49,22 @@ sub initPlugin {
 
     $prefs->setValidate({ 'validator' => 'intlimit', 'low' => 1024, 'high' => 65535 }, 'port');
 
-    $log->info("Unified Hi-Fi Control plugin initialized");
+    # Subscribe to player events for push-based updates (#77)
+    # This reduces CPU usage by avoiding constant polling
+    Slim::Control::Request->subscribe(\&_playerNotify, [
+        ['playlist'],      # Track changes, play/pause/stop
+        ['mixer'],         # Volume changes
+        ['power'],         # Power on/off
+        ['client'],        # Player connect/disconnect
+    ]);
+
+    $log->info("Unified Hi-Fi Control plugin initialized (with event subscriptions)");
 }
 
 sub shutdownPlugin {
+    # Unsubscribe from player events
+    Slim::Control::Request->unsubscribe(\&_playerNotify);
+
     Plugins::UnifiedHiFi::Helper->stop;
     $log->info("Unified Hi-Fi Control plugin shutdown");
 }
@@ -58,6 +74,94 @@ sub getDisplayName {
 }
 
 sub playerMenu { }
+
+# Handle player state change notifications and push to bridge
+sub _playerNotify {
+    my $request = shift;
+    my $client  = $request->client() || return;
+
+    # Don't notify if helper isn't running
+    return unless Plugins::UnifiedHiFi::Helper->running();
+
+    my $playerId = $client->id();
+    my $command  = $request->getRequestString();
+
+    main::DEBUGLOG && $log->is_debug && $log->debug("Player event: $playerId -> $command");
+
+    # Build notification payload
+    my $state = _getPlayerState($client);
+    my $volume = $client->volume() // 50;
+
+    # Get now playing info
+    my $song = Slim::Player::Playlist::song($client);
+    my ($title, $artist, $album, $duration) = ('', '', '', 0);
+
+    if ($song) {
+        $title    = $song->title // '';
+        $artist   = $song->artistName // '';
+        $album    = $song->album ? $song->album->name : '';
+        $duration = $song->duration // 0;
+    }
+
+    # Get current position
+    my $position = Slim::Player::Source::songTime($client) // 0;
+
+    my $payload = {
+        player_id => $playerId,
+        state     => $state,
+        volume    => int($volume),
+        title     => $title,
+        artist    => $artist,
+        album     => $album,
+        position  => $position,
+        duration  => $duration,
+    };
+
+    # POST to bridge
+    _notifyBridge($payload);
+}
+
+# Get player state string from client
+sub _getPlayerState {
+    my $client = shift;
+
+    return 'stop' unless $client->power();
+
+    my $mode = Slim::Player::Source::playmode($client) // 'stop';
+
+    return 'play'  if $mode eq 'play';
+    return 'pause' if $mode eq 'pause';
+    return 'stop';
+}
+
+# Send notification to bridge via HTTP POST
+sub _notifyBridge {
+    my $payload = shift;
+
+    my $port = $prefs->get('port') || 8088;
+    my $url  = "http://localhost:$port/api/lms/notify";
+
+    my $json = encode_json($payload);
+
+    main::DEBUGLOG && $log->is_debug && $log->debug("Notifying bridge: $json");
+
+    Slim::Networking::SimpleAsyncHTTP->new(
+        sub {
+            my $response = shift;
+            if ($response->code != 200) {
+                $log->warn("Bridge notification failed: " . $response->code);
+            }
+        },
+        sub {
+            my ($response, $error) = @_;
+            # Don't log errors during normal operation - bridge may not be ready
+            main::DEBUGLOG && $log->is_debug && $log->debug("Bridge notification error: $error");
+        },
+        {
+            timeout => 2,
+        }
+    )->post($url, 'Content-Type' => 'application/json', $json);
+}
 
 1;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -329,6 +329,8 @@ mod server {
             .route("/lms/player/{player_id}", get(api::lms_player_handler))
             .route("/lms/control", post(api::lms_control_handler))
             .route("/lms/volume", post(api::lms_volume_handler))
+            // LMS push notifications (event-driven updates from plugin, fixes #77)
+            .route("/api/lms/notify", post(api::lms_notify_handler))
             // OpenHome routes
             .route("/openhome/status", get(api::openhome_status_handler))
             .route("/openhome/zones", get(api::openhome_zones_handler))

--- a/tests/fixtures/api_routes.txt
+++ b/tests/fixtures/api_routes.txt
@@ -48,6 +48,7 @@ GET /status
 GET /upnp/status
 GET /upnp/zones
 GET /zones
+POST /api/lms/notify
 POST /api/settings
 POST /control
 POST /hqp/detect


### PR DESCRIPTION
## Summary
- Implements push-based player state notifications from LMS plugin to bridge
- Reduces CPU usage by avoiding constant 2-second polling (fixes #77)
- Adds POST `/api/lms/notify` endpoint to receive real-time player state updates

## Test plan
- [x] Verify `cargo test` passes (4 new unit tests for notification handling)
- [x] Verify `cargo clippy` passes
- [x] Verify API contract test passes with new endpoint
- [ ] Manual testing: install plugin on LMS, verify bridge receives notifications on play/pause/volume
- [ ] Verify CPU usage reduction on RPi with multiple players

## Changes
- `src/adapters/lms.rs` - Add `handle_notification()` method and `LmsNotification` struct
- `src/api/mod.rs` - Add `lms_notify_handler` for POST `/api/lms/notify`
- `src/main.rs` - Register new route
- `lms-plugin/Plugin.pm` - Subscribe to player events and POST to bridge
- `tests/fixtures/api_routes.txt` - Add new endpoint to contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented push notification mechanism for real-time LMS playback updates
  * Added new API endpoint to receive and process live player events including state (play/pause/stop), volume, and track information
  * Enabled event-driven architecture for instant status synchronization instead of relying solely on polling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->