### PR TITLE
refactor: Align API handlers with aggregator architecture + add zones_sha

### DIFF
--- a/.wm/dive_context.md
+++ b/.wm/dive_context.md
@@ -1,9 +1,8 @@
 # Dive Session
 
-**Intent:** ship
-**Started:** 2026-01-16
-**Endeavor:** 80222d6d - Unified Hi-Fi Control
-**Issue:** https://github.com/open-horizon-labs/unified-hifi-control/issues/62
+**Intent:** fix
+**Started:** 2026-01-23
+**Issue:** https://github.com/open-horizon-labs/unified-hifi-control/issues/148
 
 ## Context
 
@@ -13,51 +12,69 @@ Source-agnostic hi-fi control platform bridging music sources (Roon, UPnP, HQPla
 **Key Architecture Principle:** All backends are optional - any can contribute zones independently.
 
 ### Focus
-Issue #62: Bridge started from LMS should have LMS features auto-enabled
+Issue #148: Investigate zones_sha emission for dynamic zone detection
 
 **Problem Statement:**
-- Bridge is started via LMS plugin with env vars: `PORT=8088 LOG_LEVEL=info CONFIG_DIR=... LMS_HOST=127.0.0.1`
-- Bridge starts successfully and is accessible on port 8088
-- An `lmd-config.json` exists with correct localhost settings
-- BUT: LMS integration is NOT automatically enabled
-- User must manually enable LMS zone source
+- Roon Knob issue muness/roon-knob#112 reports zones appearing after the Knob starts don't show in the zone picker
+- PR muness/roon-knob#80 added `zones_sha` change detection on the Knob side - when the bridge reports a changed `zones_sha` in `/now_playing` responses, the Knob automatically refreshes its zone list
+- The bridge needs to emit `zones_sha` in `/now_playing` responses for this to work
 
-**Expected Behavior:**
-- When `LMS_HOST` env var is passed, LMS backend should auto-enable
-- Config from env vars should take precedence or auto-populate settings
+**Investigation Needed:**
+1. Does the bridge currently emit `zones_sha` in `/now_playing` responses?
+2. Does the bridge update `zones_sha` when the zone list changes (zones added/removed)?
+3. If not, implement `zones_sha` emission to enable dynamic zone detection
 
-**Related:**
-- Possibly duplicate of #54 (env vars ignored)
-- Recent commit 1cc6fdf mentions "LMS env var support" - may be incomplete
+### Current State Analysis
+
+**Test harness expects `zones_sha`:**
+- `tests/client_harness.rs` lines 139, 147 define `zones_sha: Option<String>` in response structs
+- This indicates the expected API contract includes `zones_sha`
+
+**Bridge does NOT currently emit `zones_sha`:**
+- `src/knobs/routes.rs` `NowPlayingResponse` struct (lines 223-244) does NOT include `zones_sha` field
+- Grep for `zones_sha` in `src/` returns no matches
+- The field is expected by clients but not emitted by the server
+
+**Required Implementation:**
+1. Add `zones_sha: Option<String>` to `NowPlayingResponse` struct
+2. Compute SHA of zone list (hash of zone IDs + names, or similar)
+3. Include `zones_sha` in all `/knob/now_playing` responses
+4. Update SHA when zones change (adapters add/remove zones)
 
 ### Constraints
 - From AGENTS.md: Follow TDD - write test first, see it fail, then fix
+- API Stability: Do NOT add/remove/modify API endpoints without explicit user approval
+- Note: Adding `zones_sha` to existing response is likely acceptable (additive, backward-compatible)
 - Multi-backend architecture: all sources optional
-- Must maintain backwards compatibility with existing config files
+- Must handle zone changes from any adapter (Roon, LMS, OpenHome, UPnP)
 
 ## Workflow
 
-1. **Understand current behavior**
-   - How does LMS backend get enabled currently?
-   - Where are env vars read?
-   - What does commit 1cc6fdf actually implement?
+1. **Verify the gap**
+   - Run existing tests to confirm `zones_sha` expectation
+   - Confirm field is missing from response
 
 2. **Write failing test**
-   - Test that LMS backend auto-enables when LMS_HOST env var present
+   - Test that `/knob/now_playing` includes `zones_sha` field
+   - Test that `zones_sha` changes when zone list changes
 
 3. **Implement fix**
-   - Wire env var to auto-enable LMS backend
+   - Add `zones_sha` field to `NowPlayingResponse`
+   - Compute hash of zone list
+   - Track zone list version/SHA in aggregator or state
 
 4. **Verify**
    - Test passes
-   - Manual verification if possible
+   - Manual verification with actual knob if possible
 
 5. **Stage, review, commit**
    - Run `sg review`
-   - Clear commit message
+   - Clear commit message referencing #148
 
 ## Sources
-- Issue: #62 (michaelherger)
-- Related: #54 (env vars ignored)
-- Commit: 1cc6fdf (recent LMS env var support)
-- Local: AGENTS.md (TDD guidelines)
+- Issue: #148 (zones_sha emission)
+- Related: muness/roon-knob#112 (zones not appearing)
+- Related: muness/roon-knob#80 (client-side zones_sha detection)
+- Local: `tests/client_harness.rs` (expected response format)
+- Local: `src/knobs/routes.rs` (current implementation)
+- Local: AGENTS.md (TDD guidelines, API stability)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,22 @@ This includes:
 - Update `api_routes.txt` without explicit approval
 - Assume API changes are "minor" or "safe"
 
+## Engineering Philosophy
+
+**Do things the right way, even if "larger" or "harder".**
+
+- Correct architecture now prevents regressions later
+- Short-term hacks create long-term maintenance burden
+- When you see an architectural inconsistency, fix it - don't work around it
+- If a component exists for a purpose (e.g., aggregator as "single source of truth"), USE IT
+
+**Examples:**
+- Don't bypass the aggregator to query adapters directly
+- Don't cache computed values at the wrong layer
+- Don't add settings-filtering at query time if it belongs at the source
+
+---
+
 ## Architecture
 
 See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the event bus pattern and design principles.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,15 @@ This includes:
 
 **Do things the right way, even if "larger" or "harder".**
 
+### Terminology: "Refactor"
+
+**Refactor means restructuring code WITHOUT changing behavior.**
+
+- A refactor is a behavior-preserving transformation
+- If you're adding a new type (e.g., `PrefixedZoneId`), wiring it through means updating ALL call sites to use it - not just adding the type definition
+- "Refactor to use X" = find every place that should use X and change it
+- Don't confuse "adding a type" with "refactoring to use a type"
+
 - Correct architecture now prevents regressions later
 - Short-term hacks create long-term maintenance burden
 - When you see an architectural inconsistency, fix it - don't work around it

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "askama_escape"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,6 +258,12 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
@@ -384,6 +402,12 @@ dependencies = [
  "ciborium-io",
  "half",
 ]
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "combine"
@@ -601,6 +625,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,6 +726,12 @@ name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
 name = "deranged"
@@ -1464,6 +1503,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1478,6 +1526,12 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 
 [[package]]
 name = "flume"
@@ -1501,6 +1555,29 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "fontconfig-parser"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+dependencies = [
+ "roxmltree 0.20.0",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser",
+]
 
 [[package]]
 name = "form_urlencoded"
@@ -1671,6 +1748,16 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "gif"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5df2ba84018d80c213569363bdcd0c64e6933c67fe4c1d60ecf822971a3c35e"
+dependencies = [
+ "color_quant",
+ "weezl",
 ]
 
 [[package]]
@@ -2087,11 +2174,31 @@ checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
+ "color_quant",
+ "gif",
+ "image-webp",
  "moxcms",
  "num-traits",
+ "png 0.18.0",
  "zune-core",
  "zune-jpeg",
 ]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "imagesize"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
 
 [[package]]
 name = "indexmap"
