### PR TITLE
refactor(lms): Bundle all binaries in universal ZIP

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,6 @@ jobs:
       build_qnap_arm: ${{ steps.decide.outputs.build_qnap_arm }}
       build_docker: ${{ steps.decide.outputs.build_docker }}
       build_linux_packages: ${{ steps.decide.outputs.build_linux_packages }}
-      lms_matrix: ${{ steps.decide.outputs.lms_matrix }}
     steps:
       - name: Decide what to build
         id: decide
@@ -207,40 +206,6 @@ jobs:
           if [[ "$HAS_LABEL_LINUX_PACKAGES" == "true" ]]; then BUILD_LINUX_PACKAGES="true"; fi
           if [[ "$INPUT_LINUX_PACKAGES" == "true" ]]; then BUILD_LINUX_PACKAGES="true"; fi
           echo "build_linux_packages=$BUILD_LINUX_PACKAGES" >> $GITHUB_OUTPUT
-
-          # LMS full ZIP matrix - only include platforms whose binaries are built
-          LMS_MATRIX='{"include":['
-          LMS_FIRST="true"
-
-          # linux-x64 always included when LMS is built (requires linux-x64 which is always built)
-          if [[ "$BUILD_LMS" == "true" ]]; then
-            LMS_MATRIX="$LMS_MATRIX"'{"platform":"linux-x64","binary_artifact":"binary-x86_64-unknown-linux-musl","binary_name":"unified-hifi-linux-x64","bundled_name":"unified-hifi-control"}'
-            LMS_FIRST="false"
-          fi
-
-          # linux-arm64 and linux-armv7 require ARM build
-          if [[ "$BUILD_LMS" == "true" && "$BUILD_LINUX_ARM" == "true" ]]; then
-            [[ "$LMS_FIRST" == "false" ]] && LMS_MATRIX="$LMS_MATRIX,"
-            LMS_MATRIX="$LMS_MATRIX"'{"platform":"linux-arm64","binary_artifact":"binary-aarch64-unknown-linux-musl","binary_name":"unified-hifi-linux-arm64","bundled_name":"unified-hifi-control"}'
-            LMS_MATRIX="$LMS_MATRIX,"'{"platform":"linux-armv7","binary_artifact":"binary-armv7-unknown-linux-musleabihf","binary_name":"unified-hifi-linux-armv7","bundled_name":"unified-hifi-control"}'
-            LMS_FIRST="false"
-          fi
-
-          # macos requires macOS build
-          if [[ "$BUILD_LMS" == "true" && "$BUILD_MACOS" == "true" ]]; then
-            [[ "$LMS_FIRST" == "false" ]] && LMS_MATRIX="$LMS_MATRIX,"
-            LMS_MATRIX="$LMS_MATRIX"'{"platform":"macos","binary_artifact":"binary-macos-universal","binary_name":"unified-hifi-macos-universal","bundled_name":"unified-hifi-control"}'
-            LMS_FIRST="false"
-          fi
-
-          # windows requires Windows build
-          if [[ "$BUILD_LMS" == "true" && "$BUILD_WINDOWS" == "true" ]]; then
-            [[ "$LMS_FIRST" == "false" ]] && LMS_MATRIX="$LMS_MATRIX,"
-            LMS_MATRIX="$LMS_MATRIX"'{"platform":"windows","binary_artifact":"binary-windows","binary_name":"unified-hifi-win64.exe","bundled_name":"unified-hifi-control.exe"}'
-          fi
-
-          LMS_MATRIX="$LMS_MATRIX]}"
-          echo "lms_matrix=$LMS_MATRIX" >> $GITHUB_OUTPUT
 
           # Step summary - show label → build mapping
           echo "### Build Plan" >> $GITHUB_STEP_SUMMARY
@@ -693,12 +658,16 @@ jobs:
           path: dist/bin/
           retention-days: 5
 
-  # Bootstrap ZIP: no bundled binaries, downloads on first run
-  # This is the default for release builds - smaller download, works on any platform
-  build-lms-bootstrap:
-    name: Build LMS Plugin (bootstrap)
-    needs: plan
-    if: needs.plan.outputs.build_lms == 'true'
+  # Universal ZIP: all platform binaries bundled
+  # Uses LMS platform folder structure so findBin() works automatically
+  build-lms-universal:
+    name: Build LMS Plugin (universal)
+    needs: [plan, build-web-assets, build-linux-x64, build-linux-arm, build-macos-universal, build-windows]
+    if: |
+      always() &&
+      needs.plan.outputs.build_lms == 'true' &&
+      needs.build-web-assets.result == 'success' &&
+      needs.build-linux-x64.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -713,21 +682,104 @@ jobs:
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
+      # Download all available binaries
+      - name: Download Linux x64 binary
+        uses: actions/download-artifact@v4
+        with:
+          name: binary-x86_64-unknown-linux-musl
+          path: binaries/
+
+      - name: Download Linux ARM64 binary
+        uses: actions/download-artifact@v4
+        if: needs.build-linux-arm.result == 'success'
+        continue-on-error: true
+        with:
+          name: binary-aarch64-unknown-linux-musl
+          path: binaries/
+
+      - name: Download Linux ARMv7 binary
+        uses: actions/download-artifact@v4
+        if: needs.build-linux-arm.result == 'success'
+        continue-on-error: true
+        with:
+          name: binary-armv7-unknown-linux-musleabihf
+          path: binaries/
+
+      - name: Download macOS binary
+        uses: actions/download-artifact@v4
+        if: needs.build-macos-universal.result == 'success'
+        continue-on-error: true
+        with:
+          name: binary-macos-universal
+          path: binaries/
+
+      - name: Download Windows binary
+        uses: actions/download-artifact@v4
+        if: needs.build-windows.result == 'success'
+        continue-on-error: true
+        with:
+          name: binary-windows
+          path: binaries/
+
+      - name: Download web assets
+        uses: actions/download-artifact@v4
+        with:
+          name: web-assets
+          path: web-assets/
+
       - name: Update install.xml version
         run: |
           sed -i "s|<version>[^<]*</version>|<version>${{ steps.version.outputs.version }}</version>|" lms-plugin/install.xml
 
