### PR TITLE
fix(knobs): Add explicit text color to intermediate state boxes

### DIFF
--- a/src/app/pages/knobs.rs
+++ b/src/app/pages/knobs.rs
@@ -655,7 +655,7 @@ fn StateCascadePreview(
                             if i == states.len() - 1 {
                                 if *is_off { "bg-red-500/20 text-red-700 dark:text-red-200 font-medium" } else { "bg-green-500/20 text-green-700 dark:text-green-200 font-medium" }
                             } else {
-                                "bg-black/5 dark:bg-white/10"
+                                "bg-black/5 dark:bg-white/10 text-gray-700 dark:text-gray-200"
                             }
                         ),
                         span { class: "text-base", "{icon}" }


### PR DESCRIPTION
## Summary
- Add `text-gray-700 dark:text-gray-200` to Normal/Dim/Sleep state boxes
- Previous fix (6b23654) missed the intermediate states - they inherited light text

## Test plan
- [x] Verify power state diagram is readable in light mode
- [x] Verify power state diagram is readable in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)