### PR TITLE
feat(packaging): Add Arch Linux/AUR support

### DIFF
--- a/build/arch/PKGBUILD
+++ b/build/arch/PKGBUILD
@@ -16,10 +16,10 @@ conflicts=("${_pkgname}")
 backup=('etc/unified-hifi-control/config.json')
 install="${_pkgname}.install"
 
-# Architecture-specific binaries
-source_x86_64=("${_pkgname}-${pkgver}-x86_64::${url}/releases/download/v${pkgver}/unified-hifi-linux-x64")
-source_aarch64=("${_pkgname}-${pkgver}-aarch64::${url}/releases/download/v${pkgver}/unified-hifi-linux-arm64")
-source_armv7h=("${_pkgname}-${pkgver}-armv7h::${url}/releases/download/v${pkgver}/unified-hifi-linux-armv7")
+# Architecture-specific binaries (renamed to 'binary' for $CARCH-agnostic reference)
+source_x86_64=("binary::${url}/releases/download/v${pkgver}/unified-hifi-linux-x64")
+source_aarch64=("binary::${url}/releases/download/v${pkgver}/unified-hifi-linux-arm64")
+source_armv7h=("binary::${url}/releases/download/v${pkgver}/unified-hifi-linux-armv7")
 
 # Web assets (same for all architectures)
 source=("web-assets-${pkgver}.tar.gz::${url}/releases/download/v${pkgver}/web-assets.tar.gz"
@@ -41,8 +41,7 @@ package() {
     cd "${srcdir}"
 
     # Install binary
-    install -Dm755 "${_pkgname}-${pkgver}-${CARCH}" \
-        "${pkgdir}/usr/bin/${_pkgname}"
+    install -Dm755 binary "${pkgdir}/usr/bin/${_pkgname}"
 
     # Install web assets
     install -dm755 "${pkgdir}/usr/share/${_pkgname}"

--- a/build/arch/PKGBUILD
+++ b/build/arch/PKGBUILD
@@ -1,0 +1,66 @@
+# Maintainer: Muness Castle <muness@gmail.com>
+# AUR Package: unified-hifi-control-bin
+# Pre-built binary package - downloads from GitHub releases
+
+pkgname=unified-hifi-control-bin
+_pkgname=unified-hifi-control
+pkgver=3.1.0
+pkgrel=1
+pkgdesc="Source-agnostic hi-fi control bridge for Roon, LMS, HQPlayer, and hardware surfaces"
+arch=('x86_64' 'aarch64' 'armv7h')
+url="https://github.com/open-horizon-labs/unified-hifi-control"
+license=('custom:PolyForm-Noncommercial-1.0.0')
+depends=()
+provides=("${_pkgname}")
+conflicts=("${_pkgname}")
+backup=('etc/unified-hifi-control/config.json')
+install="${_pkgname}.install"
+
+# Architecture-specific binaries
+source_x86_64=("${_pkgname}-${pkgver}-x86_64::${url}/releases/download/v${pkgver}/unified-hifi-linux-x64")
+source_aarch64=("${_pkgname}-${pkgver}-aarch64::${url}/releases/download/v${pkgver}/unified-hifi-linux-arm64")
+source_armv7h=("${_pkgname}-${pkgver}-armv7h::${url}/releases/download/v${pkgver}/unified-hifi-linux-armv7")
+
+# Web assets (same for all architectures)
+source=("web-assets-${pkgver}.tar.gz::${url}/releases/download/v${pkgver}/web-assets.tar.gz"
+        "${_pkgname}.service"
+        "${_pkgname}.install"
+        "LICENSE::https://polyformproject.org/wp-content/uploads/2019/06/PolyForm-Noncommercial-1.0.0.txt")
+
+# Checksums - update these for each release
+# Run: updpkgsums
+sha256sums=('SKIP'  # web-assets
+            'SKIP'  # service file
+            'SKIP'  # install script
+            'SKIP') # license
+sha256sums_x86_64=('SKIP')
+sha256sums_aarch64=('SKIP')
+sha256sums_armv7h=('SKIP')
+
+package() {
+    cd "${srcdir}"
+
+    # Install binary
+    install -Dm755 "${_pkgname}-${pkgver}-${CARCH}" \
+        "${pkgdir}/usr/bin/${_pkgname}"
+
+    # Install web assets
+    install -dm755 "${pkgdir}/usr/share/${_pkgname}"
+    cp -r public "${pkgdir}/usr/share/${_pkgname}/"
+
+    # Install systemd service
+    install -Dm644 "${_pkgname}.service" \
+        "${pkgdir}/usr/lib/systemd/system/${_pkgname}.service"
+
+    # Create config directory
+    install -dm755 "${pkgdir}/etc/${_pkgname}"
+
+    # Create state directory (for runtime data)
+    install -dm755 "${pkgdir}/var/lib/${_pkgname}"
+
+    # Symlink web assets to state directory (where service WorkingDirectory expects them)
+    ln -s "/usr/share/${_pkgname}/public" "${pkgdir}/var/lib/${_pkgname}/public"
+
+    # Install license
+    install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+}

--- a/build/arch/PKGBUILD
+++ b/build/arch/PKGBUILD
@@ -1,4 +1,5 @@
 # Maintainer: Muness Castle <muness@gmail.com>
+# Contributor: Open Horizons <muness@openhorizons.me>
 # AUR Package: unified-hifi-control-bin
 # Pre-built binary package - downloads from GitHub releases
 

--- a/build/arch/unified-hifi-control.install
+++ b/build/arch/unified-hifi-control.install
@@ -1,0 +1,35 @@
+# Arch Linux install script for unified-hifi-control
+
+post_install() {
+    echo ":: Unified Hi-Fi Control installed"
+    echo ":: To enable and start the service:"
+    echo "   systemctl enable --now unified-hifi-control"
+    echo ":: Web UI available at http://localhost:8088"
+    echo ":: Configuration: /etc/unified-hifi-control/"
+}
+
+post_upgrade() {
+    echo ":: Unified Hi-Fi Control upgraded"
+    if systemctl is-active --quiet unified-hifi-control; then
+        echo ":: Restarting service..."
+        systemctl restart unified-hifi-control
+    fi
+}
+
+pre_remove() {
+    if systemctl is-active --quiet unified-hifi-control; then
+        echo ":: Stopping unified-hifi-control service..."
+        systemctl stop unified-hifi-control
+    fi
+    if systemctl is-enabled --quiet unified-hifi-control 2>/dev/null; then
+        echo ":: Disabling unified-hifi-control service..."
+        systemctl disable unified-hifi-control
+    fi
+}
+
+post_remove() {
+    echo ":: Unified Hi-Fi Control removed"
+    echo ":: Configuration files in /etc/unified-hifi-control/ were preserved"
+    echo ":: State data in /var/lib/unified-hifi-control/ was preserved"
+    echo ":: Remove manually if no longer needed"
+}

--- a/build/arch/unified-hifi-control.service
+++ b/build/arch/unified-hifi-control.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Unified Hi-Fi Control Bridge
-Documentation=https://github.com/cloud-atlas-ai/unified-hifi-control
+Documentation=https://github.com/open-horizon-labs/unified-hifi-control
 After=network-online.target
 Wants=network-online.target
 
@@ -8,10 +8,14 @@ Wants=network-online.target
 Type=simple
 WorkingDirectory=/var/lib/unified-hifi-control
 ExecStart=/usr/bin/unified-hifi-control
+Restart=always
+RestartSec=10
+
+# Environment
+Environment=PORT=8088
 Environment=CONFIG_DIR=/etc/unified-hifi-control
 Environment=DATA_DIR=/var/lib/unified-hifi-control
-Restart=on-failure
-RestartSec=5
+Environment=RUST_LOG=info
 
 # Run as dedicated user (created dynamically)
 DynamicUser=yes
@@ -26,6 +30,11 @@ PrivateTmp=true
 ProtectKernelTunables=true
 ProtectControlGroups=true
 RestrictNamespaces=true
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=unified-hifi-control
 
 [Install]
 WantedBy=multi-user.target

--- a/docs/arch-linux.md
+++ b/docs/arch-linux.md
@@ -1,0 +1,145 @@
+# Arch Linux Installation
+
+Unified Hi-Fi Control is available for Arch Linux and Arch-based distributions (RoPieee, AudioLinux, etc.).
+
+## Installation from AUR
+
+### Using an AUR helper (recommended)
+
+```bash
+# Using yay
+yay -S unified-hifi-control-bin
+
+# Using paru
+paru -S unified-hifi-control-bin
+```
+
+### Manual installation
+
+```bash
+git clone https://aur.archlinux.org/unified-hifi-control-bin.git
+cd unified-hifi-control-bin
+makepkg -si
+```
+
+## Post-Installation
+
+### Start the service
+
+```bash
+# Enable and start the service
+sudo systemctl enable --now unified-hifi-control
+
+# Check status
+sudo systemctl status unified-hifi-control
+
+# View logs
+journalctl -u unified-hifi-control -f
+```
+
+### Access the Web UI
+
+Open your browser to: **http://localhost:8088**
+
+## Configuration
+
+Configuration files are stored in `/etc/unified-hifi-control/`.
+
+### Environment Variables
+
+The systemd service supports these environment variables (edit the service file or use a drop-in):
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PORT` | `8088` | HTTP server port |
+| `CONFIG_DIR` | `/etc/unified-hifi-control` | Configuration directory |
+| `DATA_DIR` | `/var/lib/unified-hifi-control` | State/data directory |
+| `RUST_LOG` | `info` | Log level (trace, debug, info, warn, error) |
+
+To customize, create a drop-in:
+
+```bash
+sudo systemctl edit unified-hifi-control
+```
+
+Add your overrides:
+
+```ini
+[Service]
+Environment=PORT=9000
+Environment=RUST_LOG=debug
+```
+
+## File Locations
+
+| Path | Description |
+|------|-------------|
+| `/usr/bin/unified-hifi-control` | Binary |
+| `/usr/share/unified-hifi-control/public/` | Web assets |
+| `/etc/unified-hifi-control/` | Configuration |
+| `/var/lib/unified-hifi-control/` | Runtime state, Roon tokens |
+| `/usr/lib/systemd/system/unified-hifi-control.service` | Systemd service |
+
+## Uninstallation
+
+```bash
+# Using yay
+yay -Rns unified-hifi-control-bin
+
+# Manual
+sudo pacman -Rns unified-hifi-control-bin
+```
+
+Configuration and state directories are preserved. Remove manually if no longer needed:
+
+```bash
+sudo rm -rf /etc/unified-hifi-control
+sudo rm -rf /var/lib/unified-hifi-control
+```
+
+## Building from Source
+
+If you prefer to build from source instead of using the binary package:
+
+### Prerequisites
+
+```bash
+# Install Rust
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+rustup target add wasm32-unknown-unknown
+
+# Install Dioxus CLI
+cargo install dioxus-cli
+
+# Install Node.js (for Tailwind CSS)
+sudo pacman -S nodejs npm
+```
+
+### Build
+
+```bash
+git clone https://github.com/open-horizon-labs/unified-hifi-control.git
+cd unified-hifi-control
+git checkout v3
+
+# Build CSS
+make css
+
+# Build web assets
+dx build --release --platform web --features web
+
+# Build server binary
+cargo build --release
+```
+
+The binary will be at `target/release/unified-hifi-control`.
+
+## RoPieee / AudioLinux Integration
+
+For RoPieee and AudioLinux developers: this package follows standard Arch packaging conventions. The PKGBUILD can be adapted for inclusion in your distribution's package repository.
+
+Key considerations:
+- Binary is statically linked (musl) with no runtime dependencies
+- Web assets are required at `/usr/share/unified-hifi-control/public/` (symlinked to state dir)
+- Systemd service uses `DynamicUser=yes` for security
+- Configuration persists in `/etc/unified-hifi-control/`


### PR DESCRIPTION
## Summary

Adds Arch Linux packaging support for RoPieee, AudioLinux, and other Arch-based distributions.

- PKGBUILD for binary distribution (x86_64, aarch64, armv7h)
- Install script with service management hooks
- Documentation for installation and configuration
- Updated systemd service with logging and restart config

## Tasks

- [x] Verify PKGBUILD syntax with `namcap` (passes clean)
- [x] Verify `.SRCINFO` generates correctly
- [ ] Test package build with `makepkg -si` on Arch VM (blocked: v3.1.0 not released yet)
- [ ] Verify checksums once v3.1.0 is released
- [ ] Submit to AUR after release
- [ ] Notify RoPieee maintainer (Harry/spockfish)
- [ ] Notify AudioLinux maintainer

## Files

| File | Purpose |
|------|---------|
| `build/arch/PKGBUILD` | AUR package build script |
| `build/arch/unified-hifi-control.install` | Post-install hooks |
| `build/arch/unified-hifi-control.service` | Systemd service (shared) |
| `docs/arch-linux.md` | User installation guide |

## Publishing to AUR (after v3.1.0 release)

### Prerequisites
- AUR account: https://aur.archlinux.org/register
- SSH key added to AUR account settings

### Steps

```bash
# Clone empty AUR repo (creates new package)
cd /tmp
git clone ssh://aur@aur.archlinux.org/unified-hifi-control-bin.git
cd unified-hifi-control-bin

# Copy package files
cp ~/src/unified-hifi-control/build/arch/PKGBUILD .
cp ~/src/unified-hifi-control/build/arch/unified-hifi-control.install .
cp ~/src/unified-hifi-control/build/arch/unified-hifi-control.service .

# Generate .SRCINFO (required by AUR)
makepkg --printsrcinfo > .SRCINFO

# Commit and push
git add .
git commit -m "Initial upload: v3.1.0"
git push
```

Package will appear at: https://aur.archlinux.org/packages/unified-hifi-control-bin

### For future releases

Update `pkgver` in PKGBUILD, regenerate `.SRCINFO`, commit, push.

## Notes

- Uses `-bin` suffix per AUR naming convention for binary packages
- Web assets symlinked from `/usr/share/` to `/var/lib/` working directory
- No runtime deps (musl static binary)
- Supports Roon token persistence in `/var/lib/unified-hifi-control`

## Test plan

- [ ] Build package on Arch Linux (after release)
- [ ] Install and verify service starts
- [ ] Verify web UI accessible at http://localhost:8088
- [ ] Test upgrade path
- [ ] Test removal (config preservation)

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)