-      - name: Create LMS plugin ZIP
+      - name: Bundle LMS plugin with all binaries
         run: |
           mkdir -p dist
           cd lms-plugin
+
+          # Create platform-specific Bin directories (LMS findBin convention)
+          # See: https://github.com/LMS-Community/slimserver/tree/public/9.1/Bin
+          mkdir -p Bin/x86_64-linux
+          mkdir -p Bin/aarch64-linux
+          mkdir -p Bin/arm-linux
+          mkdir -p Bin/darwin
+          mkdir -p Bin/MSWin32-x64-multi-thread
+
+          # Copy binaries to their platform folders
+          # All use same name so LMS findBin('unified-hifi-control') works
+          if [ -f ../binaries/unified-hifi-linux-x64 ]; then
+            cp ../binaries/unified-hifi-linux-x64 Bin/x86_64-linux/unified-hifi-control
+            chmod +x Bin/x86_64-linux/unified-hifi-control
+          fi
+
+          if [ -f ../binaries/unified-hifi-linux-arm64 ]; then
+            cp ../binaries/unified-hifi-linux-arm64 Bin/aarch64-linux/unified-hifi-control
+            chmod +x Bin/aarch64-linux/unified-hifi-control
+          fi
+
+          if [ -f ../binaries/unified-hifi-linux-armv7 ]; then
+            cp ../binaries/unified-hifi-linux-armv7 Bin/arm-linux/unified-hifi-control
+            chmod +x Bin/arm-linux/unified-hifi-control
+          fi
+
+          if [ -f ../binaries/unified-hifi-macos-universal ]; then
+            cp ../binaries/unified-hifi-macos-universal Bin/darwin/unified-hifi-control
+            chmod +x Bin/darwin/unified-hifi-control
+          fi
+
+          if [ -f ../binaries/unified-hifi-win64.exe ]; then
+            cp ../binaries/unified-hifi-win64.exe Bin/MSWin32-x64-multi-thread/unified-hifi-control.exe
+          fi
+
+          # Copy web assets (next to binaries, Dioxus convention)
+          cp -r ../web-assets Bin/public
+
+          # Show what we bundled
+          echo "Bundled binaries:"
+          find Bin -type f -name "unified-hifi-control*" | head -20
+
+          # Create ZIP with everything
           zip -r ../dist/lms-unified-hifi-control-${{ steps.version.outputs.version }}.zip . \
-            -x "*.git*" \
-            -x "Bin/*"
-          mkdir -p Bin
-          echo "# Binaries downloaded on first run" > Bin/.gitkeep
-          zip -r ../dist/lms-unified-hifi-control-${{ steps.version.outputs.version }}.zip Bin/.gitkeep
-          rm -rf Bin
+            -x "*.git*"
 
       - name: Repack with correct directory structure
         run: |
@@ -743,85 +795,7 @@ jobs:
       - name: Upload LMS plugin
         uses: actions/upload-artifact@v4
         with:
