### PR TITLE
fix(synology): Use SYNOPKG_PKGVAR for writable paths

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -279,6 +279,7 @@ jobs:
           if [[ "$BUILD_LINUX_ARM" == "true" ]]; then
             TRIGGER=""
             [[ "$IS_RELEASE_TRIGGER" == "true" ]] && TRIGGER="$RELEASE_TRIGGER_NAME"
+            [[ "$HAS_LABEL_ALL" == "true" ]] && TRIGGER="build:all"
             [[ "$HAS_LABEL_LINUX_ARM" == "true" ]] && TRIGGER="build:linux-arm"
             [[ "$HAS_LABEL_SYNOLOGY" == "true" ]] && TRIGGER="build:synology (implicit)"
             [[ "$HAS_LABEL_QNAP_ARM" == "true" ]] && TRIGGER="build:qnap-arm (implicit)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -277,11 +277,13 @@ jobs:
             fi
           fi
           if [[ "$BUILD_LINUX_ARM" == "true" ]]; then
-            TRIGGER="$RELEASE_TRIGGER_NAME"
+            TRIGGER=""
+            [[ "$IS_RELEASE_TRIGGER" == "true" ]] && TRIGGER="$RELEASE_TRIGGER_NAME"
             [[ "$HAS_LABEL_LINUX_ARM" == "true" ]] && TRIGGER="build:linux-arm"
             [[ "$HAS_LABEL_SYNOLOGY" == "true" ]] && TRIGGER="build:synology (implicit)"
             [[ "$HAS_LABEL_QNAP_ARM" == "true" ]] && TRIGGER="build:qnap-arm (implicit)"
             [[ "$HAS_LABEL_LINUX_PACKAGES" == "true" ]] && TRIGGER="build:linux-packages (implicit)"
+            [[ "$INPUT_LINUX_ARM" == "true" || "$INPUT_SYNOLOGY" == "true" || "$INPUT_QNAP_ARM" == "true" || "$INPUT_LINUX_PACKAGES" == "true" ]] && [[ -z "$TRIGGER" ]] && TRIGGER="workflow_dispatch"
             add_row "linux-arm" "$TRIGGER"
           fi
           if [[ "$BUILD_WINDOWS" == "true" ]]; then

--- a/build/synology/scripts/postinst
+++ b/build/synology/scripts/postinst
@@ -1,9 +1,24 @@
 #!/bin/bash
 
 PACKAGE_NAME="unified-hifi-control"
-PACKAGE_DIR="/var/packages/${PACKAGE_NAME}"
-TARGET_DIR="${PACKAGE_DIR}/target"
-PID_FILE="/var/run/${PACKAGE_NAME}.pid"
+
+# Use Synology environment variables for paths
+if [ -n "${SYNOPKG_PKGVAR}" ]; then
+    PKGVAR="${SYNOPKG_PKGVAR}"
+else
+    PKGVAR="/var/packages/${PACKAGE_NAME}/var"
+fi
+
+if [ -n "${SYNOPKG_PKGDEST}" ]; then
+    PKGDEST="${SYNOPKG_PKGDEST}"
+else
+    PKGDEST="/var/packages/${PACKAGE_NAME}/target"
+fi
+
+PID_FILE="${PKGVAR}/${PACKAGE_NAME}.pid"
+
+# Ensure var directory exists
+mkdir -p "${PKGVAR}"
 
 # Check if service was running (upgrade scenario - DSM should stop it but be safe)
 WAS_RUNNING=false
@@ -20,15 +35,12 @@ if [ -f "$PID_FILE" ]; then
 fi
 
 # Make binary executable
-chmod +x "${TARGET_DIR}/unified-hifi-control"
-
-# Create data directory if it doesn't exist
-mkdir -p "${PACKAGE_DIR}/var"
+chmod +x "${PKGDEST}/unified-hifi-control"
 
 # Restart service if it was running before upgrade
 if [ "$WAS_RUNNING" = true ]; then
     echo "Restarting service after upgrade..."
