### PR TITLE
More LMS plugin cleanup

### DIFF
--- a/lms-plugin/HTML/EN/plugins/UnifiedHiFi/settings/basic.html
+++ b/lms-plugin/HTML/EN/plugins/UnifiedHiFi/settings/basic.html
@@ -5,13 +5,11 @@
     <!-- Binary download status -->
     [% IF binaryStatus == 'not_downloaded' %]
     <div class="prefDesc" style="padding: 10px; background: #fff3cd; border: 1px solid #ffc107; border-radius: 4px; margin-bottom: 15px;">
-        <b>&#9888; Binary Required:</b> The bridge binary for <code>[% binaryPlatform %]</code> (~75 MB)
-        will be downloaded when you click "Start Bridge".
+        [% "PLUGIN_UNIFIED_HIFI_DOWNLOAD_NEEDED" | string(binaryPlatform) %]
     </div>
     [% ELSIF binaryStatus == 'downloading' %]
     <div class="prefDesc" style="padding: 10px; background: #cce5ff; border: 1px solid #007bff; border-radius: 4px; margin-bottom: 15px;">
-        <b>&#8635; Downloading:</b> Binary for <code>[% binaryPlatform %]</code> is being downloaded...
-        <br/><small>This may take a few minutes. Page will refresh automatically.</small>
+        [% "PLUGIN_UNIFIED_HIFI_DOWNLOADING" | string(binaryPlatform) %]
         <script>setTimeout(function() { location.reload(); }, 5000);</script>
     </div>
     [% END %]
@@ -46,34 +44,6 @@
         <label for="pref_autorun">Enable auto-start</label>
     [% END %]
 
-    [% WRAPPER setting title="PLUGIN_UNIFIED_HIFI_PORT" desc="PLUGIN_UNIFIED_HIFI_PORT_DESC" %]
-        <input type="number" name="pref_port" id="pref_port"
-               value="[% prefs.port || 8088 %]" min="1024" max="65535"
-               style="width: 80px;" />
-    [% END %]
-
-    [% IF binaries.size > 1; WRAPPER setting title="PLUGIN_UNIFIED_HIFI_BINARY" desc="PLUGIN_UNIFIED_HIFI_BINARY_DESC" %]
-        <select name="pref_bin" id="pref_bin">
-            [% FOREACH bin IN binaries %]
-                <option value="[% bin %]"
-                        [% IF prefs.bin == bin %]selected[% END %]>
-                    [% bin %]
-                </option>
-            [% END %]
-        </select>
-    [% END; END %]
-
-    [% WRAPPER setting title="PLUGIN_UNIFIED_HIFI_LOGLEVEL" desc="PLUGIN_UNIFIED_HIFI_LOGLEVEL_DESC" %]
-        <select name="pref_loglevel" id="pref_loglevel">
-            [% FOREACH level IN loglevels %]
-                <option value="[% level %]"
-                        [% IF prefs.loglevel == level %]selected[% END %]>
-                    [% level %]
-                </option>
-            [% END %]
-        </select>
-    [% END %]
-
 <!-- Knob Configuration Section -->
     <hr/>
     [% WRAPPER setting title="PLUGIN_UNIFIED_HIFI_KNOB" desc="" %]
@@ -94,7 +64,8 @@
             </tr>
             [% FOREACH knob = knobStatus.knobs %]
                 <tr>
-                    <td style="vertical-align: middle; padding-right: 10px">[% knob.name | html %]</td>
+                    [% knobName = knob.name || "The Knob" %]
+                    <td style="vertical-align: middle; padding-right: 10px">[% knobName | html %]</td>
                     <td style="vertical-align: middle; padding-right: 10px">[% knob.knob_id | html %]</td>
                     <td style="vertical-align: middle; padding-right: 10px">[% knob.version | html %]</td>
                     <td style="vertical-align: middle; padding-right: 10px">
@@ -106,7 +77,7 @@
                         [% END %]
                     </td>
                     <td>
-                        <input type="submit" value="[% "EDIT" | string %] &#8594;" onclick="window.open('[% webUrl %]/knobs/[% knob.knob_id | uri %]', '_blank'); return false;" />
+                        <input type="submit" value="[% "EDIT" | string %] &#8594;" onclick="window.open('[% webUrl %]/knobs', '_blank'); return false;" />
                     </td>
                 </tr>
             [% END %]

--- a/lms-plugin/Plugin.pm
+++ b/lms-plugin/Plugin.pm
@@ -26,8 +26,6 @@ my $prefs = preferences('plugin.unifiedhifi');
 $prefs->init({
     autorun  => 1,
     port     => 8088,
-    bin      => undef,
-    loglevel => 'info',
 });
 
 sub initPlugin {

--- a/lms-plugin/strings.txt
+++ b/lms-plugin/strings.txt
@@ -16,12 +16,6 @@ PLUGIN_UNIFIED_HIFI_START_BRIDGE
 PLUGIN_UNIFIED_HIFI_STOP_BRIDGE
 	EN	Stop Bridge
 
-PLUGIN_UNIFIED_HIFI_PORT
-	EN	Bridge port
-
-PLUGIN_UNIFIED_HIFI_PORT_DESC
-	EN	HTTP port for the bridge web UI and API (default: 8088). Change if conflicting with HQPlayer.
-
 PLUGIN_UNIFIED_HIFI_BINARY
 	EN	Binary
 
@@ -36,12 +30,6 @@ PLUGIN_UNIFIED_HIFI_STOPPED
 
 PLUGIN_UNIFIED_HIFI_OPENUI
 	EN	Open Web UI
-
-PLUGIN_UNIFIED_HIFI_LOGLEVEL
-	EN	Log level
-
-PLUGIN_UNIFIED_HIFI_LOGLEVEL_DESC
-	EN	Set the logging verbosity for troubleshooting.
 
 PLUGIN_UNIFIED_HIFI_STATUS
 	EN	Status
@@ -63,3 +51,9 @@ PLUGIN_UNIFIED_HIFI_KNOB_BATTERY_CHARGING
 
 PLUGIN_UNIFIED_HIFI_KNOB_ID
 	EN	ID
+
+PLUGIN_UNIFIED_HIFI_DOWNLOAD_NEEDED
+	EN	<b>&#9888; Binary Required:</b> The bridge binary for <code>%s</code> will be downloaded when you click "Start Bridge".
+
+PLUGIN_UNIFIED_HIFI_DOWNLOADING
+	EN	<b>&#8635; Downloading:</b> Binary for <code>%s</code> is being downloaded... This may take a few minutes. Page will refresh automatically.


### PR DESCRIPTION
* Remove support for different log levels: The bridge helper is set up to pipe all output to the null device. Therefore there's no reason to have a configuration for the log level. If we wanted to support logging from the bridge we could use the plugin's `plugin.unifiedhifi` logging configuration and map this to the bridge's levels.
* Remove port setting for the bridge binary. This would rarely be needed at all. Leave the pref there, so people in dire could edit the configuration file to change port.
* Remove support for multiple binaries. It wasn't really supporting more than one anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Simplified settings UI by removing port, binary selection, and log level options.
  * Added localized messages for binary download status and live download progress.
  * Knob editor now opens the knobs management list instead of individual knob detail pages.
  * Knobs without a name display a default label ("The Knob") in the list.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->