### PR TITLE
fix(ci): Disable docker build record upload to fix release artifact download

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1444,6 +1444,8 @@ jobs:
 
       - name: Build and push
         uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: false
         with:
           context: .
           file: Dockerfile.ci
@@ -1503,6 +1505,8 @@ jobs:
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: false
         with:
           context: .
           file: Dockerfile.release


### PR DESCRIPTION
## Summary
- docker/build-push-action v6 (from dependabot #185) uploads build records as artifacts by default
- These `.dockerbuild` artifacts are incompatible with `actions/download-artifact@v7` when downloading all artifacts
- This causes "Artifact download failed after 5 retries" in the Upload to Release job

## Fix
Set `DOCKER_BUILD_RECORD_UPLOAD=false` environment variable on all docker/build-push-action steps.

## References
- https://github.com/docker/build-push-action/issues/1167
- https://docs.docker.com/build/ci/github-actions/build-summary/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to optimize Docker build processes.

This release contains internal infrastructure updates with no user-facing changes or new features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->