-    "${PACKAGE_DIR}/scripts/start-stop-status" start
+    "/var/packages/${PACKAGE_NAME}/scripts/start-stop-status" start
 fi
 
 echo "Unified Hi-Fi Control installed successfully"

--- a/build/synology/scripts/postuninst
+++ b/build/synology/scripts/postuninst
@@ -3,8 +3,16 @@
 # Runs after package files are removed
 
 PACKAGE_NAME="unified-hifi-control"
-PID_FILE="/var/run/${PACKAGE_NAME}.pid"
-LOG_FILE="/var/log/${PACKAGE_NAME}.log"
+
+# Use Synology environment variables for paths
+if [ -n "${SYNOPKG_PKGVAR}" ]; then
+    PKGVAR="${SYNOPKG_PKGVAR}"
+else
+    PKGVAR="/var/packages/${PACKAGE_NAME}/var"
+fi
+
+PID_FILE="${PKGVAR}/${PACKAGE_NAME}.pid"
+LOG_FILE="${PKGVAR}/${PACKAGE_NAME}.log"
 
 # Clean up PID file if it exists
 rm -f "$PID_FILE"

--- a/build/synology/scripts/postupgrade
+++ b/build/synology/scripts/postupgrade
@@ -3,11 +3,16 @@
 # Runs after upgrade completes
 
 PACKAGE_NAME="unified-hifi-control"
-PACKAGE_DIR="/var/packages/${PACKAGE_NAME}"
-TARGET_DIR="${PACKAGE_DIR}/target"
+
+# Use Synology environment variables for paths
+if [ -n "${SYNOPKG_PKGDEST}" ]; then
+    PKGDEST="${SYNOPKG_PKGDEST}"
+else
+    PKGDEST="/var/packages/${PACKAGE_NAME}/target"
+fi
 
 # Make binary executable
-chmod +x "${TARGET_DIR}/unified-hifi-control"
+chmod +x "${PKGDEST}/unified-hifi-control"
 
 echo "Unified Hi-Fi Control upgraded successfully"
 

--- a/build/synology/scripts/preuninst
+++ b/build/synology/scripts/preuninst
@@ -1,7 +1,15 @@
 #!/bin/bash
 
 PACKAGE_NAME="unified-hifi-control"
-PID_FILE="/var/run/${PACKAGE_NAME}.pid"
+
+# Use Synology environment variables for paths
+if [ -n "${SYNOPKG_PKGVAR}" ]; then
+    PKGVAR="${SYNOPKG_PKGVAR}"
+else
+    PKGVAR="/var/packages/${PACKAGE_NAME}/var"
+fi
+
+PID_FILE="${PKGVAR}/${PACKAGE_NAME}.pid"
 
 # Stop the service if running
 if [ -f "$PID_FILE" ]; then

--- a/build/synology/scripts/start-stop-status
+++ b/build/synology/scripts/start-stop-status
@@ -1,10 +1,24 @@
 #!/bin/bash
 
 PACKAGE_NAME="unified-hifi-control"
