### PR TITLE
fix(roon): Show correct version and controller count in extension (#169)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -124,10 +124,17 @@ mod server {
         // Create all adapter instances (needed for API handlers regardless of state)
         // =========================================================================
 
+        // Initialize Knob device store early (needed for Roon extension status)
+        // Issue #76: Uses config subdirectory for knobs.json
+        let knob_store = knobs::KnobStore::new();
+        tracing::info!("Knob store initialized");
+
         // Roon adapter - coordinator handles starting based on enabled state
+        // Issue #169: Pass knob_store for controller count in extension status
         let roon = Arc::new(adapters::roon::RoonAdapter::new_configured(
             bus.clone(),
             base_url.clone(),
+            knob_store.clone(),
         ));
 
         // HQPlayer instance manager (multi-instance support, no settings toggle)
@@ -229,11 +236,6 @@ mod server {
             aggregator_for_spawn.run().await;
         });
         tracing::info!("ZoneAggregator started");
-
-        // Initialize Knob device store
-        // Issue #76: Uses config subdirectory for knobs.json
-        let knob_store = knobs::KnobStore::new();
-        tracing::info!("Knob store initialized");
 
         // Clone Roon adapter for shutdown access (cheap - just Arc clones)
         let roon_for_shutdown = roon.clone();


### PR DESCRIPTION
## Summary
- Fix Roon Settings Extension showing "0.0.0" version by using `UHC_VERSION` instead of `CARGO_PKG_VERSION`
- Add controller count to extension status (excluding built-in web client)
- New status format: `v{version} • {n} controller(s) • {url}`

## Changes
- Replace `info!` macro with `Info::new()` using `env!("UHC_VERSION")` for consistent version
- Pass `KnobStore` to `RoonAdapter` for controller count
- Move `knob_store` initialization earlier in `main.rs` (needed before Roon adapter creation)

## Test plan
- [ ] Build and run locally
- [ ] Verify Roon Settings → Extensions shows correct version (not "0.0.0")
- [ ] Verify controller count displays when hardware knobs are registered
- [ ] Verify status shows just version and URL when no controllers are registered

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Status display now includes dynamic controller count information in the extension status message.
  * Extension information registration updated to show version source and repository details.

* **Improvements**
  * Status messages enhanced to provide more detailed system information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->