### PR TITLE
fix: PUBLIC_DIR support for flexible asset location

### DIFF
--- a/build/arch/unified-hifi-control.install
+++ b/build/arch/unified-hifi-control.install
@@ -2,10 +2,12 @@
 
 post_install() {
     echo ":: Unified Hi-Fi Control installed"
-    echo ":: To enable and start the service:"
-    echo "   systemctl enable --now unified-hifi-control"
-    echo ":: Web UI available at http://localhost:8088"
-    echo ":: Configuration: /etc/unified-hifi-control/"
+    echo ""
+    echo ":: To start the service:"
+    echo "   sudo systemctl enable --now unified-hifi-control"
+    echo ""
+    echo ":: After starting, web UI will be at: http://localhost:8088"
+    echo ":: Configuration directory: /etc/unified-hifi-control/"
 }
 
 post_upgrade() {

--- a/build/arch/unified-hifi-control.service
+++ b/build/arch/unified-hifi-control.service
@@ -15,6 +15,7 @@ RestartSec=10
 Environment=PORT=8088
 Environment=CONFIG_DIR=/etc/unified-hifi-control
 Environment=DATA_DIR=/var/lib/unified-hifi-control
+Environment=PUBLIC_DIR=/usr/share/unified-hifi-control/public
 Environment=RUST_LOG=info
 
 # Run as dedicated user (created dynamically)

--- a/build/linux/unified-hifi-control.service
+++ b/build/linux/unified-hifi-control.service
@@ -15,6 +15,7 @@ RestartSec=10
 Environment=PORT=8088
 Environment=CONFIG_DIR=/etc/unified-hifi-control
 Environment=DATA_DIR=/var/lib/unified-hifi-control
+Environment=PUBLIC_DIR=/usr/share/unified-hifi-control/public
 Environment=RUST_LOG=info
 
 # Run as dedicated user (created dynamically)

--- a/build/macos/com.cloudatlas.unified-hifi-control.plist
+++ b/build/macos/com.cloudatlas.unified-hifi-control.plist
@@ -34,6 +34,10 @@
         <string>8088</string>
         <key>CONFIG_DIR</key>
         <string>/usr/local/var/unified-hifi-control</string>
+        <key>PUBLIC_DIR</key>
+        <string>/usr/local/share/unified-hifi-control/public</string>
+        <key>RUST_LOG</key>
+        <string>info</string>
     </dict>
 
     <key>WorkingDirectory</key>

--- a/build/macos/scripts/postinstall
+++ b/build/macos/scripts/postinstall
@@ -4,9 +4,18 @@
 
 set -e
 
-# Create data directory
+# Create directories
 mkdir -p /usr/local/var/unified-hifi-control
 mkdir -p /usr/local/var/log
+mkdir -p /usr/local/share/unified-hifi-control
+
+# Copy public assets (PKG should include these in payload)
+# They get installed to /usr/local/share/unified-hifi-control/public/
+if [ -d "/usr/local/share/unified-hifi-control/public" ]; then
+    echo "Web assets installed to /usr/local/share/unified-hifi-control/public/"
+else
+    echo "Warning: Web assets not found. Service may not work correctly."
+fi
 
 # Set permissions
 chmod 755 /usr/local/bin/unified-hifi-control

--- a/build/qnap/shared/unified-hifi-control.sh
+++ b/build/qnap/shared/unified-hifi-control.sh
@@ -26,6 +26,12 @@ case "$1" in
 
     cd "$QPKG_ROOT" || { echo "Failed to cd to $QPKG_ROOT"; exit 1; }
 
+    # Environment variables
+    export PORT=8088
+    export CONFIG_DIR="${QPKG_ROOT}"
+    export PUBLIC_DIR="${QPKG_ROOT}/public"
+    export RUST_LOG=info
+
     # Start the static binary (musl-linked, no dependencies)
     "${QPKG_ROOT}/unified-hifi-control" >> "$LOGF" 2>&1 &
     echo $! > "$PIDF"

--- a/build/synology/scripts/start-stop-status
+++ b/build/synology/scripts/start-stop-status
@@ -24,6 +24,12 @@ start_daemon() {
         return 1
     fi
 
+    # Environment variables
+    export PORT=8088
+    export CONFIG_DIR="${TARGET_DIR}"
+    export PUBLIC_DIR="${TARGET_DIR}/public"
+    export RUST_LOG=info
+
     # Start the binary
     nohup "${TARGET_DIR}/unified-hifi-control" >> "$LOG_FILE" 2>&1 &
     echo $! > "$PID_FILE"

--- a/build/windows/installer.wxs
+++ b/build/windows/installer.wxs
@@ -73,10 +73,24 @@
                         Remove="uninstall"
                         Wait="yes" />
 
-        <!-- Environment variable for config directory -->
+        <!-- Environment variables -->
         <Environment Id="ConfigDir"
-                     Name="UNIFIED_HIFI_CONFIG_DIR"
+                     Name="CONFIG_DIR"
                      Value="[INSTALLFOLDER]data"
+                     Permanent="no"
+                     Part="all"
+                     Action="set"
+                     System="yes" />
+        <Environment Id="PublicDir"
+                     Name="PUBLIC_DIR"
+                     Value="[INSTALLFOLDER]public"
+                     Permanent="no"
+                     Part="all"
+                     Action="set"
+                     System="yes" />
+        <Environment Id="Port"
+                     Name="PORT"
+                     Value="8088"
                      Permanent="no"
                      Part="all"
                      Action="set"

--- a/lms-plugin/Helper.pm
+++ b/lms-plugin/Helper.pm
@@ -60,7 +60,7 @@ sub pluginVersion {
     return Plugins::UnifiedHiFi::Plugin->_pluginDataFor('version') || '0.0.0';
 }
 
-# Get path to the binary using LMS's built-in findBin
+# Get path to the binary using LMS's built-in findbin
 # Binary is in platform-specific folders: Bin/darwin/, Bin/x86_64-linux/, etc.
 sub bin {
     my $class = shift;
@@ -73,10 +73,10 @@ sub bin {
 
     # Let LMS find the right binary for this platform
     # LMS knows about platform folders (darwin/, x86_64-linux/, MSWin32-x64-multi-thread/, etc.)
-    my $binary = Slim::Utils::Misc::findBin('unified-hifi-control');
+    my $binary = Slim::Utils::Misc::findbin('unified-hifi-control');
 
     if ($binary && -x $binary) {
-        $log->debug("Found binary via LMS findBin: $binary");
+        $log->debug("Found binary via LMS findbin: $binary");
         return $binary;
     }
 
@@ -117,6 +117,7 @@ sub _doStart {
     # Build environment for subprocess
     # Use plugin's Bin directory for config (contains public/ for web assets)
     my $configDir = $class->pluginBinDir();
+    my $publicDir = $class->bundledPublicDir();
     my $lmsPort = $serverPrefs->get('httpport');
 
     $log->info("Starting Unified Hi-Fi Control: $binaryPath on port $port");
@@ -130,11 +131,12 @@ sub _doStart {
     # Using local ensures they're restored after Proc::Background->new() returns
     local $ENV{PORT} = $port;
     local $ENV{CONFIG_DIR} = $configDir;
+    local $ENV{PUBLIC_DIR} = $publicDir if $publicDir;
     local $ENV{LMS_HOST} = '127.0.0.1';
     local $ENV{LMS_PORT} = $lmsPort;
     local $ENV{LMS_UNIFIEDHIFI_STARTED} = 'true';
 
-    $log->debug("Running: $binaryPath (with env: PORT=$port CONFIG_DIR=$configDir LMS_HOST=127.0.0.1 LMS_PORT=$lmsPort)");
+    $log->debug("Running: $binaryPath (with env: PORT=$port CONFIG_DIR=$configDir PUBLIC_DIR=$publicDir LMS_HOST=127.0.0.1 LMS_PORT=$lmsPort)");
 
     # Platform-specific process spawning
     if (main::ISWINDOWS) {
@@ -297,7 +299,7 @@ Binaries are bundled in the plugin ZIP in LMS platform folder structure:
       MSWin32-x64-multi-thread/unified-hifi-control.exe
       public/  (web assets)
 
-LMS's C<Slim::Utils::Misc::findBin()> automatically finds the correct binary
+LMS's C<Slim::Utils::Misc::findbin()> automatically finds the correct binary
 for the current platform.
 
 =cut


### PR DESCRIPTION
## Summary
- Add `PUBLIC_DIR` env var support in binary - creates symlink to where Dioxus expects assets
- Fix all packages to properly set CONFIG_DIR, PUBLIC_DIR, PORT env vars
- Fix LMS plugin `findBin` -> `findbin` typo (fixes #131)

## Problem
Dioxus fullstack hardcodes looking for `public/` next to the executable. This breaks deployments where binary and assets are in different locations.

## Solution
New `setup_public_directory()` function in binary that:
1. Checks `PUBLIC_DIR` env var first
2. Falls back to working directory's `public/`
3. Creates symlink from `{exe_dir}/public` -> configured location

---

## Package Fixes (All Packages Audited & Fixed)

### ✅ Docker - Already working
| Item | Location |
|------|----------|
| Binary | `/app/unified-hifi-control` |
| Public | `/app/public/` (same dir) |
| Config | `/data` |
| Env vars | `PORT=8088`, `CONFIG_DIR=/data`, `RUST_LOG=info` |

### ✅ AUR (Arch Linux) - Fixed
| Item | Location |
|------|----------|
| Binary | `/usr/bin/unified-hifi-control` |
| Public | `/usr/share/unified-hifi-control/public/` |
| Config | `/etc/unified-hifi-control/` |
| Env vars | `PORT`, `CONFIG_DIR`, `DATA_DIR`, `PUBLIC_DIR`, `RUST_LOG` |

### ✅ Linux DEB/RPM - Fixed
| Item | Location |
|------|----------|
| Binary | `/usr/bin/unified-hifi-control` |
| Public | `/usr/share/unified-hifi-control/public/` |
| Config | `/etc/unified-hifi-control/` |
| Env vars | `PORT`, `CONFIG_DIR`, `DATA_DIR`, `PUBLIC_DIR`, `RUST_LOG` |

### ✅ Synology SPK - Fixed
| Item | Location |
|------|----------|
| Binary | `/var/packages/unified-hifi-control/target/` |
| Public | Same dir (`target/public/`) |
| Config | Same dir (`target/`) |
| Env vars | `PORT`, `CONFIG_DIR`, `PUBLIC_DIR`, `RUST_LOG` |

### ✅ QNAP QPKG - Fixed
| Item | Location |
|------|----------|
| Binary | `$QPKG_ROOT/` |
| Public | Same dir (`$QPKG_ROOT/public/`) |
| Config | Same dir (`$QPKG_ROOT/`) |
| Env vars | `PORT`, `CONFIG_DIR`, `PUBLIC_DIR`, `RUST_LOG` |

### ✅ Windows MSI - Fixed
| Item | Location |
|------|----------|
| Binary | `C:\Program Files\Unified Hi-Fi Control\` |
| Public | Same dir (`[INSTALLFOLDER]public`) |
| Config | `[INSTALLFOLDER]data` |
| Env vars | `PORT`, `CONFIG_DIR`, `PUBLIC_DIR` (system-wide) |
| Note | Fixed `UNIFIED_HIFI_CONFIG_DIR` → `CONFIG_DIR` |

### ✅ macOS PKG - Fixed (plist)
| Item | Location |
|------|----------|
| Binary | `/usr/local/bin/unified-hifi-control` |
| Public | `/usr/local/share/unified-hifi-control/public/` |
| Config | `/usr/local/var/unified-hifi-control/` |
| Env vars | `PORT`, `CONFIG_DIR`, `PUBLIC_DIR`, `RUST_LOG` |
| Note | PKG building not in CI yet - only binary produced. Public assets need to be bundled when PKG is built. |

### ✅ LMS Plugin - Fixed
| Item | Location |
|------|----------|
| Binary | `Bin/{platform}/unified-hifi-control` |
| Public | `Bin/public/` |
| Config | `Bin/` |
| Env vars | `PORT`, `CONFIG_DIR`, `PUBLIC_DIR`, `LMS_HOST`, `LMS_PORT`, `LMS_UNIFIEDHIFI_STARTED` |
| Note | Fixed `findBin` → `findbin` typo |

---

## Test plan
- [ ] AUR package installs and starts on ARM64
- [ ] LMS plugin loads without findbin error
- [ ] Web UI accessible after service start
- [ ] Synology SPK starts correctly
- [ ] QNAP QPKG starts correctly

Fixes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified and clarified post-install messages and startup instructions for the service and Web UI.

* **Improvements**
  * Added configurable public-asset directory support across platforms and installers.
  * Improved asset discovery and symlink handling to make static asset serving more reliable.
  * Set default runtime environment variables for consistent startup behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->