### PR TITLE
fix(lms): remove logging settings that keep resetting

### DIFF
--- a/lms-plugin/HTML/EN/plugins/UnifiedHiFi/settings/basic.html
+++ b/lms-plugin/HTML/EN/plugins/UnifiedHiFi/settings/basic.html
@@ -61,27 +61,6 @@
         </select>
     [% END; END %]
 
-    [% WRAPPER setting title="PLUGIN_UNIFIED_HIFI_LOGLEVEL" desc="PLUGIN_UNIFIED_HIFI_LOGLEVEL_DESC" %]
-        <select name="pref_loglevel" id="pref_loglevel">
-            [% FOREACH level IN loglevels %]
-                <option value="[% level %]"
-                        [% IF prefs.loglevel == level %]selected[% END %]>
-                    [% level %]
-                </option>
-            [% END %]
-        </select>
-    [% END %]
-
-    [% WRAPPER setting title="PLUGIN_UNIFIED_HIFI_LOGGING" desc="PLUGIN_UNIFIED_HIFI_LOGGING_DESC" %]
-        <input type="checkbox" name="pref_logging" id="pref_logging"
-               value="1" [% IF prefs.logging %]checked[% END %] />
-        <label for="pref_logging">[% "PLUGIN_UNIFIED_HIFI_LOGGING_ENABLE" | string %]</label>
-        &nbsp;&nbsp;
-        <input type="checkbox" name="pref_eraselog" id="pref_eraselog"
-               value="1" [% IF prefs.eraselog %]checked[% END %] />
-        <label for="pref_eraselog">[% "PLUGIN_UNIFIED_HIFI_ERASELOG" | string %]</label>
-    [% END %]
-
 <!-- Knob Configuration Section -->
     <hr/>
     [% WRAPPER setting title="PLUGIN_UNIFIED_HIFI_KNOB" desc="" %]

--- a/lms-plugin/Plugin.pm
+++ b/lms-plugin/Plugin.pm
@@ -27,9 +27,6 @@ $prefs->init({
     autorun  => 1,
     port     => 8088,
     bin      => undef,
-    loglevel => 'info',
-    logging  => 0,      # Write bridge output to log file (disabled by default)
-    eraselog => 1,      # Clear log file on restart (prevents unbounded growth)
 });
 
 sub initPlugin {

--- a/lms-plugin/Settings.pm
+++ b/lms-plugin/Settings.pm
@@ -25,9 +25,7 @@ sub page {
 }
 
 sub prefs {
-    return ($prefs, qw(
-        autorun port bin loglevel
-    ));
+    return ($prefs, qw(autorun port bin));
 }
 
 sub handler {
@@ -50,10 +48,6 @@ sub handler {
 
         # Check if binary changed
         elsif (($params->{'pref_bin'} // '') ne ($prefs->get('bin') // '')) {
-            $needsRestart = 1;
-        }
-
-        elsif (($params->{'pref_loglevel'} // 'info') ne ($prefs->get('loglevel') // 'info')) {
             $needsRestart = 1;
         }
 
@@ -92,7 +86,6 @@ sub beforeRender {
     # Single binary per platform now - dropdown only shows if size > 1 (never)
     my $platformBinary = Plugins::UnifiedHiFi::Helper::BINARY_MAP->{Plugins::UnifiedHiFi::Helper->detectPlatform()};
     $params->{'binaries'}   = $platformBinary ? [$platformBinary] : [];
-    $params->{'loglevels'}  = ['error', 'warn', 'info', 'debug'];
 
     # Binary download status
     $params->{'binaryStatus'}   = Plugins::UnifiedHiFi::Helper->binaryStatus();

--- a/lms-plugin/strings.txt
+++ b/lms-plugin/strings.txt
@@ -37,24 +37,6 @@ PLUGIN_UNIFIED_HIFI_STOPPED
 PLUGIN_UNIFIED_HIFI_OPENUI
 	EN	Open Web UI
 
-PLUGIN_UNIFIED_HIFI_LOGLEVEL
-	EN	Log level
-
-PLUGIN_UNIFIED_HIFI_LOGLEVEL_DESC
-	EN	Set the logging verbosity for troubleshooting.
-
-PLUGIN_UNIFIED_HIFI_LOGGING
-	EN	Bridge logging
-
-PLUGIN_UNIFIED_HIFI_LOGGING_DESC
-	EN	Write bridge output to a log file for debugging.
-
-PLUGIN_UNIFIED_HIFI_LOGGING_ENABLE
-	EN	Enable logging to file
-
-PLUGIN_UNIFIED_HIFI_ERASELOG
-	EN	Clear log on restart
-
 PLUGIN_UNIFIED_HIFI_STATUS
 	EN	Status
 


### PR DESCRIPTION
## Summary
Remove the logging settings (loglevel, logging-to-file, eraselog) that keep resetting to defaults.

Bridge output now goes to /dev/null. Users can configure logging via the bridge's web UI if needed.

## Changes
- Remove `loglevel`, `logging`, `eraselog` prefs from Plugin.pm
- Remove logging UI sections from settings page
- Remove LOG_LEVEL env var (bridge uses its own default)
- Remove logging-to-file logic from Helper.pm
- Remove related strings

## Test plan
- [ ] Verify plugin settings page no longer shows logging options
- [ ] Verify bridge starts correctly without logging prefs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed log level and logging control options from the settings page
  * Updated logging output behavior to use default system handling instead of custom file writing

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->