### PR TITLE
fix(ci): Reduce WASM artifact size from 30MB to ~7MB

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -492,7 +492,8 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: wasm-assets
-          path: target/dx/
+          # Only upload release web assets, not entire target/dx/ (avoids 30MB+ bloat)
+          path: target/dx/unified-hifi-control/release/web/
           if-no-files-found: error
           retention-days: 1
 
@@ -615,7 +616,7 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           name: wasm-assets
-          path: target/dx/
+          path: target/dx/unified-hifi-control/release/web/
 
       - name: Cache generated CSS
         id: cache-css
@@ -840,7 +841,7 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           name: wasm-assets
-          path: target/dx/
+          path: target/dx/unified-hifi-control/release/web/
 
       - name: Cache generated CSS
         id: cache-css
@@ -905,7 +906,7 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           name: wasm-assets
-          path: target/dx/
+          path: target/dx/unified-hifi-control/release/web/
 
       - name: Cache generated CSS
         id: cache-css
@@ -961,7 +962,7 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           name: wasm-assets
-          path: target/dx/
+          path: target/dx/unified-hifi-control/release/web/
 
       - name: Cache generated CSS
         id: cache-css
@@ -1053,7 +1054,7 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           name: wasm-assets
-          path: target/dx/
+          path: target/dx/unified-hifi-control/release/web/
 
       - name: Cache generated CSS
         id: cache-css


### PR DESCRIPTION
## Summary
- Only upload `target/dx/unified-hifi-control/release/web/` instead of entire `target/dx/`
- The full directory includes incremental build artifacts that accumulate across cache hits
- Observed artifacts growing from 7MB to 30MB+ across PR builds

## Changes
- Upload path narrowed to release web assets only
- Download paths updated to match
- rust-embed still finds assets at `target/dx/unified-hifi-control/release/web/public/`

## Test plan
- [ ] Build completes successfully
- [ ] wasm-assets artifact is ~7MB not 30MB
- [ ] Binary smoke test passes (assets embedded correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD build workflow to reduce artifact size by targeting specific asset directories.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->