-PACKAGE_DIR="/var/packages/${PACKAGE_NAME}"
-TARGET_DIR="${PACKAGE_DIR}/target"
-PID_FILE="/var/run/${PACKAGE_NAME}.pid"
-LOG_FILE="/var/log/${PACKAGE_NAME}.log"
+
+# Use Synology environment variables for paths
+# SYNOPKG_PKGVAR: writable var directory (e.g., /var/packages/unified-hifi-control/var)
+# SYNOPKG_PKGDEST: package install directory (e.g., /var/packages/unified-hifi-control/target)
+if [ -n "${SYNOPKG_PKGVAR}" ]; then
+    PKGVAR="${SYNOPKG_PKGVAR}"
+else
+    PKGVAR="/var/packages/${PACKAGE_NAME}/var"
+fi
+
+if [ -n "${SYNOPKG_PKGDEST}" ]; then
+    PKGDEST="${SYNOPKG_PKGDEST}"
+else
+    PKGDEST="/var/packages/${PACKAGE_NAME}/target"
+fi
+
+PID_FILE="${PKGVAR}/${PACKAGE_NAME}.pid"
+LOG_FILE="${PKGVAR}/${PACKAGE_NAME}.log"
 
 start_daemon() {
     if [ -f "$PID_FILE" ]; then
@@ -19,13 +33,11 @@ start_daemon() {
 
     echo "Starting ${PACKAGE_NAME}..."
 
-    if ! cd "${TARGET_DIR}"; then
-        echo "Failed to change to ${TARGET_DIR}"
-        return 1
-    fi
+    # Ensure var directory exists
+    mkdir -p "${PKGVAR}"
 
     # Start the binary
-    nohup "${TARGET_DIR}/unified-hifi-control" >> "$LOG_FILE" 2>&1 &
+    nohup "${PKGDEST}/unified-hifi-control" >> "$LOG_FILE" 2>&1 &
     echo $! > "$PID_FILE"
 
     # Wait for process to start (configurable via STARTUP_WAIT)

--- a/build/synology/scripts/start-stop-status
+++ b/build/synology/scripts/start-stop-status
@@ -19,6 +19,7 @@ fi
 
 PID_FILE="${PKGVAR}/${PACKAGE_NAME}.pid"
 LOG_FILE="${PKGVAR}/${PACKAGE_NAME}.log"
+CONFIG_DIR="${PKGVAR}"
 
 start_daemon() {
     if [ -f "$PID_FILE" ]; then
@@ -36,8 +37,8 @@ start_daemon() {
     # Ensure var directory exists
     mkdir -p "${PKGVAR}"
 
-    # Start the binary
-    nohup "${PKGDEST}/unified-hifi-control" >> "$LOG_FILE" 2>&1 &
+    # Start the binary with config in package var directory
+    UHC_CONFIG_DIR="${CONFIG_DIR}" nohup "${PKGDEST}/unified-hifi-control" >> "$LOG_FILE" 2>&1 &
     echo $! > "$PID_FILE"
 
     # Wait for process to start (configurable via STARTUP_WAIT)


### PR DESCRIPTION
## Summary
- Fix Synology package failing to start due to permission issues
- Scripts were using `/var/run/` and `/var/log/` which require root
- Package runs as unprivileged `package` user per `conf/privilege`
- Now uses `SYNOPKG_PKGVAR` (the package-writable var directory)

Pattern copied from [Tailscale's DSM7 package](https://github.com/tailscale/tailscale-synology).

## Changes
All 5 scripts updated to use Synology environment variables:
- `start-stop-status`: PID_FILE and LOG_FILE now in SYNOPKG_PKGVAR
- `postinst`: Same + uses SYNOPKG_PKGDEST for binary path
- `preuninst`: PID_FILE in SYNOPKG_PKGVAR
- `postuninst`: Cleanup paths in SYNOPKG_PKGVAR
- `postupgrade`: Uses SYNOPKG_PKGDEST for binary path

## Test plan
- [x] Build SPK with `build:synology` label
- [ ] Install on DSM 7 NAS
- [ ] Verify service starts successfully
- [ ] Verify PID file created in `/var/packages/unified-hifi-control/var/`
- [ ] Verify logs written to same directory

Fixes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Better Synology package compatibility via environment-aware package paths.
  * More reliable service lifecycle: safer start/stop/upgrade handling, PID management, and var-dir creation.
  * Binary permission handling now uses package destination paths; scripts exit cleanly.

* **User Experience**
  * Clear installation success and web UI access messages.

* **CI**
  * Refined Linux ARM workflow trigger logic for dispatch vs. release runs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->