@@ -2192,8 +2299,19 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "serde",
+]
+
+[[package]]
+name = "kurbo"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7564e90fe3c0d5771e1f0bc95322b21baaeaa0d9213fa6a0b61c99f8b17b3bfb"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "smallvec",
 ]
 
 [[package]]
@@ -2229,6 +2347,12 @@ dependencies = [
  "cfg-if",
  "windows-link",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2472,7 +2596,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "jni-sys",
  "log",
  "ndk-sys",
@@ -2662,6 +2786,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "pin-project"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2692,6 +2822,32 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "png"
+version = "0.17.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "png"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
+dependencies = [
+ "bitflags 2.10.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "potential_utf"
@@ -2771,6 +2927,12 @@ checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -2923,7 +3085,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -3000,6 +3162,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "resvg"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b563218631706d614e23059436526d005b50ab5f2d506b55a17eb65c5eb83419"
+dependencies = [
+ "gif",
+ "image-webp",
+ "log",
+ "pico-args",
+ "rgb",
+ "svgtypes",
+ "tiny-skia",
+ "usvg",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3020,7 +3208,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
  "base64 0.21.7",
- "bitflags",
+ "bitflags 2.10.0",
  "serde",
  "serde_derive",
 ]
@@ -3041,6 +3229,21 @@ dependencies = [
  "typetag",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
+name = "roxmltree"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3132,7 +3335,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3228,6 +3431,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "rustybuzz"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
+dependencies = [
+ "bitflags 2.10.0",
+ "bytemuck",
+ "core_maths",
+ "log",
+ "smallvec",
+ "ttf-parser",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-properties",
+ "unicode-script",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3278,7 +3499,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3498,6 +3719,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "simplecss"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3597,6 +3833,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp",
+]
+
+[[package]]
 name = "subsecond"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3629,6 +3874,16 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "svgtypes"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "695b5790b3131dafa99b3bbfd25a216edb3d216dad9ca208d4657bfb8f2abc3d"
+dependencies = [
+ "kurbo",
+ "siphasher",
+]
 
 [[package]]
 name = "syn"
@@ -3667,7 +3922,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -3782,6 +4037,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
+]
+
+[[package]]
+name = "tiny-skia"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "png 0.17.16",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
 ]
 
 [[package]]
@@ -4026,7 +4307,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "async-compression",
- "bitflags",
+ "bitflags 2.10.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -4150,6 +4431,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
+]
+
+[[package]]
 name = "tungstenite"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4251,16 +4541,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
+name = "unicode-bidi-mirroring"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-script"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-vo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
 
 [[package]]
 name = "unicode-xid"
@@ -4270,7 +4596,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unified-hifi-control"
-version = "3.1.0-rc.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4294,6 +4620,7 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "reqwest",
+ "resvg",
  "roon-api",
  "rumqttc",
  "rust-embed",
@@ -4345,6 +4672,33 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "usvg"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e419dff010bb12512b0ae9e3d2f318dfbdf0167fde7eb05465134d4e8756076f"
+dependencies = [
+ "base64 0.22.1",
+ "data-url",
+ "flate2",
+ "fontdb",
+ "imagesize",
+ "kurbo",
+ "log",
+ "pico-args",
+ "roxmltree 0.21.1",
+ "rustybuzz",
+ "simplecss",
+ "siphasher",
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "xmlwriter",
+]
 
 [[package]]
 name = "utf-8"
@@ -4536,6 +4890,12 @@ checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "winapi-util"
@@ -4867,6 +5227,12 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
 name = "xxhash-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ server = [
     "dep:tracing-subscriber",
     "dep:config",
     "dep:image",
+    "dep:resvg",
     "dep:tokio-stream",
     "dep:tokio-util",
     "dep:ssdp-client",
@@ -117,7 +118,9 @@ gethostname = { version = "1.1.0", optional = true }
 rust-embed = { version = "8", optional = true }
 mime_guess = { version = "2", optional = true }
 http-body-util = { version = "0.1", optional = true }
-resvg = { version = "0.46.0", features = ["default"] }
+
+# SVG rasterization (server only)
+resvg = { version = "0.46.0", features = ["default"], optional = true }
 
 # ============ WEB-ONLY DEPENDENCIES ============
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = tr
 config = { version = "0.14", optional = true }
 
 # Image processing (server only)
-image = { version = "0.25", default-features = false, features = ["jpeg"], optional = true }
+image = { version = "0.25", default-features = false, features = ["jpeg", "png", "gif", "bmp", "webp"], optional = true }
 
 # Tokio stream utilities (server only)
 tokio-stream = { version = "0.1", features = ["sync"], optional = true }
@@ -117,6 +117,7 @@ gethostname = { version = "1.1.0", optional = true }
 rust-embed = { version = "8", optional = true }
 mime_guess = { version = "2", optional = true }
 http-body-util = { version = "0.1", optional = true }
+resvg = { version = "0.46.0", features = ["default"] }
 
 # ============ WEB-ONLY DEPENDENCIES ============
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/src/adapters/hqplayer.rs
+++ b/src/adapters/hqplayer.rs
@@ -1830,6 +1830,10 @@ impl HqpAdapter {
             is_controllable: true,
             is_seekable: true,
             last_updated,
+            is_play_allowed: state != PlaybackState::Playing,
+            is_pause_allowed: state == PlaybackState::Playing,
+            is_next_allowed: true,
+            is_previous_allowed: true,
         }
     }
 }

--- a/src/adapters/hqplayer.rs
+++ b/src/adapters/hqplayer.rs
@@ -22,7 +22,7 @@ use tokio::sync::{Mutex, RwLock};
 use tokio::time::timeout;
 
 use crate::bus::{
-    BusEvent, NowPlaying as BusNowPlaying, PlaybackState, SharedBus, TrackMetadata,
+    BusEvent, NowPlaying as BusNowPlaying, PlaybackState, PrefixedZoneId, SharedBus, TrackMetadata,
     VolumeControl as BusVolumeControl, VolumeScale, Zone as BusZone,
 };
 use crate::config::{get_config_file_path, read_config_file};
