### PR TITLE
fix(ui): Use per-zone SSE updates to prevent album art race conditions

### DIFF
--- a/src/app/sse.rs
+++ b/src/app/sse.rs
@@ -83,6 +83,19 @@ pub enum SseEvent {
     Unknown,
 }
 
+impl SseEvent {
+    /// Extract zone_id from zone-related events
+    pub fn zone_id(&self) -> Option<&str> {
+        match self {
+            SseEvent::ZoneUpdated { payload } => Some(&payload.zone_id),
+            SseEvent::ZoneRemoved { payload } => Some(&payload.zone_id),
+            SseEvent::NowPlayingChanged { payload } => Some(&payload.zone_id),
+            SseEvent::SeekPositionChanged { payload } => Some(&payload.zone_id),
+            _ => None,
+        }
+    }
+}
+
 /// Global SSE state shared via context
 #[derive(Clone, Copy)]
 pub struct SseContext {


### PR DESCRIPTION
## Summary

Fixes #109 - Zone cards displaying wrong album art when multiple zones are playing.

- **Add `SseEvent::zone_id()` helper** to extract zone_id from zone-related events
- **Selective per-zone fetching** for `NowPlayingChanged` events instead of refetching all zones
- **Atomic HashMap updates** using `with_mut()` to prevent stale data overwrites

## Root Cause Analysis

### The Problem

When multiple zones are playing, any `NowPlayingChanged` SSE event triggered ALL zone cards to refetch ALL zones' now_playing data simultaneously. This created race conditions:

```
Time T1: Zone A changes track → SSE event
Time T1: All zones start fetch_all_now_playing()

Time T1.5: Zone B also changes → SSE event  
Time T1.5: All zones start ANOTHER fetch_all_now_playing()

Time T2: Fetch #2 completes first with Zone B's new data
Time T3: Fetch #1 completes with stale Zone B data, overwrites!

Result: Zone B shows Zone A's album art (or stale data)
```

### Architecture Flow

```
[Roon/LMS Adapter]
     │
     ▼ BusEvent::NowPlayingChanged { zone_id: "roon:abc" }
     │
[SSE Handler] ──────► [Browser EventSource]
     │                       │
     │                       ▼
     │              [SseContext - GLOBAL]
     │              last_event: Signal<SseEvent>
     │              event_count: Signal<u64>  ← ALL zones subscribe
     │                       │
     │                       ▼
     │              [zones.rs use_effect]
     │              ❌ OLD: fetch_all_now_playing() ← RACE!
     │              ✅ NEW: fetch_zone_now_playing(zone_id)
```

### Key Files Changed

| File | Change |
|------|--------|
| `src/app/sse.rs` | Add `SseEvent::zone_id()` method |
| `src/app/pages/zones.rs` | Selective per-zone fetching |

## Test Plan

- [ ] Build passes (`cargo check`)
- [ ] Play music on 2+ zones simultaneously
- [ ] Change tracks on one zone → verify only that zone's art updates
- [ ] Rapid track changes on multiple zones → no art swapping

## Technical Notes

- `VolumeChanged` and `LmsPlayerStateChanged` still fetch all zones because:
  - `VolumeChanged` uses `output_id` which may differ from `zone_id`
  - `LmsPlayerStateChanged` uses `player_id` which has complex mapping

- Unit testing SSE race conditions would require mocking the entire Dioxus signal/effect system, which isn't practical. Manual verification with multiple zones is the reliable test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved now-playing updates with a mixed strategy: targeted per-zone refreshes for zone-specific events and bulk refreshes for volume/player-wide events, reducing unnecessary work and improving responsiveness.
  * Seek position changes do not trigger now-playing refreshes.

* **New Features**
  * Added a helper to fetch now-playing for a single zone and enhanced event metadata to surface affected zone IDs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->