-          name: lms-plugin-bootstrap
-          path: dist/lms-unified-hifi-control-*.zip
-          retention-days: 5
-
-  # Full ZIPs: bundled binaries + web assets for each platform
-  # Used for PR testing and offline installations
-  build-lms-full:
-    name: Build LMS Plugin (${{ matrix.platform }})
-    needs: [plan, build-web-assets, build-linux-x64, build-linux-arm, build-macos-universal, build-windows]
-    if: |
-      always() &&
-      needs.plan.outputs.build_lms == 'true' &&
-      needs.build-web-assets.result == 'success' &&
-      needs.build-linux-x64.result == 'success'
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJSON(needs.plan.outputs.lms_matrix) }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Get version
-        id: version
-        run: |
-          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/v}
-          else
-            VERSION="0.0.0-dev"
-          fi
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Download binary
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ matrix.binary_artifact }}
-          path: binary/
-
-      - name: Download web assets
-        uses: actions/download-artifact@v4
-        with:
-          name: web-assets
-          path: web-assets/
-
-      - name: Update install.xml version
-        run: |
-          sed -i "s|<version>[^<]*</version>|<version>${{ steps.version.outputs.version }}</version>|" lms-plugin/install.xml
-
-      - name: Bundle LMS plugin with binary
-        run: |
-          mkdir -p dist
-          cd lms-plugin
-
-          # Create Bin directory with bundled binary
-          mkdir -p Bin
-          cp ../binary/${{ matrix.binary_name }} Bin/${{ matrix.bundled_name }}
-          chmod +x Bin/${{ matrix.bundled_name }}
-
-          # Copy web assets to Bin/public (Dioxus expects public/ next to binary)
-          cp -r ../web-assets Bin/public
-
-          # Create ZIP with everything
-          zip -r ../dist/lms-unified-hifi-control-${{ steps.version.outputs.version }}-${{ matrix.platform }}.zip . \
-            -x "*.git*"
-
-      - name: Repack with correct directory structure
-        run: |
-          cd dist
-          mkdir -p repack
-          unzip lms-unified-hifi-control-${{ steps.version.outputs.version }}-${{ matrix.platform }}.zip -d repack/UnifiedHiFi
-          rm lms-unified-hifi-control-${{ steps.version.outputs.version }}-${{ matrix.platform }}.zip
-          cd repack
-          zip -r ../lms-unified-hifi-control-${{ steps.version.outputs.version }}-${{ matrix.platform }}.zip UnifiedHiFi
-          cd ..
-          rm -rf repack
-
-      - name: Upload LMS plugin
-        uses: actions/upload-artifact@v4
-        with:
-          name: lms-plugin-${{ matrix.platform }}
+          name: lms-plugin
           path: dist/lms-unified-hifi-control-*.zip
           retention-days: 5
 
@@ -1336,7 +1310,7 @@ jobs:
 
   upload-release:
     name: Upload to Release
-    needs: [plan, build-linux-x64, build-linux-arm, build-macos-universal, build-windows, build-linux-packages, build-lms-bootstrap, build-lms-full, build-synology, build-qnap-x64, build-qnap-arm, build-web-assets]
+    needs: [plan, build-linux-x64, build-linux-arm, build-macos-universal, build-windows, build-linux-packages, build-lms-universal, build-synology, build-qnap-x64, build-qnap-arm, build-web-assets]
     if: needs.plan.outputs.is_release == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -1483,8 +1457,7 @@ jobs:
       - build-linux-arm
       - build-macos-universal
       - build-windows
-      - build-lms-bootstrap
-      - build-lms-full
+      - build-lms-universal
       - build-synology
       - build-qnap-x64
       - build-qnap-arm

--- a/docs/gh-release.md
+++ b/docs/gh-release.md
@@ -89,8 +89,8 @@ Jobs maximize parallelism while respecting dependencies:
 
 - **Binary builds run in parallel**: Linux, macOS (x64 + arm64), and Windows start simultaneously
 - **macOS universal**: x64 and arm64 build in parallel, then combined with `lipo`
-- **Packaging waits for binaries + web assets**: Docker, Synology, QNAP, LMS-full jobs
-- **Dynamic LMS matrix**: Only builds platform variants whose binaries are enabled
+- **Packaging waits for binaries + web assets**: Docker, Synology, QNAP, LMS jobs
+- **Universal LMS ZIP**: Bundles all platform binaries in one package
 - **Optional jobs skip cleanly**: ARM builds skip if not requested
 
 The GitHub Actions UI shows the full dependency DAG.

--- a/lms-plugin/HTML/EN/plugins/UnifiedHiFi/settings/basic.html
+++ b/lms-plugin/HTML/EN/plugins/UnifiedHiFi/settings/basic.html
@@ -2,15 +2,10 @@
     [% title = "PLUGIN_UNIFIED_HIFI" %]
 
     [% WRAPPER setting title="PLUGIN_UNIFIED_HIFI" desc="" %]
-    <!-- Binary download status -->
-    [% IF binaryStatus == 'not_downloaded' %]
-    <div class="prefDesc" style="padding: 10px; background: #fff3cd; border: 1px solid #ffc107; border-radius: 4px; margin-bottom: 15px;">
-        [% "PLUGIN_UNIFIED_HIFI_DOWNLOAD_NEEDED" | string(binaryPlatform) %]
-    </div>
-    [% ELSIF binaryStatus == 'downloading' %]
-    <div class="prefDesc" style="padding: 10px; background: #cce5ff; border: 1px solid #007bff; border-radius: 4px; margin-bottom: 15px;">
-        [% "PLUGIN_UNIFIED_HIFI_DOWNLOADING" | string(binaryPlatform) %]
-        <script>setTimeout(function() { location.reload(); }, 5000);</script>
+    <!-- Binary status warning -->
+    [% IF binaryStatus == 'missing' %]
+    <div class="prefDesc" style="padding: 10px; background: #f8d7da; border: 1px solid #f5c6cb; border-radius: 4px; margin-bottom: 15px;">
+        [% "PLUGIN_UNIFIED_HIFI_BINARY_MISSING" | string %]
     </div>
     [% END %]
 
