### PR TITLE
feat(adapters): unify retry logic in AdapterHandle (#150, #147)

### DIFF
--- a/src/adapters/handle.rs
+++ b/src/adapters/handle.rs
@@ -1,17 +1,56 @@
 //! AdapterHandle - Wraps AdapterLogic with consistent lifecycle management
+//!
+//! Provides automatic retry with exponential backoff when adapters encounter errors.
+//! All retry logic is centralized here - adapters should NOT implement their own retry loops.
 
 use anyhow::Result;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use crate::adapters::traits::{AdapterContext, AdapterLogic};
 use crate::bus::{BusEvent, SharedBus};
+
+/// Retry configuration for adapter startup/run
+#[derive(Debug, Clone)]
+pub struct RetryConfig {
+    /// Initial delay between retry attempts
+    pub initial_delay: Duration,
+    /// Maximum delay (backoff caps at this value)
+    pub max_delay: Duration,
+    /// Minimum run time before resetting backoff on failure
+    /// If the adapter runs for at least this long before failing,
+    /// the backoff delay resets to initial_delay
+    pub stable_run_threshold: Duration,
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self {
+            initial_delay: Duration::from_secs(5),
+            max_delay: Duration::from_secs(60),
+            stable_run_threshold: Duration::from_secs(30),
+        }
+    }
+}
+
+impl RetryConfig {
+    /// Create a new RetryConfig with custom delays
+    pub fn new(initial_delay: Duration, max_delay: Duration) -> Self {
+        Self {
+            initial_delay,
+            max_delay,
+            stable_run_threshold: Duration::from_secs(30),
+        }
+    }
+}
 
 /// AdapterHandle wraps an AdapterLogic implementation and provides:
 /// - Consistent shutdown handling (can't forget it)
 /// - Automatic ACK on stop via AdapterStopped event
 /// - ShuttingDown event watching
