### PR TITLE
fix(lms): add configurable logging and bundle web assets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -776,8 +776,8 @@ jobs:
           cp ../binary/${{ matrix.binary_name }} Bin/${{ matrix.bundled_name }}
           chmod +x Bin/${{ matrix.bundled_name }}
 
-          # Copy web assets to public directory
-          cp -r ../web-assets public
+          # Copy web assets to Bin/public (Dioxus expects public/ next to binary)
+          cp -r ../web-assets Bin/public
 
           # Create ZIP with everything
           zip -r ../dist/lms-unified-hifi-control-${{ steps.version.outputs.version }}-${{ matrix.platform }}.zip . \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,9 @@ jobs:
         id: decide
         env:
           EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action }}
+          # The label that triggered a 'labeled' event (empty for other events)
+          LABEL_ADDED: ${{ github.event.label.name }}
           # Labels (only present on PRs)
           HAS_LABEL_ALL: ${{ contains(github.event.pull_request.labels.*.name, 'build:all') }}
           HAS_LABEL_LINUX_ARM: ${{ contains(github.event.pull_request.labels.*.name, 'build:linux-arm') }}
@@ -102,6 +105,27 @@ jobs:
           INPUT_DOCKER: ${{ inputs.build_docker }}
           INPUT_LINUX_PACKAGES: ${{ inputs.build_linux_packages }}
         run: |