@@ -49,17 +44,6 @@
                value="[% prefs.port || 8088 %]" min="1024" max="65535"
                style="width: 80px;" />
     [% END %]
-
-    [% IF binaries.size > 1; WRAPPER setting title="PLUGIN_UNIFIED_HIFI_BINARY" desc="PLUGIN_UNIFIED_HIFI_BINARY_DESC" %]
-        <select name="pref_bin" id="pref_bin">
-            [% FOREACH bin IN binaries %]
-                <option value="[% bin %]"
-                        [% IF prefs.bin == bin %]selected[% END %]>
-                    [% bin %]
-                </option>
-            [% END %]
-        </select>
-    [% END; END %]
 
 <!-- Knob Configuration Section -->
     <hr/>

--- a/lms-plugin/Helper.pm
+++ b/lms-plugin/Helper.pm
@@ -1,14 +1,12 @@
 package Plugins::UnifiedHiFi::Helper;
 
 # Binary lifecycle management for Unified Hi-Fi Control
-# Handles spawning, monitoring, restarting, and on-demand downloading
+# Handles spawning, monitoring, and restarting the bridge process
 
 use strict;
 use warnings;
 
 use File::Spec::Functions qw(catfile catdir);
-use File::Path qw(make_path);
-use File::Basename;
 use JSON::XS;
 use Proc::Background;
 
@@ -25,58 +23,18 @@ my $serverPrefs = preferences('server');
 
 my $helperProc;
 my $restarts = 0; # Restart counter
-my $downloadInProgress = 0;  # Download state flag
 
 use constant HEALTH_CHECK_INTERVAL => 30;  # seconds
 use constant MAX_RESTARTS          => 5;   # before giving up
 use constant RESTART_RESET_TIME    => 300; # reset counter after 5 min stable
 
-# Binary download configuration
-use constant BINARY_BASE_URL => 'https://github.com/open-horizon-labs/unified-hifi-control/releases/download';
-use constant WEB_ASSETS_FILE => 'web-assets.tar.gz';
-use constant BINARY_MAP => {
-    'darwin-arm64'   => 'unified-hifi-macos-universal',
-    'darwin-x86_64'  => 'unified-hifi-macos-universal',
-    'linux-x86_64'   => 'unified-hifi-linux-x64',
-    'linux-aarch64'  => 'unified-hifi-linux-arm64',
-    'linux-armv7l'   => 'unified-hifi-linux-armv7',
-    'win64'          => 'unified-hifi-win64.exe',
-};
-
-# Get the plugin data directory (survives plugin updates)
-# Uses LMS server cache directory, not plugin install directory
-sub dataDir {
-    my $class = shift;
-
-    my $cacheDir = $serverPrefs->get('cachedir');
-    return unless $cacheDir;
-
-    my $dataDir = catdir($cacheDir, 'UnifiedHiFi');
-    make_path($dataDir) unless -d $dataDir;
-
-    return $dataDir;
-}
-
-sub binDir {
-    my $class = shift;
-
-    my $dataDir = $class->dataDir();
-    return unless $dataDir;
-
-    my $binDir = catdir($dataDir, 'Bin');
-    make_path($binDir) unless -d $binDir;
-
-    return $binDir;
-}
-
 # Get the plugin install directory (where the plugin ZIP was extracted)
-# This is where bundled binaries would be if present
 sub pluginDir {
     my $class = shift;
     return Plugins::UnifiedHiFi::Plugin->_pluginDataFor('basedir');
 }
 