+/// - Automatic retry with exponential backoff
 pub struct AdapterHandle<T: AdapterLogic> {
     logic: Arc<T>,
     bus: SharedBus,
@@ -37,18 +76,107 @@ impl<T: AdapterLogic> AdapterHandle<T> {
         &self.logic
     }
 
-    /// Run the adapter with lifecycle management
+    /// Run the adapter with lifecycle management (single attempt, no retry)
     /// - Calls init() if implemented
     /// - Runs the adapter's main loop
     /// - Watches for ShuttingDown events on the bus
     /// - Publishes AdapterStopped on exit
+    ///
+    /// For automatic retry on error, use `run_with_retry()` instead.
     pub async fn run(self) -> Result<()> {
         let prefix = self.logic.prefix();
         info!("Starting adapter: {}", prefix);
 
+        // Run once without retry
+        let result = self.run_once().await;
+
+        // Automatic ACK - publish AdapterStopped
+        self.bus.publish(BusEvent::AdapterStopped {
+            adapter: prefix.to_string(),
+        });
+
+        info!("Adapter {} stopped", prefix);
+        result
+    }
+
+    /// Run the adapter with automatic retry on error
+    ///
+    /// When `run()` returns `Err`, waits with exponential backoff and retries.
+    /// When `run()` returns `Ok`, exits cleanly.
+    ///
+    /// Backoff is reset to initial delay if the adapter ran stably for at least
+    /// `config.stable_run_threshold` (default 30s) before failing.
+    ///
+    /// This is the preferred method for production use - it handles transient
+    /// failures like service restarts automatically.
+    pub async fn run_with_retry(self, config: RetryConfig) -> Result<()> {
+        let prefix = self.logic.prefix();
+        let mut delay = config.initial_delay;
+
+        loop {
+            // Check for shutdown before attempting
+            if self.shutdown.is_cancelled() {
+                info!("{}: shutdown before attempt", prefix);
+                break;
+            }
+
+            info!("{}: starting (retry delay: {:?})", prefix, delay);
+
+            let start = Instant::now();
+            match self.run_once().await {
+                Ok(()) => {
+                    info!("{}: clean exit", prefix);
+                    break;
+                }
+                Err(e) => {
+                    let run_duration = start.elapsed();
+
+                    // Reset backoff if we had a stable run before failing
+                    if run_duration >= config.stable_run_threshold {
+                        info!(
+                            "{}: ran for {:?} before failure, resetting backoff",
+                            prefix, run_duration
+                        );
+                        delay = config.initial_delay;
+                    }
+
+                    warn!("{}: error ({}), retrying in {:?}", prefix, e, delay);
+
+                    // Wait with shutdown check
+                    tokio::select! {
+                        _ = self.shutdown.cancelled() => {
+                            info!("{}: shutdown during backoff", prefix);
+                            break;
+                        }
+                        _ = tokio::time::sleep(delay) => {
+                            // Exponential backoff capped at max_delay
+                            delay = (delay * 2).min(config.max_delay);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Automatic ACK - publish AdapterStopped
+        self.bus.publish(BusEvent::AdapterStopped {
+            adapter: prefix.to_string(),
+        });
+
+        info!("{}: stopped", prefix);
+        Ok(())
+    }
+
+    /// Run the adapter once (internal helper)
+    ///
+    /// Returns:
+    /// - `Ok(())` on clean shutdown (adapter should not restart)
+    /// - `Err(...)` on error (adapter should restart)
+    async fn run_once(&self) -> Result<()> {
+        let prefix = self.logic.prefix();
+
         // Initialize
         if let Err(e) = self.logic.init().await {
-            error!("Adapter {} init failed: {}", prefix, e);
+            error!("{}: init failed: {}", prefix, e);
             return Err(e);
         }
 
@@ -62,39 +190,368 @@ impl<T: AdapterLogic> AdapterHandle<T> {
         };
 
         // Run with lifecycle management
-        tokio::select! {
+        let result = tokio::select! {
             // Run adapter-specific logic
             result = self.logic.run(ctx) => {
                 match &result {
-                    Ok(()) => info!("Adapter {} completed normally", prefix),
-                    Err(e) => error!("Adapter {} error: {}", prefix, e),
+                    Ok(()) => info!("{}: completed normally", prefix),
+                    Err(e) => error!("{}: error: {}", prefix, e),
                 }
+                result
             }
 
             // Watch for shutdown signal on bus
             _ = async {
                 while let Ok(event) = rx.recv().await {
                     if matches!(event, BusEvent::ShuttingDown { .. }) {
-                        info!("Adapter {} received ShuttingDown event", prefix);
+                        info!("{}: received ShuttingDown event", prefix);
                         break;
                     }
                 }
             } => {
-                info!("Adapter {} stopping due to ShuttingDown event", prefix);
+                info!("{}: stopping due to ShuttingDown event", prefix);
+                Ok(())
             }
 
             // Direct cancellation (backup mechanism)
             _ = self.shutdown.cancelled() => {
-                info!("Adapter {} cancelled via token", prefix);
+                info!("{}: cancelled via token", prefix);
+                Ok(())
+            }
+        };
+
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapters::traits::{AdapterCommand, AdapterCommandResponse};
+    use crate::bus::EventBus;
+    use async_trait::async_trait;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Mutex;
+
+    /// Mock adapter that fails N times then succeeds
+    #[derive(Clone)]
+    struct MockFailingAdapter {
+        prefix: &'static str,
+        fail_count: Arc<AtomicUsize>,
+        max_failures: usize,
+    }
+
+    impl MockFailingAdapter {
+        fn new(prefix: &'static str, max_failures: usize) -> Self {
+            Self {
+                prefix,
+                fail_count: Arc::new(AtomicUsize::new(0)),
+                max_failures,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl AdapterLogic for MockFailingAdapter {
+        fn prefix(&self) -> &'static str {
+            self.prefix
+        }
+
+        async fn run(&self, _ctx: AdapterContext) -> Result<()> {
+            let count = self.fail_count.fetch_add(1, Ordering::SeqCst);
+            if count < self.max_failures {
+                Err(anyhow::anyhow!("Simulated failure {}", count + 1))
+            } else {
+                Ok(())
             }
         }
 
-        // Automatic ACK - publish AdapterStopped
-        self.bus.publish(BusEvent::AdapterStopped {
-            adapter: prefix.to_string(),
-        });
+        async fn handle_command(
+            &self,
+            _zone_id: &str,
+            _command: AdapterCommand,
+        ) -> Result<AdapterCommandResponse> {
+            Ok(AdapterCommandResponse {
+                success: true,
+                error: None,
+            })
+        }
+    }
 
-        info!("Adapter {} stopped", prefix);
-        Ok(())
+    /// Mock adapter that always succeeds
+    #[derive(Clone)]
+    struct MockSuccessAdapter;
+
+    #[async_trait]
+    impl AdapterLogic for MockSuccessAdapter {
+        fn prefix(&self) -> &'static str {
+            "mock-success"
+        }
+
+        async fn run(&self, _ctx: AdapterContext) -> Result<()> {
+            Ok(())
+        }
+
+        async fn handle_command(
+            &self,
+            _zone_id: &str,
+            _command: AdapterCommand,
+        ) -> Result<AdapterCommandResponse> {
+            Ok(AdapterCommandResponse {
+                success: true,
+                error: None,
+            })
+        }
+    }
+
+    fn test_bus() -> SharedBus {
+        Arc::new(EventBus::new(100))
+    }
+
+    #[tokio::test]
+    async fn test_run_with_retry_success_on_first_try() {
+        let bus = test_bus();
+        let shutdown = CancellationToken::new();
+        let adapter = MockSuccessAdapter;
+
+        let handle = AdapterHandle::new(adapter, bus, shutdown);
+        let config = RetryConfig::new(Duration::from_millis(10), Duration::from_millis(100));
+
+        let result = handle.run_with_retry(config).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_run_with_retry_retries_on_failure() {
+        let bus = test_bus();
+        let shutdown = CancellationToken::new();
+        let adapter = MockFailingAdapter::new("mock-failing", 2);
+        let attempt_tracker = adapter.fail_count.clone();
+
+        let handle = AdapterHandle::new(adapter, bus, shutdown);
+        let config = RetryConfig::new(Duration::from_millis(10), Duration::from_millis(100));
+
+        let result = handle.run_with_retry(config).await;
+        assert!(result.is_ok());
+        // Should have attempted 3 times: 2 failures + 1 success
+        assert_eq!(attempt_tracker.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn test_run_with_retry_shutdown_during_backoff() {
+        let bus = test_bus();
+        let shutdown = CancellationToken::new();
+        let adapter = MockFailingAdapter::new("mock-failing", 100); // Many failures
+        let attempt_tracker = adapter.fail_count.clone();
+
+        let shutdown_clone = shutdown.clone();
+        let handle = AdapterHandle::new(adapter, bus, shutdown);
+        let config = RetryConfig::new(
+            Duration::from_secs(10), // Long delay
+            Duration::from_secs(60),
+        );
+
+        // Spawn the retry loop
+        let task = tokio::spawn(async move { handle.run_with_retry(config).await });
+
+        // Wait a bit for first attempt
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Cancel during backoff
+        shutdown_clone.cancel();
+
+        // Should exit cleanly
+        let result = task.await.unwrap();
+        assert!(result.is_ok());
+
+        // Should have attempted at least once
+        assert!(attempt_tracker.load(Ordering::SeqCst) >= 1);
+    }
+
+    #[tokio::test]
+    async fn test_run_with_retry_shutdown_before_first_attempt() {
+        let bus = test_bus();
+        let shutdown = CancellationToken::new();
+        shutdown.cancel(); // Cancel before starting
+
+        let adapter = MockFailingAdapter::new("mock-failing", 100);
+        let attempt_tracker = adapter.fail_count.clone();
+
+        let handle = AdapterHandle::new(adapter, bus, shutdown);
+        let config = RetryConfig::default();
+
+        let result = handle.run_with_retry(config).await;
+        assert!(result.is_ok());
+
+        // Should not have attempted at all
+        assert_eq!(attempt_tracker.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn test_retry_config_default() {
+        let config = RetryConfig::default();
+        assert_eq!(config.initial_delay, Duration::from_secs(5));
+        assert_eq!(config.max_delay, Duration::from_secs(60));
+        assert_eq!(config.stable_run_threshold, Duration::from_secs(30));
+    }
+
+    #[tokio::test]
+    async fn test_backoff_progression() {
+        // Verify the backoff doubling logic
+        let mut delay = Duration::from_secs(5);
+        let max_delay = Duration::from_secs(60);
+
+        // 5 -> 10 -> 20 -> 40 -> 60 -> 60
+        let expected = [5, 10, 20, 40, 60, 60];
+
+        for expected_secs in expected {
+            assert_eq!(delay.as_secs(), expected_secs);
+            delay = (delay * 2).min(max_delay);
+        }
+    }
+
+    /// Mock adapter that runs for configurable durations then fails/succeeds
+    struct MockTimedAdapter {
+        /// Durations to run before failing, then succeeds on last call
+        run_durations: Arc<Mutex<Vec<Duration>>>,
+        call_count: Arc<AtomicUsize>,
+        /// Record the delay used before each retry (for verification)
+        retry_delays: Arc<Mutex<Vec<Instant>>>,
+    }
+
+    impl MockTimedAdapter {
+        fn new(durations: Vec<Duration>) -> Self {
+            Self {
+                run_durations: Arc::new(Mutex::new(durations)),
+                call_count: Arc::new(AtomicUsize::new(0)),
+                retry_delays: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+    }
+
+    impl Clone for MockTimedAdapter {
+        fn clone(&self) -> Self {
+            Self {
+                run_durations: self.run_durations.clone(),
+                call_count: self.call_count.clone(),
+                retry_delays: self.retry_delays.clone(),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl AdapterLogic for MockTimedAdapter {
+        fn prefix(&self) -> &'static str {
+            "mock-timed"
+        }
+
+        async fn run(&self, _ctx: AdapterContext) -> Result<()> {
+            let count = self.call_count.fetch_add(1, Ordering::SeqCst);
+
+            // Record when this attempt started
+            {
+                let mut delays = self.retry_delays.lock().unwrap();
+                delays.push(Instant::now());
+            }
+
+            // Get duration before await (drop lock before sleeping)
+            let duration = {
+                let durations = self.run_durations.lock().unwrap();
+                if count < durations.len() {
+                    Some(durations[count])
+                } else {
+                    None
+                }
+            };
+
+            if let Some(dur) = duration {
+                // Sleep for specified duration then fail
+                tokio::time::sleep(dur).await;
+                Err(anyhow::anyhow!("Simulated failure after {:?}", dur))
+            } else {
+                // No more durations - succeed
+                Ok(())
+            }
+        }
+
+        async fn handle_command(
+            &self,
+            _zone_id: &str,
+            _command: AdapterCommand,
+        ) -> Result<AdapterCommandResponse> {
+            Ok(AdapterCommandResponse {
+                success: true,
+                error: None,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn test_backoff_reset_after_stable_run() {
+        // Test that backoff resets after a stable run
+        //
+        // Scenario:
+        // 1. First run: fails immediately (short run)
+        // 2. Second run: runs for stable_threshold, then fails
+        // 3. Third run: succeeds
+        //
+        // Expected behavior:
+        // - After first (short) failure: delay doubles (10ms -> 20ms)
+        // - After second (stable) failure: delay resets to initial (10ms)
+
+        let bus = test_bus();
+        let shutdown = CancellationToken::new();
+
+        // Run durations: 0ms (immediate fail), 60ms (stable), then succeed
+        let adapter = MockTimedAdapter::new(vec![
+            Duration::from_millis(0),  // First: immediate failure
+            Duration::from_millis(60), // Second: stable run then failure
+        ]);
+        let retry_delays = adapter.retry_delays.clone();
+
+        let handle = AdapterHandle::new(adapter, bus, shutdown);
+        let config = RetryConfig {
+            initial_delay: Duration::from_millis(10),
+            max_delay: Duration::from_millis(100),
+            stable_run_threshold: Duration::from_millis(50), // 50ms = stable
+        };
+
+        let start = Instant::now();
+        let result = handle.run_with_retry(config).await;
+        assert!(result.is_ok());
+
+        // Check timing of retry attempts
+        let delays = retry_delays.lock().unwrap();
+        assert_eq!(delays.len(), 3, "Should have 3 attempts");
+
+        // Gap between attempt 1 and 2: should be ~10ms (initial delay, short run)
+        let gap1 = delays[1].duration_since(delays[0]);
+        // Gap between attempt 2 and 3: should be ~10ms (reset after stable run)
+        // NOT 20ms (which would be doubled delay)
+        let gap2 = delays[2].duration_since(delays[1]);
+
+        // Allow some tolerance for timing
+        // First gap: 0ms run + 10ms wait = ~10ms
+        assert!(
+            gap1 >= Duration::from_millis(8) && gap1 <= Duration::from_millis(25),
+            "First gap should be ~10ms, was {:?}",
+            gap1
+        );
+
+        // Second gap: 60ms run + 10ms wait (reset) = ~70ms
+        // If backoff wasn't reset, it would be 60ms run + 20ms wait = ~80ms
+        assert!(
+            gap2 >= Duration::from_millis(65) && gap2 <= Duration::from_millis(85),
+            "Second gap should be ~70ms (with reset), was {:?}",
+            gap2
+        );
+
+        // Total time sanity check
+        let total = start.elapsed();
+        assert!(
+            total < Duration::from_millis(150),
+            "Total time too long: {:?}",
+            total
+        );
     }
 }

--- a/src/adapters/openhome.rs
+++ b/src/adapters/openhome.rs
@@ -158,12 +158,14 @@ impl OpenHomeAdapter {
 
     /// Start SSDP discovery (internal - use Startable trait)
     async fn start_internal(&self) -> anyhow::Result<()> {
-        // Check if already running (read lock only)
+        // Use write lock to atomically check and set running flag
+        // This prevents race conditions where multiple starts could pass the check
         {
-            let state = self.state.read().await;
+            let mut state = self.state.write().await;
             if state.running {
                 return Ok(());
             }
+            state.running = true;
         }
 
         // Create fresh cancellation token for this run (previous token may be cancelled)

--- a/src/adapters/openhome.rs
+++ b/src/adapters/openhome.rs
@@ -4,9 +4,8 @@
 //! OpenHome is an extension of UPnP that provides richer metadata and more
 //! control actions (next/previous track, playlists, etc.)
 
-use crate::bus::{
-    BusEvent, PlaybackState, PrefixedZoneId, SharedBus, VolumeControl as BusVolumeControl, Zone,
-};
+use anyhow::Result;
+use async_trait::async_trait;
 use futures::StreamExt;
 use quick_xml::de::from_str as xml_from_str;
 use reqwest::Client;
@@ -18,6 +17,14 @@ use std::time::Duration;
 use tokio::sync::RwLock;
 use tokio::time::interval;
 use tokio_util::sync::CancellationToken;
+
+use crate::adapters::handle::{AdapterHandle, RetryConfig};
+use crate::adapters::traits::{
+    AdapterCommand, AdapterCommandResponse, AdapterContext, AdapterLogic,
+};
+use crate::bus::{
+    BusEvent, PlaybackState, PrefixedZoneId, SharedBus, VolumeControl as BusVolumeControl, Zone,
+};
 
 /// OpenHome URNs to search for - devices may advertise different services
 const OPENHOME_URNS: &[&str] = &[
@@ -123,6 +130,7 @@ struct OpenHomeState {
 }
 
 /// OpenHome adapter for discovering and controlling OpenHome devices
+#[derive(Clone)]
 pub struct OpenHomeAdapter {
     state: Arc<RwLock<OpenHomeState>>,
     bus: SharedBus,
@@ -150,12 +158,12 @@ impl OpenHomeAdapter {
 
     /// Start SSDP discovery (internal - use Startable trait)
     async fn start_internal(&self) -> anyhow::Result<()> {
+        // Check if already running (read lock only)
         {
-            let mut state = self.state.write().await;
+            let state = self.state.read().await;
             if state.running {
                 return Ok(());
             }
-            state.running = true;
         }
 
         // Create fresh cancellation token for this run (previous token may be cancelled)
@@ -165,23 +173,11 @@ impl OpenHomeAdapter {
             token.clone()
         };
 
-        // Spawn discovery task
-        let state = self.state.clone();
-        let bus = self.bus.clone();
-        let http = self.http.clone();
-        let shutdown_clone = shutdown.clone();
+        // Create AdapterHandle and spawn run_with_retry
+        let handle = AdapterHandle::new(self.clone(), self.bus.clone(), shutdown);
 
         tokio::spawn(async move {
-            Self::discovery_loop(state.clone(), bus.clone(), http.clone(), shutdown_clone).await;
-        });
-
-        // Spawn polling task
-        let state = self.state.clone();
-        let bus = self.bus.clone();
-        let http = self.http.clone();
-
-        tokio::spawn(async move {
-            Self::poll_loop(state, bus, http, shutdown).await;
+            let _ = handle.run_with_retry(RetryConfig::default()).await;
         });
 
         tracing::info!("OpenHome adapter started");
@@ -975,6 +971,93 @@ fn openhome_device_to_zone(device: &OpenHomeDevice) -> Zone {
         is_pause_allowed: device.state == "playing",
         is_next_allowed: true,
         is_previous_allowed: true,
+    }
+}
+
+// AdapterLogic implementation for unified retry handling
+#[async_trait]
+impl AdapterLogic for OpenHomeAdapter {
+    fn prefix(&self) -> &'static str {
+        "openhome"
+    }
+
+    async fn run(&self, ctx: AdapterContext) -> Result<()> {
+        // Mark as running
+        {
+            let mut state = self.state.write().await;
+            state.running = true;
+        }
+
+        // Run discovery and poll loops concurrently with shutdown check
+        let discovery_state = self.state.clone();
+        let discovery_bus = self.bus.clone();
+        let discovery_http = self.http.clone();
+        let discovery_shutdown = ctx.shutdown.clone();
+
+        let poll_state = self.state.clone();
+        let poll_bus = self.bus.clone();
+        let poll_http = self.http.clone();
+        let poll_shutdown = ctx.shutdown.clone();
+
+        tokio::select! {
+            _ = ctx.shutdown.cancelled() => {
+                tracing::info!("OpenHome adapter received shutdown signal");
+            }
+            _ = Self::discovery_loop(discovery_state, discovery_bus, discovery_http, discovery_shutdown) => {
+                tracing::info!("OpenHome discovery loop ended");
+            }
+            _ = Self::poll_loop(poll_state, poll_bus, poll_http, poll_shutdown) => {
+                tracing::info!("OpenHome poll loop ended");
+            }
+        }
+
+        // Clean up state on exit
+        {
+            let mut state = self.state.write().await;
+            state.running = false;
+            state.devices.clear();
+        }
+
+        tracing::info!("OpenHome adapter stopped");
+        Ok(())
+    }
+
+    async fn handle_command(
+        &self,
+        zone_id: &str,
+        command: AdapterCommand,
+    ) -> Result<AdapterCommandResponse> {
+        // Strip prefix if present
+        let uuid = zone_id.strip_prefix("openhome:").unwrap_or(zone_id);
+
+        let result = match command {
+            AdapterCommand::Play => self.control(uuid, "play", None).await,
+            AdapterCommand::Pause => self.control(uuid, "pause", None).await,
+            AdapterCommand::PlayPause => self.control(uuid, "play_pause", None).await,
+            AdapterCommand::Stop => self.control(uuid, "stop", None).await,
+            AdapterCommand::Next => self.control(uuid, "next", None).await,
+            AdapterCommand::Previous => self.control(uuid, "previous", None).await,
+            AdapterCommand::VolumeAbsolute(v) => self.control(uuid, "vol_abs", Some(v)).await,
+            AdapterCommand::VolumeRelative(v) => self.control(uuid, "vol_rel", Some(v)).await,
+            AdapterCommand::Mute(_) => {
+                // OpenHome mute not directly supported via this adapter yet
+                return Ok(AdapterCommandResponse {
+                    success: false,
+                    error: Some("Mute not supported by OpenHome adapter".to_string()),
+                });
+            }
+        };
+
+        match result {
+            Ok(()) => Ok(AdapterCommandResponse {
+                success: true,
+                error: None,
+            }),
+            Err(e) => Ok(AdapterCommandResponse {
+                success: false,
+                error: Some(e.to_string()),
+            }),
+        }
     }
 }
 

--- a/src/adapters/upnp.rs
+++ b/src/adapters/upnp.rs
@@ -142,12 +142,14 @@ impl UPnPAdapter {
 
     /// Start SSDP discovery (internal - use Startable trait)
     async fn start_internal(&self) -> anyhow::Result<()> {
-        // Check if already running (read lock only)
+        // Use write lock to atomically check and set running flag
+        // This prevents race conditions where multiple starts could pass the check
         {
-            let state = self.state.read().await;
+            let mut state = self.state.write().await;
             if state.running {
                 return Ok(());
             }
+            state.running = true;
         }
 
         // Create fresh cancellation token for this run (previous token may be cancelled)

--- a/src/adapters/upnp.rs
+++ b/src/adapters/upnp.rs
@@ -4,9 +4,15 @@
 //! Pure UPnP/DLNA has limited metadata support compared to OpenHome.
 //! Specifically, next/previous track are NOT supported by pure UPnP.
 
+use crate::adapters::handle::{AdapterHandle, RetryConfig};
+use crate::adapters::traits::{
+    AdapterCommand, AdapterCommandResponse, AdapterContext, AdapterLogic,
+};
 use crate::bus::{
     BusEvent, PlaybackState, PrefixedZoneId, SharedBus, VolumeControl as BusVolumeControl, Zone,
 };
+use anyhow::Result;
+use async_trait::async_trait;
 use futures::StreamExt;
 use quick_xml::de::from_str as xml_from_str;
 use regex::Regex;
@@ -108,6 +114,7 @@ struct UPnPState {
 }
 
 /// UPnP adapter for discovering and controlling DLNA Media Renderers
+#[derive(Clone)]
 pub struct UPnPAdapter {
     state: Arc<RwLock<UPnPState>>,
     bus: SharedBus,
@@ -135,12 +142,12 @@ impl UPnPAdapter {
 
     /// Start SSDP discovery (internal - use Startable trait)
     async fn start_internal(&self) -> anyhow::Result<()> {
+        // Check if already running (read lock only)
         {
-            let mut state = self.state.write().await;
+            let state = self.state.read().await;
             if state.running {
                 return Ok(());
             }
-            state.running = true;
         }
 
         // Create fresh cancellation token for this run (previous token may be cancelled)
@@ -150,23 +157,13 @@ impl UPnPAdapter {
             token.clone()
         };
 
-        // Spawn discovery task
-        let state = self.state.clone();
+        // Create AdapterHandle and spawn with retry
+        let adapter = self.clone();
         let bus = self.bus.clone();
-        let http = self.http.clone();
-        let shutdown_clone = shutdown.clone();
 
         tokio::spawn(async move {
-            Self::discovery_loop(state.clone(), bus.clone(), http.clone(), shutdown_clone).await;
-        });
-
-        // Spawn polling task
-        let state = self.state.clone();
-        let bus = self.bus.clone();
-        let http = self.http.clone();
-
-        tokio::spawn(async move {
-            Self::poll_loop(state, bus, http, shutdown).await;
+            let handle = AdapterHandle::new(adapter, bus, shutdown);
+            handle.run_with_retry(RetryConfig::default()).await
         });
 
         tracing::info!("UPnP adapter started");
@@ -898,6 +895,105 @@ fn upnp_renderer_to_zone(renderer: &UPnPRenderer) -> Zone {
         is_pause_allowed: renderer.state == "playing",
         is_next_allowed: false,
         is_previous_allowed: false,
+    }
+}
+
+#[async_trait]
+impl AdapterLogic for UPnPAdapter {
+    fn prefix(&self) -> &'static str {
+        "upnp"
+    }
+
+    async fn run(&self, ctx: AdapterContext) -> Result<()> {
+        // Mark as running
+        {
+            let mut state = self.state.write().await;
+            state.running = true;
+        }
+
+        // Run discovery and poll loops concurrently with shutdown check
+        let state = self.state.clone();
+        let bus = ctx.bus.clone();
+        let http = self.http.clone();
+        let shutdown = ctx.shutdown.clone();
+
+        let discovery_state = state.clone();
+        let discovery_bus = bus.clone();
+        let discovery_http = http.clone();
+        let discovery_shutdown = shutdown.clone();
+
+        let poll_state = state.clone();
+        let poll_bus = bus.clone();
+        let poll_http = http.clone();
+        let poll_shutdown = shutdown.clone();
+
+        tokio::select! {
+            _ = shutdown.cancelled() => {
+                tracing::info!("UPnP adapter shutting down");
+            }
+            _ = async {
+                tokio::join!(
+                    Self::discovery_loop(discovery_state, discovery_bus, discovery_http, discovery_shutdown),
+                    Self::poll_loop(poll_state, poll_bus, poll_http, poll_shutdown)
+                );
+            } => {}
+        }
+
+        // Cleanup state on exit
+        {
+            let mut state = self.state.write().await;
+            state.running = false;
+            state.renderers.clear();
+        }
+
+        Ok(())
+    }
+
+    async fn handle_command(
+        &self,
+        zone_id: &str,
+        command: AdapterCommand,
+    ) -> Result<AdapterCommandResponse> {
+        // Strip "upnp:" prefix if present (bus/aggregator uses prefixed IDs)
+        let uuid = zone_id.strip_prefix("upnp:").unwrap_or(zone_id);
+
+        let result = match command {
+            AdapterCommand::Play => self.control(uuid, "play", None).await,
+            AdapterCommand::Pause => self.control(uuid, "pause", None).await,
+            AdapterCommand::PlayPause => self.control(uuid, "play_pause", None).await,
+            AdapterCommand::Stop => self.control(uuid, "stop", None).await,
+            AdapterCommand::Next => {
+                return Ok(AdapterCommandResponse {
+                    success: false,
+                    error: Some("Next track not supported by pure UPnP renderers".to_string()),
+                });
+            }
+            AdapterCommand::Previous => {
+                return Ok(AdapterCommandResponse {
+                    success: false,
+                    error: Some("Previous track not supported by pure UPnP renderers".to_string()),
+                });
+            }
+            AdapterCommand::VolumeAbsolute(vol) => self.control(uuid, "vol_abs", Some(vol)).await,
+            AdapterCommand::VolumeRelative(delta) => {
+                self.control(uuid, "vol_rel", Some(delta)).await
+            }
+            AdapterCommand::Mute(mute) => {
+                self.control(uuid, "mute", Some(if mute { 1 } else { 0 }))
+                    .await
+            }
+        };
+
+        match result {
+            Ok(()) => Ok(AdapterCommandResponse {
+                success: true,
+                error: None,
+            }),
+            Err(e) => Ok(AdapterCommandResponse {
+                success: false,
+                error: Some(e.to_string()),
+            }),
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Centralizes all adapter retry logic in `AdapterHandle::run_with_retry()` with exponential backoff (5s initial, 60s max)
- Implements `AdapterLogic` trait for all adapters (Roon, LMS, OpenHome, UPnP)
- Removes bespoke retry code from individual adapters

## Changes
- **handle.rs**: Add `RetryConfig` and `run_with_retry()` method with 6 unit tests
- **roon.rs**: Remove outer retry loop, implement AdapterLogic, use `restart_needed` flag for core lost/channel close
- **lms.rs**: Remove CLI retry loop, implement AdapterLogic with concurrent CLI subscription + polling, CLI failure is non-fatal
- **openhome.rs**: Implement AdapterLogic
- **upnp.rs**: Implement AdapterLogic
- **adapter_integration.rs**: Fix async test to wait for connection

## How retry works now
```
AdapterHandle::run_with_retry()
  └─ loop
      ├─ logic.init()
      ├─ logic.run(ctx) → returns Ok(shutdown) or Err(restart)
      ├─ if Ok: break (clean shutdown)
      └─ if Err: sleep(backoff), backoff *= 2, retry
```

- `run()` returns `Ok(())` on clean shutdown (no restart)
- `run()` returns `Err(...)` when restart is needed (triggers retry)

## Test plan
- [x] Unit tests for retry behavior (backoff progression, shutdown during backoff, clean exit)
- [x] Integration tests pass
- [ ] Manual test: Restart Roon Core → bridge reconnects
- [ ] Manual test: Start bridge before LMS → bridge connects when LMS starts

Fixes #150 (Roon doesn't reconnect after server restart)
Fixes #147 (LMS times out during startup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable automatic retry with exponential backoff and stable-run reset for adapters.
  * New adapter run APIs offering single-run and retry lifecycle modes; adapters publish lifecycle events.

* **Refactor**
  * Centralized adapter lifecycle, restart and shutdown semantics; adapters now expose a unified lifecycle/command surface and are cloneable.
  * Polling, discovery and CLI flows unified under the centralized lifecycle path.

* **Tests**
  * Added tests for backoff, retry and shutdown; integration tests now await async connections.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->