+          # Skip if triggered by a non-build label (e.g., arch, coderabbit)
+          # Only the 'build-me' label should trigger builds via labeled event
+          if [[ "$EVENT_ACTION" == "labeled" && "$LABEL_ADDED" != "build-me" ]]; then
+            echo "::notice::Skipping: labeled event for '$LABEL_ADDED' (only 'build-me' triggers builds)"
+            echo "### ⏭️ Skipped" >> $GITHUB_STEP_SUMMARY
+            echo "Label \`$LABEL_ADDED\` added - only \`build-me\` triggers builds." >> $GITHUB_STEP_SUMMARY
+            # Set all outputs to false/empty so dependent jobs skip
+            echo "is_release=false" >> $GITHUB_OUTPUT
+            echo "build_linux_arm=false" >> $GITHUB_OUTPUT
+            echo "build_macos=false" >> $GITHUB_OUTPUT
+            echo "build_windows=false" >> $GITHUB_OUTPUT
+            echo "build_lms=false" >> $GITHUB_OUTPUT
+            echo "build_synology=false" >> $GITHUB_OUTPUT
+            echo "build_qnap=false" >> $GITHUB_OUTPUT
+            echo "build_qnap_arm=false" >> $GITHUB_OUTPUT
+            echo "build_docker=false" >> $GITHUB_OUTPUT
+            echo "build_linux_packages=false" >> $GITHUB_OUTPUT
+            echo "lms_matrix=[]" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
           # Helper function
           should_build() {
             [[ "$EVENT_NAME" == "release" ]] && return 0
@@ -290,7 +314,7 @@ jobs:
             echo "|-------|--------------|" >> $GITHUB_STEP_SUMMARY
             printf "%s" "$TABLE_ROWS" >> $GITHUB_STEP_SUMMARY
           else
-            echo "_No optional builds enabled. Add labels like \`build:lms\`, \`build:macos\`, etc._" >> $GITHUB_STEP_SUMMARY
+            echo "_No optional builds enabled. Add \`build:*\` labels then \`build-me\` to trigger._" >> $GITHUB_STEP_SUMMARY
           fi
 
   # =============================================================================
@@ -1498,7 +1522,7 @@ jobs:
             echo "| $name | $size |" >> $GITHUB_STEP_SUMMARY
           done || echo "| (none) | - |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "_Add labels to enable optional builds: build:lms, build:synology, build:qnap-arm, build:linux-arm, build:macos, build:windows, build:all_" >> $GITHUB_STEP_SUMMARY
+          echo "_Add \`build:*\` labels to configure builds, then add \`build-me\` to trigger. Labels: build:lms, build:synology, build:qnap-arm, build:linux-arm, build:macos, build:windows, build:all_" >> $GITHUB_STEP_SUMMARY
 
   # =============================================================================
   # PR Comment with Artifact Links

--- a/docs/gh-release.md
+++ b/docs/gh-release.md
@@ -147,9 +147,22 @@ The comment is updated on each push, so you always see the latest artifacts.
 
 ## Label Triggers
 
-Adding a label to a PR triggers a new workflow run (via the `labeled` event type). This means:
-- Add `build:lms-macos` → new run starts with LMS + macOS builds enabled
-- No need to push a commit just to trigger a build with different labels
+Labels control builds in two ways:
+
+**`build:*` labels** control WHAT gets built (see table above).
+
+**`build-me` label** controls WHEN to re-trigger builds:
+- Adding any `build:*` label does NOT trigger a new workflow run
+- Only the `build-me` label triggers builds via the labeled event
+- To re-trigger: remove `build-me`, then add it again
+
+**Workflow:**
+1. Add `build:lms` label to enable LMS builds
+2. Add `build-me` label to trigger the build
+3. Build runs, sees `build:lms` label, builds LMS
+4. To re-run with same labels: remove `build-me`, add it back
+
+This prevents spurious builds from non-build labels (arch, coderabbit, etc.).
 
 ## Caching Strategies
 

--- a/lms-plugin/HTML/EN/plugins/UnifiedHiFi/settings/basic.html
+++ b/lms-plugin/HTML/EN/plugins/UnifiedHiFi/settings/basic.html
@@ -74,6 +74,16 @@
         </select>
     [% END %]
 
+    [% WRAPPER setting title="PLUGIN_UNIFIED_HIFI_LOGGING" desc="PLUGIN_UNIFIED_HIFI_LOGGING_DESC" %]
+        <input type="checkbox" name="pref_logging" id="pref_logging"
+               value="1" [% IF prefs.logging %]checked[% END %] />
+        <label for="pref_logging">[% "PLUGIN_UNIFIED_HIFI_LOGGING_ENABLE" | string %]</label>
+        &nbsp;&nbsp;
+        <input type="checkbox" name="pref_eraselog" id="pref_eraselog"
+               value="1" [% IF prefs.eraselog %]checked[% END %] />
+        <label for="pref_eraselog">[% "PLUGIN_UNIFIED_HIFI_ERASELOG" | string %]</label>
+    [% END %]
+
 <!-- Knob Configuration Section -->
     <hr/>
     [% WRAPPER setting title="PLUGIN_UNIFIED_HIFI_KNOB" desc="" %]

--- a/lms-plugin/HTML/EN/plugins/UnifiedHiFi/settings/basic.html
+++ b/lms-plugin/HTML/EN/plugins/UnifiedHiFi/settings/basic.html
@@ -5,13 +5,11 @@
     <!-- Binary download status -->
     [% IF binaryStatus == 'not_downloaded' %]
     <div class="prefDesc" style="padding: 10px; background: #fff3cd; border: 1px solid #ffc107; border-radius: 4px; margin-bottom: 15px;">
-        <b>&#9888; Binary Required:</b> The bridge binary for <code>[% binaryPlatform %]</code> (~75 MB)
-        will be downloaded when you click "Start Bridge".
+        [% "PLUGIN_UNIFIED_HIFI_DOWNLOAD_NEEDED" | string(binaryPlatform) %]
     </div>
     [% ELSIF binaryStatus == 'downloading' %]
     <div class="prefDesc" style="padding: 10px; background: #cce5ff; border: 1px solid #007bff; border-radius: 4px; margin-bottom: 15px;">
-        <b>&#8635; Downloading:</b> Binary for <code>[% binaryPlatform %]</code> is being downloaded...
-        <br/><small>This may take a few minutes. Page will refresh automatically.</small>
+        [% "PLUGIN_UNIFIED_HIFI_DOWNLOADING" | string(binaryPlatform) %]
         <script>setTimeout(function() { location.reload(); }, 5000);</script>
     </div>
     [% END %]
@@ -116,7 +114,7 @@
                         [% END %]
                     </td>
                     <td>
-                        <input type="submit" value="[% "EDIT" | string %] &#8594;" onclick="window.open('[% webUrl %]/knobs/[% knob.knob_id | uri %]', '_blank'); return false;" />
+                        <input type="submit" value="[% "EDIT" | string %] &#8594;" onclick="window.open('[% webUrl %]/knobs', '_blank'); return false;" />
                     </td>
                 </tr>
             [% END %]

--- a/lms-plugin/Helper.pm
+++ b/lms-plugin/Helper.pm
@@ -589,6 +589,7 @@ sub stop {
     Slim::Utils::Timers::killTimers($class, \&_resetRestarts);
 
     $helperProc && $helperProc->die;
+    $helperProc && $helperProc->wait;  # Reap zombie process
     $restarts = 0;
 }
 

--- a/lms-plugin/Plugin.pm
+++ b/lms-plugin/Plugin.pm
@@ -28,6 +28,8 @@ $prefs->init({
     port     => 8088,
     bin      => undef,
     loglevel => 'info',
+    logging  => 0,      # Write bridge output to log file (disabled by default)
+    eraselog => 1,      # Clear log file on restart (prevents unbounded growth)
 });
 
 sub initPlugin {

--- a/lms-plugin/strings.txt
+++ b/lms-plugin/strings.txt
@@ -43,6 +43,18 @@ PLUGIN_UNIFIED_HIFI_LOGLEVEL
 PLUGIN_UNIFIED_HIFI_LOGLEVEL_DESC
 	EN	Set the logging verbosity for troubleshooting.
 
+PLUGIN_UNIFIED_HIFI_LOGGING
+	EN	Bridge logging
+
+PLUGIN_UNIFIED_HIFI_LOGGING_DESC
+	EN	Write bridge output to a log file for debugging.
+
+PLUGIN_UNIFIED_HIFI_LOGGING_ENABLE
+	EN	Enable logging to file
+
+PLUGIN_UNIFIED_HIFI_ERASELOG
+	EN	Clear log on restart
+
 PLUGIN_UNIFIED_HIFI_STATUS
 	EN	Status
 

--- a/lms-plugin/strings.txt
+++ b/lms-plugin/strings.txt
@@ -75,3 +75,9 @@ PLUGIN_UNIFIED_HIFI_KNOB_BATTERY_CHARGING
 
 PLUGIN_UNIFIED_HIFI_KNOB_ID
 	EN	ID
+
+PLUGIN_UNIFIED_HIFI_DOWNLOAD_NEEDED
+	EN	<b>&#9888; Binary Required:</b> The bridge binary for <code>%s</code> will be downloaded when you click "Start Bridge".
+
+PLUGIN_UNIFIED_HIFI_DOWNLOADING
+	EN	<b>&#8635; Downloading:</b> Binary for <code>%s</code> is being downloaded... This may take a few minutes. Page will refresh automatically.


### PR DESCRIPTION
## Summary
- Bundle web assets in `Bin/public/` so Dioxus finds assets relative to binary
- Use exec wrapper for proper PID tracking (stop works correctly)
- Add macOS xattr fix for Gatekeeper quarantine
- Add logging pref (disabled by default) - writes to LMS log dir
- Add eraselog pref (enabled by default) - clears log on restart
- Pass `LMS_UNIFIEDHIFI_STARTED` env var for auto-enable

Related to #62

## Test plan
- [ ] Verify LMS plugin starts bridge correctly on macOS
- [ ] Verify stop command terminates bridge process
- [ ] Verify logging prefs work when enabled
- [ ] Verify web UI assets load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added logging controls in UnifiedHiFi: enable bridge logging and option to erase log on restart; default preferences introduced.

* **Localization**
  * New English strings for logging UI and bridge download/status messages.

* **Behavior Change**
  * Knob "Edit" now opens the general knobs page (/knobs).
  * CI labeling updated: build:* labels select what to build; build-me controls triggering. Optional builds now give clearer guidance and web assets are copied to Bin/public.

* **Documentation**
  * Release notes updated with the two-tier labeling model and usage guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->