### PR TITLE
fix(adapters): Use correct volume_step instead of hardcoding 1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2148,12 +2148,12 @@ dependencies = [
 
 [[package]]
 name = "if-addrs"
-version = "0.12.0"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2a33e9c38988ecbda730c85b0fd9ddcdf83c0305ac7fd21c8bb9f57f2f0cc8"
+checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3215,11 +3215,11 @@ dependencies = [
 
 [[package]]
 name = "roon-api"
-version = "0.2.0"
-source = "git+https://github.com/TheAppgineer/rust-roon-api.git?tag=0.2.0#b035a4426cea07ddee6f8cb989f19d044cd190ac"
+version = "0.3.1"
+source = "git+https://github.com/open-horizon-labs/rust-roon-api.git?branch=fix%2Ffractional-volume#f9727e29c88023bca62e96983eb4ef15807f7d10"
 dependencies = [
  "futures-util",
- "if-addrs 0.12.0",
+ "if-addrs 0.13.4",
  "log",
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,8 @@ tower = { version = "0.5", optional = true }
 tower-http = { version = "0.6", features = ["cors", "compression-gzip", "trace"], optional = true }
 
 # Roon API (server only)
-roon-api = { git = "https://github.com/TheAppgineer/rust-roon-api.git", tag = "0.2.0", features = ["transport", "image", "status"], optional = true }
+roon-api = { git = "https://github.com/open-horizon-labs/rust-roon-api.git", branch = "fix/fractional-volume", features = ["transport", "image", "status"], optional = true }
+# TODO: Switch back to upstream after https://github.com/TheAppgineer/rust-roon-api/pull/1 is merged
 
 # HTTP client (server only)
 reqwest = { version = "0.12", default-features = false, features = ["json", "cookies", "rustls-tls"], optional = true }

--- a/src/adapters/lms.rs
+++ b/src/adapters/lms.rs
@@ -954,10 +954,12 @@ impl LmsAdapter {
         self.state.read().await.players.values().cloned().collect()
     }
 
-    /// Change volume
-    pub async fn change_volume(&self, player_id: &str, value: i32, relative: bool) -> Result<()> {
+    /// Change volume (f32 for fractional step support)
+    pub async fn change_volume(&self, player_id: &str, value: f32, relative: bool) -> Result<()> {
         let command = if relative { "vol_rel" } else { "vol_abs" };
-        self.control(player_id, command, Some(value)).await
+        // LMS uses integer volume 0-100, round at the last moment
+        self.control(player_id, command, Some(value.round() as i32))
+            .await
     }
 }
 

--- a/src/adapters/lms.rs
+++ b/src/adapters/lms.rs
@@ -971,7 +971,9 @@ fn lms_player_to_zone(player: &LmsPlayer) -> Zone {
             value: player.volume as f32,
             min: 0.0,
             max: 100.0,
-            step: 1.0,
+            // LMS hardcodes $increment = 2.5 in Slim/Player/Client.pm:755
+            // This is not queryable via CLI/JSON-RPC, so we use the constant.
+            step: 2.5,
             is_muted: false, // LMS doesn't expose mute via JSON-RPC status
             scale: crate::bus::VolumeScale::Percentage,
             output_id: Some(player.playerid.clone()),

--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -750,9 +750,10 @@ async fn run_roon_loop(
                         let mut s = state_for_events.write().await;
                         for zone in zones {
                             tracing::debug!(
-                                "Zone update: {} ({})",
+                                "Zone update: {} ({}) - now_playing: {:?}",
                                 zone.display_name,
-                                zone.zone_id
+                                zone.zone_id,
+                                zone.now_playing.as_ref().map(|np| &np.three_line.line1)
                             );
                             let converted = convert_zone(&zone);
                             let is_new = !s.zones.contains_key(&zone.zone_id);

--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -386,9 +386,9 @@ impl RoonAdapter {
             }
         };
 
-        // Roon transport API takes i32, round at the last moment to preserve precision
+        // Roon transport API now takes f64 to support fractional dB steps
         transport
-            .change_volume(output_id, &mode, final_value.round() as i32)
+            .change_volume(output_id, &mode, final_value as f64)
             .await;
         Ok(())
     }
@@ -661,7 +661,7 @@ async fn run_roon_loop(
             };
 
             match event {
-                CoreEvent::Found(mut core) => {
+                CoreEvent::Registered(mut core, _token) => {
                     let core_name = core.display_name.clone();
                     let core_version = core.display_version.clone();
 

--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -112,6 +112,8 @@ pub struct VolumeInfo {
     pub min: Option<f32>,
     pub max: Option<f32>,
     pub is_muted: Option<bool>,
+    /// Volume step size from Roon API (varies per zone)
+    pub step: Option<f32>,
 }
 
 /// Now playing information
@@ -502,6 +504,7 @@ fn convert_zone(roon_zone: &RoonZone) -> Zone {
                 min: v.min,
                 max: v.max,
                 is_muted: v.is_muted,
+                step: v.step,
             }),
         })
         .collect();
@@ -534,7 +537,7 @@ fn roon_zone_to_bus_zone(zone: &Zone) -> BusZone {
             value: v.value.unwrap_or(50.0),
             min: v.min.unwrap_or(-64.0),
             max: v.max.unwrap_or(0.0),
-            step: 1.0,
+            step: v.step.unwrap_or(1.0),
             is_muted: v.is_muted.unwrap_or(false),
             scale: crate::bus::VolumeScale::Decibel,
             output_id: Some(o.output_id.clone()),

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -285,11 +285,11 @@ pub async fn roon_control_handler(
     }
 }
 
-/// Volume request body
+/// Volume request body (f32 for fractional step support)
 #[derive(Deserialize)]
 pub struct VolumeRequest {
     pub output_id: String,
-    pub value: i32,
+    pub value: f32,
     #[serde(default)]
     pub relative: bool,
 }
@@ -704,7 +704,7 @@ pub async fn lms_control_handler(
 #[derive(Deserialize)]
 pub struct LmsVolumeRequest {
     pub player_id: String,
-    pub value: i32,
+    pub value: f32,
     #[serde(default)]
     pub relative: bool,
 }

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -97,6 +97,8 @@ pub struct NowPlaying {
     pub is_playing: bool,
     pub volume: Option<f32>,
     pub volume_type: Option<String>,
+    /// Volume step size (e.g., 0.5 for Roon, 2.5 for LMS)
+    pub volume_step: Option<f32>,
     pub is_previous_allowed: bool,
     pub is_next_allowed: bool,
 }

--- a/src/app/components/volume.rs
+++ b/src/app/components/volume.rs
@@ -36,11 +36,23 @@ impl VolumeType {
     }
 }
 
+/// Format volume for display, showing decimals only when step is fractional
+fn format_volume(volume: f32, step: Option<f32>, suffix: &str) -> String {
+    // Show decimals if step is fractional (not a whole number)
+    let show_decimal = step.map(|s| s.fract() != 0.0).unwrap_or(false);
+    if show_decimal {
+        format!("{:.1}{}", volume, suffix)
+    } else {
+        format!("{}{}", volume.round() as i32, suffix)
+    }
+}
+
 /// Compact volume controls for zone cards
 #[component]
 pub fn VolumeControlsCompact(
     volume: Option<f32>,
     volume_type: Option<String>,
+    volume_step: Option<f32>,
     on_vol_down: EventHandler<()>,
     on_vol_up: EventHandler<()>,
 ) -> Element {
@@ -53,10 +65,10 @@ pub fn VolumeControlsCompact(
 
     let volume_display = match vol_type {
         VolumeType::Db => volume
-            .map(|v| format!("{} dB", v.round() as i32))
+            .map(|v| format_volume(v, volume_step, " dB"))
             .unwrap_or_default(),
         VolumeType::Number => volume
-            .map(|v| format!("{}", v.round() as i32))
+            .map(|v| format_volume(v, volume_step, ""))
             .unwrap_or_default(),
         VolumeType::Incremental | VolumeType::Fixed => String::new(),
     };
@@ -87,6 +99,7 @@ pub fn VolumeControlsCompact(
 pub fn VolumeControlsFull(
     volume: Option<f32>,
     volume_type: Option<String>,
+    volume_step: Option<f32>,
     on_vol_down: EventHandler<()>,
     on_vol_up: EventHandler<()>,
 ) -> Element {
@@ -99,10 +112,10 @@ pub fn VolumeControlsFull(
 
     let volume_display = match vol_type {
         VolumeType::Db => volume
-            .map(|v| format!("{} dB", v.round() as i32))
+            .map(|v| format_volume(v, volume_step, " dB"))
             .unwrap_or_default(),
         VolumeType::Number => volume
-            .map(|v| format!("{}", v.round() as i32))
+            .map(|v| format_volume(v, volume_step, ""))
             .unwrap_or_default(),
         VolumeType::Incremental | VolumeType::Fixed => String::new(),
     };

--- a/src/app/pages/zone.rs
+++ b/src/app/pages/zone.rs
@@ -17,7 +17,7 @@ struct ControlRequest {
     zone_id: String,
     action: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    value: Option<i32>,
+    value: Option<f64>,
 }
 
 /// Pipeline setting request
@@ -166,7 +166,7 @@ pub fn Zone() -> Element {
     });
 
     // Control handler
-    let control = move |(action, value): (&'static str, Option<i32>)| {
+    let control = move |(action, value): (&'static str, Option<f64>)| {
         if let Some(zone_id) = selected_zone_id() {
             let action = action.to_string();
             spawn(async move {
@@ -367,7 +367,7 @@ pub fn Zone() -> Element {
 fn ZoneDisplay(
     zone: ZoneData,
     now_playing: Option<NowPlaying>,
-    on_control: EventHandler<(&'static str, Option<i32>)>,
+    on_control: EventHandler<(&'static str, Option<f64>)>,
 ) -> Element {
     let np = now_playing.as_ref();
     let is_playing = np.map(|n| n.is_playing).unwrap_or(false);
@@ -435,6 +435,7 @@ fn ZoneDisplay(
 
     let can_prev = np.map(|n| n.is_previous_allowed).unwrap_or(false);
     let can_next = np.map(|n| n.is_next_allowed).unwrap_or(false);
+    let volume_step = np.and_then(|n| n.volume_step).map(|s| s as f64);
 
     rsx! {
         article { id: "zone-display",
@@ -497,12 +498,12 @@ fn ZoneDisplay(
                             }
                             button {
                                 class: "w-10",
-                                onclick: move |_| on_control.call(("vol_down", Some(2))),
+                                onclick: move |_| on_control.call(("vol_down", volume_step)),
                                 "−"
                             }
                             button {
                                 class: "w-10",
-                                onclick: move |_| on_control.call(("vol_up", Some(2))),
+                                onclick: move |_| on_control.call(("vol_up", volume_step)),
                                 "+"
                             }
                         }

--- a/src/app/pages/zones.rs
+++ b/src/app/pages/zones.rs
@@ -349,6 +349,7 @@ fn ZoneCard(
     // Extract volume info for component
     let volume = np.and_then(|n| n.volume);
     let volume_type = np.and_then(|n| n.volume_type.clone());
+    let volume_step = np.and_then(|n| n.volume_step);
 
     // Album art URL with cache-busting image_key
     let base_image_url = np.and_then(|n| n.image_url.clone()).unwrap_or_default();
@@ -465,6 +466,7 @@ fn ZoneCard(
                 VolumeControlsCompact {
                     volume: volume,
                     volume_type: volume_type,
+                    volume_step: volume_step,
                     on_vol_down: move |_| on_control.call((zone_id_vol_down.clone(), "vol_down".to_string())),
                     on_vol_up: move |_| on_control.call((zone_id_vol_up.clone(), "vol_up".to_string())),
                 }

--- a/src/app/pages/zones.rs
+++ b/src/app/pages/zones.rs
@@ -13,6 +13,8 @@ use std::collections::HashMap;
 struct ControlRequest {
     zone_id: String,
     action: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    value: Option<f64>,
 }
 
 /// Fetch now playing for all zones
@@ -135,7 +137,11 @@ pub fn Zones() -> Element {
     // Control handler
     let control = move |(zone_id, action): (String, String)| {
         spawn(async move {
-            let req = ControlRequest { zone_id, action };
+            let req = ControlRequest {
+                zone_id,
+                action,
+                value: None,
+            };
             if let Err(e) = crate::app::api::post_json_no_response("/control", &req).await {
                 #[cfg(target_arch = "wasm32")]
                 web_sys::console::warn_1(&format!("Control request failed: {e}").into());

--- a/src/bin/protocol_checker.rs
+++ b/src/bin/protocol_checker.rs
@@ -80,6 +80,7 @@ struct VolumeInfo {
     min: Option<f32>,
     max: Option<f32>,
     is_muted: Option<bool>,
+    step: Option<f32>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/knobs/routes.rs
+++ b/src/knobs/routes.rs
@@ -565,7 +565,7 @@ async fn control_roon(
                 )
             })?;
             // Use as_f64() which handles both JSON integers and floats
-            let step = value.and_then(|v| v.as_f64()).unwrap_or(1.0) as i32;
+            let step = value.and_then(|v| v.as_f64()).unwrap_or(1.0) as f32;
             state
                 .roon
                 .change_volume(&output, step, true)
@@ -586,7 +586,7 @@ async fn control_roon(
                 )
             })?;
             // Use as_f64() which handles both JSON integers and floats
-            let step = value.and_then(|v| v.as_f64()).unwrap_or(1.0) as i32;
+            let step = value.and_then(|v| v.as_f64()).unwrap_or(1.0) as f32;
             state
                 .roon
                 .change_volume(&output, -step, true)
@@ -610,7 +610,7 @@ async fn control_roon(
             tracing::debug!("vol_abs raw value: {:?}", value);
             // Use as_f64() which handles both JSON integers and floats
             // (as_i64() returns None for floats like 75.0, causing fallback to 50)
-            let vol = value.and_then(|v| v.as_f64()).unwrap_or(50.0) as i32;
+            let vol = value.and_then(|v| v.as_f64()).unwrap_or(50.0) as f32;
             state
                 .roon
                 .change_volume(&output, vol, false)
@@ -656,7 +656,7 @@ async fn control_lms(
         "stop" => "stop",
         "vol_up" | "volume_up" => {
             // Use as_f64() which handles both JSON integers and floats
-            let step = value.and_then(|v| v.as_f64()).unwrap_or(5.0) as i32;
+            let step = value.and_then(|v| v.as_f64()).unwrap_or(2.5) as f32;
             state
                 .lms
                 .change_volume(player_id, step, true)
@@ -671,7 +671,7 @@ async fn control_lms(
         }
         "vol_down" | "volume_down" => {
             // Use as_f64() which handles both JSON integers and floats
-            let step = value.and_then(|v| v.as_f64()).unwrap_or(5.0) as i32;
+            let step = value.and_then(|v| v.as_f64()).unwrap_or(2.5) as f32;
             state
                 .lms
                 .change_volume(player_id, -step, true)
@@ -686,7 +686,7 @@ async fn control_lms(
         }
         "vol_abs" | "volume" => {
             // Use as_f64() which handles both JSON integers and floats
-            let vol = value.and_then(|v| v.as_f64()).unwrap_or(50.0) as i32;
+            let vol = value.and_then(|v| v.as_f64()).unwrap_or(50.0) as f32;
             state
                 .lms
                 .change_volume(player_id, vol, false)

--- a/src/knobs/routes.rs
+++ b/src/knobs/routes.rs
@@ -23,6 +23,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::api::AppState;
+use crate::bus::VolumeControl;
 use crate::knobs::image::placeholder_svg;
 use crate::knobs::store::{KnobConfigUpdate, KnobStatusUpdate};
 
@@ -94,6 +95,8 @@ pub struct ZoneInfo {
     pub zone_name: String,
     pub source: String,
     pub state: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub volume_control: Option<VolumeControl>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dsp: Option<DspInfo>,
 }
@@ -171,6 +174,7 @@ pub async fn get_all_zones_internal(state: &AppState) -> Vec<ZoneInfo> {
             zone_name: z.zone_name,
             source: z.source,
             state: z.state.to_string(),
+            volume_control: z.volume_control,
         })
         .collect()
 }
@@ -1184,6 +1188,7 @@ mod tests {
             zone_name: name.to_string(),
             source: "test".to_string(),
             state: "stopped".to_string(),
+            volume_control: None,
             dsp: None,
         }
     }

--- a/tests/adapter_integration.rs
+++ b/tests/adapter_integration.rs
@@ -179,7 +179,7 @@ mod lms_integration {
         let (bus, _rx) = test_bus();
         let adapter = LmsAdapter::new(bus);
 
-        let result = adapter.change_volume("player-1", 50, false).await;
+        let result = adapter.change_volume("player-1", 50.0, false).await;
         assert!(result.is_err());
     }
 }

--- a/tests/aggregator_lint.rs
+++ b/tests/aggregator_lint.rs
@@ -1,0 +1,57 @@
+//! Aggregator regression tests
+//!
+//! Bug: NowPlayingChanged updates a separate HashMap, not zone.now_playing.
+//! This causes now_playing to become stale after initial ZoneDiscovered.
+//!
+//! The routes use zone.now_playing which is never updated after discovery.
+
+use std::fs;
+
+/// Aggregator must update zone.now_playing when NowPlayingChanged arrives.
+///
+/// Bug: NowPlayingChanged stored in separate HashMap (self.now_playing),
+/// but routes read from zone.now_playing which is stale.
+///
+/// Fix: Update zone.now_playing in NowPlayingChanged handler.
+#[test]
+fn lint_aggregator_updates_zone_now_playing() {
+    let src = fs::read_to_string("src/aggregator.rs").expect("Failed to read src/aggregator.rs");
+
+    // The NowPlayingChanged handler must update zone.now_playing, not just self.now_playing
+    // Look for pattern: zones.write().await getting zone by zone_id and updating now_playing
+    let updates_zone_now_playing = src.contains("zone.now_playing = Some(")
+        || src.contains("zone.now_playing = Some(NowPlaying");
+
+    assert!(
+        updates_zone_now_playing,
+        "REGRESSION: Aggregator NowPlayingChanged must update zone.now_playing.\n\
+         Bug: Track info (title, artist, album) not updating after initial discovery.\n\
+         Currently NowPlayingChanged only updates self.now_playing HashMap,\n\
+         but routes read from zone.now_playing which becomes stale.\n\
+         Fix: In NowPlayingChanged handler, also update the zone's now_playing field."
+    );
+}
+
+/// Routes must not rely on stale zone.now_playing - verify aggregator merges it.
+#[test]
+fn lint_aggregator_merges_now_playing_for_get_zone() {
+    let src = fs::read_to_string("src/aggregator.rs").expect("Failed to read src/aggregator.rs");
+
+    // Either:
+    // 1. get_zone merges now_playing from separate HashMap into zone, OR
+    // 2. NowPlayingChanged updates zone.now_playing directly (preferred)
+
+    // Check for option 1: get_zone merges now_playing
+    let merges_in_get_zone = src.contains("fn get_zone")
+        && (src.contains(".now_playing.read()") || src.contains("get_now_playing"));
+
+    // Check for option 2: NowPlayingChanged updates zone directly
+    let updates_zone_directly = src.contains("zone.now_playing = Some(");
+
+    assert!(
+        merges_in_get_zone || updates_zone_directly,
+        "REGRESSION: Aggregator must ensure zone.now_playing is current.\n\
+         Either update zone.now_playing in NowPlayingChanged handler,\n\
+         or merge it in get_zone() before returning."
+    );
+}

--- a/tests/volume_safety.rs
+++ b/tests/volume_safety.rs
@@ -29,8 +29,8 @@ fn db_output() -> Output {
 fn db_zone_respects_db_range() {
     let output = db_output();
     let (min, max) = get_volume_range(Some(&output));
-    assert_eq!(min, -64);
-    assert_eq!(max, 0);
+    assert_eq!(min, -64.0);
+    assert_eq!(max, 0.0);
 }
 
 #[test]
@@ -39,21 +39,21 @@ fn critical_db_minus12_stays_minus12() {
     // -12 dB is a reasonable listening level, NOT maximum volume
     let output = db_output();
     let (min, max) = get_volume_range(Some(&output));
-    assert_eq!(clamp(-12, min, max), -12);
+    assert_eq!(clamp(-12.0, min, max), -12.0);
 }
 
 #[test]
 fn db_values_below_zone_min_clamp_to_min() {
     let output = db_output();
     let (min, max) = get_volume_range(Some(&output));
-    assert_eq!(clamp(-100, min, max), -64);
+    assert_eq!(clamp(-100.0, min, max), -64.0);
 }
 
 #[test]
 fn db_values_above_zone_max_clamp_to_max() {
     let output = db_output();
     let (min, max) = get_volume_range(Some(&output));
-    assert_eq!(clamp(10, min, max), 0);
+    assert_eq!(clamp(10.0, min, max), 0.0);
 }
 
 // =============================================================================
@@ -78,29 +78,29 @@ fn pct_output() -> Output {
 fn pct_zone_respects_0_100_range() {
     let output = pct_output();
     let (min, max) = get_volume_range(Some(&output));
-    assert_eq!(min, 0);
-    assert_eq!(max, 100);
+    assert_eq!(min, 0.0);
+    assert_eq!(max, 100.0);
 }
 
 #[test]
 fn pct_50_stays_50() {
     let output = pct_output();
     let (min, max) = get_volume_range(Some(&output));
-    assert_eq!(clamp(50, min, max), 50);
+    assert_eq!(clamp(50.0, min, max), 50.0);
 }
 
 #[test]
 fn pct_values_below_0_clamp_to_0() {
     let output = pct_output();
     let (min, max) = get_volume_range(Some(&output));
-    assert_eq!(clamp(-10, min, max), 0);
+    assert_eq!(clamp(-10.0, min, max), 0.0);
 }
 
 #[test]
 fn pct_values_above_100_clamp_to_100() {
     let output = pct_output();
     let (min, max) = get_volume_range(Some(&output));
-    assert_eq!(clamp(150, min, max), 100);
+    assert_eq!(clamp(150.0, min, max), 100.0);
 }
 
 // =============================================================================
@@ -115,15 +115,15 @@ fn missing_volume_uses_safe_defaults() {
         volume: None,
     };
     let (min, max) = get_volume_range(Some(&output));
-    assert_eq!(min, 0);
-    assert_eq!(max, 100);
+    assert_eq!(min, 0.0);
+    assert_eq!(max, 100.0);
 }
 
 #[test]
 fn none_output_uses_safe_defaults() {
     let (min, max) = get_volume_range(None);
-    assert_eq!(min, 0);
-    assert_eq!(max, 100);
+    assert_eq!(min, 0.0);
+    assert_eq!(max, 100.0);
 }
 
 // =============================================================================
@@ -132,20 +132,20 @@ fn none_output_uses_safe_defaults() {
 
 #[test]
 fn clamp_value_exactly_at_min_boundary() {
-    assert_eq!(clamp(-64, -64, 0), -64);
-    assert_eq!(clamp(0, 0, 100), 0);
+    assert_eq!(clamp(-64.0, -64.0, 0.0), -64.0);
+    assert_eq!(clamp(0.0, 0.0, 100.0), 0.0);
 }
 
 #[test]
 fn clamp_value_exactly_at_max_boundary() {
-    assert_eq!(clamp(0, -64, 0), 0);
-    assert_eq!(clamp(100, 0, 100), 100);
+    assert_eq!(clamp(0.0, -64.0, 0.0), 0.0);
+    assert_eq!(clamp(100.0, 0.0, 100.0), 100.0);
 }
 
 #[test]
 fn clamp_value_in_middle_of_range() {
-    assert_eq!(clamp(-32, -64, 0), -32);
-    assert_eq!(clamp(50, 0, 100), 50);
+    assert_eq!(clamp(-32.0, -64.0, 0.0), -32.0);
+    assert_eq!(clamp(50.0, 0.0, 100.0), 50.0);
 }
 
 // =============================================================================
@@ -155,7 +155,7 @@ fn clamp_value_in_middle_of_range() {
 #[test]
 fn relative_step_clamped_prevents_wild_jumps() {
     // Even if someone sends +50, it should be clamped to MAX_RELATIVE_STEP (10)
-    let max_step = 10;
-    assert_eq!(clamp(50, -max_step, max_step), max_step);
-    assert_eq!(clamp(-50, -max_step, max_step), -max_step);
+    let max_step = 10.0;
+    assert_eq!(clamp(50.0, -max_step, max_step), max_step);
+    assert_eq!(clamp(-50.0, -max_step, max_step), -max_step);
 }

--- a/tests/volume_safety.rs
+++ b/tests/volume_safety.rs
@@ -20,6 +20,7 @@ fn db_output() -> Output {
             min: Some(-64.0),
             max: Some(0.0),
             is_muted: Some(false),
+            step: Some(1.0),
         }),
     }
 }
@@ -68,6 +69,7 @@ fn pct_output() -> Output {
             min: Some(0.0),
             max: Some(100.0),
             is_muted: Some(false),
+            step: Some(1.0),
         }),
     }
 }

--- a/tests/volume_step.rs
+++ b/tests/volume_step.rs
@@ -1,0 +1,102 @@
+//! Volume step regression tests
+//!
+//! Bug: Adapters hardcode volume_step to 1.0, ignoring backend-specific values.
+//!
+//! See: https://github.com/cloud-atlas-ai/unified-hifi-control/issues/152
+//!
+//! Test strategy:
+//! 1. Source-scanning lint tests (catch obvious regressions)
+//! 2. Unit tests calling pub(crate) conversion functions (verify behavior)
+
+use std::fs;
+
+// =============================================================================
+// LINT TESTS: Source scanning to catch hardcoded step values
+// These are a first line of defense, not a replacement for unit tests.
+// =============================================================================
+
+/// Roon adapter must not hardcode step: 1.0 - API provides the value.
+#[test]
+fn lint_roon_no_hardcoded_step() {
+    let src =
+        fs::read_to_string("src/adapters/roon.rs").expect("Failed to read src/adapters/roon.rs");
+
+    // Bug: roon_zone_to_bus_zone hardcodes "step: 1.0"
+    // Fix: use v.step.unwrap_or(1.0)
+    let has_hardcoded = src.contains("step: 1.0,");
+
+    assert!(
+        !has_hardcoded,
+        "REGRESSION: Roon adapter hardcodes 'step: 1.0'.\n\
+         Fix: Use v.step.unwrap_or(1.0) in roon_zone_to_bus_zone()"
+    );
+}
+
+/// LMS adapter must use step: 2.5 (from LMS server), not 1.0.
+#[test]
+fn lint_lms_uses_correct_step() {
+    let src =
+        fs::read_to_string("src/adapters/lms.rs").expect("Failed to read src/adapters/lms.rs");
+
+    // LMS server hardcodes $increment = 2.5 in Slim/Player/Client.pm:755
+    // Not queryable via API, so we must use the constant.
+    let has_correct = src.contains("step: 2.5");
+
+    assert!(
+        has_correct,
+        "REGRESSION: LMS adapter should use 'step: 2.5'.\n\
+         LMS server hardcodes increment=2.5 in Slim/Player/Client.pm:755"
+    );
+}
+
+/// OpenHome adapter should call Characteristics to get VolumeSteps.
+#[test]
+fn lint_openhome_queries_characteristics() {
+    let src = fs::read_to_string("src/adapters/openhome.rs")
+        .expect("Failed to read src/adapters/openhome.rs");
+
+    // OpenHome Volume service exposes VolumeSteps via Characteristics action
+    // Step = VolumeMax / VolumeSteps
+    let calls_characteristics = src.contains("Characteristics");
+
+    assert!(
+        calls_characteristics,
+        "OpenHome adapter should query 'Characteristics' action for VolumeSteps.\n\
+         See: http://wiki.openhome.org/wiki/Av:Developer:VolumeService"
+    );
+}
+
+/// HQPlayer correctly uses vol_range.step - ensure we don't regress.
+#[test]
+fn lint_hqplayer_uses_api_step() {
+    let src = fs::read_to_string("src/adapters/hqplayer.rs")
+        .expect("Failed to read src/adapters/hqplayer.rs");
+
+    let uses_api = src.contains("vol_range.step");
+
+    assert!(
+        uses_api,
+        "HQPlayer should use vol_range.step - don't break the working adapter!"
+    );
+}
+
+// =============================================================================
+// UNIT TESTS: Call actual conversion functions
+// Requires: make lms_player_to_zone and roon_zone_to_bus_zone pub(crate)
+// =============================================================================
+
+// TODO: Add unit tests once conversion functions are exposed as pub(crate):
+//
+// #[test]
+// fn lms_player_to_zone_uses_step_2_5() {
+//     let player = LmsPlayer { volume: 50, ... };
+//     let zone = lms_player_to_zone(&player);
+//     assert_eq!(zone.volume_control.unwrap().step, 2.5);
+// }
+//
+// #[test]
+// fn roon_zone_to_bus_zone_uses_api_step() {
+//     let zone = Zone { outputs: vec![Output { volume: Some(VolumeInfo { step: Some(0.5), ... }) }] };
+//     let bus_zone = roon_zone_to_bus_zone(&zone);
+//     assert_eq!(bus_zone.volume_control.unwrap().step, 0.5);
+// }


### PR DESCRIPTION
## Summary

Fixes regression where all adapters hardcoded `volume_step` to 1.0, ignoring backend-specific values.

- **Roon**: Use `v.step` from API (varies per zone)
- **LMS**: Use constant `2.5` (from LMS server `Slim/Player/Client.pm:755`)
- **OpenHome**: Query `Characteristics` action for `VolumeSteps`

## Test plan

- [x] Added `tests/volume_step.rs` with lint tests for each adapter
- [x] All existing tests pass
- [ ] Manual test with Roon zone that has non-1.0 step
- [ ] Manual test with LMS player (should use 2.5 step)
- [ ] Manual test with OpenHome device

## Breaking Change

`VolumeInfo` struct now includes `step: Option<f32>` field.

Closes #152
Related: https://github.com/muness/roon-knob/issues/102

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * LMS uses 2.5 volume increments and preserves fractional precision until sending to devices.
  * OpenHome queries devices for volume max/steps with sensible fallbacks.
  * Roon preserves and exposes device-specific fractional volume steps end-to-end.
  * APIs, Zone info and Now Playing include optional volume step/control; volume requests accept fractional values.
  * Aggregator stores Now Playing per-zone; UI shows decimals when steps are fractional.

* **Tests**
  * Added regression and safety tests validating volume-step handling and schemas.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->