### PR TITLE
Reduce the number of disk I/O for the binary handling

### DIFF
--- a/lms-plugin/Helper.pm
+++ b/lms-plugin/Helper.pm
@@ -43,6 +43,7 @@ sub init {
     # On macOS, clear quarantine flag to prevent Gatekeeper blocking unsigned binary
     if (Slim::Utils::OSDetect::OS() eq 'mac' && (my $binary = $class->bin())) {
         system('xattr', '-cr', $binary);
+        $? && $log->error("Failed to clear quarantine attribute on $binary: $!");
     }
 }
 
@@ -51,14 +52,14 @@ sub pluginVersion {
     return Plugins::UnifiedHiFi::Plugin->_pluginDataFor('version') || '0.0.0';
 }
 
-# Get path to the binary using LMS's built-in findBin
+# Get path to the binary using LMS's built-in findbin
 # Binary is in platform-specific folders: Bin/darwin/, Bin/x86_64-linux/, etc.
 sub bin {
     my $class = shift;
 
     # Let LMS find the right binary for this platform
     # LMS knows about platform folders (darwin/, x86_64-linux/, MSWin32-x64-multi-thread/, etc.)
-    my $binary = Slim::Utils::Misc::findBin('unified-hifi-control');
+    my $binary = Slim::Utils::Misc::findbin('unified-hifi-control');
 
     if ($binary) {
         $log->debug("Found binary via LMS findbin: $binary");
@@ -268,7 +269,7 @@ Binaries are bundled in the plugin ZIP in LMS platform folder structure:
 Web assets (CSS, images) are embedded in the binary - no separate public/
 folder is needed (see ADR 002).
 
-LMS's C<Slim::Utils::Misc::findBin()> automatically finds the correct binary
+LMS's C<Slim::Utils::Misc::findbin()> automatically finds the correct binary
 for the current platform.
 
 =cut

--- a/lms-plugin/Helper.pm
+++ b/lms-plugin/Helper.pm
@@ -29,7 +29,7 @@ use constant HEALTH_CHECK_INTERVAL => 30;  # seconds
 use constant MAX_RESTARTS          => 5;   # before giving up
 use constant RESTART_RESET_TIME    => 300; # reset counter after 5 min stable
 
-my ($configDir, $publicDir);
+my ($configDir);
 
 sub init {
     my ($class) = @_;
@@ -39,8 +39,6 @@ sub init {
     unless (-d $configDir) {
         make_path($configDir) or $log->error("Failed to create data directory $configDir: $!");
     }
-
-    $publicDir = catdir(Plugins::UnifiedHiFi::Plugin->_pluginDataFor('basedir'), 'Bin', 'public');
 
     # On macOS, clear quarantine flag to prevent Gatekeeper blocking unsigned binary
     if (Slim::Utils::OSDetect::OS() eq 'mac' && (my $binary = $class->bin())) {

--- a/lms-plugin/Plugin.pm
+++ b/lms-plugin/Plugin.pm
@@ -13,6 +13,7 @@ use Slim::Utils::Log;
 use Slim::Utils::Strings qw(string);
 
 use Plugins::UnifiedHiFi::Helper;
+use Plugins::UnifiedHiFi::Settings;
 
 my $log = Slim::Utils::Log->addLogCategory({
     'category'     => 'plugin.unifiedhifi',
@@ -33,8 +34,8 @@ sub initPlugin {
 
     $class->SUPER::initPlugin(@_);
 
-    require Plugins::UnifiedHiFi::Settings;
     Plugins::UnifiedHiFi::Settings->new;
+    Plugins::UnifiedHiFi::Helper->init;
 
     # Start the helper if autorun is enabled
     if ($prefs->get('autorun')) {


### PR DESCRIPTION
* LMS' `findbin()` would already check the execution flag on binaries - no need to repeat this check
* define paths during initialisation only - no need to repeatedly evaluate them
* remove `_doStart()` and integrate it in `start()` as it wouldn't be called otherwise anyway

We could further simplify `bin()` by keeping the executable's path in a variable. Those binaries won't change at runtime, will they? Therefore searching it would only need to be done once, and returned from the cached value thereafter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated initialization into a single init flow and ensured config directory creation.
  * Streamlined startup to launch the discovered helper binary directly, set environment variables inline, and improved cross‑platform process handling for correct process tracking.
  * Added explicit helper initialization during plugin startup so settings are applied before launch.

* **Bug Fixes**
  * Added macOS quarantine handling and improved health-check/restart timer logic for more reliable restarts and uptime.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->