### PR TITLE
feat: organize config files into unified-hifi/ subdirectory (#76)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3649,6 +3649,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4254,6 +4267,7 @@ dependencies = [
  "sha2",
  "ssdp-client",
  "syn",
+ "tempfile",
  "thiserror 2.0.17",
  "tokio",
  "tokio-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,6 +133,7 @@ tokio-test = "0.4"
 serial_test = "3"
 syn = { version = "2", features = ["full", "parsing", "visit"] }
 walkdir = "2"
+tempfile = "3"
 
 [profile.release]
 lto = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,6 +91,9 @@ mod server {
         let config = config::load_config()?;
         tracing::info!("Configuration loaded, port: {}", config.port);
 
+        // Issue #76: Migrate config files to unified-hifi/ subdirectory
+        config::migrate_config_to_subdir();
+
         // Migrate Node.js config files if present (seamless Docker image swap)
         config::migrate_nodejs_configs();
 
@@ -215,8 +218,8 @@ mod server {
         tracing::info!("ZoneAggregator started");
 
         // Initialize Knob device store
-        let data_dir = config::get_data_dir();
-        let knob_store = knobs::KnobStore::new(data_dir);
+        // Issue #76: Uses config subdirectory for knobs.json
+        let knob_store = knobs::KnobStore::new();
         tracing::info!("Knob store initialized");
 
         // Clone Roon adapter for shutdown access (cheap - just Arc clones)

--- a/tests/client_harness.rs
+++ b/tests/client_harness.rs
@@ -189,7 +189,7 @@ async fn create_test_app() -> Router {
     let lms = Arc::new(LmsAdapter::new(bus.clone()));
     let openhome = Arc::new(OpenHomeAdapter::new(bus.clone()));
     let upnp = Arc::new(UPnPAdapter::new(bus.clone()));
-    let knob_store = KnobStore::new(std::env::temp_dir());
+    let knob_store = KnobStore::new();
 
     // Build startable adapters list
     let startable_adapters: Vec<Arc<dyn Startable>> =

--- a/tests/protocol_integration.rs
+++ b/tests/protocol_integration.rs
@@ -56,7 +56,7 @@ async fn create_test_app() -> Router {
     let lms = Arc::new(LmsAdapter::new(bus.clone()));
     let openhome = Arc::new(OpenHomeAdapter::new(bus.clone()));
     let upnp = Arc::new(UPnPAdapter::new(bus.clone()));
-    let knob_store = KnobStore::new(std::env::temp_dir());
+    let knob_store = KnobStore::new();
 
     // Build startable adapters list
     let startable_adapters: Vec<Arc<dyn Startable>> =


### PR DESCRIPTION
Closes #76

## Summary

- Organizes config files into a `unified-hifi/` subdirectory to reduce clutter
- Implements automatic migration on startup (moves files from config dir root to subdirectory)
- Adds backwards-compatible reading (checks subdirectory first, falls back to root for legacy files)
- Updates all adapters and modules to use new config file helpers

## New Structure

```
~/.config/unified-hifi-control/
└── unified-hifi/
    ├── app-settings.json
    ├── lms-config.json
    ├── hqp-config.json
    ├── hqp-zone-links.json
    ├── roon_state.json
    └── knobs.json
```

## Migration Safety

- Won't overwrite existing files in subdirectory
- Handles cross-device moves (copy + delete fallback)
- Also migrates `roon_state.json` from XDG_DATA_HOME on Linux (where data dir differs from config dir)

## Test Plan

- [x] All existing tests pass
- [x] New tests cover migration scenarios
- [x] Clippy passes with no new warnings
- [x] TDD approach followed per AGENTS.md

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration files are now organized in a unified subdirectory with automatic migration from legacy locations.
  * Added backward-compatible fallback to support existing config file locations.

* **Chores**
  * Simplified knob store initialization to remove explicit directory parameters.
  * Refactored configuration file path resolution for centralized management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->