-# Get the Bin directory inside the plugin install location (for bundled binaries)
+# Get the Bin directory inside the plugin install location
 sub pluginBinDir {
     my $class = shift;
 
@@ -86,55 +44,15 @@ sub pluginBinDir {
     return catdir($pluginDir, 'Bin');
 }
 
-# Get bundled binary path (if it exists in the plugin install directory)
-sub bundledBin {
+# Get bundled web assets directory
+sub bundledPublicDir {
     my $class = shift;
 
     my $pluginBinDir = $class->pluginBinDir();
     return unless $pluginBinDir;
 
-    my $platform = $class->detectPlatform();
-    my $binaryName = BINARY_MAP->{$platform};
-    return unless $binaryName;
-
-    # Bundled binaries use a generic name: unified-hifi-control (or .exe on Windows)
-    my $bundledName = main::ISWINDOWS ? 'unified-hifi-control.exe' : 'unified-hifi-control';
-    my $bundledPath = catfile($pluginBinDir, $bundledName);
-
-    return (-e $bundledPath && -x _) ? $bundledPath : undef;
-}
-
-# Get bundled web assets directory (if it exists in the plugin install directory)
-sub bundledPublicDir {
-    my $class = shift;
-
-    my $pluginDir = $class->pluginDir();
-    return unless $pluginDir;
-
-    my $publicDir = catdir($pluginDir, 'public');
+    my $publicDir = catdir($pluginBinDir, 'public');
     return (-d $publicDir) ? $publicDir : undef;
-}
-
-# Detect platform for binary download
-sub detectPlatform {
-    my $class = shift;
-
-    my $details = Slim::Utils::OSDetect::details();
-    my $arch = $details->{'osArch'} || $details->{'binArch'} || 'x86_64';
-
-    if (main::ISMAC) {
-        return $arch =~ /arm|aarch64/i ? 'darwin-arm64' : 'darwin-x86_64';
-    } elsif (main::ISWINDOWS) {
-        return 'win64';
-    # Linux and other Unix-like systems
-    } elsif ($arch =~ /aarch64|arm64/i) {
-        return 'linux-aarch64';
-    } elsif ($arch =~ /arm/i) {
-        return 'linux-armv7l';
-    }
-
-    # Fallback to x86_64
-    return 'linux-x86_64';
 }
 
 # Get plugin version from install.xml
@@ -142,353 +60,34 @@ sub pluginVersion {
     return Plugins::UnifiedHiFi::Plugin->_pluginDataFor('version') || '0.0.0';
 }
 
-# Check if binary needs download
-# Returns false if bundled binary exists or if cached binary exists
-sub needsBinaryDownload {
-    my $class = shift;
-
-    my $platform = $class->detectPlatform();
-    my $binaryName = BINARY_MAP->{$platform};
-    if (!$binaryName) {
-        $log->error("Unsupported platform: $platform");
-        return 0;
-    }
-
-    # Check for bundled binary first (no download needed)
-    if ($class->bundledBin()) {
-        return 0;
-    }
-
-    # Check cached binary
-    my $binaryPath = $class->bin();
-    return !(-e $binaryPath && -x _);
-}
-
-# Check if web assets need download
-# Returns false if bundled public dir exists or if cached public dir exists
-sub needsWebAssetsDownload {
-    my $class = shift;
-
-    # Check for bundled web assets first (no download needed)
-    if ($class->bundledPublicDir()) {
-        return 0;
-    }
-
-    # Check cached web assets
-    my $publicDir = catdir($class->binDir(), 'public');
-    return !(-d $publicDir);
-}
-
-# Get binary status for UI
-sub binaryStatus {
-    my $class = shift;
-
-    return 'downloading' if $downloadInProgress;
-    return ($class->needsBinaryDownload() || $class->needsWebAssetsDownload()) ? 'not_downloaded' : 'installed';
-}
-
-# Download binary for current platform (async-friendly)
-sub ensureBinary {
-    my ($class, $callback) = @_;
-
-    my $platform = $class->detectPlatform();
-    my $binaryName = BINARY_MAP->{$platform};
-
-    unless ($binaryName) {
-        $log->error("No binary available for platform: $platform");
-        $callback->(undef, "Unsupported platform: $platform") if $callback;
-        return;
-    }
-
-    my $binaryPath = $class->bin();
-
-    # Callback wrapper that ensures web assets before final callback
-    my $withWebAssets = sub {
-        my $path = shift;
-        $class->ensureWebAssets(sub {
-            my ($success, $error) = @_;
-            if ($success) {
-                $callback->($path) if $callback;
-            } else {
-                $callback->(undef, "Web assets download failed: $error") if $callback;
-            }
-        });
-    };
-
-    # Already exists and executable
-    if (-e $binaryPath && -x _) {
-        # Binary exists, ensure web assets too
-        $withWebAssets->($binaryPath);
-        return $binaryPath;
-    }
-
-    # Need to download
-    $log->info("Binary not found, downloading $binaryName for $platform...");
-
-    my $version = $class->pluginVersion();
-    my $url = BINARY_BASE_URL . "/v$version/$binaryName";
-
-    $class->downloadBinary($url, $binaryPath, sub {
-        my ($success, $error) = @_;
-        if ($success) {
-            chmod 0755, $binaryPath;
-            $log->info("Binary downloaded successfully: $binaryPath");
-            # Now ensure web assets
-            $withWebAssets->($binaryPath);
-        } else {
-            $log->error("Binary download failed: $error");
-            $callback->(undef, $error) if $callback;
-        }
-    });
-
-    return;  # Async - result via callback
-}
-
-# Download and extract web assets tarball
-sub ensureWebAssets {
-    my ($class, $callback) = @_;
-
-    # Check for bundled web assets first
-    my $bundledPublic = $class->bundledPublicDir();
-    if ($bundledPublic) {
-        $log->debug("Using bundled web assets at $bundledPublic");
-        $callback->(1) if $callback;
-        return 1;
-    }
-
-    my $binDir = $class->binDir();
-    my $publicDir = catdir($binDir, 'public');
-
-    # Already exists in cache
-    if (-d $publicDir) {
-        $log->debug("Web assets already present at $publicDir");
-        $callback->(1) if $callback;
-        return 1;
-    }
-
-    $log->info("Web assets not found, downloading...");
-
-    my $version = $class->pluginVersion();
-    my $url = BINARY_BASE_URL . "/v$version/" . WEB_ASSETS_FILE;
-    my $tarballPath = catfile($binDir, WEB_ASSETS_FILE);
-
-    $class->downloadFile($url, $tarballPath, sub {
-        my ($success, $error) = @_;
-        if ($success) {
-            # Extract tarball
-            my $result = $class->extractTarball($tarballPath, $binDir);
-            unlink $tarballPath;  # Clean up tarball
-            if ($result) {
-                $log->info("Web assets extracted to $publicDir");
-                $callback->(1) if $callback;
-            } else {
-                $callback->(0, "Failed to extract web assets") if $callback;
-            }
-        } else {
-            $log->error("Web assets download failed: $error");
-            $callback->(0, $error) if $callback;
-        }
-    });
-
-    return;  # Async
-}
-
-# Extract tarball to destination directory
-sub extractTarball {
-    my ($class, $tarball, $destDir) = @_;
-
-    eval {
-        require Archive::Tar;
-        my $tar = Archive::Tar->new($tarball);
-        $tar->setcwd($destDir);
-        $tar->extract();
-        return 1;
-    };
-
-    if ($@) {
-        # Fallback to system tar command
-        $log->debug("Archive::Tar not available, using system tar");
-        my $result = system("tar", "-xzf", $tarball, "-C", $destDir);
-        return $result == 0;
-    }
-
-    return 1;
-}
-
-# Download file from URL (with redirect handling) - generic version
-sub downloadFile {
-    my ($class, $url, $dest, $callback, $redirectCount) = @_;
-    $redirectCount //= 0;
-
-    # Prevent infinite redirects
-    if ($redirectCount > 5) {
-        $downloadInProgress = 0;
-        $callback->(0, "Too many redirects") if $callback;
-        return;
-    }
-
-    $downloadInProgress = 1 if $redirectCount == 0;
-
-    # Ensure destination directory exists
-    my $destDir = dirname($dest);
-    make_path($destDir) unless -d $destDir;
-
-    $log->info("Downloading from $url" . ($redirectCount ? " (redirect $redirectCount)" : ""));
-
-    eval {
-        my $http = Slim::Networking::SimpleAsyncHTTP->new(
-            sub {
-                my $response = shift;
-
-                my $code = $response->code;
-
-                # Handle redirects (301, 302, 303, 307, 308)
-                if ($code >= 300 && $code < 400) {
-                    my $location = $response->headers->header('Location');
-                    if ($location) {
-                        $log->debug("Following redirect to: $location");
-                        $class->downloadFile($location, $dest, $callback, $redirectCount + 1);
-                        return;
-                    }
-                }
-
-                $downloadInProgress = 0;
-
-                if ($code == 200) {
-                    # Write to file
-                    open my $fh, '>', $dest or do {
-                        $callback->(0, "Cannot write to $dest: $!") if $callback;
-                        return;
-                    };
-                    binmode $fh;
-                    print $fh $response->content;
-                    close $fh;
-
-                    $callback->(1) if $callback;
-                } else {
-                    $callback->(0, "HTTP $code: " . $response->message) if $callback;
-                }
-            },
-            sub {
-                my ($response, $error) = @_;
-                $downloadInProgress = 0;
-                $callback->(0, $error // "Download failed") if $callback;
-            },
-            {
-                timeout => 300,  # 5 minute timeout
-            }
-        );
-
-        $http->get($url);
-    };
-
-    if ($@) {
-        $downloadInProgress = 0;
-        $log->error("Download error: $@");
-        $callback->(0, $@) if $callback;
-    }
-}
-
-# Download binary from URL (with redirect handling)
-sub downloadBinary {
-    my ($class, $url, $dest, $callback, $redirectCount) = @_;
-    $redirectCount //= 0;
-
-    # Prevent infinite redirects
-    if ($redirectCount > 5) {
-        $downloadInProgress = 0;
-        $callback->(0, "Too many redirects") if $callback;
-        return;
-    }
-
-    $downloadInProgress = 1 if $redirectCount == 0;
-
-    # Ensure Bin directory exists
-    my $bindir = $class->binDir();
-    make_path($bindir) unless -d $bindir;
-
-    $log->info("Downloading binary from $url" . ($redirectCount ? " (redirect $redirectCount)" : ""));
-
-    eval {
-        my $http = Slim::Networking::SimpleAsyncHTTP->new(
-            sub {
-                my $response = shift;
-
-                my $code = $response->code;
-
-                # Handle redirects (301, 302, 303, 307, 308)
-                if ($code >= 300 && $code < 400) {
-                    my $location = $response->headers->header('Location');
-                    if ($location) {
-                        $log->debug("Following redirect to: $location");
-                        $class->downloadBinary($location, $dest, $callback, $redirectCount + 1);
-                        return;
-                    }
-                }
-
-                $downloadInProgress = 0;
-
-                if ($code == 200) {
-                    # Write binary to file
-                    open my $fh, '>', $dest or do {
-                        $callback->(0, "Cannot write to $dest: $!") if $callback;
-                        return;
-                    };
-                    binmode $fh;
-                    print $fh $response->content;
-                    close $fh;
-
-                    $callback->(1) if $callback;
-                } else {
-                    $callback->(0, "HTTP $code: " . $response->message) if $callback;
-                }
-            },
-            sub {
-                my ($response, $error) = @_;
-                $downloadInProgress = 0;
-                $callback->(0, $error // "Download failed") if $callback;
-            },
-            {
-                timeout => 300,  # 5 minute timeout for large binary
-            }
-        );
-
-        $http->get($url);
-    };
-
-    if ($@) {
-        $downloadInProgress = 0;
-        $log->error("Download error: $@");
-        $callback->(0, $@) if $callback;
-    }
-}
-
-# Get path to the binary to use
-# Priority: 1. Bundled binary (in plugin install dir), 2. Cached binary (in LMS cache)
+# Get path to the binary using LMS's built-in findBin
+# Binary is in platform-specific folders: Bin/darwin/, Bin/x86_64-linux/, etc.
 sub bin {
     my $class = shift;
 
-    # Check for bundled binary first
-    my $bundled = $class->bundledBin();
-    if ($bundled) {
-        $log->debug("Using bundled binary: $bundled");
-        return $bundled;
+    # Register our plugin's Bin directory with LMS's binary finder
+    my $pluginBinDir = $class->pluginBinDir();
+    if ($pluginBinDir && -d $pluginBinDir) {
+        Slim::Utils::Misc::addFindBinPaths($pluginBinDir);
     }
 
-    # Fall back to cached binary
-    my $selected = $prefs->get('bin');
+    # Let LMS find the right binary for this platform
+    # LMS knows about platform folders (darwin/, x86_64-linux/, MSWin32-x64-multi-thread/, etc.)
+    my $binary = Slim::Utils::Misc::findBin('unified-hifi-control');
 
-    if (!$selected) {
-        $selected = BINARY_MAP->{$class->detectPlatform()};
-        $prefs->set('bin', $selected) if $selected;
+    if ($binary && -x $binary) {
+        $log->debug("Found binary via LMS findBin: $binary");
+        return $binary;
     }
 
-    return unless $selected;
+    $log->error("No binary found for this platform. Plugin may need reinstallation.");
+    return;
+}
 
-    my $binaryPath = catfile($class->binDir(), $selected);
-    chmod 0755, $binaryPath if !main::ISWINDOWS && -f $binaryPath && !-x _;
-
-    return $binaryPath;
+# Binary status is always 'installed' since we bundle all binaries
+sub binaryStatus {
+    my $class = shift;
+    return $class->bin() ? 'installed' : 'missing';
 }
 
 # Start the helper process
@@ -496,25 +95,10 @@ sub start {
     my $class = shift;
 
     return if running();
-    return if $downloadInProgress;  # Don't start while downloading
 
     my $binary = $class->bin();
 
-    # If no binary, try to download it
-    unless ($binary && -e $binary) {
-        if ($class->needsBinaryDownload()) {
-            $log->info("Binary not found, initiating download...");
-            $class->ensureBinary(sub {
-                my ($path, $error) = @_;
-                if ($path) {
-                    # Download complete, now start
-                    $class->_doStart($path);
-                } else {
-                    $log->error("Cannot start: $error");
-                }
-            });
-            return;  # Will start via callback
-        }
+    unless ($binary) {
         $log->error("No suitable binary found for this platform");
         return;
     }
@@ -531,8 +115,8 @@ sub _doStart {
     my $port = $prefs->get('port') || 8088;
 
     # Build environment for subprocess
-    # Use plugin's data directory (survives plugin updates)
-    my $configDir = $class->dataDir();
+    # Use plugin's Bin directory for config (contains public/ for web assets)
+    my $configDir = $class->pluginBinDir();
     my $lmsPort = $serverPrefs->get('httpport');
 
     $log->info("Starting Unified Hi-Fi Control: $binaryPath on port $port");
@@ -694,23 +278,17 @@ Plugins::UnifiedHiFi::Helper - Binary lifecycle management
 
 Manages the unified-hifi-control binary: spawning, monitoring, and restarting.
 
-Supports two modes of binary deployment:
+Binaries are bundled in the plugin ZIP in LMS platform folder structure:
 
-=over 4
+    Bin/
+      darwin/unified-hifi-control
+      x86_64-linux/unified-hifi-control
+      aarch64-linux/unified-hifi-control
+      arm-linux/unified-hifi-control
+      MSWin32-x64-multi-thread/unified-hifi-control.exe
+      public/  (web assets)
 
-=item Bundled (full ZIP)
-
-The plugin ZIP includes pre-built binaries in C<Bin/> and web assets in C<public/>.
-These are used directly without any download. Used for PR testing and offline installs.
-
-=item Bootstrap (default)
-
-The plugin ZIP includes only Perl code. On first run, the binary and web assets
-are downloaded from GitHub releases and cached in the LMS cache directory.
-This is the default for release builds - smaller download, works on any platform.
-
-=back
-
-Binary lookup priority: bundled (plugin install dir) > cached (LMS cache dir).
+LMS's C<Slim::Utils::Misc::findBin()> automatically finds the correct binary
+for the current platform.
 
 =cut

--- a/lms-plugin/Plugin.pm
+++ b/lms-plugin/Plugin.pm
@@ -26,7 +26,6 @@ my $prefs = preferences('plugin.unifiedhifi');
 $prefs->init({
     autorun  => 1,
     port     => 8088,
-    bin      => undef,
 });
 
 sub initPlugin {

--- a/lms-plugin/Settings.pm
+++ b/lms-plugin/Settings.pm
@@ -25,7 +25,7 @@ sub page {
 }
 
 sub prefs {
-    return ($prefs, qw(autorun port bin));
+    return ($prefs, qw(autorun port));
 }
 
 sub handler {
@@ -43,11 +43,6 @@ sub handler {
     my $needsRestart = 0;
     if ($params->{'saveSettings'}) {
         if (($params->{'pref_port'} // 8088) != ($prefs->get('port') // 8088)) {
-            $needsRestart = 1;
-        }
-
-        # Check if binary changed
-        elsif (($params->{'pref_bin'} // '') ne ($prefs->get('bin') // '')) {
             $needsRestart = 1;
         }
 
@@ -81,15 +76,9 @@ sub beforeRender {
     }
 
     # Add template variables
-    $params->{'running'}    = Plugins::UnifiedHiFi::Helper->running();
-    $params->{'webUrl'}     = Plugins::UnifiedHiFi::Helper->webUrl();
-    # Single binary per platform now - dropdown only shows if size > 1 (never)
-    my $platformBinary = Plugins::UnifiedHiFi::Helper::BINARY_MAP->{Plugins::UnifiedHiFi::Helper->detectPlatform()};
-    $params->{'binaries'}   = $platformBinary ? [$platformBinary] : [];
-
-    # Binary download status
-    $params->{'binaryStatus'}   = Plugins::UnifiedHiFi::Helper->binaryStatus();
-    $params->{'binaryPlatform'} = Plugins::UnifiedHiFi::Helper->detectPlatform();
+    $params->{'running'}      = Plugins::UnifiedHiFi::Helper->running();
+    $params->{'webUrl'}       = Plugins::UnifiedHiFi::Helper->webUrl();
+    $params->{'binaryStatus'} = Plugins::UnifiedHiFi::Helper->binaryStatus();
 
     return $class->SUPER::beforeRender($params, $client);
 }

--- a/lms-plugin/strings.txt
+++ b/lms-plugin/strings.txt
@@ -22,11 +22,8 @@ PLUGIN_UNIFIED_HIFI_PORT
 PLUGIN_UNIFIED_HIFI_PORT_DESC
 	EN	HTTP port for the bridge web UI and API (default: 8088). Change if conflicting with HQPlayer.
 
-PLUGIN_UNIFIED_HIFI_BINARY
-	EN	Binary
-
-PLUGIN_UNIFIED_HIFI_BINARY_DESC
-	EN	Select which binary to use for your platform.
+PLUGIN_UNIFIED_HIFI_BINARY_MISSING
+	EN	<b>&#9888; Binary Missing:</b> No binary found for this platform. Please reinstall the plugin.
 
 PLUGIN_UNIFIED_HIFI_RUNNING
 	EN	Running
@@ -57,9 +54,3 @@ PLUGIN_UNIFIED_HIFI_KNOB_BATTERY_CHARGING
 
 PLUGIN_UNIFIED_HIFI_KNOB_ID
 	EN	ID
-
-PLUGIN_UNIFIED_HIFI_DOWNLOAD_NEEDED
-	EN	<b>&#9888; Binary Required:</b> The bridge binary for <code>%s</code> will be downloaded when you click "Start Bridge".
-
-PLUGIN_UNIFIED_HIFI_DOWNLOADING
-	EN	<b>&#8635; Downloading:</b> Binary for <code>%s</code> is being downloaded... This may take a few minutes. Page will refresh automatically.


### PR DESCRIPTION
## Summary
- Replace download-on-demand with pre-bundled universal ZIP containing all platform binaries
- Use LMS's built-in `findBin()` with platform folder structure
- Remove ~485 lines of download/async code

## Changes
- **build.yml**: Replace `build-lms-bootstrap` + `build-lms-full` matrix with single `build-lms-universal`
- **Helper.pm**: Remove download machinery, use `Slim::Utils::Misc::findBin()`
- **Settings.pm**: Remove binary dropdown
- **basic.html**: Simplify status UI
- **strings.txt**: Remove download-related strings

## ZIP Structure
```
Bin/
  darwin/unified-hifi-control
  x86_64-linux/unified-hifi-control
  aarch64-linux/unified-hifi-control
  arm-linux/unified-hifi-control
  MSWin32-x64-multi-thread/unified-hifi-control.exe
  public/
```

Closes #125

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * LMS plugin now uses universal binary packaging with all platform binaries bundled together.

* **Bug Fixes**
  * Simplified binary management and discovery process.

* **UI Changes**
  * Removed manual binary selection interface from plugin settings.
  * Added "Binary Missing" alert when binary is unavailable.
  * Streamlined settings interface for improved clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->