### PR TITLE
fix(lms): Sync install.xml version with repo.xml on release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1754,12 +1754,17 @@ jobs:
           sed -i "s|URL_PLACEHOLDER|${REPO_URL}/releases/download/v${VERSION}/lms-unified-hifi-control-${VERSION}.zip|" lms-plugin/repo.xml
           sed -i "s|SHA_PLACEHOLDER|$SHA|" lms-plugin/repo.xml
 
+      - name: Update install.xml version
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          sed -i "s|<version>[^<]*</version>|<version>$VERSION</version>|" lms-plugin/install.xml
+
       - name: Commit and push
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add lms-plugin/repo.xml
-          git commit -m "chore: Update repo.xml to v${{ steps.version.outputs.version }} [skip ci]" || echo "No changes to commit"
+          git add lms-plugin/repo.xml lms-plugin/install.xml
+          git commit -m "chore: Update LMS plugin to v${{ steps.version.outputs.version }} [skip ci]" || echo "No changes to commit"
           git push
 
   publish-aur:

--- a/lms-plugin/install.xml
+++ b/lms-plugin/install.xml
@@ -2,7 +2,7 @@
 <extension>
   <name>PLUGIN_UNIFIED_HIFI</name>
   <module>Plugins::UnifiedHiFi::Plugin</module>
-  <version>3.0.0-rc.1</version>
+  <version>3.1.3</version>
   <description>PLUGIN_UNIFIED_HIFI_DESC</description>
   <creator>Muness Castle</creator>
   <link>https://forums.lyrion.org/forum/user-forums/3rd-party-hardware/1804977-roon-knob-includes-lms-support</link>


### PR DESCRIPTION
## Summary
- Adds install.xml version update to the `update-repo-xml` workflow job
- Fixes current version mismatch (3.0.0-rc.1 → 3.1.3)

The release workflow was updating `repo.xml` but not `install.xml`, leaving them out of sync.

## Test plan
- [ ] Verify CI passes
- [ ] Next release should update both files in the chore commit

Fixes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated LMS plugin version to 3.1.3
  * Improved version consistency in release automation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->