@@ -600,7 +600,7 @@ impl HqpAdapter {
 
         if let Some(ref h) = host {
             // Emit ZoneRemoved for this HQPlayer instance
-            let zone_id = format!("hqplayer:{}", instance_name.as_deref().unwrap_or(h));
+            let zone_id = PrefixedZoneId::hqplayer(instance_name.as_deref().unwrap_or(h));
             self.bus.publish(BusEvent::ZoneRemoved { zone_id });
 
             self.bus
@@ -638,7 +638,7 @@ impl HqpAdapter {
         if let Some(ref h) = host {
             tracing::warn!("HQPlayer connection lost to {}", h);
             // Emit ZoneRemoved for this HQPlayer instance
-            let zone_id = format!("hqplayer:{}", instance_name.as_deref().unwrap_or(h));
+            let zone_id = PrefixedZoneId::hqplayer(instance_name.as_deref().unwrap_or(h));
             self.bus.publish(BusEvent::ZoneRemoved { zone_id });
         }
     }

--- a/src/adapters/lms.rs
+++ b/src/adapters/lms.rs
@@ -29,7 +29,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
 use crate::adapters::lms_discovery::discover_lms_servers;
-use crate::bus::{BusEvent, PlaybackState, SharedBus, VolumeControl, Zone};
+use crate::bus::{BusEvent, PlaybackState, PrefixedZoneId, SharedBus, VolumeControl, Zone};
 use crate::config::{get_config_file_path, read_config_file};
 
 const LMS_CONFIG_FILE: &str = "lms-config.json";
@@ -1064,7 +1064,7 @@ async fn update_players_internal(
         for player_id in &removed {
             tracing::debug!("LMS player removed: {}", player_id);
             bus.publish(BusEvent::ZoneRemoved {
-                zone_id: format!("lms:{}", player_id),
+                zone_id: PrefixedZoneId::lms(player_id),
             });
         }
     }
@@ -1232,7 +1232,7 @@ async fn handle_cli_event(
             // Refresh player status on playlist changes
             match rpc.get_player_status(&player_id).await {
                 Ok(status) => {
-                    let zone_id = format!("lms:{}", player_id);
+                    let zone_id = PrefixedZoneId::lms(&player_id);
 
                     // Update cached state
                     {

--- a/src/adapters/lms.rs
+++ b/src/adapters/lms.rs
@@ -996,6 +996,11 @@ fn lms_player_to_zone(player: &LmsPlayer) -> Zone {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_millis() as u64,
+        // LMS always allows playback controls when powered and connected
+        is_play_allowed: player.state != "playing",
+        is_pause_allowed: player.state == "playing",
+        is_next_allowed: true,
+        is_previous_allowed: true,
     }
 }
 

--- a/src/adapters/openhome.rs
+++ b/src/adapters/openhome.rs
@@ -4,7 +4,9 @@
 //! OpenHome is an extension of UPnP that provides richer metadata and more
 //! control actions (next/previous track, playlists, etc.)
 
-use crate::bus::{BusEvent, PlaybackState, SharedBus, VolumeControl as BusVolumeControl, Zone};
+use crate::bus::{
+    BusEvent, PlaybackState, PrefixedZoneId, SharedBus, VolumeControl as BusVolumeControl, Zone,
+};
 use futures::StreamExt;
 use quick_xml::de::from_str as xml_from_str;
 use reqwest::Client;
@@ -386,7 +388,7 @@ impl OpenHomeAdapter {
             tracing::info!("Removing stale OpenHome device: {}", uuid);
             s.devices.remove(&uuid);
             bus.publish(BusEvent::ZoneRemoved {
-                zone_id: format!("openhome:{}", uuid),
+                zone_id: PrefixedZoneId::openhome(&uuid),
             });
         }
     }
@@ -454,7 +456,7 @@ impl OpenHomeAdapter {
                     if device.state != new_state {
                         device.state = new_state.clone();
                         bus.publish(BusEvent::ZoneUpdated {
-                            zone_id: format!("openhome:{}", uuid),
+                            zone_id: PrefixedZoneId::openhome(uuid),
                             display_name: device.name.clone(),
                             state: new_state,
                         });
@@ -534,7 +536,7 @@ impl OpenHomeAdapter {
                             let image_key = track_info.album_art_uri.clone();
                             device.track_info = Some(track_info);
                             bus.publish(BusEvent::NowPlayingChanged {
-                                zone_id: format!("openhome:{}", uuid),
+                                zone_id: PrefixedZoneId::openhome(uuid),
                                 title,
                                 artist,
                                 album,

--- a/src/adapters/openhome.rs
+++ b/src/adapters/openhome.rs
@@ -932,6 +932,10 @@ fn openhome_device_to_zone(device: &OpenHomeDevice) -> Zone {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_millis() as u64,
+        is_play_allowed: device.state != "playing",
+        is_pause_allowed: device.state == "playing",
+        is_next_allowed: true,
+        is_previous_allowed: true,
     }
 }
 

--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -758,17 +758,21 @@ async fn run_roon_loop(
                                 bus_for_events.publish(BusEvent::ZoneDiscovered { zone: bus_zone });
                             } else {
                                 // Existing zone - emit ZoneUpdated
+                                // Use prefixed zone_id to match ZoneDiscovered format
+                                let prefixed_zone_id = format!("roon:{}", converted.zone_id);
                                 bus_for_events.publish(BusEvent::ZoneUpdated {
-                                    zone_id: converted.zone_id.clone(),
+                                    zone_id: prefixed_zone_id.clone(),
                                     display_name: converted.display_name.clone(),
                                     state: converted.state.clone(),
                                 });
                             }
 
                             // Publish now playing changed if present
+                            // Use prefixed zone_id to match aggregator's stored format
+                            let prefixed_zone_id = format!("roon:{}", converted.zone_id);
                             if let Some(ref np) = converted.now_playing {
                                 bus_for_events.publish(BusEvent::NowPlayingChanged {
-                                    zone_id: converted.zone_id.clone(),
+                                    zone_id: prefixed_zone_id.clone(),
                                     title: Some(np.title.clone()),
                                     artist: Some(np.artist.clone()),
                                     album: Some(np.album.clone()),
@@ -814,9 +818,10 @@ async fn run_roon_loop(
                                     np.seek_position = seek.seek_position;
 
                                     // Publish seek position changed
+                                    // Use prefixed zone_id to match aggregator's stored format
                                     if let Some(pos) = seek.seek_position {
                                         bus_for_events.publish(BusEvent::SeekPositionChanged {
-                                            zone_id: seek.zone_id.clone(),
+                                            zone_id: format!("roon:{}", seek.zone_id),
                                             position: pos,
                                         });
                                     }
@@ -831,8 +836,9 @@ async fn run_roon_loop(
                             s.zones.remove(&zone_id);
 
                             // Publish zone removed event
+                            // Use prefixed zone_id to match aggregator's stored format
                             bus_for_events.publish(BusEvent::ZoneRemoved {
-                                zone_id: zone_id.clone(),
+                                zone_id: format!("roon:{}", zone_id),
                             });
                         }
                     }

--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -564,6 +564,10 @@ fn roon_zone_to_bus_zone(zone: &Zone) -> BusZone {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_millis() as u64,
+        is_play_allowed: zone.is_play_allowed,
+        is_pause_allowed: zone.is_pause_allowed,
+        is_next_allowed: zone.is_next_allowed,
+        is_previous_allowed: zone.is_previous_allowed,
     }
 }
 

--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -18,7 +18,7 @@ use tokio::sync::{oneshot, RwLock};
 use tokio_util::sync::CancellationToken;
 
 use crate::bus::{
-    BusEvent, NowPlaying as BusNowPlaying, PlaybackState, SharedBus,
+    BusEvent, NowPlaying as BusNowPlaying, PlaybackState, PrefixedZoneId, SharedBus,
     VolumeControl as BusVolumeControl, Zone as BusZone,
 };
 use crate::config::get_config_file_path;
@@ -759,7 +759,7 @@ async fn run_roon_loop(
                             } else {
                                 // Existing zone - emit ZoneUpdated
                                 // Use prefixed zone_id to match ZoneDiscovered format
-                                let prefixed_zone_id = format!("roon:{}", converted.zone_id);
+                                let prefixed_zone_id = PrefixedZoneId::roon(&converted.zone_id);
                                 bus_for_events.publish(BusEvent::ZoneUpdated {
                                     zone_id: prefixed_zone_id.clone(),
                                     display_name: converted.display_name.clone(),
@@ -769,7 +769,7 @@ async fn run_roon_loop(
 
                             // Publish now playing changed if present
                             // Use prefixed zone_id to match aggregator's stored format
-                            let prefixed_zone_id = format!("roon:{}", converted.zone_id);
+                            let prefixed_zone_id = PrefixedZoneId::roon(&converted.zone_id);
                             if let Some(ref np) = converted.now_playing {
                                 bus_for_events.publish(BusEvent::NowPlayingChanged {
                                     zone_id: prefixed_zone_id.clone(),
@@ -821,7 +821,7 @@ async fn run_roon_loop(
                                     // Use prefixed zone_id to match aggregator's stored format
                                     if let Some(pos) = seek.seek_position {
                                         bus_for_events.publish(BusEvent::SeekPositionChanged {
-                                            zone_id: format!("roon:{}", seek.zone_id),
+                                            zone_id: PrefixedZoneId::roon(&seek.zone_id),
                                             position: pos,
                                         });
                                     }
@@ -838,7 +838,7 @@ async fn run_roon_loop(
                             // Publish zone removed event
                             // Use prefixed zone_id to match aggregator's stored format
                             bus_for_events.publish(BusEvent::ZoneRemoved {
-                                zone_id: format!("roon:{}", zone_id),
+                                zone_id: PrefixedZoneId::roon(&zone_id),
                             });
                         }
                     }

--- a/src/adapters/upnp.rs
+++ b/src/adapters/upnp.rs
@@ -894,8 +894,8 @@ fn upnp_renderer_to_zone(renderer: &UPnPRenderer) -> Zone {
             .as_millis() as u64,
         is_play_allowed: renderer.state != "playing",
         is_pause_allowed: renderer.state == "playing",
-        is_next_allowed: true,
-        is_previous_allowed: true,
+        is_next_allowed: false,
+        is_previous_allowed: false,
     }
 }
 

--- a/src/adapters/upnp.rs
+++ b/src/adapters/upnp.rs
@@ -4,7 +4,9 @@
 //! Pure UPnP/DLNA has limited metadata support compared to OpenHome.
 //! Specifically, next/previous track are NOT supported by pure UPnP.
 
-use crate::bus::{BusEvent, PlaybackState, SharedBus, VolumeControl as BusVolumeControl, Zone};
+use crate::bus::{
+    BusEvent, PlaybackState, PrefixedZoneId, SharedBus, VolumeControl as BusVolumeControl, Zone,
+};
 use futures::StreamExt;
 use quick_xml::de::from_str as xml_from_str;
 use regex::Regex;
@@ -375,7 +377,7 @@ impl UPnPAdapter {
             tracing::info!("Removing stale UPnP renderer: {}", uuid);
             s.renderers.remove(&uuid);
             bus.publish(BusEvent::ZoneRemoved {
-                zone_id: format!("upnp:{}", uuid),
+                zone_id: PrefixedZoneId::upnp(&uuid),
             });
         }
     }
@@ -467,7 +469,7 @@ impl UPnPAdapter {
                         if renderer.state != new_state {
                             renderer.state = new_state.clone();
                             bus.publish(BusEvent::ZoneUpdated {
-                                zone_id: format!("upnp:{}", uuid),
+                                zone_id: PrefixedZoneId::upnp(uuid),
                                 display_name: renderer.name.clone(),
                                 state: new_state,
                             });

--- a/src/adapters/upnp.rs
+++ b/src/adapters/upnp.rs
@@ -892,6 +892,10 @@ fn upnp_renderer_to_zone(renderer: &UPnPRenderer) -> Zone {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_millis() as u64,
+        is_play_allowed: renderer.state != "playing",
+        is_pause_allowed: renderer.state == "playing",
+        is_next_allowed: true,
+        is_previous_allowed: true,
     }
 }
 

--- a/src/aggregator.rs
+++ b/src/aggregator.rs
@@ -47,7 +47,7 @@ impl ZoneAggregator {
                     state,
                 } => {
                     debug!("Zone updated: {}", zone_id);
-                    if let Some(zone) = self.zones.write().await.get_mut(&zone_id) {
+                    if let Some(zone) = self.zones.write().await.get_mut(zone_id.as_str()) {
                         zone.zone_name = display_name;
                         zone.state = state.as_str().into();
                     }
@@ -55,8 +55,8 @@ impl ZoneAggregator {
 
                 BusEvent::ZoneRemoved { zone_id } => {
                     debug!("Zone removed: {}", zone_id);
-                    self.zones.write().await.remove(&zone_id);
-                    self.now_playing.write().await.remove(&zone_id);
+                    self.zones.write().await.remove(zone_id.as_str());
+                    self.now_playing.write().await.remove(zone_id.as_str());
                 }
 
                 BusEvent::NowPlayingChanged {
@@ -76,7 +76,10 @@ impl ZoneAggregator {
                         duration: None,
                         metadata: None,
                     };
-                    self.now_playing.write().await.insert(zone_id, np);
+                    self.now_playing
+                        .write()
+                        .await
+                        .insert(zone_id.to_string(), np);
                 }
 
                 BusEvent::VolumeChanged {
@@ -115,7 +118,7 @@ impl ZoneAggregator {
 
                 BusEvent::SeekPositionChanged { zone_id, position } => {
                     debug!("Seek position changed: {} = {}", zone_id, position);
-                    if let Some(np) = self.now_playing.write().await.get_mut(&zone_id) {
+                    if let Some(np) = self.now_playing.write().await.get_mut(zone_id.as_str()) {
                         np.seek_position = Some(position as f64);
                     }
                 }

--- a/src/app/pages/zones.rs
+++ b/src/app/pages/zones.rs
@@ -97,8 +97,9 @@ pub fn Zones() -> Element {
         // zones update rapidly (fixes issue #109 - wrong album art display)
         if let Some(ref evt) = event {
             match evt {
-                // Zone-scoped event: fetch only the specific zone that changed
-                SseEvent::NowPlayingChanged { .. } => {
+                // Zone-scoped events: fetch only the specific zone that changed
+                // ZoneUpdated includes state changes (play/pause) that affect is_playing
+                SseEvent::NowPlayingChanged { .. } | SseEvent::ZoneUpdated { .. } => {
                     if let Some(zone_id) = evt.zone_id() {
                         let zone_id = zone_id.to_string();
                         spawn(async move {

--- a/src/bus/events.rs
+++ b/src/bus/events.rs
@@ -42,6 +42,18 @@ pub struct Zone {
 
     /// Last update timestamp (milliseconds since epoch)
     pub last_updated: u64,
+
+    /// Whether play command is currently allowed
+    pub is_play_allowed: bool,
+
+    /// Whether pause command is currently allowed
+    pub is_pause_allowed: bool,
+
+    /// Whether next track command is allowed
+    pub is_next_allowed: bool,
+
+    /// Whether previous track command is allowed
+    pub is_previous_allowed: bool,
 }
 
 /// Playback state enumeration
@@ -609,6 +621,10 @@ mod tests {
                 is_controllable: true,
                 is_seekable: true,
                 last_updated: 0,
+                is_play_allowed: true,
+                is_pause_allowed: false,
+                is_next_allowed: true,
+                is_previous_allowed: true,
             },
         };
         assert_eq!(event.event_type(), "zone_discovered");

--- a/src/bus/events.rs
+++ b/src/bus/events.rs
@@ -190,6 +190,16 @@ pub struct TrackMetadata {
     pub disc_number: Option<u32>,
 }
 
+/// Image data returned from adapters
+#[derive(Debug, Clone)]
+pub struct ImageData {
+    /// MIME content type (e.g., "image/jpeg", "image/png")
+    pub content_type: String,
+
+    /// Raw image bytes
+    pub data: Vec<u8>,
+}
+
 /// Zone update payload for partial updates.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ZoneUpdate {

--- a/src/knobs/image.rs
+++ b/src/knobs/image.rs
@@ -2,7 +2,8 @@
 //!
 //! The S3 Knob uses a 240x240 LCD that expects RGB565 format (2 bytes per pixel).
 //! This module handles:
-//! - JPEG decoding
+//! - JPEG, PNG, GIF, BMP, WebP decoding
+//! - SVG rasterization (via resvg)
 //! - Image resizing (bilinear)
 //! - RGB565 conversion (little-endian for ESP32)
 
@@ -16,15 +17,29 @@ pub struct Rgb565Image {
     pub height: u32,
 }
 
-/// Convert any image buffer (JPEG, PNG, etc.) to RGB565 format for ESP32 LCD
+/// Convert any image buffer (JPEG, PNG, SVG, etc.) to RGB565 format for ESP32 LCD
 ///
 /// Returns RGB565 data in little-endian byte order (ESP32 native).
-/// Supports JPEG, PNG, GIF, BMP, ICO, TIFF, WebP, and other formats via the `image` crate.
+/// Supports JPEG, PNG, GIF, BMP, ICO, TIFF, WebP via the `image` crate,
+/// and SVG via `resvg`.
 pub fn jpeg_to_rgb565(
     image_data: &[u8],
     target_width: u32,
     target_height: u32,
 ) -> Result<Rgb565Image, image::ImageError> {
+    // Check if it's SVG (starts with '<' after optional whitespace/BOM)
+    let trimmed = image_data
+        .iter()
+        .find(|&&b| b != 0xEF && b != 0xBB && b != 0xBF && !b.is_ascii_whitespace());
+
+    if trimmed == Some(&b'<') {
+        // Try SVG rasterization
+        if let Ok(rgb565) = svg_to_rgb565(image_data, target_width, target_height) {
+            return Ok(rgb565);
+        }
+        // Fall through to try as regular image if SVG parsing fails
+    }
+
     // Auto-detect format and decode (works with JPEG, PNG, GIF, BMP, etc.)
     let img = image::load_from_memory(image_data)?;
 
@@ -40,6 +55,66 @@ pub fn jpeg_to_rgb565(
 
     Ok(Rgb565Image {
         data: rgb565_data,
+        width: target_width,
+        height: target_height,
+    })
+}
+
+/// Rasterize SVG to RGB565 format
+pub fn svg_to_rgb565(
+    svg_data: &[u8],
+    target_width: u32,
+    target_height: u32,
+) -> Result<Rgb565Image, Box<dyn std::error::Error + Send + Sync>> {
+    use resvg::tiny_skia::{Pixmap, Transform};
+    use resvg::usvg::{Options, Tree};
+
+    // Parse SVG
+    let tree = Tree::from_data(svg_data, &Options::default())?;
+
+    // Get original size
+    let size = tree.size();
+    let (orig_w, orig_h) = (size.width(), size.height());
+
+    // Calculate scale to fit target dimensions
+    let scale_x = target_width as f32 / orig_w;
+    let scale_y = target_height as f32 / orig_h;
+    let scale = scale_x.min(scale_y);
+
+    // Create pixmap for rendering
+    let mut pixmap = Pixmap::new(target_width, target_height).ok_or("Failed to create pixmap")?;
+
+    // Fill with dark background (matches placeholder style)
+    pixmap.fill(resvg::tiny_skia::Color::from_rgba8(51, 51, 51, 255));
+
+    // Center the scaled image
+    let scaled_w = orig_w * scale;
+    let scaled_h = orig_h * scale;
+    let offset_x = (target_width as f32 - scaled_w) / 2.0;
+    let offset_y = (target_height as f32 - scaled_h) / 2.0;
+
+    // Render SVG
+    let transform = Transform::from_scale(scale, scale).post_translate(offset_x, offset_y);
+    resvg::render(&tree, transform, &mut pixmap.as_mut());
+
+    // Convert RGBA to RGB565
+    let pixels = pixmap.data();
+    let mut rgb565 = Vec::with_capacity((target_width * target_height * 2) as usize);
+
+    for chunk in pixels.chunks(4) {
+        let r = chunk[0] >> 3; // 5 bits
+        let g = chunk[1] >> 2; // 6 bits
+        let b = chunk[2] >> 3; // 5 bits
+
+        let pixel_value: u16 = ((r as u16) << 11) | ((g as u16) << 5) | (b as u16);
+
+        // Little-endian for ESP32
+        rgb565.push((pixel_value & 0xFF) as u8);
+        rgb565.push((pixel_value >> 8) as u8);
+    }
+
+    Ok(Rgb565Image {
+        data: rgb565,
         width: target_width,
         height: target_height,
     })
@@ -137,6 +212,7 @@ pub fn placeholder_svg(width: u32, height: u32) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use image::ImageEncoder;
 
     #[test]
     fn test_rgb565_conversion() {
@@ -182,5 +258,73 @@ mod tests {
         assert!(svg.contains("width=\"240\""));
         assert!(svg.contains("height=\"240\""));
         assert!(svg.contains("No Image"));
+    }
+
+    #[test]
+    fn test_svg_to_rgb565() {
+        // Simple red square SVG
+        let svg = r#"<svg xmlns="http://www.w3.org/2000/svg" width="2" height="2">
+            <rect width="100%" height="100%" fill="red"/>
+        </svg>"#;
+
+        let result = svg_to_rgb565(svg.as_bytes(), 2, 2).expect("SVG conversion should work");
+
+        assert_eq!(result.width, 2);
+        assert_eq!(result.height, 2);
+        assert_eq!(result.data.len(), 8); // 2x2 pixels * 2 bytes
+
+        // All pixels should be red: RGB565 0xF800 -> LE: 0x00, 0xF8
+        for i in 0..4 {
+            assert_eq!(result.data[i * 2], 0x00, "Red low byte at pixel {}", i);
+            assert_eq!(result.data[i * 2 + 1], 0xF8, "Red high byte at pixel {}", i);
+        }
+    }
+
+    #[test]
+    fn test_placeholder_svg_to_rgb565() {
+        // Verify placeholder SVG can be converted to RGB565
+        let svg = placeholder_svg(240, 240);
+        let result = svg_to_rgb565(svg.as_bytes(), 240, 240);
+        assert!(result.is_ok(), "Placeholder SVG should convert to RGB565");
+
+        let rgb565 = result.unwrap();
+        assert_eq!(rgb565.width, 240);
+        assert_eq!(rgb565.height, 240);
+        assert_eq!(rgb565.data.len(), 240 * 240 * 2);
+    }
+
+    #[test]
+    fn test_png_to_rgb565() {
+        // Create a 2x2 red PNG programmatically
+        let mut img = image::RgbaImage::new(2, 2);
+        for pixel in img.pixels_mut() {
+            *pixel = image::Rgba([255, 0, 0, 255]); // Red
+        }
+
+        // Encode as PNG
+        let mut png_data = Vec::new();
+        let encoder = image::codecs::png::PngEncoder::new(&mut png_data);
+        encoder
+            .write_image(&img, 2, 2, image::ExtendedColorType::Rgba8)
+            .expect("PNG encoding should work");
+
+        // Convert to RGB565
+        let result = jpeg_to_rgb565(&png_data, 2, 2);
+        assert!(
+            result.is_ok(),
+            "PNG should convert to RGB565: {:?}",
+            result.err()
+        );
+
+        let rgb565 = result.unwrap();
+        assert_eq!(rgb565.width, 2);
+        assert_eq!(rgb565.height, 2);
+        assert_eq!(rgb565.data.len(), 8); // 2x2 pixels * 2 bytes
+
+        // All pixels should be red: RGB565 0xF800 -> LE: 0x00, 0xF8
+        for i in 0..4 {
+            assert_eq!(rgb565.data[i * 2], 0x00, "Red low byte at pixel {}", i);
+            assert_eq!(rgb565.data[i * 2 + 1], 0xF8, "Red high byte at pixel {}", i);
+        }
     }
 }

--- a/src/knobs/image.rs
+++ b/src/knobs/image.rs
@@ -20,8 +20,7 @@ pub struct Rgb565Image {
 /// Convert any image buffer (JPEG, PNG, SVG, etc.) to RGB565 format for ESP32 LCD
 ///
 /// Returns RGB565 data in little-endian byte order (ESP32 native).
-/// Supports JPEG, PNG, GIF, BMP, ICO, TIFF, WebP via the `image` crate,
-/// and SVG via `resvg`.
+/// Supports JPEG, PNG, GIF, BMP, WebP via the `image` crate, and SVG via `resvg`.
 pub fn jpeg_to_rgb565(
     image_data: &[u8],
     target_width: u32,

--- a/src/knobs/image.rs
+++ b/src/knobs/image.rs
@@ -16,16 +16,17 @@ pub struct Rgb565Image {
     pub height: u32,
 }
 
-/// Convert JPEG buffer to RGB565 format for ESP32 LCD
+/// Convert any image buffer (JPEG, PNG, etc.) to RGB565 format for ESP32 LCD
 ///
 /// Returns RGB565 data in little-endian byte order (ESP32 native).
+/// Supports JPEG, PNG, GIF, BMP, ICO, TIFF, WebP, and other formats via the `image` crate.
 pub fn jpeg_to_rgb565(
-    jpeg_data: &[u8],
+    image_data: &[u8],
     target_width: u32,
     target_height: u32,
 ) -> Result<Rgb565Image, image::ImageError> {
-    // Decode JPEG
-    let img = image::load_from_memory_with_format(jpeg_data, ImageFormat::Jpeg)?;
+    // Auto-detect format and decode (works with JPEG, PNG, GIF, BMP, etc.)
+    let img = image::load_from_memory(image_data)?;
 
     // Resize if needed
     let img = if img.width() != target_width || img.height() != target_height {
@@ -42,6 +43,15 @@ pub fn jpeg_to_rgb565(
         width: target_width,
         height: target_height,
     })
+}
+
+/// Convert any image buffer to RGB565 format (alias with clearer name)
+pub fn image_bytes_to_rgb565(
+    image_data: &[u8],
+    target_width: u32,
+    target_height: u32,
+) -> Result<Rgb565Image, image::ImageError> {
+    jpeg_to_rgb565(image_data, target_width, target_height)
 }
 
 /// Convert any image to RGB565 format

--- a/src/knobs/routes.rs
+++ b/src/knobs/routes.rs
@@ -476,6 +476,12 @@ pub async fn knob_image_handler(
         .await
     {
         Ok(image_data) => {
+            // If RGB565 was requested but conversion failed (content_type != octet-stream),
+            // return the placeholder instead of misleading headers
+            if format == Some("rgb565") && image_data.content_type != "application/octet-stream" {
+                return placeholder_response();
+            }
+
             let mut response = Response::builder()
                 .status(StatusCode::OK)
                 .header(header::CONTENT_TYPE, &image_data.content_type);

--- a/tests/adapter_integration.rs
+++ b/tests/adapter_integration.rs
@@ -17,7 +17,7 @@ use tokio::time::timeout;
 use unified_hifi_control::adapters::hqplayer::HqpAdapter;
 use unified_hifi_control::adapters::lms::LmsAdapter;
 use unified_hifi_control::adapters::Startable;
-use unified_hifi_control::bus::{create_bus, BusEvent, SharedBus};
+use unified_hifi_control::bus::{create_bus, BusEvent, PrefixedZoneId, SharedBus};
 
 // =============================================================================
 // Test utilities
@@ -243,22 +243,22 @@ mod bus_integration {
             },
             BusEvent::RoonDisconnected,
             BusEvent::ZoneUpdated {
-                zone_id: "zone-1".to_string(),
+                zone_id: PrefixedZoneId::roon("zone-1"),
                 display_name: "Living Room".to_string(),
                 state: "playing".to_string(),
             },
             BusEvent::ZoneRemoved {
-                zone_id: "zone-1".to_string(),
+                zone_id: PrefixedZoneId::roon("zone-1"),
             },
             BusEvent::NowPlayingChanged {
-                zone_id: "zone-1".to_string(),
+                zone_id: PrefixedZoneId::roon("zone-1"),
                 title: Some("Track".to_string()),
                 artist: Some("Artist".to_string()),
                 album: Some("Album".to_string()),
                 image_key: None,
             },
             BusEvent::SeekPositionChanged {
-                zone_id: "zone-1".to_string(),
+                zone_id: PrefixedZoneId::roon("zone-1"),
                 position: 120,
             },
             BusEvent::VolumeChanged {

--- a/tests/architecture_lint.rs
+++ b/tests/architecture_lint.rs
@@ -143,8 +143,10 @@ fn analyze_file(path: &Path) -> Vec<(String, String, String)> {
         }
     }
 
-    // Only check api/ directory
-    if !path_str.contains("/api/") && !path_str.contains("\\api\\") {
+    // Only check api/ and knobs/ directories
+    let is_api = path_str.contains("/api/") || path_str.contains("\\api\\");
+    let is_knobs = path_str.contains("/knobs/") || path_str.contains("\\knobs\\");
+    if !is_api && !is_knobs {
         return vec![];
     }
 

--- a/tests/architecture_lint.rs
+++ b/tests/architecture_lint.rs
@@ -69,8 +69,6 @@ const ALLOWED_CONTEXTS: &[&str] = &[
     // Configuration endpoints
     "_configure_handler",
     "_config_handler",
-    // Image endpoints (Roon-specific image API)
-    "_image_handler",
     // Discovery endpoints
     "_discover_handler",
     "_detect_handler",

--- a/tests/client_harness.rs
+++ b/tests/client_harness.rs
@@ -528,7 +528,15 @@ mod knob_client {
 
         // For valid responses, knob expects these EXACT field names
         // Node.js returns line1/line2/is_playing, NOT title/artist/state
-        let required_fields = ["line1", "line2", "is_playing", "zone_id", "zones"];
+        // zones_sha added in PR #149 for dynamic zone detection (#148)
+        let required_fields = [
+            "line1",
+            "line2",
+            "is_playing",
+            "zone_id",
+            "zones",
+            "zones_sha",
+        ];
         for field in required_fields {
             assert!(
                 json.get(field).is_some(),

--- a/tests/protocol_schema.rs
+++ b/tests/protocol_schema.rs
@@ -93,7 +93,7 @@ struct ErrorResponse {
 }
 
 // Use production BusEvent to keep schema in sync
-use unified_hifi_control::bus::BusEvent;
+use unified_hifi_control::bus::{BusEvent, PrefixedZoneId};
 
 // ============================================================================
 // Schema Validation Tests
@@ -427,14 +427,14 @@ mod bus_event_schema {
     #[test]
     fn validates_zone_updated() {
         let event = BusEvent::ZoneUpdated {
-            zone_id: "zone-1".to_string(),
+            zone_id: PrefixedZoneId::roon("zone-1"),
             display_name: "Living Room".to_string(),
             state: "playing".to_string(),
         };
 
         let json = serde_json::to_value(&event).unwrap();
         assert_eq!(json["type"], "ZoneUpdated");
-        assert_eq!(json["payload"]["zone_id"], "zone-1");
+        assert_eq!(json["payload"]["zone_id"], "roon:zone-1");
         assert_eq!(json["payload"]["display_name"], "Living Room");
         assert_eq!(json["payload"]["state"], "playing");
     }
@@ -442,7 +442,7 @@ mod bus_event_schema {
     #[test]
     fn validates_now_playing_changed() {
         let event = BusEvent::NowPlayingChanged {
-            zone_id: "zone-1".to_string(),
+            zone_id: PrefixedZoneId::roon("zone-1"),
             title: Some("Test Song".to_string()),
             artist: Some("Test Artist".to_string()),
             album: Some("Test Album".to_string()),
@@ -457,7 +457,7 @@ mod bus_event_schema {
     #[test]
     fn validates_now_playing_with_nulls() {
         let event = BusEvent::NowPlayingChanged {
-            zone_id: "zone-1".to_string(),
+            zone_id: PrefixedZoneId::roon("zone-1"),
             title: None,
             artist: None,
             album: None,
@@ -471,7 +471,7 @@ mod bus_event_schema {
     #[test]
     fn validates_seek_position_changed() {
         let event = BusEvent::SeekPositionChanged {
-            zone_id: "zone-1".to_string(),
+            zone_id: PrefixedZoneId::roon("zone-1"),
             position: 12345,
         };
 
@@ -851,7 +851,7 @@ mod contract_tests {
     #[test]
     fn sse_event_format() {
         let event = BusEvent::ZoneUpdated {
-            zone_id: "zone-1".to_string(),
+            zone_id: PrefixedZoneId::roon("zone-1"),
             display_name: "Test".to_string(),
             state: "playing".to_string(),
         };

--- a/tests/zones_sha_integration.rs
+++ b/tests/zones_sha_integration.rs
@@ -5,6 +5,8 @@
 
 mod mock_servers;
 
+use serial_test::serial;
+
 use axum::{
     body::Body,
     http::{Request, StatusCode},
@@ -109,6 +111,7 @@ async fn create_test_app_with_lms(mock_addr: std::net::SocketAddr) -> Router {
 
 /// Issue #148: /knob/now_playing MUST include zones_sha for dynamic zone detection
 #[tokio::test]
+#[serial]
 async fn now_playing_includes_zones_sha() {
     // Enable LMS adapter in settings (simulates plugin signal)
     std::env::set_var("LMS_UNIFIEDHIFI_STARTED", "true");
@@ -165,9 +168,6 @@ async fn now_playing_includes_zones_sha() {
     );
 
     mock.stop().await;
-
-    // Clean up env var
-    std::env::remove_var("LMS_UNIFIEDHIFI_STARTED");
 }
 
 // Note: A test for "zones_sha changes when zones change" would require

--- a/tests/zones_sha_integration.rs
+++ b/tests/zones_sha_integration.rs
@@ -1,0 +1,160 @@
+//! Integration test for zones_sha in /knob/now_playing responses
+//!
+//! This test verifies that the bridge emits zones_sha for dynamic zone detection.
+//! Issue #148: zones appearing after client starts should be detected.
+
+mod mock_servers;
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+    routing::{get, post},
+    Router,
+};
+use serde::Deserialize;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio_util::sync::CancellationToken;
+use tower::ServiceExt;
+
+use mock_servers::lms::MockLmsServer;
+use unified_hifi_control::adapters::hqplayer::{HqpInstanceManager, HqpZoneLinkService};
+use unified_hifi_control::adapters::lms::LmsAdapter;
+use unified_hifi_control::adapters::openhome::OpenHomeAdapter;
+use unified_hifi_control::adapters::roon::RoonAdapter;
+use unified_hifi_control::adapters::upnp::UPnPAdapter;
+use unified_hifi_control::adapters::Startable;
+use unified_hifi_control::aggregator::ZoneAggregator;
+use unified_hifi_control::api::AppState;
+use unified_hifi_control::bus::create_bus;
+use unified_hifi_control::coordinator::AdapterCoordinator;
+use unified_hifi_control::knobs::{self, KnobStore};
+
+/// Response from /knob/now_playing - must include zones_sha
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct NowPlayingResponse {
+    zone_id: String,
+    line1: String,
+    line2: String,
+    is_playing: bool,
+    zones: Vec<serde_json::Value>,
+    config_sha: Option<String>,
+    zones_sha: Option<String>, // This is what we're testing!
+}
+
+/// Create test app with LMS adapter connected to mock server
+async fn create_test_app_with_lms(mock_addr: std::net::SocketAddr) -> Router {
+    let bus = create_bus();
+    let coordinator = Arc::new(AdapterCoordinator::new(bus.clone()));
+
+    let roon = Arc::new(RoonAdapter::new_disconnected(bus.clone()));
+    let hqp_instances = Arc::new(HqpInstanceManager::new(bus.clone()));
+    let hqplayer = hqp_instances.get_default().await;
+    let hqp_zone_links = Arc::new(HqpZoneLinkService::new(hqp_instances.clone()));
+    let lms = Arc::new(LmsAdapter::new(bus.clone()));
+    let openhome = Arc::new(OpenHomeAdapter::new(bus.clone()));
+    let upnp = Arc::new(UPnPAdapter::new(bus.clone()));
+    let knob_store = KnobStore::new();
+
+    // Configure and start LMS adapter with mock server
+    lms.configure(
+        mock_addr.ip().to_string(),
+        Some(mock_addr.port()),
+        None,
+        None,
+    )
+    .await;
+    lms.start().await.expect("LMS adapter should start");
+
+    // Wait for adapter to discover players
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let startable_adapters: Vec<Arc<dyn Startable>> =
+        vec![roon.clone(), lms.clone(), openhome.clone(), upnp.clone()];
+
+    let aggregator = Arc::new(ZoneAggregator::new(bus.clone()));
+    let state = AppState::new(
+        roon,
+        hqplayer,
+        hqp_instances,
+        hqp_zone_links,
+        lms,
+        openhome,
+        upnp,
+        knob_store,
+        bus,
+        aggregator,
+        coordinator,
+        startable_adapters,
+        Instant::now(),
+        CancellationToken::new(),
+    );
+
+    Router::new()
+        .route("/knob/zones", get(knobs::knob_zones_handler))
+        .route("/knob/now_playing", get(knobs::knob_now_playing_handler))
+        .route("/knob/control", post(knobs::knob_control_handler))
+        .with_state(state)
+}
+
+/// Issue #148: /knob/now_playing MUST include zones_sha for dynamic zone detection
+#[tokio::test]
+async fn now_playing_includes_zones_sha() {
+    // Start mock LMS with a player
+    let mock = MockLmsServer::start().await;
+    mock.add_player("aa:bb:cc:dd:ee:ff", "Test Player").await;
+    mock.set_mode("aa:bb:cc:dd:ee:ff", "stop").await;
+
+    // Create app connected to mock
+    let app = create_test_app_with_lms(mock.addr()).await;
+
+    // Request now_playing for the LMS zone
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/knob/now_playing?zone_id=lms:aa:bb:cc:dd:ee:ff")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let status = response.status();
+    let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let body_str = String::from_utf8_lossy(&body);
+
+    // Should succeed
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "Expected OK, got {status}. Body: {body_str}"
+    );
+
+    // Parse response
+    let parsed: NowPlayingResponse =
+        serde_json::from_slice(&body).expect(&format!("Failed to parse response: {body_str}"));
+
+    // THE KEY ASSERTION: zones_sha must be present
+    assert!(
+        parsed.zones_sha.is_some(),
+        "zones_sha MUST be present in /knob/now_playing response for dynamic zone detection (issue #148). Response: {body_str}"
+    );
+
+    // Verify it's a valid hash (8 hex chars)
+    let sha = parsed.zones_sha.unwrap();
+    assert_eq!(sha.len(), 8, "zones_sha should be 8 hex chars, got: {sha}");
+    assert!(
+        sha.chars().all(|c| c.is_ascii_hexdigit()),
+        "zones_sha should be hex, got: {sha}"
+    );
+
+    mock.stop().await;
+}
+
+// Note: A test for "zones_sha changes when zones change" would require
+// enabling the LMS adapter in settings, which needs env var configuration.
+// The key regression test (zones_sha is present) is covered above.


### PR DESCRIPTION
## Summary

This PR aligns API handlers with the documented architecture principle: **"UI talks to aggregator only (never directly to backends)"**.

### What Changed

1. **zones_sha for dynamic zone detection** (Issue #148)
   - Add `zones_sha` field to `/knob/now_playing` response
   - SHA256 hash (8 hex chars) of zone list, changes when zones are added/removed
   - Enables roon-knob clients to detect new zones appearing after startup

2. **Zone queries use aggregator** 
   - `get_all_zones_internal()` → `aggregator.get_zones()`
   - `knob_now_playing_handler()` → `aggregator.get_zone()`
   - Removed 4 adapter-specific code paths (~260 lines → ~80 lines)

3. **Image fetching unified**
   - Add `AppState::get_image()` that routes to correct adapter based on zone_id
   - `knob_image_handler()` → uses aggregator for zone lookup + unified image service
   - Support for any image format (JPEG, PNG, GIF, etc.) not just JPEG
   - RGB565 conversion moved into unified interface

4. **Playback control fields added to bus::Zone**
   - `is_play_allowed`, `is_pause_allowed`, `is_next_allowed`, `is_previous_allowed`
   - All adapters populate these fields from their backend state

5. **Architecture lint extended**
   - Now checks `src/knobs/` in addition to `src/api/`
   - Removed `_image_handler` exception (no longer needed)

### Why

The previous code bypassed the aggregator to query adapters directly, violating the event bus architecture. This caused:
- Duplicate zone lookup logic across handlers
- Settings filtering scattered across routes instead of centralized
- Image handler couldn't benefit from aggregator's cached state

### Fixes

- #148 - zones_sha for dynamic zone detection
- #143 - RGB565 image format (PNG now works, not just JPEG)
- #151 - Image fetching through unified adapter interface

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * now_playing responses include a deterministic, order‑insensitive 8‑char hex zones_sha.
  * Zone identifiers are now namespaced/prefixed for clearer source attribution.
  * Zones expose control flags: play/pause/next/previous allowed.
  * Image service auto-detects JPEG/PNG/GIF/BMP/WebP/SVG, can emit RGB565, and falls back to placeholders on failure.

* **Tests**
  * Added unit and integration tests validating zones_sha presence, format, determinism, and behavior on zone changes.

* **Documentation**
  * Expanded architecture, UI stack, and build/run guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->