### PR TITLE
feat: add MCP server for AI assistant integration

### DIFF
--- a/.claude-plugin/plugin/plugin.json
+++ b/.claude-plugin/plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "hifi-control",
+  "version": "2.5.1",
+  "description": "Unified Hi-Fi Control - Control Roon and HQPlayer",
+  "skills": [
+    {
+      "name": "sync-upstream",
+      "description": "Sync saas main branch with open source upstream v3 branch. Fetches, merges, resolves Docker conflicts, and pushes.",
+      "path": "skills/sync-upstream.md"
+    }
+  ]
+}

--- a/.claude-plugin/plugin/skills/sync-upstream.md
+++ b/.claude-plugin/plugin/skills/sync-upstream.md
@@ -1,0 +1,40 @@
+# Sync Upstream
+
+Sync the saas main branch with the open source upstream v3 branch.
+
+## Usage
+
+```
+/sync-upstream
+```
+
+## What This Does
+
+1. Fetches latest from all remotes
+2. Checks for new commits in `origin/v3` that aren't in `main`
+3. If new commits exist, merges `origin/v3` into `main`
+4. Resolves common conflicts:
+   - **docker.yml**: Always deleted (removed from saas fork)
+   - **build.yml**: Keep HEAD (saas has `main` branch support, Docker sections removed)
+   - **LMS plugin files**: Take upstream versions (version numbers)
+5. Pushes updated `main` to `saas` remote
+
+## Conflict Resolution Strategy
+
+- The saas fork removes Docker support, so any Docker-related changes from upstream are discarded
+- The saas fork adds `main` to branch triggers in CI, which upstream doesn't have
+- LMS plugin version files should always match upstream releases
+
+## Remotes
+
+- `origin`: Open source repo (open-horizon-labs/unified-hifi-control)
+- `saas`: Private fork (open-horizon-labs/unified-hifi-control-saas)
+
+## After Syncing
+
+If you have a PR branch that needs rebasing:
+```bash
+git checkout <pr-branch>
+git rebase main
+git push saas <pr-branch> --force-with-lease
+```

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -421,9 +421,9 @@ jobs:
           # Version is baked in at compile time, but we accept stale version display
           # for PRs in exchange for cache efficiency. Releases change Cargo.toml anyway.
           # Note: Tailwind version pinned in Makefile - update cache key when upgrading
