### PR TITLE
feat(mcp): Add LMS browse and play support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,8 +201,8 @@ MCP (Model Context Protocol) enables AI assistants (Claude, ChatGPT, BoltAI, etc
 | `hifi_zones` | List all playback zones |
 | `hifi_now_playing` | Get current track info |
 | `hifi_control` | Play, pause, next, previous, volume |
-| `hifi_search` | Search library/TIDAL/Qobuz (Roon only) |
-| `hifi_play` | AI DJ: search and play/queue/radio |
+| `hifi_search` | Search library/TIDAL/Qobuz (Roon, LMS) |
+| `hifi_play` | Search and play/queue/radio (Roon, LMS) |
 | `hifi_status` | Bridge connection status |
 | `hifi_hqplayer_status` | HQPlayer pipeline status |
 | `hifi_hqplayer_profiles` | List HQPlayer configs |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,9 +178,9 @@ MCP (Model Context Protocol) enables AI assistants (Claude, ChatGPT, BoltAI, etc
 | Discovery (zones) | ✅ | ✅ | ✅ | ✅ |
 | Transport (play/pause/next) | ✅ | ✅ | ✅ | ✅ |
 | Volume control | ✅ | ✅ | ❌ | ❌ |
-| Search | ✅ | ❌ | ❌ | ❌ |
-| Play by query | ✅ | ❌ | ❌ | ❌ |
-| Queue building | ✅ | ❌ | ❌ | ❌ |
+| Search | ✅ | ✅ | ❌ | ❌ |
+| Play by query | ✅ | ✅ | ❌ | ❌ |
+| Queue building | ✅ | ✅ | ❌ | ❌ |
 
 ### Tool Design Principles
 

--- a/README.md
+++ b/README.md
@@ -144,15 +144,15 @@ Control your hi-fi with natural language. The bridge includes an MCP server so C
 | `hifi_zones` | List available zones (Roon, LMS, OpenHome, UPnP) |
 | `hifi_now_playing` | Get current track, artist, album, play state |
 | `hifi_control` | Play, pause, next, previous, volume control |
-| `hifi_search` | Search library, TIDAL, or Qobuz *(Roon only)* |
-| `hifi_play` | AI DJ: search and play/queue in one command *(Roon only)* |
+| `hifi_search` | Search library, TIDAL, or Qobuz *(Roon, LMS)* |
+| `hifi_play` | Search and play/queue in one command *(Roon, LMS)* |
 | `hifi_status` | Overall bridge status |
 | `hifi_hqplayer_status` | HQPlayer Embedded status and pipeline |
 | `hifi_hqplayer_profiles` | List saved HQPlayer profiles |
 | `hifi_hqplayer_load_profile` | Switch HQPlayer profile |
 | `hifi_hqplayer_set_pipeline` | Change filter, shaper, dither settings |
 
-*Search and play are currently Roon-only. Transport controls work with all adapters. [LMS search/play contributions welcome!](https://github.com/open-horizon-labs/unified-hifi-control/issues)*
+*Search and play work with Roon and LMS. Transport controls work with all adapters.*
 
 ### Example Usage
 

--- a/src/adapters/lms.rs
+++ b/src/adapters/lms.rs
@@ -1059,13 +1059,12 @@ impl LmsAdapter {
 
         let mut results = Vec::new();
 
-        // Look for streaming providers (TIDAL, Qobuz) and drill into them
+        // Look for providers and drill into them to find playable items
         for item in items {
             if results.len() >= limit {
                 break;
             }
 
-            let name = item.get("name").and_then(|v| v.as_str()).unwrap_or("");
             let item_id = item.get("id").and_then(|v| v.as_str());
             let has_items = item.get("hasitems").and_then(|v| v.as_i64()).unwrap_or(0) == 1;
             let is_audio = item.get("isaudio").and_then(|v| v.as_i64()).unwrap_or(0) == 1
@@ -1079,12 +1078,9 @@ impl LmsAdapter {
                 continue;
             }
 
-            // Check if this is a streaming provider we should drill into
-            let is_streaming_provider = name == "TIDAL" || name == "Qobuz" || name == "Everything";
-
+            // Drill into any provider that has sub-items (TIDAL, Qobuz, Spotify, Deezer, etc.)
             if let Some(item_id) = item_id {
-                if has_items && is_streaming_provider {
-                    // Drill into this provider to find songs
+                if has_items {
                     if let Ok(songs) = self
                         .drill_into_songs(&player_id, query, item_id, limit - results.len())
                         .await

--- a/src/adapters/lms.rs
+++ b/src/adapters/lms.rs
@@ -817,6 +817,7 @@ impl LmsAdapter {
 
     /// Get player status (delegates to shared RPC)
     pub async fn get_player_status(&self, player_id: &str) -> Result<LmsPlayer> {
+        let player_id = strip_lms_prefix(player_id);
         self.rpc.get_player_status(player_id).await
     }
 
@@ -989,6 +990,7 @@ impl LmsAdapter {
 
     /// Get cached player
     pub async fn get_cached_player(&self, player_id: &str) -> Option<LmsPlayer> {
+        let player_id = strip_lms_prefix(player_id);
         self.state.read().await.players.get(player_id).cloned()
     }
 
@@ -1085,7 +1087,8 @@ impl LmsAdapter {
                 .and_then(|v| v.as_i64());
 
             // Determine result type based on available fields
-            let result_type = if item.get("album_id").is_some() || item.get("album").is_some() {
+            // Must match the id extraction logic above - only classify as Album if album_id exists
+            let result_type = if item.get("album_id").is_some() {
                 Some(LmsSearchResultType::Album)
             } else if item.get("artist_id").is_some()
                 || (item.get("contributor").is_some() && item.get("album").is_none())

--- a/src/adapters/openhome.rs
+++ b/src/adapters/openhome.rs
@@ -39,6 +39,12 @@ const POLL_INTERVAL: Duration = Duration::from_secs(2);
 const STALE_THRESHOLD: Duration = Duration::from_secs(90);
 const SOAP_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Strip "openhome:" prefix from device UUIDs.
+/// MCP and aggregator use prefixed IDs, but OpenHome API expects bare UUIDs.
+fn strip_openhome_prefix(id: &str) -> &str {
+    id.strip_prefix("openhome:").unwrap_or(id)
+}
+
 /// OpenHome device information
 #[derive(Debug, Clone, Serialize)]
 pub struct OpenHomeDevice {
@@ -750,6 +756,7 @@ impl OpenHomeAdapter {
         action: &str,
         value: Option<i32>,
     ) -> anyhow::Result<()> {
+        let uuid = strip_openhome_prefix(uuid);
         let location = {
             let state = self.state.read().await;
             state

--- a/src/adapters/openhome.rs
+++ b/src/adapters/openhome.rs
@@ -722,12 +722,14 @@ impl OpenHomeAdapter {
 
     /// Get specific zone by UUID
     pub async fn get_zone(&self, uuid: &str) -> Option<OpenHomeDevice> {
+        let uuid = strip_openhome_prefix(uuid);
         let state = self.state.read().await;
         state.devices.get(uuid).cloned()
     }
 
     /// Get now playing info for a zone
     pub async fn get_now_playing(&self, uuid: &str) -> Option<OpenHomeNowPlaying> {
+        let uuid = strip_openhome_prefix(uuid);
         let state = self.state.read().await;
         let device = state.devices.get(uuid)?;
         let track = device.track_info.as_ref();

--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -371,6 +371,7 @@ impl RoonAdapter {
 
     /// Get specific zone
     pub async fn get_zone(&self, zone_id: &str) -> Option<Zone> {
+        let zone_id = strip_roon_prefix(zone_id);
         let state = self.state.read().await;
         state.zones.get(zone_id).cloned()
     }

--- a/src/adapters/upnp.rs
+++ b/src/adapters/upnp.rs
@@ -34,6 +34,12 @@ const POLL_INTERVAL: Duration = Duration::from_secs(2);
 const STALE_THRESHOLD: Duration = Duration::from_secs(90);
 const SOAP_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Strip "upnp:" prefix from renderer UUIDs.
+/// MCP and aggregator use prefixed IDs, but UPnP API expects bare UUIDs.
+fn strip_upnp_prefix(id: &str) -> &str {
+    id.strip_prefix("upnp:").unwrap_or(id)
+}
+
 /// UPnP Media Renderer information
 #[derive(Debug, Clone, Serialize)]
 pub struct UPnPRenderer {
@@ -687,6 +693,7 @@ impl UPnPAdapter {
         action: &str,
         value: Option<i32>,
     ) -> anyhow::Result<()> {
+        let uuid = strip_upnp_prefix(uuid);
         let (av_url, rc_url) = {
             let state = self.state.read().await;
             let renderer = state

--- a/src/adapters/upnp.rs
+++ b/src/adapters/upnp.rs
@@ -661,12 +661,14 @@ impl UPnPAdapter {
 
     /// Get specific renderer by UUID
     pub async fn get_renderer(&self, uuid: &str) -> Option<UPnPRenderer> {
+        let uuid = strip_upnp_prefix(uuid);
         let state = self.state.read().await;
         state.renderers.get(uuid).cloned()
     }
 
     /// Get now playing info for a renderer
     pub async fn get_now_playing(&self, uuid: &str) -> Option<UPnPNowPlaying> {
+        let uuid = strip_upnp_prefix(uuid);
         let state = self.state.read().await;
         let renderer = state.renderers.get(uuid)?;
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -361,7 +361,7 @@ pub async fn roon_image_handler(
 }
 
 // =============================================================================
-// Roon Browse handlers (AI DJ Phase 1)
+// Roon Browse handlers
 // =============================================================================
 
 /// Query params for search request

--- a/src/main.rs
+++ b/src/main.rs
@@ -279,7 +279,7 @@ mod server {
             .route("/roon/control", post(api::roon_control_handler))
             .route("/roon/volume", post(api::roon_volume_handler))
             .route("/roon/image", get(api::roon_image_handler))
-            // Roon Browse routes (AI DJ Phase 1)
+            // Roon Browse routes
             .route("/roon/search", get(api::roon_search_handler))
             .route("/roon/play", post(api::roon_play_handler))
             .route("/roon/play_item", post(api::roon_play_item_handler))

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -422,8 +422,13 @@ impl ServerHandler for HifiMcpHandler {
             HifiTools::HifiSearchTool(args) => {
                 // Route based on zone_id prefix
                 if args.zone_id.as_ref().is_some_and(|z| z.starts_with("lms:")) {
-                    // LMS search - library only (source param ignored)
-                    match self.state.lms.search(&args.query, Some(10)).await {
+                    // LMS search - uses globalsearch for all providers (library, TIDAL, Qobuz, etc.)
+                    match self
+                        .state
+                        .lms
+                        .search(&args.query, args.zone_id.as_deref(), Some(10))
+                        .await
+                    {
                         Ok(results) => {
                             let mcp_results: Vec<McpSearchResult> = results
                                 .into_iter()

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -69,7 +69,7 @@ pub struct HifiControlTool {
 /// Search for music
 #[mcp_tool(
     name = "hifi_search",
-    description = "Search for tracks, albums, or artists in Library, TIDAL, or Qobuz (Roon and LMS zones - OpenHome/UPnP contributions welcome!)",
+    description = "Search for tracks, albums, or artists in Library, TIDAL, or Qobuz (Roon and LMS zones)",
     read_only_hint = true
 )]
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
@@ -87,7 +87,7 @@ pub struct HifiSearchTool {
 /// Search and play music - the AI DJ command
 #[mcp_tool(
     name = "hifi_play",
-    description = "Search and play music - the AI DJ command. Searches and plays, queues, or starts radio from the first matching result. Use action='queue' to add to queue without interrupting current playback. action='radio' is Roon-only. (Roon and LMS zones - OpenHome/UPnP contributions welcome!)"
+    description = "Search and play music - the AI DJ command. Searches and plays, queues, or starts radio from the first matching result. Use action='queue' to add to queue without interrupting current playback. action='radio' is Roon-only. (Roon and LMS zones)"
 )]
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct HifiPlayTool {

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -84,10 +84,10 @@ pub struct HifiSearchTool {
     pub source: Option<String>,
 }
 
-/// Search and play music - the AI DJ command
+/// Search and play music in one command
 #[mcp_tool(
     name = "hifi_play",
-    description = "Search and play music - the AI DJ command. Searches and plays, queues, or starts radio from the first matching result. Use action='queue' to add to queue without interrupting current playback. action='radio' is Roon-only. (Roon and LMS zones)"
+    description = "Search and play music. Searches and plays, queues, or starts radio from the first matching result. Use action='queue' to add to queue without interrupting current playback. action='radio' is Roon-only. (Roon and LMS zones)"
 )]
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct HifiPlayTool {

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -69,7 +69,7 @@ pub struct HifiControlTool {
 /// Search for music
 #[mcp_tool(
     name = "hifi_search",
-    description = "Search for tracks, albums, or artists in Library, TIDAL, or Qobuz (Roon and LMS zones)",
+    description = "Search for tracks, albums, or artists. Roon: searches Library, TIDAL, or Qobuz (use source param). LMS: searches all installed providers including streaming plugins.",
     read_only_hint = true
 )]
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
@@ -79,7 +79,7 @@ pub struct HifiSearchTool {
     /// Optional zone ID for context-aware results
     #[serde(skip_serializing_if = "Option::is_none")]
     pub zone_id: Option<String>,
-    /// Where to search: "library" (default), "tidal", or "qobuz"
+    /// Where to search: "library" (default), "tidal", or "qobuz". Roon only; LMS searches all providers.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
 }
@@ -87,7 +87,7 @@ pub struct HifiSearchTool {
 /// Search and play music in one command
 #[mcp_tool(
     name = "hifi_play",
-    description = "Search and play music. Searches and plays, queues, or starts radio from the first matching result. Use action='queue' to add to queue without interrupting current playback. action='radio' is Roon-only. (Roon and LMS zones)"
+    description = "Search and play music. Searches and plays, queues, or starts radio from the first matching result. Use action='queue' to add to queue. action='radio' and source param are Roon-only; LMS searches all providers."
 )]
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct HifiPlayTool {
@@ -95,10 +95,10 @@ pub struct HifiPlayTool {
     pub query: String,
     /// Zone ID to play on (get from hifi_zones)
     pub zone_id: String,
-    /// Where to search: "library" (default), "tidal", or "qobuz"
+    /// Where to search: "library" (default), "tidal", or "qobuz". Roon only; LMS searches all providers.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
-    /// What to do: "play" (default), "queue", or "radio"
+    /// What to do: "play" (default), "queue", or "radio". radio is Roon-only.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub action: Option<String>,
 }

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -87,7 +87,7 @@ pub struct HifiSearchTool {
 /// Search and play music - the AI DJ command
 #[mcp_tool(
     name = "hifi_play",
-    description = "Search and play music - the AI DJ command. Searches and plays, queues, or starts radio from the first matching result. Use action='queue' to add to queue without interrupting current playback. (Roon and LMS zones - OpenHome/UPnP contributions welcome!)"
+    description = "Search and play music - the AI DJ command. Searches and plays, queues, or starts radio from the first matching result. Use action='queue' to add to queue without interrupting current playback. action='radio' is Roon-only. (Roon and LMS zones - OpenHome/UPnP contributions welcome!)"
 )]
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct HifiPlayTool {

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -499,14 +499,12 @@ impl ServerHandler for HifiMcpHandler {
                         );
                     }
 
-                    // Strip lms: prefix for the adapter
-                    let player_id = args.zone_id.strip_prefix("lms:").unwrap_or(&args.zone_id);
                     let action = LmsPlayAction::parse(args.action.as_deref());
 
                     match self
                         .state
                         .lms
-                        .search_and_play(&args.query, player_id, action)
+                        .search_and_play(&args.query, &args.zone_id, action)
                         .await
                     {
                         Ok(message) => Ok(Self::text_result(message)),

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -422,13 +422,7 @@ impl ServerHandler for HifiMcpHandler {
             HifiTools::HifiSearchTool(args) => {
                 // Route based on zone_id prefix
                 if args.zone_id.as_ref().is_some_and(|z| z.starts_with("lms:")) {
-                    // LMS search - library only, no streaming services
-                    if args.source.as_deref().is_some_and(|s| s != "library") {
-                        return Self::error_result(
-                            "LMS only supports library search (no TIDAL/Qobuz)".into(),
-                        );
-                    }
-
+                    // LMS search - library only (source param ignored)
                     match self.state.lms.search(&args.query, Some(10)).await {
                         Ok(results) => {
                             let mcp_results: Vec<McpSearchResult> = results
@@ -498,16 +492,10 @@ impl ServerHandler for HifiMcpHandler {
                 if args.zone_id.starts_with("lms:") {
                     use crate::adapters::lms::LmsPlayAction;
 
-                    // LMS doesn't support streaming services or radio
-                    if args.source.as_deref().is_some_and(|s| s != "library") {
-                        return Self::error_result(
-                            "LMS only supports library playback (no TIDAL/Qobuz)".into(),
-                        );
-                    }
+                    // LMS: source param ignored (library only), radio not supported
                     if args.action.as_deref() == Some("radio") {
                         return Self::error_result(
-                            "LMS does not support radio mode. Use 'play' or 'queue' instead."
-                                .into(),
+                            "Radio mode not supported for LMS. Use 'play' or 'queue'.".into(),
                         );
                     }
 

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -69,14 +69,14 @@ pub struct HifiControlTool {
 /// Search for music
 #[mcp_tool(
     name = "hifi_search",
-    description = "Search for tracks, albums, or artists. Roon: searches Library, TIDAL, or Qobuz (use source param). LMS: searches all installed providers including streaming plugins.",
+    description = "Search for tracks, albums, or artists. Roon: searches Library, TIDAL, or Qobuz (use source param). LMS: searches all installed providers including streaming plugins (zone_id recommended as different players may have different sources configured).",
     read_only_hint = true
 )]
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct HifiSearchTool {
     /// Search query (e.g., "Hotel California", "Eagles", "jazz piano")
     pub query: String,
-    /// Optional zone ID for context-aware results
+    /// Zone ID for context-aware results. Recommended for LMS (different players may have different sources).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub zone_id: Option<String>,
     /// Where to search: "library" (default), "tidal", or "qobuz". Roon only; LMS searches all providers.


### PR DESCRIPTION
## Summary

Extends `hifi_search` and `hifi_play` MCP tools to support LMS zones, enabling AI assistants to search the LMS music library and queue/play tracks by natural language query.

- Add `LmsSearchResult` type and `LmsPlayAction` enum to lms adapter
- Add `LmsAdapter::search()` method using JSON-RPC `["search"]` query
- Add `LmsAdapter::search_and_play()` combining search + playlistcontrol
- Route LMS zones in MCP handlers by `zone_id` prefix detection (`lms:`)
- Update tool descriptions to reflect LMS support
- Update AGENTS.md MCP capabilities table

## Test plan

- [x] Test `hifi_search` with `zone_id="lms:xx:xx:xx"` and query (e.g., "Beatles")
- [x] Test `hifi_play` with `query="Abbey Road"` `action="play"`
- [x] Test `hifi_play` with `query="some track"` `action="queue"`

Fixes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LMS zones now support global search and play-by-query across providers; results can be played, queued, or inserted, with user-facing summaries.
* **Bug Fixes**
  * Clear error when requesting unsupported "radio" on LMS.
  * Improved normalization of prefixed zone/ID values for more reliable lookups and routing.
* **Documentation**
  * Capability table, tool descriptions, and README updated to reflect LMS support and formatting tweaks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->