### PR TITLE
fix(knobs): Include zones_sha in error responses

### DIFF
--- a/src/knobs/routes.rs
+++ b/src/knobs/routes.rs
@@ -252,12 +252,14 @@ pub async fn knob_now_playing_handler(
         Some(id) => id,
         None => {
             let zone_infos = get_zone_infos(&state).await;
+            let zones_sha = compute_zones_sha(&zone_infos);
             return Err((
                 StatusCode::BAD_REQUEST,
                 Json(serde_json::json!({
                     "error": "zone_id required",
                     "error_code": "MISSING_ZONE_ID",
-                    "zones": zone_infos
+                    "zones": zone_infos,
+                    "zones_sha": zones_sha
                 })),
             ));
         }
@@ -303,12 +305,14 @@ pub async fn knob_now_playing_handler(
     let zone = match state.aggregator.get_zone(&prefixed_zone_id).await {
         Some(z) => z,
         None => {
+            let zones_sha = compute_zones_sha(&zone_infos);
             return Err((
                 StatusCode::NOT_FOUND,
                 Json(serde_json::json!({
                     "error": "zone not found",
                     "error_code": "ZONE_NOT_FOUND",
-                    "zones": zone_infos
+                    "zones": zone_infos,
+                    "zones_sha": zones_sha
                 })),
             ));
         }
@@ -327,12 +331,14 @@ pub async fn knob_now_playing_handler(
     };
 
     if !adapter_enabled {
+        let zones_sha = compute_zones_sha(&zone_infos);
         return Err((
             StatusCode::NOT_FOUND,
             Json(serde_json::json!({
                 "error": "zone not found",
                 "error_code": "ZONE_NOT_FOUND",
-                "zones": zone_infos
+                "zones": zone_infos,
+                "zones_sha": zones_sha
             })),
         ));
     }


### PR DESCRIPTION
## Summary
- Include `zones_sha` in `/knob/now_playing` error responses (ZONE_NOT_FOUND, MISSING_ZONE_ID)

## Problem
After a bridge restart, the knob shows stale/incorrect metadata until power cycled because:
1. Bridge restarts, zones not yet discovered
2. Knob polls with old zone_id, gets ZONE_NOT_FOUND error
3. Error response included `zones` list but NOT `zones_sha`
4. Knob had no way to detect when zone list changes
5. Even after zones appear, knob doesn't know to refresh

## Fix
Add `zones_sha` to all error responses that include `zones`. Now the knob can:
1. Monitor `zones_sha` even in error responses
2. Detect when zone list changes (empty → populated)
3. Automatically refresh when zones become available

## Test plan
- [x] `cargo test zones_sha` passes
- [x] Pre-commit checks pass (fmt, clippy)
- [ ] Manual test: restart bridge while knob connected, verify metadata recovers without power cycle

Fixes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Error responses for zone issues (missing zone ID, zone not found, or adapter disabled) now consistently include the zones_sha field alongside zone information. This matches successful responses and provides consistent, clearer context in failure scenarios to aid troubleshooting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->