### PR TITLE
fix: Hydrate zone.now_playing from aggregator's separate map

### DIFF
--- a/src/app/pages/zones.rs
+++ b/src/app/pages/zones.rs
@@ -366,15 +366,16 @@ fn ZoneCard(
     let has_image = !image_url.is_empty();
 
     // Now playing display
-    let (track, artist) = np
+    let (track, artist, album) = np
         .map(|n| {
             if n.line1.as_deref().unwrap_or("Idle") != "Idle" {
                 (
                     n.line1.clone().unwrap_or_default(),
                     n.line2.clone().unwrap_or_default(),
+                    n.line3.clone().unwrap_or_default(),
                 )
             } else {
-                (String::new(), String::new())
+                (String::new(), String::new(), String::new())
             }
         })
         .unwrap_or_default();
@@ -427,6 +428,9 @@ fn ZoneCard(
                     if !track.is_empty() {
                         p { class: "font-medium text-sm truncate mb-1", "{track}" }
                         p { class: "text-sm text-muted truncate", "{artist}" }
+                        if !album.is_empty() {
+                            p { class: "text-xs text-muted truncate", "{album}" }
+                        }
                     } else {
                         p { class: "text-sm text-muted", "Nothing playing" }
                     }


### PR DESCRIPTION
## Summary
- Fix now_playing (track/artist/album/art) not updating in web UI
- The aggregator stores now_playing updates in a separate map, but `get_zone()` was returning zones with stale data
- Now all zone getters hydrate the now_playing field from current state
- Also adds album (line3) display to the zones listing page

## Root Cause
When `NowPlayingChanged` events arrive, the aggregator updates `self.now_playing` map but the `Zone` struct stored in `self.zones` retains stale `now_playing` data. The `/now_playing` endpoint was using `zone.now_playing` which never reflected updates.

## Test plan
- [ ] Start playback on a zone
- [ ] Change tracks with prev/next
- [ ] Verify track name, artist, album, and art update in web UI
- [ ] Verify play/pause state updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Zone now playing display enhanced to include album information in addition to track and artist names
  * Zone cards now display complete now playing metadata with album details when music is actively playing
  * Improved consistency of now playing information across all zone views

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->