### PR TITLE
refactor(lms): Split CLI subscription into independent adapter (#165)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,13 @@ Use GitHub for all task tracking:
 - Describe what changed and how to test
 - Request review from coderabbit and superego
 
+### Git Workflow
+**DO NOT force push (`git push --force` or `git push -f`)**
+- This project uses squash merges, so commit history cleanup is unnecessary
+- Force pushing breaks checkouts for anyone tracking the branch
+- Force pushing loses SHA references (builds, comments, reviews)
+- Just push new commits - they all get squashed on merge anyway
+
 ---
 
 ## Code Review

--- a/src/adapters/lms.rs
+++ b/src/adapters/lms.rs
@@ -1667,8 +1667,7 @@ impl AdapterLogic for LmsCliAdapter {
 
         // Run CLI subscription - this will retry via AdapterHandle on failure
         let result =
-            run_cli_subscription_once(&host, &self.state, &ctx.bus, &self.rpc, &ctx.shutdown)
-                .await;
+            run_cli_subscription_once(&host, &self.state, &ctx.bus, &self.rpc, &ctx.shutdown).await;
 
         // Always reset flag on exit so polling switches to fast interval
         {
@@ -1752,11 +1751,7 @@ pub fn create_lms_adapters(bus: SharedBus) -> (Arc<LmsAdapter>, Arc<LmsCliAdapte
     let lms = Arc::new(LmsAdapter::new(bus.clone()));
 
     // Create CLI adapter with shared state
-    let cli = Arc::new(LmsCliAdapter::new(
-        lms.state.clone(),
-        lms.rpc.clone(),
-        bus,
-    ));
+    let cli = Arc::new(LmsCliAdapter::new(lms.state.clone(), lms.rpc.clone(), bus));
 
     (lms, cli)
 }

--- a/src/adapters/openhome.rs
+++ b/src/adapters/openhome.rs
@@ -950,7 +950,8 @@ fn openhome_device_to_zone(device: &OpenHomeDevice) -> Zone {
                 step,
                 is_muted: device.muted,
                 scale: crate::bus::VolumeScale::Percentage,
-                output_id: Some(device.uuid.clone()),
+                // Use prefixed output_id for consistent aggregator matching
+                output_id: Some(format!("openhome:{}", device.uuid)),
             }
         }),
         now_playing: device.track_info.as_ref().map(|t| crate::bus::NowPlaying {

--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -576,6 +576,7 @@ fn convert_zone(roon_zone: &RoonZone) -> Zone {
 /// Convert local Zone to bus Zone for ZoneDiscovered event
 fn roon_zone_to_bus_zone(zone: &Zone) -> BusZone {
     // Get volume from first output (if available)
+    // Use prefixed output_id for consistent aggregator matching
     let volume_control = zone.outputs.first().and_then(|o| {
         o.volume.as_ref().map(|v| BusVolumeControl {
             value: v.value.unwrap_or(50.0),
@@ -584,7 +585,7 @@ fn roon_zone_to_bus_zone(zone: &Zone) -> BusZone {
             step: v.step.unwrap_or(1.0),
             is_muted: v.is_muted.unwrap_or(false),
             scale: crate::bus::VolumeScale::Decibel,
-            output_id: Some(o.output_id.clone()),
+            output_id: Some(format!("roon:{}", o.output_id)),
         })
     });
 
@@ -858,7 +859,7 @@ async fn run_roon_loop(
 
                                     if vol_changed {
                                         bus_for_events.publish(BusEvent::VolumeChanged {
-                                            output_id: output.output_id.clone(),
+                                            output_id: format!("roon:{}", output.output_id),
                                             value: vol.value.unwrap_or(0.0),
                                             is_muted: vol.is_muted.unwrap_or(false),
                                         });

--- a/src/adapters/upnp.rs
+++ b/src/adapters/upnp.rs
@@ -883,7 +883,8 @@ fn upnp_renderer_to_zone(renderer: &UPnPRenderer) -> Zone {
             step: 1.0,
             is_muted: renderer.muted,
             scale: crate::bus::VolumeScale::Percentage,
-            output_id: Some(renderer.uuid.clone()),
+            // Use prefixed output_id for consistent aggregator matching
+            output_id: Some(format!("upnp:{}", renderer.uuid)),
         }),
         now_playing: None, // UPnP track info would need separate DIDL-Lite parsing
         source: "upnp".to_string(),

--- a/src/aggregator.rs
+++ b/src/aggregator.rs
@@ -94,19 +94,16 @@ impl ZoneAggregator {
                         output_id, value, is_muted
                     );
                     // Find zone containing this output and update volume_control
+                    // All adapters must use prefixed output_ids (e.g., "lms:xx:xx:xx", "roon:output-id")
+                    // The lint test `bus_events_use_prefixed_output_ids` enforces this.
                     let mut zones = self.zones.write().await;
                     for zone in zones.values_mut() {
-                        // Match by volume_control.output_id (works for Roon where output_id != zone_id)
-                        // Fall back to zone_id suffix match for LMS (output_id is player MAC)
                         let matches = zone
                             .volume_control
                             .as_ref()
                             .and_then(|vc| vc.output_id.as_ref())
                             .map(|oid| oid == &output_id)
-                            .unwrap_or_else(|| {
-                                // Fallback: check if zone_id ends with output_id (LMS style)
-                                zone.zone_id.ends_with(&output_id)
-                            });
+                            .unwrap_or(false);
 
                         if matches {
                             if let Some(ref mut vc) = zone.volume_control {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1058,24 +1058,13 @@ pub async fn hqp_configure_handler(
 /// GET /lms/config - Get current LMS configuration
 pub async fn lms_config_handler(State(state): State<AppState>) -> impl IntoResponse {
     let status = state.lms.get_status().await;
-    // Get poll interval from env or use default
-    let poll_interval_secs = std::env::var("LMS_POLL_INTERVAL")
-        .ok()
-        .and_then(|s| s.parse::<u64>().ok())
-        .unwrap_or(2);
-    // When CLI active, poll interval is 15x base
-    let effective_poll_interval = if status.cli_subscription_active {
-        poll_interval_secs * 15
-    } else {
-        poll_interval_secs
-    };
     Json(serde_json::json!({
         "configured": status.host.is_some(),
         "connected": status.connected,
         "host": status.host,
         "port": status.port,
         "cli_subscription_active": status.cli_subscription_active,
-        "poll_interval_secs": effective_poll_interval
+        "poll_interval_secs": status.poll_interval_secs
     }))
 }
 

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -113,6 +113,12 @@ pub struct LmsConfig {
     pub connected: bool,
     pub host: Option<String>,
     pub port: Option<u16>,
+    /// Whether CLI subscription is active (real-time events vs polling-only)
+    #[serde(default)]
+    pub cli_subscription_active: bool,
+    /// Current poll interval in seconds (2s when CLI down, 30s when CLI up)
+    #[serde(default)]
+    pub poll_interval_secs: u64,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -121,11 +121,21 @@ pub struct LmsConfig {
     pub poll_interval_secs: u64,
 }
 
+/// Wrapper for /lms/players response
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct LmsPlayersResponse {
+    pub players: Vec<LmsPlayer>,
+}
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
 pub struct LmsPlayer {
+    /// Player ID (MAC address) - API returns "playerid" field
+    #[serde(alias = "playerid")]
     pub player_id: String,
     pub name: String,
     pub mode: String,
+    /// Current track title - API returns "title" field
+    #[serde(alias = "title")]
     pub current_title: Option<String>,
     pub artist: Option<String>,
     pub volume: i32,

--- a/src/app/pages/lms.rs
+++ b/src/app/pages/lms.rs
@@ -150,8 +150,20 @@ pub fn Lms() -> Element {
                     div { class: "mb-4",
                         if let Some(ref c) = cfg {
                             if c.configured && c.connected {
-                                span { class: "status-ok",
-                                    "✓ Connected to {c.host.as_deref().unwrap_or(\"\")}:{c.port.unwrap_or(9000)}"
+                                div {
+                                    span { class: "status-ok",
+                                        "✓ Connected to {c.host.as_deref().unwrap_or(\"\")}:{c.port.unwrap_or(9000)}"
+                                    }
+                                }
+                                // Debug info: CLI subscription and polling
+                                div { class: "text-sm text-muted mt-1",
+                                    if c.cli_subscription_active {
+                                        span { class: "text-green-600", "CLI: active" }
+                                    } else {
+                                        span { class: "text-yellow-600", "CLI: inactive (polling only)" }
+                                    }
+                                    span { class: "mx-2", "•" }
+                                    span { "Poll: {c.poll_interval_secs}s" }
                                 }
                             } else if c.configured {
                                 span { class: "status-err",

--- a/src/app/pages/lms.rs
+++ b/src/app/pages/lms.rs
@@ -4,7 +4,7 @@
 
 use dioxus::prelude::*;
 
-use crate::app::api::{AppSettings, LmsConfig, LmsPlayer};
+use crate::app::api::{AppSettings, LmsConfig, LmsPlayer, LmsPlayersResponse};
 use crate::app::components::Layout;
 use crate::app::sse::use_sse;
 
@@ -48,11 +48,12 @@ pub fn Lms() -> Element {
             .ok()
     });
 
-    // Load players resource
+    // Load players resource (API returns { players: [...] })
     let mut players = use_resource(|| async {
-        crate::app::api::fetch_json::<Vec<LmsPlayer>>("/lms/players")
+        crate::app::api::fetch_json::<LmsPlayersResponse>("/lms/players")
             .await
             .ok()
+            .map(|r| r.players)
     });
 
     // Check if LMS is enabled

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -19,7 +19,8 @@ use std::sync::Arc;
 
 /// All available adapters in the system.
 /// This is the single source of truth for what adapters exist.
-pub const AVAILABLE_ADAPTERS: &[&str] = &["roon", "lms", "openhome", "upnp"];
+/// Note: "lms-cli" is a companion to "lms" and shares its enabled state.
+pub const AVAILABLE_ADAPTERS: &[&str] = &["roon", "lms", "lms-cli", "openhome", "upnp"];
 
 /// Registered adapter with its spawn function
 struct RegisteredAdapter {
@@ -74,6 +75,8 @@ impl AdapterCoordinator {
             let enabled = match name {
                 "roon" => settings.roon,
                 "lms" => settings.lms,
+                // lms-cli shares enabled state with lms (companion adapter)
+                "lms-cli" => settings.lms,
                 "openhome" => settings.openhome,
                 "upnp" => settings.upnp,
                 _ => false,

--- a/tests/architecture_lint.rs
+++ b/tests/architecture_lint.rs
@@ -406,10 +406,15 @@ const ADAPTER_SPECIFIC_EVENTS: &[&str] = &[
 
 /// Patterns that indicate playback state changes that should also emit ZoneUpdated
 /// If you see these patterns, ZoneUpdated should be emitted nearby (within ~50 lines)
-const STATE_CHANGE_PATTERNS: &[(&str, &str)] = &[(
-    "LmsPlayerStateChanged",
-    "When emitting LmsPlayerStateChanged, also emit ZoneUpdated to update aggregator",
-)];
+///
+/// Note: LmsPlayerStateChanged has been removed - we now only emit ZoneUpdated which
+/// SSE uses directly (checking for "lms:" prefix in zone_id). The lint heuristic
+/// looks for zone_id = PrefixedZoneId:: in the preceding 2000 chars, which could have
+/// false negatives if the variable is named differently or passed through a function.
+const STATE_CHANGE_PATTERNS: &[(&str, &str)] = &[
+    // Add adapter-specific state events here if they need to also emit ZoneUpdated
+    // Currently empty - all state changes go through ZoneUpdated directly
+];
 
 #[test]
 fn bus_event_schema_documented() {


### PR DESCRIPTION
## Summary

Separates LMS into two adapters with independent AdapterHandle retry:

- **LmsAdapter**: HTTP polling only (port 9000)
- **LmsCliAdapter**: CLI subscription only (port 9090)

Both share `LmsState` and coordinate via `cli_subscription_active` flag:
- CLI connects → flag=true → polling slows to 30s
- CLI fails → flag=false → polling speeds to 2s

## Benefits

- CLI gets independent retry via AdapterHandle
- CLI failure/recovery doesn't affect polling
- Cleaner separation of concerns
- Each adapter simpler and more focused

## Implementation

- Added `LmsCliAdapter` struct implementing `AdapterLogic` + `Startable`
- Factory function `create_lms_adapters()` creates both with shared state
- Removed CLI task spawning from `LmsAdapter::run()`
- Updated `main.rs` to use factory and register both adapters

## Testing

- All existing tests pass
- CLI adapter gets independent retry on failure
- Polling continues at fast interval when CLI is down

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * LMS split into two startable components (polling adapter and CLI subscription adapter) with shared state; CLI adapter added to available adapters.

* **New Features**
  * API and server UI now show CLI subscription status and poll interval; richer LMS player/status data and a players list endpoint.

* **Bug Fixes**
  * Standardized prefixed output IDs across adapters and stricter matching in the aggregator.

* **Tests**
  * New tests enforce prefixed output IDs and volume/event reporting conventions.

* **Documentation**
  * Added Git Workflow guidance to AGENTS.md.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->