-          key: wasm-v2-tw4.1.18-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml', 'Dioxus.toml', 'src/**/*.rs', 'assets/**', 'src/input.css', 'public/dx-components-theme.css') }}
+          key: wasm-v3-tw4.1.18-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml', 'Dioxus.toml', 'src/**/*.rs', 'assets/**', 'src/input.css', 'public/dx-components-theme.css') }}
           restore-keys: |
-            wasm-v2-
+            wasm-v3-
 
       - name: Setup Rust
         if: steps.cache-wasm.outputs.cache-hit != 'true'
@@ -514,9 +514,9 @@ jobs:
             target/dx/
             target/wasm32-unknown-unknown/
           # Same cache key as build-wasm job - shares cached artifacts
-          key: wasm-v2-tw4.1.18-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml', 'Dioxus.toml', 'src/**/*.rs', 'assets/**', 'src/input.css', 'public/dx-components-theme.css') }}
+          key: wasm-v3-tw4.1.18-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml', 'Dioxus.toml', 'src/**/*.rs', 'assets/**', 'src/input.css', 'public/dx-components-theme.css') }}
           restore-keys: |
-            wasm-v2-
+            wasm-v3-
 
       - name: Setup Rust
         if: steps.cache-wasm.outputs.cache-hit != 'true'

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "unified-hifi-control": {
+      "type": "http",
+      "url": "http://192.168.1.2:8089/mcp"
+    }
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "unified-hifi-control": {
       "type": "http",
-      "url": "http://192.168.1.2:8089/mcp"
+      "url": "http://192.168.1.2:8088/mcp"
     }
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,52 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the event bus pattern and d
 - Aggregator owns state (merge, hydrate, track last-seen)
 - UI talks to aggregator only (never directly to backends)
 
+## MCP Server (AI Assistant Integration)
+
+**Endpoint:** `http://<host>:8088/mcp` (Streamable HTTP transport)
+
+MCP (Model Context Protocol) enables AI assistants (Claude, ChatGPT, BoltAI, etc.) to control music playback.
+
+### Current Capabilities
+
+| Feature | Roon | LMS | OpenHome | UPnP |
+|---------|------|-----|----------|------|
+| Discovery (zones) | ✅ | ✅ | ✅ | ✅ |
+| Transport (play/pause/next) | ✅ | ✅ | ✅ | ✅ |
+| Volume control | ✅ | ✅ | ❌ | ❌ |
+| Search | ✅ | ❌ | ❌ | ❌ |
+| Play by query | ✅ | ❌ | ❌ | ❌ |
+| Queue building | ✅ | ❌ | ❌ | ❌ |
+
+### Tool Design Principles
+
+**Every tool must work as documented.** AI models try the "obvious" thing first - if it fails, they give up or confuse users.
+
+- **No broken tools** - If a tool can't reliably do what its description says, remove it
+- **No orphaned fields** - Don't return data (like `item_key`) that can't be used by any tool
+- **Clear queue pattern** - Use `hifi_play` with `action='queue'` to build playlists; call multiple times for multiple tracks
+
+**Tool descriptions are documentation.** AI models read descriptions to decide which tool to use. Be explicit about capabilities:
+- ❌ "Searches and immediately plays" (hides queue capability)
+- ✅ "Searches and plays, queues, or starts radio. Use action='queue' to add to queue."
+
+### Current Tools (10)
+
+| Tool | Purpose |
+|------|---------|
+| `hifi_zones` | List all playback zones |
+| `hifi_now_playing` | Get current track info |
+| `hifi_control` | Play, pause, next, previous, volume |
+| `hifi_search` | Search library/TIDAL/Qobuz (Roon only) |
+| `hifi_play` | AI DJ: search and play/queue/radio |
+| `hifi_status` | Bridge connection status |
+| `hifi_hqplayer_status` | HQPlayer pipeline status |
+| `hifi_hqplayer_profiles` | List HQPlayer configs |
+| `hifi_hqplayer_load_profile` | Load HQPlayer config |
+| `hifi_hqplayer_set_pipeline` | Change HQPlayer setting |
+
+---
+
 ## UI Stack
 
 **Web UI:** Dioxus + Tailwind CSS + DioxusLabs components

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,6 +239,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-server"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ab4a3ec9ea8a657c72d99a03a824af695bd0fb5ec639ccbd9cd3543b41a5f9"
+dependencies = [
+ "bytes",
+ "fs-err",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-util",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "base16"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -679,18 +695,8 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
-dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -707,36 +713,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling_core"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
-dependencies = [
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn",
-]
-
-[[package]]
 name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core 0.21.3",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
-dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote",
  "syn",
 ]
@@ -1464,12 +1446,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
-name = "dyn-clone"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
-
-[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1493,7 +1469,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f43e744e4ea338060faee68ed933e46e722fb7f3617e722a5772d7e856d8b3ce"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn",
@@ -1626,6 +1602,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs-err"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf68cef89750956493a66a10f512b9e58d9db21f2a573c079c0bdf1207a54a7"
+dependencies = [
+ "autocfg",
+ "tokio",
 ]
 
 [[package]]
@@ -2726,6 +2712,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2769,12 +2764,6 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
-
-[[package]]
-name = "pastey"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
 name = "pathdiff"
@@ -3135,26 +3124,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ref-cast"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
-dependencies = [
- "ref-cast-impl",
-]
-
-[[package]]
-name = "ref-cast-impl"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "regex"
 version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3268,51 +3237,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rmcp"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1815dbc06c414d720f8bc1951eccd66bc99efc6376331f1e7093a119b3eb508"
-dependencies = [
- "async-trait",
- "axum",
- "base64 0.22.1",
- "bytes",
- "chrono",
- "futures",
- "http",
- "http-body",
- "http-body-util",
- "pastey",
- "pin-project-lite",
- "rand 0.9.2",
- "rmcp-macros",
- "schemars",
- "serde",
- "serde_json",
- "sse-stream",
- "thiserror 2.0.18",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "tower-service",
- "tracing",
- "uuid",
-]
-
-[[package]]
-name = "rmcp-macros"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f0bc7008fa102e771a76c6d2c9b253be3f2baa5964e060464d038ae1cbc573"
-dependencies = [
- "darling 0.23.0",
- "proc-macro2",
- "quote",
- "serde_json",
- "syn",
-]
-
-[[package]]
 name = "ron"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3417,6 +3341,77 @@ checksum = "3e0698206bcb8882bf2a9ecb4c1e7785db57ff052297085a6efd4fe42302068a"
 dependencies = [
  "cfg-if",
  "ordered-multimap",
+]
+
+[[package]]
+name = "rust-mcp-macros"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ca08e51769637b29c365e88f67096acb29310c080775af9dd73a936c2b9ccb7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
+name = "rust-mcp-schema"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ed324cdee4b735926a1eaa7741b63a5d103ee08bbe0d3701398279b0c3bf3ce"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "rust-mcp-sdk"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26451e57e1872f1727e29b961cb2a1f7793c567a349aeb52b5b7716475dbf05"
+dependencies = [
+ "async-trait",
+ "axum",
+ "axum-server",
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "rust-mcp-macros",
+ "rust-mcp-schema",
+ "rust-mcp-transport",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "rust-mcp-transport"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc5c1534d052a9ccb136539e4014645d6b3d77d8ab92ef5730cb7448c893d910"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "reqwest",
+ "rust-mcp-schema",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
 ]
 
 [[package]]
@@ -3593,32 +3588,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schemars"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54e910108742c57a770f492731f99be216a52fadd361b06c8fb59d74ccc267d2"
-dependencies = [
- "chrono",
- "dyn-clone",
- "ref-cast",
- "schemars_derive",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars_derive"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4908ad288c5035a8eb12cfdf0d49270def0a268ee162b75eeee0f85d155a7c45"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3703,17 +3672,6 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "serde_derive_internals"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3975,19 +3933,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sse-stream"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb4dc4d33c68ec1f27d386b5610a351922656e1fdf5c05bbaad930cd1519479a"
-dependencies = [
- "bytes",
- "futures-util",
- "http-body",
- "http-body-util",
- "pin-project-lite",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4001,12 +3946,6 @@ checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 dependencies = [
  "float-cmp",
 ]
-
-[[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subsecond"
@@ -4174,7 +4113,9 @@ checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -4788,10 +4729,10 @@ dependencies = [
  "regex",
  "reqwest",
  "resvg",
- "rmcp",
  "roon-api",
  "rumqttc",
  "rust-embed",
+ "rust-mcp-sdk",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,8 +679,18 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -697,12 +707,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core",
+ "darling_core 0.21.3",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn",
 ]
@@ -1430,6 +1464,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1453,7 +1493,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f43e744e4ea338060faee68ed933e46e722fb7f3617e722a5772d7e856d8b3ce"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn",
@@ -1483,7 +1523,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2636,7 +2676,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2729,6 +2769,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
 name = "pathdiff"
@@ -2996,7 +3042,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3086,6 +3132,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.10.0",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3199,6 +3265,51 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmcp"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1815dbc06c414d720f8bc1951eccd66bc99efc6376331f1e7093a119b3eb508"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "futures",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pastey",
+ "pin-project-lite",
+ "rand 0.9.2",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "sse-stream",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower-service",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f0bc7008fa102e771a76c6d2c9b253be3f2baa5964e060464d038ae1cbc573"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
 ]
 
 [[package]]
@@ -3339,7 +3450,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3482,6 +3593,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54e910108742c57a770f492731f99be216a52fadd361b06c8fb59d74ccc267d2"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4908ad288c5035a8eb12cfdf0d49270def0a268ee162b75eeee0f85d155a7c45"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3566,6 +3703,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3827,6 +3975,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sse-stream"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb4dc4d33c68ec1f27d386b5610a351922656e1fdf5c05bbaad930cd1519479a"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3840,6 +4001,12 @@ checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 dependencies = [
  "float-cmp",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subsecond"
@@ -3947,7 +4114,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4621,6 +4788,7 @@ dependencies = [
  "regex",
  "reqwest",
  "resvg",
+ "rmcp",
  "roon-api",
  "rumqttc",
  "rust-embed",
@@ -4904,7 +5072,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ http-body-util = { version = "0.1", optional = true }
 resvg = { version = "0.46.0", features = ["default"], optional = true }
 
 # MCP server (server only)
-rust-mcp-sdk = { version = "0.8", default-features = false, features = ["server", "macros", "hyper-server"], optional = true }
+rust-mcp-sdk = { version = "0.8", default-features = false, features = ["server", "macros", "hyper-server", "sse"], optional = true }
 
 # ============ WEB-ONLY DEPENDENCIES ============
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ server = [
     "dep:rust-embed",
     "dep:mime_guess",
     "dep:http-body-util",
+    "dep:rmcp",
 ]
 web = ["dioxus/web"]
 
@@ -88,7 +89,7 @@ tower = { version = "0.5", optional = true }
 tower-http = { version = "0.6", features = ["cors", "compression-gzip", "trace"], optional = true }
 
 # Roon API (server only)
-roon-api = { git = "https://github.com/open-horizon-labs/rust-roon-api.git", branch = "fix/fractional-volume", features = ["transport", "image", "status"], optional = true }
+roon-api = { git = "https://github.com/open-horizon-labs/rust-roon-api.git", branch = "fix/fractional-volume", features = ["transport", "image", "status", "browse"], optional = true }
 # TODO: Switch back to upstream after https://github.com/TheAppgineer/rust-roon-api/pull/1 is merged
 
 # HTTP client (server only)
@@ -122,6 +123,9 @@ http-body-util = { version = "0.1", optional = true }
 
 # SVG rasterization (server only)
 resvg = { version = "0.46.0", features = ["default"], optional = true }
+
+# MCP server (server only)
+rmcp = { version = "0.13", features = ["server", "transport-streamable-http-server", "macros"], optional = true }
 
 # ============ WEB-ONLY DEPENDENCIES ============
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ server = [
     "dep:rust-embed",
     "dep:mime_guess",
     "dep:http-body-util",
-    "dep:rmcp",
+    "dep:rust-mcp-sdk",
 ]
 web = ["dioxus/web"]
 
@@ -125,7 +125,7 @@ http-body-util = { version = "0.1", optional = true }
 resvg = { version = "0.46.0", features = ["default"], optional = true }
 
 # MCP server (server only)
-rmcp = { version = "0.13", features = ["server", "transport-streamable-http-server", "macros"], optional = true }
+rust-mcp-sdk = { version = "0.8", default-features = false, features = ["server", "macros", "hyper-server"], optional = true }
 
 # ============ WEB-ONLY DEPENDENCIES ============
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/README.md
+++ b/README.md
@@ -119,22 +119,19 @@ If you route audio through HQPlayer for upsampling or filtering, this bridge let
 
 ## MCP Server (Claude Integration)
 
-Control your hi-fi with natural language. The bridge includes an MCP server so Claude can play, pause, adjust volume, and switch HQPlayer profiles.
+Control your hi-fi with natural language. The bridge includes an MCP server so Claude can search, play, queue music, adjust volume, and switch HQPlayer profiles.
 
 ### Setup
 
 1. Start the bridge (`docker compose up -d`)
-2. Add to your Claude Code MCP config:
+2. Add to your MCP config (Claude Code, ChatGPT, BoltAI, etc.):
 
 ```json
 {
   "mcpServers": {
-    "hifi": {
-      "command": "npx",
-      "args": ["unified-hifi-control-mcp"],
-      "env": {
-        "HIFI_BRIDGE_URL": "http://localhost:8088"
-      }
+    "unified-hifi-control": {
+      "type": "http",
+      "url": "http://<your-bridge-host>:8088/mcp"
     }
   }
 }
@@ -144,18 +141,22 @@ Control your hi-fi with natural language. The bridge includes an MCP server so C
 
 | Tool | Description |
 |------|-------------|
-| `hifi_zones` | List available zones (Roon, Lyrion, OpenHome, UPnP) |
+| `hifi_zones` | List available zones (Roon, LMS, OpenHome, UPnP) |
 | `hifi_now_playing` | Get current track, artist, album, play state |
 | `hifi_control` | Play, pause, next, previous, volume control |
+| `hifi_search` | Search library, TIDAL, or Qobuz *(Roon only)* |
+| `hifi_play` | AI DJ: search and play/queue in one command *(Roon only)* |
+| `hifi_status` | Overall bridge status |
 | `hifi_hqplayer_status` | HQPlayer Embedded status and pipeline |
 | `hifi_hqplayer_profiles` | List saved HQPlayer profiles |
 | `hifi_hqplayer_load_profile` | Switch HQPlayer profile |
 | `hifi_hqplayer_set_pipeline` | Change filter, shaper, dither settings |
-| `hifi_status` | Overall bridge status |
+
+*Search and play are currently Roon-only. Transport controls work with all adapters. [LMS search/play contributions welcome!](https://github.com/open-horizon-labs/unified-hifi-control/issues)*
 
 ### Example Usage
 
-Ask Claude: "What's playing right now?" or "Turn the volume down a bit" or "Switch to my DSD profile in HQPlayer"
+Ask Claude: "Play some jazz piano" or "Queue Hotel California" or "What's playing?" or "Turn the volume down"
 
 <details>
 <summary><strong>Firmware Updates (roon-knob)</strong></summary>

--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -5,6 +5,9 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use roon_api::{
+    browse::{
+        Browse, BrowseOpts, BrowseResult, Item as BrowseItem, ItemHint, LoadOpts, LoadResult,
+    },
     image::{Args as ImageArgs, Format as ImageFormat, Image, Scale, Scaling},
     status::{self, Status},
     transport::{self, volume, Control, Transport, Zone as RoonZone},
@@ -32,8 +35,84 @@ use crate::knobs::KnobStore;
 
 const ROON_STATE_FILE: &str = "roon_state.json";
 
+/// Timeout for browse/load requests
+const BROWSE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Default search result limit
+const DEFAULT_SEARCH_LIMIT: usize = 50;
+
+/// Category names returned by Roon search - these are containers, not playable items
+const CATEGORY_NAMES: &[&str] = &[
+    "Albums",
+    "Tracks",
+    "Artists",
+    "Works",
+    "Composers",
+    "Genres",
+    "Tags",
+];
+
+/// Search source - where to search
+#[derive(Debug, Clone, Copy, Default)]
+pub enum SearchSource {
+    #[default]
+    Library,
+    Tidal,
+    Qobuz,
+}
+
+/// Play action - what to do with the selected item
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum PlayAction {
+    #[default]
+    Play,
+    Queue,
+    Radio,
+}
+
+impl PlayAction {
+    /// Parse from string, defaulting to Play for unknown values
+    pub fn parse(s: &str) -> Self {
+        match s.to_lowercase().as_str() {
+            "queue" | "add" => Self::Queue,
+            "radio" | "start_radio" => Self::Radio,
+            _ => Self::Play,
+        }
+    }
+
+    /// Get the Roon action title
+    fn action_title(&self) -> &'static str {
+        match self {
+            Self::Play => "Play Now",
+            Self::Queue => "Queue",
+            Self::Radio => "Start Radio",
+        }
+    }
+}
+
+/// Find the first playable item in a list (hint is Action or ActionList)
+fn find_playable_item(items: &[BrowseItem]) -> Option<&BrowseItem> {
+    items.iter().find(|item| {
+        matches!(
+            item.hint,
+            Some(ItemHint::Action) | Some(ItemHint::ActionList)
+        )
+    })
+}
+
+/// Check if an item is a category (Albums, Tracks, etc.) rather than playable content
+fn is_category(item: &BrowseItem) -> bool {
+    CATEGORY_NAMES.contains(&item.title.as_str())
+}
+
 /// Pending image request - stores the oneshot sender to deliver the result
 type ImageRequest = oneshot::Sender<Option<ImageData>>;
+
+/// Pending browse request - stores the oneshot sender to deliver the result
+type BrowseRequest = oneshot::Sender<Result<BrowseResult>>;
+
+/// Pending load request - stores the oneshot sender to deliver the result
+type LoadRequest = oneshot::Sender<Result<LoadResult>>;
 
 /// Image data returned from Roon
 #[derive(Debug, Clone)]
@@ -152,8 +231,13 @@ struct RoonState {
     zones: HashMap<String, Zone>,
     transport: Option<Transport>,
     image: Option<Image>,
+    browse: Option<Browse>,
     /// Pending image requests: request_id -> (image_key, oneshot sender)
     pending_images: HashMap<usize, (String, ImageRequest)>,
+    /// Pending browse requests: request_id -> (session_key, oneshot sender)
+    pending_browses: HashMap<usize, (Option<String>, BrowseRequest)>,
+    /// Pending load requests: request_id -> (session_key, oneshot sender)
+    pending_loads: HashMap<usize, (Option<String>, LoadRequest)>,
 }
 
 /// Roon adapter
@@ -445,6 +529,704 @@ impl RoonAdapter {
             Err(_) => Err(anyhow::anyhow!("Image request timed out")),
         }
     }
+
+    // =========================================================================
+    // Browse API methods (consolidated from RoonBrowseAdapter)
+    // =========================================================================
+
+    /// Check if browse service is connected
+    pub async fn is_browse_connected(&self) -> bool {
+        let state = self.state.read().await;
+        state.connected && state.browse.is_some()
+    }
+
+    /// Browse the Roon library hierarchy
+    pub async fn browse(&self, opts: BrowseOpts) -> Result<BrowseResult> {
+        let (tx, rx) = oneshot::channel();
+        let session_key = opts.multi_session_key.clone();
+
+        let browse = {
+            let state = self.state.read().await;
+            state.browse.clone().ok_or_else(|| {
+                anyhow::anyhow!("Browse service not available - not connected to Roon")
+            })?
+        };
+
+        let req_id = browse.browse(&opts).await;
+
+        let req_id = match req_id {
+            Some(id) => {
+                let mut state = self.state.write().await;
+                state.pending_browses.insert(id, (session_key.clone(), tx));
+                id
+            }
+            None => return Err(anyhow::anyhow!("Failed to initiate browse request")),
+        };
+
+        tracing::debug!("Browse request initiated with req_id {}", req_id);
+
+        let result = tokio::time::timeout(BROWSE_TIMEOUT, rx).await;
+
+        if result.is_err() {
+            let mut state = self.state.write().await;
+            state.pending_browses.remove(&req_id);
+        }
+
+        match result {
+            Ok(Ok(data)) => data,
+            Ok(Err(_)) => Err(anyhow::anyhow!("Browse request cancelled")),
+            Err(_) => Err(anyhow::anyhow!("Browse request timed out")),
+        }
+    }
+
+    /// Load items from the current browse position (for pagination)
+    pub async fn load(&self, opts: LoadOpts) -> Result<LoadResult> {
+        let (tx, rx) = oneshot::channel();
+        let session_key = opts.multi_session_key.clone();
+
+        let browse = {
+            let state = self.state.read().await;
+            state.browse.clone().ok_or_else(|| {
+                anyhow::anyhow!("Browse service not available - not connected to Roon")
+            })?
+        };
+
+        let req_id = browse.load(&opts).await;
+
+        let req_id = match req_id {
+            Some(id) => {
+                let mut state = self.state.write().await;
+                state.pending_loads.insert(id, (session_key.clone(), tx));
+                id
+            }
+            None => return Err(anyhow::anyhow!("Failed to initiate load request")),
+        };
+
+        tracing::debug!("Load request initiated with req_id {}", req_id);
+
+        let result = tokio::time::timeout(BROWSE_TIMEOUT, rx).await;
+
+        if result.is_err() {
+            let mut state = self.state.write().await;
+            state.pending_loads.remove(&req_id);
+        }
+
+        match result {
+            Ok(Ok(data)) => data,
+            Ok(Err(_)) => Err(anyhow::anyhow!("Load request cancelled")),
+            Err(_) => Err(anyhow::anyhow!("Load request timed out")),
+        }
+    }
+
+    /// Search the Roon library, TIDAL, or Qobuz
+    pub async fn search(
+        &self,
+        query: &str,
+        zone_id: Option<&str>,
+        limit: Option<usize>,
+        source: SearchSource,
+    ) -> Result<Vec<BrowseItem>> {
+        let session_key = format!(
+            "search_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        );
+
+        let source_name = match source {
+            SearchSource::Library => "Library",
+            SearchSource::Tidal => "TIDAL",
+            SearchSource::Qobuz => "Qobuz",
+        };
+
+        // Step 1: Navigate to root
+        let root_opts = BrowseOpts {
+            multi_session_key: Some(session_key.clone()),
+            zone_or_output_id: zone_id.map(|z| z.to_string()),
+            pop_all: true,
+            ..Default::default()
+        };
+        self.browse(root_opts).await?;
+
+        let root_load = LoadOpts {
+            multi_session_key: Some(session_key.clone()),
+            count: Some(10),
+            ..Default::default()
+        };
+        let root_items = self.load(root_load).await?;
+
+        // Find source item
+        let source_item = root_items
+            .items
+            .iter()
+            .find(|item| item.title == source_name)
+            .ok_or_else(|| anyhow::anyhow!("{} not found in browse root", source_name))?;
+
+        let source_key = source_item
+            .item_key
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("{} has no item_key", source_name))?;
+
+        // Step 2: Browse into source
+        let source_opts = BrowseOpts {
+            multi_session_key: Some(session_key.clone()),
+            item_key: Some(source_key),
+            zone_or_output_id: zone_id.map(|z| z.to_string()),
+            ..Default::default()
+        };
+        self.browse(source_opts).await?;
+
+        let source_load = LoadOpts {
+            multi_session_key: Some(session_key.clone()),
+            count: Some(10),
+            ..Default::default()
+        };
+        let source_items = self.load(source_load).await?;
+
+        // Find Search item
+        let search_item = source_items
+            .items
+            .iter()
+            .find(|item| item.title == "Search")
+            .ok_or_else(|| anyhow::anyhow!("Search not found in {}", source_name))?;
+
+        let search_key = search_item
+            .item_key
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("Search has no item_key"))?;
+
+        // Step 3: Search with query
+        let search_opts = BrowseOpts {
+            multi_session_key: Some(session_key.clone()),
+            item_key: Some(search_key),
+            input: Some(query.to_string()),
+            zone_or_output_id: zone_id.map(|z| z.to_string()),
+            ..Default::default()
+        };
+        let search_result = self.browse(search_opts).await?;
+
+        // Step 4: Load search results
+        if let Some(list) = &search_result.list {
+            if list.count > 0 {
+                let load_opts = LoadOpts {
+                    multi_session_key: Some(session_key),
+                    count: Some(limit.unwrap_or(DEFAULT_SEARCH_LIMIT)),
+                    ..Default::default()
+                };
+                let load_result = self.load(load_opts).await?;
+                return Ok(load_result.items);
+            }
+        }
+
+        Ok(vec![])
+    }
+
+    /// Search and play the first matching result
+    pub async fn search_and_play(
+        &self,
+        query: &str,
+        zone_id: &str,
+        source: SearchSource,
+        action: PlayAction,
+    ) -> Result<String> {
+        let session_key = format!(
+            "play_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        );
+
+        let source_name = match source {
+            SearchSource::Library => "Library",
+            SearchSource::Tidal => "TIDAL",
+            SearchSource::Qobuz => "Qobuz",
+        };
+
+        let bare_zone_id = zone_id.strip_prefix("roon:").unwrap_or(zone_id);
+
+        // Navigate to root
+        self.browse(BrowseOpts {
+            multi_session_key: Some(session_key.clone()),
+            zone_or_output_id: Some(bare_zone_id.to_string()),
+            pop_all: true,
+            ..Default::default()
+        })
+        .await?;
+
+        let root_items = self
+            .load(LoadOpts {
+                multi_session_key: Some(session_key.clone()),
+                count: Some(10),
+                ..Default::default()
+            })
+            .await?;
+
+        // Find source
+        let source_item = root_items
+            .items
+            .iter()
+            .find(|item| item.title == source_name)
+            .ok_or_else(|| anyhow::anyhow!("{} not found", source_name))?;
+
+        let source_key = source_item
+            .item_key
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("{} has no item_key", source_name))?;
+
+        // Browse into source
+        self.browse(BrowseOpts {
+            multi_session_key: Some(session_key.clone()),
+            item_key: Some(source_key),
+            zone_or_output_id: Some(bare_zone_id.to_string()),
+            ..Default::default()
+        })
+        .await?;
+
+        let source_items = self
+            .load(LoadOpts {
+                multi_session_key: Some(session_key.clone()),
+                count: Some(10),
+                ..Default::default()
+            })
+            .await?;
+
+        // Find Search
+        let search_item = source_items
+            .items
+            .iter()
+            .find(|item| item.title == "Search")
+            .ok_or_else(|| anyhow::anyhow!("Search not found in {}", source_name))?;
+
+        let search_key = search_item
+            .item_key
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("Search has no item_key"))?;
+
+        // Search with query
+        self.browse(BrowseOpts {
+            multi_session_key: Some(session_key.clone()),
+            item_key: Some(search_key),
+            input: Some(query.to_string()),
+            zone_or_output_id: Some(bare_zone_id.to_string()),
+            ..Default::default()
+        })
+        .await?;
+
+        let search_results = self
+            .load(LoadOpts {
+                multi_session_key: Some(session_key.clone()),
+                count: Some(20),
+                ..Default::default()
+            })
+            .await?;
+
+        // Find first playable item
+        if let Some(playable) = find_playable_item(&search_results.items) {
+            let playable_title = playable.title.clone();
+            let playable_key = playable
+                .item_key
+                .clone()
+                .ok_or_else(|| anyhow::anyhow!("Playable item has no item_key"))?;
+
+            return self
+                .execute_play_action(
+                    &session_key,
+                    bare_zone_id,
+                    &playable_title,
+                    &playable_key,
+                    action,
+                )
+                .await;
+        }
+
+        // Try navigating deeper
+        if let Some(result) = self
+            .try_navigate_to_playable(&session_key, bare_zone_id, &search_results.items, action)
+            .await?
+        {
+            return Ok(result);
+        }
+
+        // Try category fallback
+        if let Some(result) = self
+            .try_category_playable(&session_key, bare_zone_id, &search_results.items, action)
+            .await?
+        {
+            return Ok(result);
+        }
+
+        Err(anyhow::anyhow!("No playable results found for '{}'", query))
+    }
+
+    /// Try to navigate into the first non-category item to find playable content
+    async fn try_navigate_to_playable(
+        &self,
+        session_key: &str,
+        zone_id: &str,
+        items: &[BrowseItem],
+        action: PlayAction,
+    ) -> Result<Option<String>> {
+        let first = match items.first() {
+            Some(item) if !is_category(item) && item.item_key.is_some() => item,
+            _ => return Ok(None),
+        };
+
+        let first_title = first.title.clone();
+        let first_key = first
+            .item_key
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("Item has no key"))?;
+
+        self.browse(BrowseOpts {
+            multi_session_key: Some(session_key.to_string()),
+            item_key: Some(first_key),
+            zone_or_output_id: Some(zone_id.to_string()),
+            ..Default::default()
+        })
+        .await?;
+
+        let inner_items = self
+            .load(LoadOpts {
+                multi_session_key: Some(session_key.to_string()),
+                count: Some(20),
+                ..Default::default()
+            })
+            .await?;
+
+        if let Some(playable) = find_playable_item(&inner_items.items) {
+            let play_key = playable
+                .item_key
+                .clone()
+                .ok_or_else(|| anyhow::anyhow!("Item has no key"))?;
+            return Ok(Some(
+                self.execute_play_action(session_key, zone_id, &first_title, &play_key, action)
+                    .await?,
+            ));
+        }
+
+        // Try one more level
+        if let Some(inner_first) = inner_items.items.first() {
+            if matches!(inner_first.hint, Some(ItemHint::List)) {
+                if let Some(inner_key) = &inner_first.item_key {
+                    self.browse(BrowseOpts {
+                        multi_session_key: Some(session_key.to_string()),
+                        item_key: Some(inner_key.clone()),
+                        zone_or_output_id: Some(zone_id.to_string()),
+                        ..Default::default()
+                    })
+                    .await?;
+
+                    let deeper = self
+                        .load(LoadOpts {
+                            multi_session_key: Some(session_key.to_string()),
+                            count: Some(20),
+                            ..Default::default()
+                        })
+                        .await?;
+
+                    if let Some(playable) = find_playable_item(&deeper.items) {
+                        let play_key = playable
+                            .item_key
+                            .clone()
+                            .ok_or_else(|| anyhow::anyhow!("Item has no key"))?;
+                        return Ok(Some(
+                            self.execute_play_action(
+                                session_key,
+                                zone_id,
+                                &first_title,
+                                &play_key,
+                                action,
+                            )
+                            .await?,
+                        ));
+                    }
+                }
+            }
+        }
+
+        Ok(None)
+    }
+
+    /// Try to find playable content in Albums or Tracks category
+    async fn try_category_playable(
+        &self,
+        session_key: &str,
+        zone_id: &str,
+        items: &[BrowseItem],
+        action: PlayAction,
+    ) -> Result<Option<String>> {
+        let category = items
+            .iter()
+            .find(|item| item.title == "Albums" || item.title == "Tracks");
+
+        let cat = match category {
+            Some(c) if c.item_key.is_some() => c,
+            _ => return Ok(None),
+        };
+
+        let cat_key = cat
+            .item_key
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("Category has no key"))?;
+
+        self.browse(BrowseOpts {
+            multi_session_key: Some(session_key.to_string()),
+            item_key: Some(cat_key),
+            zone_or_output_id: Some(zone_id.to_string()),
+            ..Default::default()
+        })
+        .await?;
+
+        let category_items = self
+            .load(LoadOpts {
+                multi_session_key: Some(session_key.to_string()),
+                count: Some(20),
+                ..Default::default()
+            })
+            .await?;
+
+        if let Some(playable) = find_playable_item(&category_items.items) {
+            let title = playable.title.clone();
+            let key = playable
+                .item_key
+                .clone()
+                .ok_or_else(|| anyhow::anyhow!("Playable item has no item_key"))?;
+
+            return Ok(Some(
+                self.execute_play_action(session_key, zone_id, &title, &key, action)
+                    .await?,
+            ));
+        }
+
+        // Try first item in category
+        if let Some(first_item) = category_items.items.first() {
+            if let Some(first_key) = &first_item.item_key {
+                let first_title = first_item.title.clone();
+
+                self.browse(BrowseOpts {
+                    multi_session_key: Some(session_key.to_string()),
+                    item_key: Some(first_key.clone()),
+                    zone_or_output_id: Some(zone_id.to_string()),
+                    ..Default::default()
+                })
+                .await?;
+
+                let deeper_items = self
+                    .load(LoadOpts {
+                        multi_session_key: Some(session_key.to_string()),
+                        count: Some(20),
+                        ..Default::default()
+                    })
+                    .await?;
+
+                if let Some(playable) = find_playable_item(&deeper_items.items) {
+                    let key = playable
+                        .item_key
+                        .clone()
+                        .ok_or_else(|| anyhow::anyhow!("Item has no key"))?;
+                    return Ok(Some(
+                        self.execute_play_action(session_key, zone_id, &first_title, &key, action)
+                            .await?,
+                    ));
+                }
+            }
+        }
+
+        Ok(None)
+    }
+
+    /// Play an item by its item_key
+    pub async fn play_item(
+        &self,
+        item_key: &str,
+        zone_id: &str,
+        action: PlayAction,
+    ) -> Result<String> {
+        if item_key.is_empty() {
+            return Err(anyhow::anyhow!("item_key cannot be empty"));
+        }
+        if item_key.len() > 500 {
+            return Err(anyhow::anyhow!("item_key appears malformed (too long)"));
+        }
+
+        let session_key = format!(
+            "play_item_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        );
+
+        let bare_zone_id = zone_id.strip_prefix("roon:").unwrap_or(zone_id);
+
+        self.browse(BrowseOpts {
+            multi_session_key: Some(session_key.clone()),
+            item_key: Some(item_key.to_string()),
+            zone_or_output_id: Some(bare_zone_id.to_string()),
+            ..Default::default()
+        })
+        .await?;
+
+        let items = self
+            .load(LoadOpts {
+                multi_session_key: Some(session_key.clone()),
+                count: Some(20),
+                ..Default::default()
+            })
+            .await?;
+
+        if let Some(playable) = find_playable_item(&items.items) {
+            let title = playable.title.clone();
+            let key = playable
+                .item_key
+                .clone()
+                .ok_or_else(|| anyhow::anyhow!("Item has no key"))?;
+            return self
+                .execute_play_action(&session_key, bare_zone_id, &title, &key, action)
+                .await;
+        }
+
+        // Try "Play Album" action
+        if let Some(play_album) = items.items.iter().find(|i| i.title == "Play Album") {
+            let key = play_album
+                .item_key
+                .clone()
+                .ok_or_else(|| anyhow::anyhow!("Play Album has no key"))?;
+            return self
+                .execute_play_action(&session_key, bare_zone_id, "Album", &key, action)
+                .await;
+        }
+
+        // Try navigating into first item
+        if let Some(first) = items.items.first() {
+            if let Some(key) = &first.item_key {
+                self.browse(BrowseOpts {
+                    multi_session_key: Some(session_key.clone()),
+                    item_key: Some(key.clone()),
+                    zone_or_output_id: Some(bare_zone_id.to_string()),
+                    ..Default::default()
+                })
+                .await?;
+
+                let deeper = self
+                    .load(LoadOpts {
+                        multi_session_key: Some(session_key.clone()),
+                        count: Some(20),
+                        ..Default::default()
+                    })
+                    .await?;
+
+                if let Some(playable) = find_playable_item(&deeper.items) {
+                    let title = playable.title.clone();
+                    let item_key = playable
+                        .item_key
+                        .clone()
+                        .ok_or_else(|| anyhow::anyhow!("Item has no key"))?;
+                    return self
+                        .execute_play_action(&session_key, bare_zone_id, &title, &item_key, action)
+                        .await;
+                }
+
+                if let Some(play_album) = deeper.items.iter().find(|i| i.title == "Play Album") {
+                    let key = play_album
+                        .item_key
+                        .clone()
+                        .ok_or_else(|| anyhow::anyhow!("Play Album has no key"))?;
+                    return self
+                        .execute_play_action(&session_key, bare_zone_id, &first.title, &key, action)
+                        .await;
+                }
+            }
+        }
+
+        Err(anyhow::anyhow!(
+            "Could not find playable content for item_key '{}'",
+            item_key
+        ))
+    }
+
+    /// Execute a play action on a specific item
+    async fn execute_play_action(
+        &self,
+        session_key: &str,
+        zone_id: &str,
+        item_title: &str,
+        item_key: &str,
+        action: PlayAction,
+    ) -> Result<String> {
+        self.browse(BrowseOpts {
+            multi_session_key: Some(session_key.to_string()),
+            item_key: Some(item_key.to_string()),
+            zone_or_output_id: Some(zone_id.to_string()),
+            ..Default::default()
+        })
+        .await?;
+
+        let mut actions = self
+            .load(LoadOpts {
+                multi_session_key: Some(session_key.to_string()),
+                count: Some(10),
+                ..Default::default()
+            })
+            .await?;
+
+        // Handle double-nested action_list
+        if actions.items.len() == 1 {
+            if let Some(item) = actions.items.first() {
+                if matches!(item.hint, Some(ItemHint::ActionList)) {
+                    if let Some(key) = &item.item_key {
+                        self.browse(BrowseOpts {
+                            multi_session_key: Some(session_key.to_string()),
+                            item_key: Some(key.clone()),
+                            zone_or_output_id: Some(zone_id.to_string()),
+                            ..Default::default()
+                        })
+                        .await?;
+
+                        actions = self
+                            .load(LoadOpts {
+                                multi_session_key: Some(session_key.to_string()),
+                                count: Some(10),
+                                ..Default::default()
+                            })
+                            .await?;
+                    }
+                }
+            }
+        }
+
+        let action_title = action.action_title();
+
+        let action_item = actions
+            .items
+            .iter()
+            .find(|item| item.title == action_title)
+            .ok_or_else(|| {
+                let available: Vec<_> = actions.items.iter().map(|i| &i.title).collect();
+                anyhow::anyhow!(
+                    "Action '{}' not available. Available: {:?}",
+                    action_title,
+                    available
+                )
+            })?;
+
+        let action_key = action_item
+            .item_key
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("Action has no item_key"))?;
+
+        self.browse(BrowseOpts {
+            multi_session_key: Some(session_key.to_string()),
+            item_key: Some(action_key),
+            zone_or_output_id: Some(zone_id.to_string()),
+            ..Default::default()
+        })
+        .await?;
+
+        Ok(format!("{}: {}", action_title, item_title))
+    }
 }
 
 #[async_trait]
@@ -703,6 +1485,7 @@ async fn run_roon_loop(
     let services = vec![
         Services::Transport(Transport::new()),
         Services::Image(Image::new()),
+        Services::Browse(Browse::new()),
         Services::Status(status),
     ];
 
@@ -784,6 +1567,7 @@ async fn run_roon_loop(
                     // Get transport and image services BEFORE acquiring lock
                     let transport = core.get_transport().cloned();
                     let image = core.get_image().cloned();
+                    let browse = core.get_browse().cloned();
 
                     // Subscribe to zones BEFORE acquiring lock (async operation)
                     if let Some(ref t) = transport {
@@ -798,10 +1582,15 @@ async fn run_roon_loop(
                         s.core_version = Some(core_version.clone());
                         s.transport = transport;
                         s.image = image.clone();
+                        s.browse = browse.clone();
                     }
 
                     if image.is_some() {
                         tracing::info!("Roon Image service available");
+                    }
+
+                    if browse.is_some() {
+                        tracing::info!("Roon Browse service available");
                     }
 
                     // Publish connected event (after lock released)
@@ -835,7 +1624,10 @@ async fn run_roon_loop(
                         s.zones.clear();
                         s.transport = None;
                         s.image = None;
+                        s.browse = None;
                         s.pending_images.clear();
+                        s.pending_browses.clear();
+                        s.pending_loads.clear();
                     }
 
                     // Publish disconnected event
@@ -1049,6 +1841,52 @@ async fn run_roon_loop(
                             }
                         }
                     }
+                    Parsed::BrowseResult(result, session_key) => {
+                        tracing::debug!(
+                            "Roon BrowseResult action={:?}, session_key={:?}",
+                            result.action,
+                            session_key
+                        );
+                        let mut s = state_for_events.write().await;
+                        if let Some(req_id) = s
+                            .pending_browses
+                            .iter()
+                            .find(|(_, (key, _))| key == &session_key)
+                            .map(|(k, _)| *k)
+                        {
+                            if let Some((_key, sender)) = s.pending_browses.remove(&req_id) {
+                                if sender.send(Ok(result)).is_err() {
+                                    tracing::debug!(
+                                        "Browse request cancelled (receiver dropped): {:?}",
+                                        session_key
+                                    );
+                                }
+                            }
+                        }
+                    }
+                    Parsed::LoadResult(result, session_key) => {
+                        tracing::debug!(
+                            "Roon LoadResult {} items, session_key={:?}",
+                            result.items.len(),
+                            session_key
+                        );
+                        let mut s = state_for_events.write().await;
+                        if let Some(req_id) = s
+                            .pending_loads
+                            .iter()
+                            .find(|(_, (key, _))| key == &session_key)
+                            .map(|(k, _)| *k)
+                        {
+                            if let Some((_key, sender)) = s.pending_loads.remove(&req_id) {
+                                if sender.send(Ok(result)).is_err() {
+                                    tracing::debug!(
+                                        "Load request cancelled (receiver dropped): {:?}",
+                                        session_key
+                                    );
+                                }
+                            }
+                        }
+                    }
                     _ => {}
                 }
             }
@@ -1071,8 +1909,11 @@ async fn run_roon_loop(
         s.connected = false;
         s.transport = None;
         s.image = None;
+        s.browse = None;
         s.zones.clear();
         s.pending_images.clear();
+        s.pending_browses.clear();
+        s.pending_loads.clear();
     }
 
     // Check if restart is needed

--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -401,6 +401,9 @@ impl RoonAdapter {
     /// Naively clamping to 0-100 would send -12 dB → 0 (MAX VOLUME), risking
     /// equipment damage. See tests/volume_safety.rs for regression protection.
     pub async fn change_volume(&self, output_id: &str, value: f32, relative: bool) -> Result<()> {
+        // Strip "roon:" prefix if present (MCP/aggregator uses prefixed IDs)
+        let output_id = output_id.strip_prefix("roon:").unwrap_or(output_id);
+
         // Clone transport and gather volume info while holding lock, then release before await
         let (transport, mode, final_value) = {
             let state = self.state.read().await;
@@ -453,6 +456,9 @@ impl RoonAdapter {
 
     /// Mute/unmute
     pub async fn mute(&self, output_id: &str, mute: bool) -> Result<()> {
+        // Strip "roon:" prefix if present (MCP/aggregator uses prefixed IDs)
+        let output_id = output_id.strip_prefix("roon:").unwrap_or(output_id);
+
         // Clone transport while holding lock, then release before await
         let transport = {
             let state = self.state.read().await;

--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -371,6 +371,9 @@ impl RoonAdapter {
 
     /// Control playback
     pub async fn control(&self, zone_id: &str, action: &str) -> Result<()> {
+        // Strip "roon:" prefix if present (MCP/aggregator uses prefixed IDs)
+        let zone_id = zone_id.strip_prefix("roon:").unwrap_or(zone_id);
+
         // Clone transport while holding lock, then release before await
         let transport = {
             let state = self.state.read().await;

--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -541,7 +541,13 @@ impl RoonAdapter {
     }
 
     /// Browse the Roon library hierarchy
-    pub async fn browse(&self, opts: BrowseOpts) -> Result<BrowseResult> {
+    pub async fn browse(&self, mut opts: BrowseOpts) -> Result<BrowseResult> {
+        // Strip "roon:" prefix from zone IDs so callers can pass API-returned IDs directly
+        if let Some(zone) = opts.zone_or_output_id.as_deref() {
+            if let Some(stripped) = zone.strip_prefix("roon:") {
+                opts.zone_or_output_id = Some(stripped.to_string());
+            }
+        }
         let (tx, rx) = oneshot::channel();
         let session_key = opts.multi_session_key.clone();
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -288,7 +288,9 @@ pub async fn roon_control_handler(
 /// Volume request body (f32 for fractional step support)
 #[derive(Deserialize)]
 pub struct VolumeRequest {
-    pub output_id: String,
+    /// Zone ID (also accepts output_id for backwards compatibility)
+    #[serde(alias = "output_id")]
+    pub zone_id: String,
     pub value: f32,
     #[serde(default)]
     pub relative: bool,
@@ -301,7 +303,7 @@ pub async fn roon_volume_handler(
 ) -> impl IntoResponse {
     match state
         .roon
-        .change_volume(&req.output_id, req.value, req.relative)
+        .change_volume(&req.zone_id, req.value, req.relative)
         .await
     {
         Ok(()) => (StatusCode::OK, Json(serde_json::json!({"ok": true}))).into_response(),

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -359,6 +359,375 @@ pub async fn roon_image_handler(
 }
 
 // =============================================================================
+// Roon Browse handlers (AI DJ Phase 1)
+// =============================================================================
+
+/// Query params for search request
+#[derive(Deserialize)]
+pub struct SearchQuery {
+    pub q: String,
+    #[serde(default)]
+    pub zone_id: Option<String>,
+    #[serde(default)]
+    pub limit: Option<usize>,
+    /// Search source: "library" (default), "tidal", or "qobuz"
+    #[serde(default)]
+    pub source: Option<String>,
+}
+
+/// Request body for play action
+#[derive(Deserialize)]
+pub struct PlayRequest {
+    pub query: String,
+    pub zone_id: String,
+    /// Source: "library" (default), "tidal", or "qobuz"
+    #[serde(default)]
+    pub source: Option<String>,
+    /// Action: "play" (default), "queue", or "radio"
+    #[serde(default)]
+    pub action: Option<String>,
+}
+
+/// Search result item (simplified from roon_api::browse::Item)
+#[derive(Serialize)]
+pub struct SearchResultItem {
+    pub title: String,
+    pub subtitle: Option<String>,
+    pub item_key: Option<String>,
+    pub hint: Option<String>,
+}
+
+impl From<roon_api::browse::Item> for SearchResultItem {
+    fn from(item: roon_api::browse::Item) -> Self {
+        use roon_api::browse::ItemHint;
+        Self {
+            title: item.title,
+            subtitle: item.subtitle,
+            item_key: item.item_key,
+            hint: item.hint.map(|h| {
+                match h {
+                    ItemHint::None => "none",
+                    ItemHint::Action => "action",
+                    ItemHint::ActionList => "action_list",
+                    ItemHint::List => "list",
+                    ItemHint::Header => "header",
+                }
+                .to_string()
+            }),
+        }
+    }
+}
+
+/// GET /roon/search - Search the Roon library, TIDAL, or Qobuz
+pub async fn roon_search_handler(
+    State(state): State<AppState>,
+    Query(params): Query<SearchQuery>,
+) -> impl IntoResponse {
+    use crate::adapters::roon::SearchSource;
+
+    if !state.roon.is_browse_connected().await {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ErrorResponse {
+                error: "Roon Browse not connected".to_string(),
+            }),
+        )
+            .into_response();
+    }
+
+    let source = match params.source.as_deref() {
+        Some("tidal") => SearchSource::Tidal,
+        Some("qobuz") => SearchSource::Qobuz,
+        _ => SearchSource::Library,
+    };
+
+    match state
+        .roon
+        .search(&params.q, params.zone_id.as_deref(), params.limit, source)
+        .await
+    {
+        Ok(items) => {
+            let results: Vec<SearchResultItem> = items.into_iter().map(|i| i.into()).collect();
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({ "results": results })),
+            )
+                .into_response()
+        }
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: e.to_string(),
+            }),
+        )
+            .into_response(),
+    }
+}
+
+/// POST /roon/play - Search and play music
+pub async fn roon_play_handler(
+    State(state): State<AppState>,
+    Json(req): Json<PlayRequest>,
+) -> impl IntoResponse {
+    use crate::adapters::roon::{PlayAction, SearchSource};
+
+    if !state.roon.is_browse_connected().await {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ErrorResponse {
+                error: "Roon Browse not connected".to_string(),
+            }),
+        )
+            .into_response();
+    }
+
+    let source = match req.source.as_deref() {
+        Some("tidal") => SearchSource::Tidal,
+        Some("qobuz") => SearchSource::Qobuz,
+        _ => SearchSource::Library,
+    };
+
+    let action = PlayAction::parse(req.action.as_deref().unwrap_or("play"));
+
+    match state
+        .roon
+        .search_and_play(&req.query, &req.zone_id, source, action)
+        .await
+    {
+        Ok(message) => (
+            StatusCode::OK,
+            Json(serde_json::json!({ "message": message })),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: e.to_string(),
+            }),
+        )
+            .into_response(),
+    }
+}
+
+/// Play item request body
+#[derive(Deserialize)]
+pub struct PlayItemRequest {
+    pub item_key: String,
+    pub zone_id: String,
+    #[serde(default)]
+    pub action: Option<String>,
+}
+
+/// POST /roon/play_item - Play a specific item by its key
+pub async fn roon_play_item_handler(
+    State(state): State<AppState>,
+    Json(req): Json<PlayItemRequest>,
+) -> impl IntoResponse {
+    use crate::adapters::roon::PlayAction;
+
+    if !state.roon.is_browse_connected().await {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ErrorResponse {
+                error: "Roon Browse not connected".to_string(),
+            }),
+        )
+            .into_response();
+    }
+
+    let action = PlayAction::parse(req.action.as_deref().unwrap_or("play"));
+
+    match state
+        .roon
+        .play_item(&req.item_key, &req.zone_id, action)
+        .await
+    {
+        Ok(message) => (
+            StatusCode::OK,
+            Json(serde_json::json!({ "message": message })),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: e.to_string(),
+            }),
+        )
+            .into_response(),
+    }
+}
+
+/// Browse request body
+#[derive(Deserialize)]
+pub struct BrowseRequest {
+    #[serde(default)]
+    pub item_key: Option<String>,
+    #[serde(default)]
+    pub zone_id: Option<String>,
+    #[serde(default)]
+    pub pop_all: bool,
+    #[serde(default)]
+    pub input: Option<String>,
+    /// Session key for maintaining browse state across requests
+    #[serde(default)]
+    pub session_key: Option<String>,
+}
+
+/// Browse result converted to serializable format
+#[derive(Serialize)]
+pub struct BrowseResultResponse {
+    pub action: String,
+    pub list: Option<BrowseListInfo>,
+    pub is_error: Option<bool>,
+    pub message: Option<String>,
+    /// Session key to use for subsequent browse calls
+    pub session_key: String,
+    /// Items at the current browse level
+    pub items: Vec<BrowseItemResponse>,
+}
+
+#[derive(Serialize)]
+pub struct BrowseListInfo {
+    pub title: String,
+    pub count: u32,
+    pub level: u32,
+    pub subtitle: Option<String>,
+    pub image_key: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct BrowseItemResponse {
+    pub title: String,
+    pub subtitle: Option<String>,
+    pub item_key: Option<String>,
+    pub hint: Option<String>,
+    pub image_key: Option<String>,
+}
+
+/// POST /roon/browse - Browse the Roon library hierarchy
+pub async fn roon_browse_handler(
+    State(state): State<AppState>,
+    Json(req): Json<BrowseRequest>,
+) -> impl IntoResponse {
+    use roon_api::browse::{BrowseOpts, ItemHint, LoadOpts};
+
+    if !state.roon.is_browse_connected().await {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ErrorResponse {
+                error: "Roon Browse not connected".to_string(),
+            }),
+        )
+            .into_response();
+    }
+
+    // Use provided session_key or generate a new one
+    let session_key = req.session_key.unwrap_or_else(|| {
+        format!(
+            "browse_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        )
+    });
+
+    let opts = BrowseOpts {
+        item_key: req.item_key,
+        zone_or_output_id: req.zone_id,
+        pop_all: req.pop_all,
+        input: req.input,
+        multi_session_key: Some(session_key.clone()),
+        ..Default::default()
+    };
+
+    // Browse to the level
+    let browse_result = match state.roon.browse(opts).await {
+        Ok(result) => result,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response()
+        }
+    };
+
+    // Load items at this level
+    let items = if let Some(ref list) = browse_result.list {
+        if list.count > 0 {
+            let load_opts = LoadOpts {
+                multi_session_key: Some(session_key.clone()),
+                count: Some(50), // Load up to 50 items
+                ..Default::default()
+            };
+            match state.roon.load(load_opts).await {
+                Ok(load_result) => load_result
+                    .items
+                    .into_iter()
+                    .map(|item| {
+                        let hint_str = item.hint.map(|h| match h {
+                            ItemHint::Action => "action",
+                            ItemHint::ActionList => "action_list",
+                            ItemHint::List => "list",
+                            ItemHint::Header => "header",
+                            ItemHint::None => "none",
+                        });
+                        BrowseItemResponse {
+                            title: item.title,
+                            subtitle: item.subtitle,
+                            item_key: item.item_key,
+                            hint: hint_str.map(|s| s.to_string()),
+                            image_key: item.image_key,
+                        }
+                    })
+                    .collect(),
+                Err(_) => vec![],
+            }
+        } else {
+            vec![]
+        }
+    } else {
+        vec![]
+    };
+
+    use roon_api::browse::Action;
+    let action_str = match browse_result.action {
+        Action::None => "none",
+        Action::Message => "message",
+        Action::List => "list",
+        Action::ReplaceItem => "replace_item",
+        Action::RemoveItem => "remove_item",
+    };
+
+    let response = BrowseResultResponse {
+        action: action_str.to_string(),
+        list: browse_result.list.map(|l| BrowseListInfo {
+            title: l.title,
+            count: l.count as u32,
+            level: l.level,
+            subtitle: l.subtitle,
+            image_key: l.image_key,
+        }),
+        is_error: browse_result.is_error,
+        message: browse_result.message,
+        session_key,
+        items,
+    };
+    (StatusCode::OK, Json(response)).into_response()
+}
+
+/// GET /roon/browse/status - Check if browse service is connected
+pub async fn roon_browse_status_handler(State(state): State<AppState>) -> impl IntoResponse {
+    let connected = state.roon.is_browse_connected().await;
+    Json(serde_json::json!({
+        "connected": connected
+    }))
+}
+
+// =============================================================================
 // HQPlayer handlers
 // =============================================================================
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -684,7 +684,15 @@ pub async fn roon_browse_handler(
                         }
                     })
                     .collect(),
-                Err(_) => vec![],
+                Err(e) => {
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(ErrorResponse {
+                            error: format!("Browse load error: {}", e),
+                        }),
+                    )
+                        .into_response();
+                }
             }
         } else {
             vec![]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,4 +52,6 @@ pub mod firmware;
 #[cfg(feature = "server")]
 pub mod knobs;
 #[cfg(feature = "server")]
+pub mod mcp;
+#[cfg(feature = "server")]
 pub mod mdns;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,8 @@
 #[cfg(feature = "server")]
 mod server {
     use unified_hifi_control::{
-        adapters, aggregator, api, app, bus, config, coordinator, embedded, firmware, knobs, mdns,
+        adapters, aggregator, api, app, bus, config, coordinator, embedded, firmware, knobs, mcp,
+        mdns,
     };
 
     // Import Startable trait for adapter lifecycle methods
@@ -275,6 +276,12 @@ mod server {
             .route("/roon/control", post(api::roon_control_handler))
             .route("/roon/volume", post(api::roon_volume_handler))
             .route("/roon/image", get(api::roon_image_handler))
+            // Roon Browse routes (AI DJ Phase 1)
+            .route("/roon/search", get(api::roon_search_handler))
+            .route("/roon/play", post(api::roon_play_handler))
+            .route("/roon/play_item", post(api::roon_play_item_handler))
+            .route("/roon/browse", post(api::roon_browse_handler))
+            .route("/roon/browse/status", get(api::roon_browse_status_handler))
             // HQPlayer routes
             .route("/hqplayer/status", get(api::hqp_status_handler))
             .route("/hqplayer/pipeline", get(api::hqp_pipeline_handler))
@@ -430,6 +437,8 @@ mod server {
                     ))
                 }),
             )
+            // MCP server for AI assistant integration
+            .nest_service("/mcp", mcp::create_mcp_service(state.clone()))
             // Middleware
             .layer(CorsLayer::permissive())
             .layer(CompressionLayer::new())

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -66,10 +66,10 @@ pub struct HifiControlTool {
     pub value: Option<f64>,
 }
 
-/// Search for music
+/// Search for music (Roon zones only)
 #[mcp_tool(
     name = "hifi_search",
-    description = "Search for tracks, albums, or artists in Library, TIDAL, or Qobuz",
+    description = "Search for tracks, albums, or artists in Library, TIDAL, or Qobuz (Roon zones only)",
     read_only_hint = true
 )]
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
@@ -84,10 +84,10 @@ pub struct HifiSearchTool {
     pub source: Option<String>,
 }
 
-/// Search and play music - the AI DJ command
+/// Search and play music - the AI DJ command (Roon zones only)
 #[mcp_tool(
     name = "hifi_play",
-    description = "Search and play music - the AI DJ command. Searches and plays, queues, or starts radio from the first matching result. Use action='queue' to add to queue without interrupting current playback."
+    description = "Search and play music - the AI DJ command. Searches and plays, queues, or starts radio from the first matching result. Use action='queue' to add to queue without interrupting current playback. (Roon zones only - LMS/OpenHome/UPnP contributions welcome!)"
 )]
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct HifiPlayTool {
@@ -776,6 +776,8 @@ pub fn create_mcp_extension(state: AppState) -> axum::Extension<McpExtState> {
             "Unified Hi-Fi Control MCP Server - Control Your Music System\n\n\
             Use hifi_zones to list available zones, hifi_now_playing to see what's playing, \
             hifi_control for playback control, hifi_search to find music, and hifi_play to play it.\n\n\
+            Note: hifi_search and hifi_play currently work with Roon zones only. \
+            Transport controls (play/pause/next/volume) work with all zones (Roon, LMS, OpenHome, UPnP).\n\n\
             To build a playlist: call hifi_play multiple times with action='queue'. The first track \
             can use action='play' to start playback, then subsequent tracks use action='queue' to add to the queue."
                 .into(),

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -139,7 +139,7 @@ pub struct McpBrowseResult {
 /// Arguments for hifi_hqplayer_set_pipeline
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct HqpSetPipelineArgs {
-    /// Setting to change: mode, samplerate, filter1x, filterNx, shaper
+    /// Setting to change: mode, samplerate, filter1x, filterNx, shaper, dither
     pub setting: String,
     /// New value for the setting
     pub value: String,
@@ -575,7 +575,7 @@ impl HifiMcpServer {
 
     /// Change an HQPlayer pipeline setting
     #[tool(
-        description = "Change an HQPlayer pipeline setting (mode, samplerate, filter1x, filterNx, shaper)"
+        description = "Change an HQPlayer pipeline setting (mode, samplerate, filter1x, filterNx, shaper, dither)"
     )]
     async fn hifi_hqplayer_set_pipeline(
         &self,
@@ -604,12 +604,13 @@ impl HifiMcpServer {
                     )]));
                 }
             }
-            "shaper" => {
+            "shaper" | "dither" => {
+                // shaper (DSD) and dither (PCM) use the same HQPlayer API
                 if let Some(v) = parse_value(&args.value) {
                     self.state.hqplayer.set_shaper(v).await
                 } else {
                     return Ok(CallToolResult::error(vec![Content::text(
-                        "Invalid shaper value (expected integer)",
+                        "Invalid shaper/dither value (expected integer)",
                     )]));
                 }
             }
@@ -633,7 +634,7 @@ impl HifiMcpServer {
             }
             _ => {
                 return Ok(CallToolResult::error(vec![Content::text(format!(
-                    "Unknown setting: {}. Valid settings: mode, samplerate, filter1x, filterNx, shaper",
+                    "Unknown setting: {}. Valid settings: mode, samplerate, filter1x, filterNx, shaper, dither",
                     args.setting
                 ))]));
             }

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -318,22 +318,10 @@ impl HifiMcpHandler {
                 .change_volume(zone_id, value as f32, relative)
                 .await
         } else if zone_id.starts_with("roon:") || !zone_id.contains(':') {
-            // Roon change_volume expects output_id, not zone_id
-            // Look up the zone and get its first output
-            let bare_zone_id = zone_id.strip_prefix("roon:").unwrap_or(zone_id);
-            match self.state.roon.get_zone(bare_zone_id).await {
-                Some(zone) => {
-                    if let Some(output) = zone.outputs.first() {
-                        self.state
-                            .roon
-                            .change_volume(&output.output_id, value as f32, relative)
-                            .await
-                    } else {
-                        return Self::error_result("Zone has no outputs".into());
-                    }
-                }
-                None => return Self::error_result(format!("Zone not found: {}", zone_id)),
-            }
+            self.state
+                .roon
+                .change_volume(zone_id, value as f32, relative)
+                .await
         } else {
             return Self::error_result("Volume control not supported for this zone type".into());
         };

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -87,7 +87,7 @@ pub struct HifiSearchTool {
 /// Search and play music - the AI DJ command
 #[mcp_tool(
     name = "hifi_play",
-    description = "Search and play music - the AI DJ command. Searches and immediately plays the first matching result."
+    description = "Search and play music - the AI DJ command. Searches and plays, queues, or starts radio from the first matching result. Use action='queue' to add to queue without interrupting current playback."
 )]
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct HifiPlayTool {
@@ -103,10 +103,10 @@ pub struct HifiPlayTool {
     pub action: Option<String>,
 }
 
-/// Play a specific item by its item_key
+/// Play or queue a specific item by its item_key
 #[mcp_tool(
     name = "hifi_play_item",
-    description = "Play a specific item by its item_key (from hifi_search or hifi_browse results). Use this when you want to play a specific search result rather than the first match."
+    description = "Play or queue a specific item by its item_key (from hifi_search or hifi_browse results). Use action='queue' to add to the current queue without interrupting playback. To build a playlist, call this multiple times with action='queue' for each track."
 )]
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct HifiPlayItemTool {
@@ -916,7 +916,9 @@ pub fn create_mcp_extension(state: AppState) -> axum::Extension<McpExtState> {
         instructions: Some(
             "Unified Hi-Fi Control MCP Server - Control Your Music System\n\n\
             Use hifi_zones to list available zones, hifi_now_playing to see what's playing, \
-            hifi_control for playback control, hifi_search to find music, and hifi_play to play it."
+            hifi_control for playback control, hifi_search to find music, and hifi_play to play it.\n\n\
+            To build a playlist: use hifi_search to find tracks, then call hifi_play_item multiple times \
+            with action='queue' for each track. The first track can use action='play' to start playback."
                 .into(),
         ),
         protocol_version: ProtocolVersion::V2025_11_25.into(),

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -179,7 +179,7 @@ impl HifiMcpServer {
     }
 
     /// List all available playback zones
-    #[tool(description = "List all available Roon zones for playback control")]
+    #[tool(description = "List all available playback zones (Roon, LMS, OpenHome, UPnP)")]
     async fn hifi_zones(&self) -> Result<CallToolResult, McpError> {
         let zones = self.state.aggregator.get_zones().await;
         let mcp_zones: Vec<McpZone> = zones

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -201,7 +201,6 @@ struct McpNowPlaying {
 struct McpSearchResult {
     title: String,
     subtitle: Option<String>,
-    item_key: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -442,7 +441,6 @@ impl ServerHandler for HifiMcpHandler {
                             .map(|item| McpSearchResult {
                                 title: item.title,
                                 subtitle: item.subtitle,
-                                item_key: item.item_key,
                             })
                             .collect();
                         Ok(Self::json_result(&mcp_results))

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -179,7 +179,10 @@ impl HifiMcpServer {
     }
 
     /// List all available playback zones
-    #[tool(description = "List all available playback zones (Roon, LMS, OpenHome, UPnP)")]
+    #[tool(
+        description = "List all available playback zones (Roon, LMS, OpenHome, UPnP)",
+        annotations(read_only_hint = true)
+    )]
     async fn hifi_zones(&self) -> Result<CallToolResult, McpError> {
         let zones = self.state.aggregator.get_zones().await;
         let mcp_zones: Vec<McpZone> = zones
@@ -199,7 +202,8 @@ impl HifiMcpServer {
 
     /// Get current playback state for a zone
     #[tool(
-        description = "Get current playback state for a zone (track, artist, album, play state, volume)"
+        description = "Get current playback state for a zone (track, artist, album, play state, volume)",
+        annotations(read_only_hint = true)
     )]
     async fn hifi_now_playing(
         &self,
@@ -317,7 +321,10 @@ impl HifiMcpServer {
     }
 
     /// Search for tracks, albums, or artists
-    #[tool(description = "Search for tracks, albums, or artists in Library, TIDAL, or Qobuz")]
+    #[tool(
+        description = "Search for tracks, albums, or artists in Library, TIDAL, or Qobuz",
+        annotations(read_only_hint = true)
+    )]
     async fn hifi_search(
         &self,
         Parameters(args): Parameters<SearchArgs>,
@@ -417,7 +424,8 @@ impl HifiMcpServer {
 
     /// Navigate the Roon library hierarchy
     #[tool(
-        description = "Navigate the Roon library hierarchy (artists, albums, genres, etc). Returns items at the current level. Use session_key from previous response to maintain navigation state."
+        description = "Navigate the Roon library hierarchy (artists, albums, genres, etc). Returns items at the current level. Use session_key from previous response to maintain navigation state.",
+        annotations(read_only_hint = true)
     )]
     async fn hifi_browse(
         &self,
@@ -490,7 +498,10 @@ impl HifiMcpServer {
     }
 
     /// Check if the Roon Browse service is connected
-    #[tool(description = "Check if the Roon Browse service is connected")]
+    #[tool(
+        description = "Check if the Roon Browse service is connected",
+        annotations(read_only_hint = true)
+    )]
     async fn hifi_browse_status(&self) -> Result<CallToolResult, McpError> {
         let connected = self.state.roon.is_browse_connected().await;
         let json = serde_json::json!({
@@ -503,7 +514,10 @@ impl HifiMcpServer {
     }
 
     /// Get overall bridge status
-    #[tool(description = "Get overall bridge status (Roon connection, HQPlayer config)")]
+    #[tool(
+        description = "Get overall bridge status (Roon connection, HQPlayer config)",
+        annotations(read_only_hint = true)
+    )]
     async fn hifi_status(&self) -> Result<CallToolResult, McpError> {
         let roon_status = self.state.roon.get_status().await;
         let hqp_status = self.state.hqplayer.get_status().await;
@@ -525,7 +539,10 @@ impl HifiMcpServer {
     }
 
     /// Get HQPlayer Embedded status and current pipeline settings
-    #[tool(description = "Get HQPlayer Embedded status and current pipeline settings")]
+    #[tool(
+        description = "Get HQPlayer Embedded status and current pipeline settings",
+        annotations(read_only_hint = true)
+    )]
     async fn hifi_hqplayer_status(&self) -> Result<CallToolResult, McpError> {
         let status = self.state.hqplayer.get_status().await;
         let pipeline = self.state.hqplayer.get_pipeline_status().await.ok();
@@ -546,7 +563,10 @@ impl HifiMcpServer {
     }
 
     /// List available HQPlayer Embedded configurations
-    #[tool(description = "List available HQPlayer Embedded configurations")]
+    #[tool(
+        description = "List available HQPlayer Embedded configurations",
+        annotations(read_only_hint = true)
+    )]
     async fn hifi_hqplayer_profiles(&self) -> Result<CallToolResult, McpError> {
         let profiles = self.state.hqplayer.get_cached_profiles().await;
         let profile_names: Vec<String> = profiles.into_iter().map(|p| p.title).collect();
@@ -556,7 +576,10 @@ impl HifiMcpServer {
     }
 
     /// Load an HQPlayer Embedded configuration
-    #[tool(description = "Load an HQPlayer Embedded configuration (will restart HQPlayer)")]
+    #[tool(
+        description = "Load an HQPlayer Embedded configuration (will restart HQPlayer)",
+        annotations(destructive_hint = true)
+    )]
     async fn hifi_hqplayer_load_profile(
         &self,
         Parameters(args): Parameters<HqpLoadProfileArgs>,

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -3,7 +3,7 @@
 //! Provides HTTP endpoints for MCP clients with both Streamable HTTP and SSE transports.
 //! Routes are integrated into the main Axum app on port 8088 at /mcp endpoint.
 
-use crate::api::AppState;
+use crate::api::{load_app_settings, AppState};
 use async_trait::async_trait;
 use axum::http::{HeaderMap, Method, Uri};
 use axum::{body::Body, extract::Extension, response::IntoResponse};
@@ -345,8 +345,9 @@ impl ServerHandler for HifiMcpHandler {
     ) -> Result<ListToolsResult, RpcError> {
         let mut tools = HifiTools::tools();
 
-        // Filter out HQPlayer tools if not configured
-        if !self.state.hqplayer.is_configured().await {
+        // Filter out HQPlayer tools if adapter is disabled in settings
+        let settings = load_app_settings();
+        if !settings.adapters.hqplayer {
             tools.retain(|t| !t.name.starts_with("hifi_hqplayer"));
         }
 

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1,0 +1,720 @@
+//! MCP (Model Context Protocol) server for AI assistant integration
+//!
+//! Provides an HTTP endpoint at `/mcp` for mobile MCP clients like BoltAI iOS.
+//! Uses the official rmcp SDK with Streamable HTTP transport.
+
+use crate::api::AppState;
+use rmcp::{
+    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
+    model::*,
+    schemars, tool, tool_handler, tool_router, ErrorData as McpError, ServerHandler,
+};
+use serde::{Deserialize, Serialize};
+
+/// MCP server for Hi-Fi control
+#[derive(Clone)]
+pub struct HifiMcpServer {
+    state: AppState,
+    tool_router: ToolRouter<HifiMcpServer>,
+}
+
+/// Zone info returned by hifi_zones
+#[derive(Debug, Serialize, schemars::JsonSchema)]
+pub struct McpZone {
+    pub zone_id: String,
+    pub zone_name: String,
+    pub state: String,
+    pub volume: Option<f64>,
+    pub is_muted: Option<bool>,
+}
+
+/// Now playing info returned by hifi_now_playing
+#[derive(Debug, Serialize, schemars::JsonSchema)]
+pub struct McpNowPlaying {
+    pub zone_id: String,
+    pub zone_name: String,
+    pub state: String,
+    pub title: Option<String>,
+    pub artist: Option<String>,
+    pub album: Option<String>,
+    pub volume: Option<f64>,
+    pub is_muted: Option<bool>,
+}
+
+/// Arguments for hifi_now_playing
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct NowPlayingArgs {
+    /// The zone ID to query (get from hifi_zones)
+    pub zone_id: String,
+}
+
+/// Arguments for hifi_control
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ControlArgs {
+    /// The zone ID to control
+    pub zone_id: String,
+    /// Action: play, pause, next, previous, volume_set, volume_up, volume_down
+    pub action: String,
+    /// For volume actions: the level (0-100 for volume_set) or amount to change
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<f64>,
+}
+
+/// Arguments for hifi_search
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct SearchArgs {
+    /// Search query (e.g., "Hotel California", "Eagles", "jazz piano")
+    pub query: String,
+    /// Optional zone ID for context-aware results
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub zone_id: Option<String>,
+    /// Where to search: "library" (default), "tidal", or "qobuz"
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+}
+
+/// Search result item (simplified from Roon's BrowseItem)
+#[derive(Debug, Serialize, schemars::JsonSchema)]
+pub struct McpSearchResult {
+    pub title: String,
+    pub subtitle: Option<String>,
+    pub item_key: Option<String>,
+}
+
+/// Arguments for hifi_play
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct PlayArgs {
+    /// What to play (e.g., "early Michael Jackson", "Dark Side of the Moon")
+    pub query: String,
+    /// Zone ID to play on (get from hifi_zones)
+    pub zone_id: String,
+    /// Where to search: "library" (default), "tidal", or "qobuz"
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    /// What to do: "play" (default), "queue", or "radio"
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub action: Option<String>,
+}
+
+/// Arguments for hifi_play_item
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct PlayItemArgs {
+    /// The item_key from search or browse results
+    pub item_key: String,
+    /// Zone ID to play on (get from hifi_zones)
+    pub zone_id: String,
+    /// What to do: "play" (default), "queue", or "radio"
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub action: Option<String>,
+}
+
+/// Arguments for hifi_browse
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct BrowseArgs {
+    /// Key of item to browse into (from previous browse or search)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub item_key: Option<String>,
+    /// Session key from previous browse to maintain navigation state
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_key: Option<String>,
+    /// Optional zone ID for context
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub zone_id: Option<String>,
+    /// Search input for this browse level
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input: Option<String>,
+    /// Reset to root level
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pop_all: Option<bool>,
+}
+
+/// Browse result item
+#[derive(Debug, Serialize, schemars::JsonSchema)]
+pub struct McpBrowseResult {
+    pub items: Vec<McpSearchResult>,
+    pub session_key: Option<String>,
+    pub list_title: Option<String>,
+}
+
+/// Arguments for hifi_hqplayer_set_pipeline
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct HqpSetPipelineArgs {
+    /// Setting to change: mode, samplerate, filter1x, filterNx, shaper, dither
+    pub setting: String,
+    /// New value for the setting
+    pub value: String,
+}
+
+/// Arguments for hifi_hqplayer_load_profile
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct HqpLoadProfileArgs {
+    /// Configuration name to load (get from hifi_hqplayer_profiles)
+    pub profile: String,
+}
+
+/// HQPlayer status response
+#[derive(Debug, Serialize, schemars::JsonSchema)]
+pub struct McpHqpStatus {
+    pub connected: bool,
+    pub host: Option<String>,
+    pub pipeline: Option<McpPipelineStatus>,
+}
+
+/// Pipeline status
+#[derive(Debug, Serialize, schemars::JsonSchema)]
+pub struct McpPipelineStatus {
+    pub state: String,
+    pub filter: String,
+    pub shaper: String,
+    pub rate: u32,
+}
+
+#[tool_router]
+impl HifiMcpServer {
+    pub fn new(state: AppState) -> Self {
+        Self {
+            state,
+            tool_router: Self::tool_router(),
+        }
+    }
+
+    /// List all available playback zones
+    #[tool(description = "List all available Roon zones for playback control")]
+    async fn hifi_zones(&self) -> Result<CallToolResult, McpError> {
+        let zones = self.state.aggregator.get_zones().await;
+        let mcp_zones: Vec<McpZone> = zones
+            .into_iter()
+            .map(|z| McpZone {
+                zone_id: z.zone_id,
+                zone_name: z.zone_name,
+                state: z.state.to_string(),
+                volume: z.volume_control.as_ref().map(|v| v.value as f64),
+                is_muted: z.volume_control.as_ref().map(|v| v.is_muted),
+            })
+            .collect();
+
+        let json = serde_json::to_string_pretty(&mcp_zones).unwrap_or_else(|_| "[]".to_string());
+        Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
+
+    /// Get current playback state for a zone
+    #[tool(
+        description = "Get current playback state for a zone (track, artist, album, play state, volume)"
+    )]
+    async fn hifi_now_playing(
+        &self,
+        Parameters(args): Parameters<NowPlayingArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let zone = self.state.aggregator.get_zone(&args.zone_id).await;
+
+        match zone {
+            Some(z) => {
+                let np = McpNowPlaying {
+                    zone_id: z.zone_id,
+                    zone_name: z.zone_name,
+                    state: z.state.to_string(),
+                    title: z.now_playing.as_ref().map(|n| n.title.clone()),
+                    artist: z.now_playing.as_ref().map(|n| n.artist.clone()),
+                    album: z.now_playing.as_ref().map(|n| n.album.clone()),
+                    volume: z.volume_control.as_ref().map(|v| v.value as f64),
+                    is_muted: z.volume_control.as_ref().map(|v| v.is_muted),
+                };
+                let json = serde_json::to_string_pretty(&np).unwrap_or_else(|_| "{}".to_string());
+                Ok(CallToolResult::success(vec![Content::text(json)]))
+            }
+            None => Ok(CallToolResult::error(vec![Content::text(format!(
+                "Zone not found: {}",
+                args.zone_id
+            ))])),
+        }
+    }
+
+    /// Control playback: play, pause, next, previous, or adjust volume
+    #[tool(description = "Control playback: play, pause, next, previous, or adjust volume")]
+    async fn hifi_control(
+        &self,
+        Parameters(args): Parameters<ControlArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        // Map MCP actions to backend actions
+        let backend_action = match args.action.as_str() {
+            "play" | "pause" | "playpause" => "play_pause",
+            "next" => "next",
+            "previous" | "prev" => "previous",
+            "volume_set" => {
+                if let Some(v) = args.value {
+                    return self.set_volume(&args.zone_id, v, false).await;
+                }
+                return Ok(CallToolResult::error(vec![Content::text(
+                    "volume_set requires a value (0-100)",
+                )]));
+            }
+            "volume_up" => {
+                let delta = args.value.unwrap_or(5.0);
+                return self.set_volume(&args.zone_id, delta, true).await;
+            }
+            "volume_down" => {
+                let delta = args.value.unwrap_or(5.0);
+                return self.set_volume(&args.zone_id, -delta, true).await;
+            }
+            other => other,
+        };
+
+        // Determine which adapter to use based on zone_id prefix
+        let result = if args.zone_id.starts_with("lms:") {
+            self.state
+                .lms
+                .control(&args.zone_id, backend_action, None)
+                .await
+        } else if args.zone_id.starts_with("openhome:") {
+            self.state
+                .openhome
+                .control(&args.zone_id, backend_action, None)
+                .await
+        } else if args.zone_id.starts_with("upnp:") {
+            self.state
+                .upnp
+                .control(&args.zone_id, backend_action, None)
+                .await
+        } else {
+            // Default to Roon
+            self.state.roon.control(&args.zone_id, backend_action).await
+        };
+
+        match result {
+            Ok(()) => {
+                // Return updated state
+                if let Some(zone) = self.state.aggregator.get_zone(&args.zone_id).await {
+                    let np = McpNowPlaying {
+                        zone_id: zone.zone_id,
+                        zone_name: zone.zone_name,
+                        state: zone.state.to_string(),
+                        title: zone.now_playing.as_ref().map(|n| n.title.clone()),
+                        artist: zone.now_playing.as_ref().map(|n| n.artist.clone()),
+                        album: zone.now_playing.as_ref().map(|n| n.album.clone()),
+                        volume: zone.volume_control.as_ref().map(|v| v.value as f64),
+                        is_muted: zone.volume_control.as_ref().map(|v| v.is_muted),
+                    };
+                    let json =
+                        serde_json::to_string_pretty(&np).unwrap_or_else(|_| "{}".to_string());
+                    Ok(CallToolResult::success(vec![Content::text(format!(
+                        "Action '{}' executed.\n\nCurrent state:\n{}",
+                        args.action, json
+                    ))]))
+                } else {
+                    Ok(CallToolResult::success(vec![Content::text(format!(
+                        "Action '{}' executed.",
+                        args.action
+                    ))]))
+                }
+            }
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
+                "Control error: {}",
+                e
+            ))])),
+        }
+    }
+
+    /// Search for tracks, albums, or artists
+    #[tool(description = "Search for tracks, albums, or artists in Library, TIDAL, or Qobuz")]
+    async fn hifi_search(
+        &self,
+        Parameters(args): Parameters<SearchArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        use crate::adapters::roon::SearchSource;
+
+        let source = match args.source.as_deref() {
+            Some("tidal") => SearchSource::Tidal,
+            Some("qobuz") => SearchSource::Qobuz,
+            _ => SearchSource::Library,
+        };
+        let zone_id = args.zone_id.as_deref();
+
+        match self
+            .state
+            .roon
+            .search(&args.query, zone_id, Some(10), source)
+            .await
+        {
+            Ok(results) => {
+                // Convert BrowseItems to serializable McpSearchResults
+                let mcp_results: Vec<McpSearchResult> = results
+                    .into_iter()
+                    .map(|item| McpSearchResult {
+                        title: item.title,
+                        subtitle: item.subtitle,
+                        item_key: item.item_key,
+                    })
+                    .collect();
+                let json =
+                    serde_json::to_string_pretty(&mcp_results).unwrap_or_else(|_| "[]".to_string());
+                Ok(CallToolResult::success(vec![Content::text(json)]))
+            }
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
+                "Search error: {}",
+                e
+            ))])),
+        }
+    }
+
+    /// Search and play music - the AI DJ command
+    #[tool(
+        description = "Search and play music - the AI DJ command. Searches and immediately plays the first matching result."
+    )]
+    async fn hifi_play(
+        &self,
+        Parameters(args): Parameters<PlayArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        use crate::adapters::roon::{PlayAction, SearchSource};
+
+        let source = match args.source.as_deref() {
+            Some("tidal") => SearchSource::Tidal,
+            Some("qobuz") => SearchSource::Qobuz,
+            _ => SearchSource::Library,
+        };
+        let action = PlayAction::parse(args.action.as_deref().unwrap_or("play"));
+
+        match self
+            .state
+            .roon
+            .search_and_play(&args.query, &args.zone_id, source, action)
+            .await
+        {
+            Ok(message) => Ok(CallToolResult::success(vec![Content::text(message)])),
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
+                "Play error: {}",
+                e
+            ))])),
+        }
+    }
+
+    /// Play a specific item by its item_key
+    #[tool(
+        description = "Play a specific item by its item_key (from hifi_search or hifi_browse results). Use this when you want to play a specific search result rather than the first match."
+    )]
+    async fn hifi_play_item(
+        &self,
+        Parameters(args): Parameters<PlayItemArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        use crate::adapters::roon::PlayAction;
+
+        let action = PlayAction::parse(args.action.as_deref().unwrap_or("play"));
+
+        match self
+            .state
+            .roon
+            .play_item(&args.item_key, &args.zone_id, action)
+            .await
+        {
+            Ok(message) => Ok(CallToolResult::success(vec![Content::text(message)])),
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
+                "Play item error: {}",
+                e
+            ))])),
+        }
+    }
+
+    /// Navigate the Roon library hierarchy
+    #[tool(
+        description = "Navigate the Roon library hierarchy (artists, albums, genres, etc). Returns items at the current level. Use session_key from previous response to maintain navigation state."
+    )]
+    async fn hifi_browse(
+        &self,
+        Parameters(args): Parameters<BrowseArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        use roon_api::browse::{BrowseOpts, LoadOpts};
+
+        // Generate or use provided session key
+        let session_key = args.session_key.unwrap_or_else(|| {
+            format!(
+                "mcp_browse_{}",
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_nanos()
+            )
+        });
+
+        let opts = BrowseOpts {
+            item_key: args.item_key,
+            multi_session_key: Some(session_key.clone()),
+            zone_or_output_id: args.zone_id,
+            input: args.input,
+            pop_all: args.pop_all.unwrap_or(false),
+            ..Default::default()
+        };
+
+        match self.state.roon.browse(opts).await {
+            Ok(result) => {
+                // Load items using the same session key
+                match self
+                    .state
+                    .roon
+                    .load(LoadOpts {
+                        multi_session_key: Some(session_key.clone()),
+                        count: Some(20),
+                        ..Default::default()
+                    })
+                    .await
+                {
+                    Ok(items) => {
+                        let mcp_result = McpBrowseResult {
+                            items: items
+                                .items
+                                .into_iter()
+                                .map(|item| McpSearchResult {
+                                    title: item.title,
+                                    subtitle: item.subtitle,
+                                    item_key: item.item_key,
+                                })
+                                .collect(),
+                            session_key: Some(session_key),
+                            list_title: result.list.as_ref().map(|l| l.title.clone()),
+                        };
+                        let json = serde_json::to_string_pretty(&mcp_result)
+                            .unwrap_or_else(|_| "{}".to_string());
+                        Ok(CallToolResult::success(vec![Content::text(json)]))
+                    }
+                    Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
+                        "Browse load error: {}",
+                        e
+                    ))])),
+                }
+            }
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
+                "Browse error: {}",
+                e
+            ))])),
+        }
+    }
+
+    /// Check if the Roon Browse service is connected
+    #[tool(description = "Check if the Roon Browse service is connected")]
+    async fn hifi_browse_status(&self) -> Result<CallToolResult, McpError> {
+        let connected = self.state.roon.is_browse_connected().await;
+        let json = serde_json::json!({
+            "connected": connected,
+            "service": "roon_browse"
+        });
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string_pretty(&json).unwrap_or_else(|_| "{}".to_string()),
+        )]))
+    }
+
+    /// Get overall bridge status
+    #[tool(description = "Get overall bridge status (Roon connection, HQPlayer config)")]
+    async fn hifi_status(&self) -> Result<CallToolResult, McpError> {
+        let roon_status = self.state.roon.get_status().await;
+        let hqp_status = self.state.hqplayer.get_status().await;
+
+        let status = serde_json::json!({
+            "roon": {
+                "connected": roon_status.connected,
+                "core_name": roon_status.core_name,
+            },
+            "hqplayer": {
+                "connected": hqp_status.connected,
+                "host": hqp_status.host,
+            }
+        });
+
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string_pretty(&status).unwrap_or_else(|_| "{}".to_string()),
+        )]))
+    }
+
+    /// Get HQPlayer Embedded status and current pipeline settings
+    #[tool(description = "Get HQPlayer Embedded status and current pipeline settings")]
+    async fn hifi_hqplayer_status(&self) -> Result<CallToolResult, McpError> {
+        let status = self.state.hqplayer.get_status().await;
+        let pipeline = self.state.hqplayer.get_pipeline_status().await.ok();
+
+        let mcp_status = McpHqpStatus {
+            connected: status.connected,
+            host: status.host,
+            pipeline: pipeline.map(|p| McpPipelineStatus {
+                state: p.status.state,
+                filter: p.status.active_filter,
+                shaper: p.status.active_shaper,
+                rate: p.status.active_rate,
+            }),
+        };
+
+        let json = serde_json::to_string_pretty(&mcp_status).unwrap_or_else(|_| "{}".to_string());
+        Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
+
+    /// List available HQPlayer Embedded configurations
+    #[tool(description = "List available HQPlayer Embedded configurations")]
+    async fn hifi_hqplayer_profiles(&self) -> Result<CallToolResult, McpError> {
+        let profiles = self.state.hqplayer.get_cached_profiles().await;
+        let profile_names: Vec<String> = profiles.into_iter().map(|p| p.title).collect();
+        let json =
+            serde_json::to_string_pretty(&profile_names).unwrap_or_else(|_| "[]".to_string());
+        Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
+
+    /// Load an HQPlayer Embedded configuration
+    #[tool(description = "Load an HQPlayer Embedded configuration (will restart HQPlayer)")]
+    async fn hifi_hqplayer_load_profile(
+        &self,
+        Parameters(args): Parameters<HqpLoadProfileArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        match self.state.hqplayer.load_profile(&args.profile).await {
+            Ok(()) => Ok(CallToolResult::success(vec![Content::text(format!(
+                "Loaded profile: {}",
+                args.profile
+            ))])),
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
+                "Failed to load profile: {}",
+                e
+            ))])),
+        }
+    }
+
+    /// Change an HQPlayer pipeline setting
+    #[tool(description = "Change an HQPlayer pipeline setting (filter, shaper, dither, etc)")]
+    async fn hifi_hqplayer_set_pipeline(
+        &self,
+        Parameters(args): Parameters<HqpSetPipelineArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let result = match args.setting.as_str() {
+            "filter1x" | "filter_1x" => {
+                if let Ok(v) = args.value.parse::<u32>() {
+                    self.state.hqplayer.set_filter_1x(v).await
+                } else {
+                    return Ok(CallToolResult::error(vec![Content::text(
+                        "Invalid filter1x value (expected integer)",
+                    )]));
+                }
+            }
+            "filterNx" | "filter_nx" | "filternx" => {
+                if let Ok(v) = args.value.parse::<u32>() {
+                    self.state.hqplayer.set_filter_nx(v).await
+                } else {
+                    return Ok(CallToolResult::error(vec![Content::text(
+                        "Invalid filterNx value (expected integer)",
+                    )]));
+                }
+            }
+            "shaper" => {
+                if let Ok(v) = args.value.parse::<u32>() {
+                    self.state.hqplayer.set_shaper(v).await
+                } else {
+                    return Ok(CallToolResult::error(vec![Content::text(
+                        "Invalid shaper value (expected integer)",
+                    )]));
+                }
+            }
+            "rate" | "samplerate" => {
+                if let Ok(v) = args.value.parse::<u32>() {
+                    self.state.hqplayer.set_rate(v).await
+                } else {
+                    return Ok(CallToolResult::error(vec![Content::text(
+                        "Invalid rate value (expected integer)",
+                    )]));
+                }
+            }
+            "mode" => {
+                if let Ok(v) = args.value.parse::<u32>() {
+                    self.state.hqplayer.set_mode(v).await
+                } else {
+                    return Ok(CallToolResult::error(vec![Content::text(
+                        "Invalid mode value (expected integer)",
+                    )]));
+                }
+            }
+            _ => {
+                return Ok(CallToolResult::error(vec![Content::text(format!(
+                    "Unknown setting: {}. Valid settings: mode, samplerate, filter1x, filterNx, shaper",
+                    args.setting
+                ))]));
+            }
+        };
+
+        match result {
+            Ok(()) => Ok(CallToolResult::success(vec![Content::text(format!(
+                "Set {} to {}",
+                args.setting, args.value
+            ))])),
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
+                "Failed to set {}: {}",
+                args.setting, e
+            ))])),
+        }
+    }
+}
+
+impl HifiMcpServer {
+    // Helper method for volume control (not a tool, just internal)
+    async fn set_volume(
+        &self,
+        zone_id: &str,
+        value: f64,
+        relative: bool,
+    ) -> Result<CallToolResult, McpError> {
+        let result = if zone_id.starts_with("lms:") {
+            self.state
+                .lms
+                .change_volume(zone_id, value as f32, relative)
+                .await
+        } else if zone_id.starts_with("roon:") || !zone_id.contains(':') {
+            self.state
+                .roon
+                .change_volume(zone_id, value as f32, relative)
+                .await
+        } else {
+            return Ok(CallToolResult::error(vec![Content::text(
+                "Volume control not supported for this zone type",
+            )]));
+        };
+
+        match result {
+            Ok(()) => Ok(CallToolResult::success(vec![Content::text(format!(
+                "Volume {}",
+                if relative { "adjusted" } else { "set" }
+            ))])),
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
+                "Volume error: {}",
+                e
+            ))])),
+        }
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for HifiMcpServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            protocol_version: ProtocolVersion::V_2024_11_05,
+            capabilities: ServerCapabilities::builder().enable_tools().build(),
+            server_info: Implementation::from_build_env(),
+            instructions: Some(
+                "Unified Hi-Fi Control MCP Server - Control Your Music System\n\n\
+                Use hifi_zones to list available zones, hifi_now_playing to see what's playing, \
+                hifi_control for playback control, hifi_search to find music, and hifi_play to play it."
+                    .to_string(),
+            ),
+        }
+    }
+}
+
+/// Create the MCP service for mounting on the axum router
+///
+/// Returns a service that can be mounted with `router.nest_service("/mcp", mcp_service)`
+pub fn create_mcp_service(state: AppState) -> StreamableHttpService {
+    use rmcp::transport::streamable_http_server::{
+        session::local::LocalSessionManager, StreamableHttpServerConfig,
+        StreamableHttpService as SHS,
+    };
+
+    let state_clone = state.clone();
+    SHS::new(
+        move || Ok(HifiMcpServer::new(state_clone.clone())),
+        LocalSessionManager::default().into(),
+        StreamableHttpServerConfig::default(),
+    )
+}
+
+/// Type alias for the MCP service
+pub type StreamableHttpService =
+    rmcp::transport::streamable_http_server::StreamableHttpService<HifiMcpServer>;

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -694,7 +694,7 @@ impl HifiMcpServer {
 impl ServerHandler for HifiMcpServer {
     fn get_info(&self) -> ServerInfo {
         ServerInfo {
-            protocol_version: ProtocolVersion::V_2024_11_05,
+            protocol_version: ProtocolVersion::LATEST,
             capabilities: ServerCapabilities::builder().enable_tools().build(),
             server_info: Implementation::from_build_env(),
             instructions: Some(

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -139,7 +139,7 @@ pub struct McpBrowseResult {
 /// Arguments for hifi_hqplayer_set_pipeline
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct HqpSetPipelineArgs {
-    /// Setting to change: mode, samplerate, filter1x, filterNx, shaper, dither
+    /// Setting to change: mode, samplerate, filter1x, filterNx, shaper
     pub setting: String,
     /// New value for the setting
     pub value: String,

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -343,10 +343,17 @@ impl ServerHandler for HifiMcpHandler {
         _params: Option<PaginatedRequestParams>,
         _runtime: Arc<dyn McpServer>,
     ) -> Result<ListToolsResult, RpcError> {
+        let mut tools = HifiTools::tools();
+
+        // Filter out HQPlayer tools if not configured
+        if !self.state.hqplayer.is_configured().await {
+            tools.retain(|t| !t.name.starts_with("hifi_hqplayer"));
+        }
+
         Ok(ListToolsResult {
             meta: None,
             next_cursor: None,
-            tools: HifiTools::tools(),
+            tools,
         })
     }
 

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -574,7 +574,9 @@ impl HifiMcpServer {
     }
 
     /// Change an HQPlayer pipeline setting
-    #[tool(description = "Change an HQPlayer pipeline setting (filter, shaper, dither, etc)")]
+    #[tool(
+        description = "Change an HQPlayer pipeline setting (mode, samplerate, filter1x, filterNx, shaper)"
+    )]
     async fn hifi_hqplayer_set_pipeline(
         &self,
         Parameters(args): Parameters<HqpSetPipelineArgs>,

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -53,7 +53,7 @@ pub struct NowPlayingArgs {
 pub struct ControlArgs {
     /// The zone ID to control
     pub zone_id: String,
-    /// Action: play, pause, next, previous, volume_set, volume_up, volume_down
+    /// Action: play, pause, playpause, next, previous, volume_set, volume_up, volume_down
     pub action: String,
     /// For volume actions: the level (0-100 for volume_set) or amount to change
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -233,8 +233,10 @@ impl HifiMcpServer {
         }
     }
 
-    /// Control playback: play, pause, next, previous, or adjust volume
-    #[tool(description = "Control playback: play, pause, next, previous, or adjust volume")]
+    /// Control playback: play, pause, playpause (toggle), next, previous, or adjust volume
+    #[tool(
+        description = "Control playback: play, pause, playpause (toggle), next, previous, or adjust volume"
+    )]
     async fn hifi_control(
         &self,
         Parameters(args): Parameters<ControlArgs>,

--- a/tests/fixtures/api_routes.txt
+++ b/tests/fixtures/api_routes.txt
@@ -47,7 +47,9 @@ GET /now_playing
 GET /now_playing/image
 GET /openhome/status
 GET /openhome/zones
+GET /roon/browse/status
 GET /roon/image
+GET /roon/search
 GET /roon/status
 GET /roon/zone/{zone_id}
 GET /roon/zones
@@ -74,6 +76,9 @@ POST /lms/configure
 POST /lms/control
 POST /lms/volume
 POST /openhome/control
+POST /roon/browse
 POST /roon/control
+POST /roon/play
+POST /roon/play_item
 POST /roon/volume
 POST /upnp/control

--- a/tests/fixtures/api_routes.txt
+++ b/tests/fixtures/api_routes.txt
@@ -13,6 +13,7 @@
 # multi-line closures that the route extractor doesn't detect, and they may change
 # with build configuration.
 
+DELETE /mcp
 GET /admin
 GET /api/settings
 GET /assets/{*path}
@@ -43,6 +44,7 @@ GET /lms/player/{player_id}
 GET /lms/players
 GET /lms/status
 GET /manifest-s3.json
+GET /mcp
 GET /now_playing
 GET /now_playing/image
 GET /openhome/status
@@ -75,6 +77,7 @@ POST /knob/control
 POST /lms/configure
 POST /lms/control
 POST /lms/volume
+POST /mcp
 POST /openhome/control
 POST /roon/browse
 POST /roon/control

--- a/tests/volume_step.rs
+++ b/tests/volume_step.rs
@@ -130,7 +130,7 @@ fn lint_roon_change_volume_uses_f32() {
         fs::read_to_string("src/adapters/roon.rs").expect("Failed to read src/adapters/roon.rs");
 
     // The function signature must use f32 for fractional step support
-    let uses_f32 = src.contains("fn change_volume(&self, output_id: &str, value: f32");
+    let uses_f32 = src.contains("fn change_volume(&self, zone_id: &str, value: f32");
 
     assert!(
         uses_f32,


### PR DESCRIPTION
## Summary

Adds MCP (Model Context Protocol) server for AI assistant integration. AI assistants like Claude Code and BoltAI can now control your music system.

**Endpoint:** `http://<host>:8088/mcp` (Streamable HTTP transport)

**Available tools:**
- `hifi_zones` - List all playback zones
- `hifi_now_playing` - Get current track info
- `hifi_control` - Play, pause, next, previous, volume control
- `hifi_search` - Search library, TIDAL, or Qobuz
- `hifi_play` - AI DJ: search and play in one command
- `hifi_play_item` - Play specific item by key
- `hifi_browse` - Navigate Roon library hierarchy
- `hifi_status` - Get bridge status
- `hifi_hqplayer_*` - HQPlayer control tools

## Configuration

**Claude Code** - Add to `.mcp.json`:
```json
{
  "mcpServers": {
    "unified-hifi-control": {
      "type": "http",
      "url": "http://<your-host>:8088/mcp"
    }
  }
}
```

**BoltAI** - Add endpoint: `http://<your-host>:8088/mcp`

## Implementation

- Uses [rust-mcp-sdk](https://github.com/rust-mcp/rust-mcp-sdk) for MCP protocol handling
- Integrated into main Axum router (single port 8088)
- Supports Streamable HTTP transport (2024-11-05 protocol version)
- Session-based connections with automatic cleanup

## New API Endpoints

- `DELETE /mcp` - MCP session termination
- `GET /mcp` - MCP SSE stream
- `POST /mcp` - MCP JSON-RPC requests
- `GET /roon/search` - Search Roon library
- `POST /roon/play` - Play search result
- `POST /roon/play_item` - Play specific item
- `POST /roon/browse` - Browse library hierarchy
- `GET /roon/browse/status` - Browse service status

## Test plan
- [x] `cargo check --features server` passes
- [x] `cargo test --features server` passes
- [x] API contract fixture updated
- [x] MCP tools tested with Claude Code
- [x] Volume control works via MCP

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Roon browse/search/play (Library, Tidal, Qobuz) with sessioned browsing and play/queue/radio actions; new API endpoints for search, play, play_item, browse, browse/status
  * MCP server integration exposing /mcp endpoints and a Hi‑Fi control toolbox; many additional media/control routes added

* **Compatibility**
  * Volume control accepts legacy field name as an alias for zone_id

* **Bug Fixes / Simplifications**
  * Streamlined zone volume handling to operate directly on zone_id

* **Documentation**
  * Added plugin manifest, "Sync Upstream" skill doc, AGENTS/README updates

* **Chores**
  * Added MCP config file and rotated CI build cache keys

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->