### PR TITLE
fix(hqplayer): Correct value/index semantics for Set commands

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "unified-hifi-control": {
       "type": "http",
-      "url": "http://192.168.1.2:8088/mcp"
+      "url": "http://localhost:8089/mcp"
     }
   }
 }

--- a/docs/hqplayer-protocol-audit.md
+++ b/docs/hqplayer-protocol-audit.md
@@ -8,44 +8,44 @@ Comprehensive audit comparing our HQPlayer adapter implementation against the of
 
 ## Commands Audit
 
-### ✅ Fully Implemented (Correct Semantics)
+### Fully Implemented (Correct Semantics)
 
 | Command | hqp-control | Our Implementation | Notes |
 |---------|-------------|-------------------|-------|
-| `GetInfo` | `<GetInfo/>` | ✅ Correct | Returns name, product, version, platform, engine |
-| `State` | `<State/>` | ✅ Correct | Returns full playback state |
-| `Status` | `<Status subscribe="0/1"/>` | ✅ Correct | Returns playback position and status |
-| `GetModes` | `<GetModes/>` | ✅ Correct | Returns mode list with index, name, value |
-| `GetFilters` | `<GetFilters/>` | ✅ Correct | Returns filter list with index, name, value, arg |
-| `GetShapers` | `<GetShapers/>` | ✅ Correct | Returns shaper list with index, name, value |
-| `GetRates` | `<GetRates/>` | ✅ Correct | Returns rate list with index, rate |
-| `VolumeRange` | `<VolumeRange/>` | ✅ Correct | Returns min, max, enabled, adaptive |
-| `Play` | `<Play/>` | ✅ Correct | Basic playback |
-| `Pause` | `<Pause/>` | ✅ Correct | Pause playback |
-| `Stop` | `<Stop/>` | ✅ Correct | Stop playback |
-| `Previous` | `<Previous/>` | ✅ Correct | Previous track |
-| `Next` | `<Next/>` | ✅ Correct | Next track |
-| `Seek` | `<Seek value="pos"/>` | ✅ Correct | Seek to position in seconds |
-| `Volume` | `<Volume value="dB"/>` | ✅ Correct | Set volume in dB |
-| `VolumeUp` | `<VolumeUp/>` | ✅ Correct | Volume increment |
-| `VolumeDown` | `<VolumeDown/>` | ✅ Correct | Volume decrement |
-| `VolumeMute` | `<VolumeMute/>` | ✅ Correct | Toggle mute |
-| `MatrixListProfiles` | `<MatrixListProfiles/>` | ✅ Correct | List matrix profiles |
-| `MatrixGetProfile` | `<MatrixGetProfile/>` | ✅ Correct | Get current matrix profile |
-| `MatrixSetProfile` | `<MatrixSetProfile value="name"/>` | ✅ Correct | Set matrix profile by NAME (string) |
+| `GetInfo` | `<GetInfo/>` | Correct | Returns name, product, version, platform, engine |
+| `State` | `<State/>` | Correct | Returns full playback state |
+| `Status` | `<Status subscribe="0/1"/>` | Correct | Returns playback position and status |
+| `GetModes` | `<GetModes/>` | Correct | Returns mode list with index, name, value |
+| `GetFilters` | `<GetFilters/>` | Correct | Returns filter list with index, name, value, arg |
+| `GetShapers` | `<GetShapers/>` | Correct | Returns shaper list with index, name, value |
+| `GetRates` | `<GetRates/>` | Correct | Returns rate list with index, rate |
+| `VolumeRange` | `<VolumeRange/>` | Correct | Returns min, max, enabled, adaptive |
+| `Play` | `<Play/>` | Correct | Basic playback |
+| `Pause` | `<Pause/>` | Correct | Pause playback |
+| `Stop` | `<Stop/>` | Correct | Stop playback |
+| `Previous` | `<Previous/>` | Correct | Previous track |
+| `Next` | `<Next/>` | Correct | Next track |
+| `Seek` | `<Seek value="pos"/>` | Correct | Seek to position in seconds |
+| `Volume` | `<Volume value="dB"/>` | Correct | Set volume in dB |
+| `VolumeUp` | `<VolumeUp/>` | Correct | Volume increment |
+| `VolumeDown` | `<VolumeDown/>` | Correct | Volume decrement |
+| `VolumeMute` | `<VolumeMute/>` | Correct | Toggle mute |
+| `MatrixListProfiles` | `<MatrixListProfiles/>` | Correct | List matrix profiles |
+| `MatrixGetProfile` | `<MatrixGetProfile/>` | Correct | Get current matrix profile |
+| `MatrixSetProfile` | `<MatrixSetProfile value="name"/>` | Correct | Set matrix profile by NAME (string) |
 
-### 🔧 Fixed in This PR (Value/Index Semantics)
+### Fixed in This PR (Value/Index Semantics)
 
 | Command | hqp-control | Our Fix | Issue |
 |---------|-------------|---------|-------|
-| `SetMode` | `<SetMode value="X"/>` | Send VALUE directly | Was converting value→index incorrectly |
-| `SetFilter` | `<SetFilter value="X" value1x="Y"/>` | Send VALUE directly | Was converting value→index incorrectly |
-| `SetShaping` | `<SetShaping value="X"/>` | Send VALUE directly | Was converting value→index incorrectly |
-| `SetRate` | `<SetRate value="X"/>` | ✅ Keep index lookup | RateItem has no VALUE field, uses index |
+| `SetMode` | `<SetMode value="X"/>` | Send VALUE directly | Was converting value->index incorrectly |
+| `SetFilter` | `<SetFilter value="X" value1x="Y"/>` | Send VALUE directly | Was converting value->index incorrectly |
+| `SetShaping` | `<SetShaping value="X"/>` | Send VALUE directly | Was converting value->index incorrectly |
+| `SetRate` | `<SetRate value="X"/>` | Keep index lookup | RateItem has no VALUE field, uses index |
 
 **Note on SetRate:** Unlike filters/shapers/modes, RateItem only has `index` and `rate` fields (no `value`). The SetRate command expects the INDEX from the rates list. Our implementation correctly looks up the rate value (e.g., 48000) and converts it to the corresponding index.
 
-### ⚠️ Implemented but Not Exposed via API
+### Implemented but Not Exposed via API
 
 | Command | hqp-control | Status | Notes |
 |---------|-------------|--------|-------|
@@ -55,9 +55,10 @@ Comprehensive audit comparing our HQPlayer adapter implementation against the of
 | `SetRandom` | `<SetRandom value="0/1"/>` | State parsed but no set API | Shuffle toggle |
 | `SetAdaptiveVolume` | `<SetAdaptiveVolume value="0/1"/>` | State parsed but no set API | Adaptive volume |
 
-### ❌ Not Implemented (Potential Future Features)
+### Not Implemented (Potential Future Features)
 
 #### Playback Control
+
 | Command | Description | Priority |
 |---------|-------------|----------|
 | `Backward` | Seek backward | Low (rarely used) |
@@ -66,6 +67,7 @@ Comprehensive audit comparing our HQPlayer adapter implementation against the of
 | `PlayNextURI` | Queue next URI | Medium |
 
 #### Playlist Management
+
 | Command | Description | Priority |
 |---------|-------------|----------|
 | `PlaylistAdd` | Add URI to playlist | Medium |
@@ -76,6 +78,7 @@ Comprehensive audit comparing our HQPlayer adapter implementation against the of
 | `PlaylistMoveUp/Down` | Reorder playlist | Low |
 
 #### Library
+
 | Command | Description | Priority |
 |---------|-------------|----------|
 | `LibraryGet` | Browse library | Low |
@@ -83,6 +86,7 @@ Comprehensive audit comparing our HQPlayer adapter implementation against the of
 | `LibraryFavorite*` | Favorite management | Low |
 
 #### Display/Transport
+
 | Command | Description | Priority |
 |---------|-------------|----------|
 | `GetDisplay/SetDisplay` | Display mode (time/remain/total) | Low |
@@ -90,6 +94,7 @@ Comprehensive audit comparing our HQPlayer adapter implementation against the of
 | `GetInputs` | List available inputs | Medium |
 
 #### Advanced
+
 | Command | Description | Priority |
 |---------|-------------|----------|
 | `Set20kFilter` | 20kHz lowpass filter toggle | Low |
@@ -99,6 +104,7 @@ Comprehensive audit comparing our HQPlayer adapter implementation against the of
 | `ConfigurationLoad` | Load config (requires auth) | Low |
 
 #### Authentication (Requires Crypto)
+
 | Command | Description | Priority |
 |---------|-------------|----------|
 | `SessionAuthentication` | ECDH + Ed25519 handshake | Low |
@@ -127,6 +133,7 @@ emit ratesItem(index, rate);
 ### State Response Fields
 
 The State XML response contains:
+
 - `filter` - current filter VALUE
 - `filter1x` - 1x filter VALUE (when using split filters)
 - `filterNx` - Nx filter VALUE (when using split filters)
@@ -139,11 +146,13 @@ The State XML response contains:
 ### Key Insight: VALUE vs INDEX
 
 For most list items, HQPlayer has TWO different identifiers:
+
 1. **index** - Position in the list (0, 1, 2, ...)
 2. **value** - HQPlayer's internal ID (can be non-sequential, e.g., IIR2 has value=57)
 
 Example from filter list:
-```
+
+```text
 index=0, value=0, name=none
 index=1, value=1, name=IIR
 index=2, value=57, name=IIR2  <-- Note: value != index
@@ -181,6 +190,5 @@ curl -X POST http://localhost:8089/hqp/pipeline \
 
 ## References
 
-- hqp-control v5.2.30 source: `/Users/muness1/src/hqp-control-5230-src/`
-- Protocol documentation: `hqplayer_control_protocol.md`
-- HQPlayer Desktop by Signalyst
+- hqp-control v5.2.30 source: Available from Signalyst (HQPlayer author Jussi Laako)
+- HQPlayer Desktop/Embedded by Signalyst: <https://www.signalyst.com/consumer.html>

--- a/docs/hqplayer-protocol-audit.md
+++ b/docs/hqplayer-protocol-audit.md
@@ -1,0 +1,186 @@
+# HQPlayer Protocol Audit
+
+## Summary
+
+Comprehensive audit comparing our HQPlayer adapter implementation against the official `hqp-control` v5.2.30 reference source code.
+
+**Key Finding:** HQPlayer's Set commands (SetMode, SetFilter, SetShaping) expect the **VALUE field** from list items, not the array **index**. Despite the hqp-control command-line help text saying `--set-filter <index>`, the actual XML protocol uses the `value` attribute which corresponds to HQPlayer's internal ID (the VALUE field), not the position in the list.
+
+## Commands Audit
+
+### ✅ Fully Implemented (Correct Semantics)
+
+| Command | hqp-control | Our Implementation | Notes |
+|---------|-------------|-------------------|-------|
+| `GetInfo` | `<GetInfo/>` | ✅ Correct | Returns name, product, version, platform, engine |
+| `State` | `<State/>` | ✅ Correct | Returns full playback state |
+| `Status` | `<Status subscribe="0/1"/>` | ✅ Correct | Returns playback position and status |
+| `GetModes` | `<GetModes/>` | ✅ Correct | Returns mode list with index, name, value |
+| `GetFilters` | `<GetFilters/>` | ✅ Correct | Returns filter list with index, name, value, arg |
+| `GetShapers` | `<GetShapers/>` | ✅ Correct | Returns shaper list with index, name, value |
+| `GetRates` | `<GetRates/>` | ✅ Correct | Returns rate list with index, rate |
+| `VolumeRange` | `<VolumeRange/>` | ✅ Correct | Returns min, max, enabled, adaptive |
+| `Play` | `<Play/>` | ✅ Correct | Basic playback |
+| `Pause` | `<Pause/>` | ✅ Correct | Pause playback |
+| `Stop` | `<Stop/>` | ✅ Correct | Stop playback |
+| `Previous` | `<Previous/>` | ✅ Correct | Previous track |
+| `Next` | `<Next/>` | ✅ Correct | Next track |
+| `Seek` | `<Seek value="pos"/>` | ✅ Correct | Seek to position in seconds |
+| `Volume` | `<Volume value="dB"/>` | ✅ Correct | Set volume in dB |
+| `VolumeUp` | `<VolumeUp/>` | ✅ Correct | Volume increment |
+| `VolumeDown` | `<VolumeDown/>` | ✅ Correct | Volume decrement |
+| `VolumeMute` | `<VolumeMute/>` | ✅ Correct | Toggle mute |
+| `MatrixListProfiles` | `<MatrixListProfiles/>` | ✅ Correct | List matrix profiles |
+| `MatrixGetProfile` | `<MatrixGetProfile/>` | ✅ Correct | Get current matrix profile |
+| `MatrixSetProfile` | `<MatrixSetProfile value="name"/>` | ✅ Correct | Set matrix profile by NAME (string) |
+
+### 🔧 Fixed in This PR (Value/Index Semantics)
+
+| Command | hqp-control | Our Fix | Issue |
+|---------|-------------|---------|-------|
+| `SetMode` | `<SetMode value="X"/>` | Send VALUE directly | Was converting value→index incorrectly |
+| `SetFilter` | `<SetFilter value="X" value1x="Y"/>` | Send VALUE directly | Was converting value→index incorrectly |
+| `SetShaping` | `<SetShaping value="X"/>` | Send VALUE directly | Was converting value→index incorrectly |
+| `SetRate` | `<SetRate value="X"/>` | ✅ Keep index lookup | RateItem has no VALUE field, uses index |
+
+**Note on SetRate:** Unlike filters/shapers/modes, RateItem only has `index` and `rate` fields (no `value`). The SetRate command expects the INDEX from the rates list. Our implementation correctly looks up the rate value (e.g., 48000) and converts it to the corresponding index.
+
+### ⚠️ Implemented but Not Exposed via API
+
+| Command | hqp-control | Status | Notes |
+|---------|-------------|--------|-------|
+| `SetInvert` | `<SetInvert value="0/1"/>` | State parsed but no set API | Polarity inversion |
+| `SetConvolution` | `<SetConvolution value="0/1"/>` | State parsed but no set API | Convolution engine toggle |
+| `SetRepeat` | `<SetRepeat value="0/1/2"/>` | State parsed but no set API | 0=off, 1=track, 2=all |
+| `SetRandom` | `<SetRandom value="0/1"/>` | State parsed but no set API | Shuffle toggle |
+| `SetAdaptiveVolume` | `<SetAdaptiveVolume value="0/1"/>` | State parsed but no set API | Adaptive volume |
+
+### ❌ Not Implemented (Potential Future Features)
+
+#### Playback Control
+| Command | Description | Priority |
+|---------|-------------|----------|
+| `Backward` | Seek backward | Low (rarely used) |
+| `Forward` | Seek forward | Low (rarely used) |
+| `SelectTrack` | Jump to playlist index | Medium |
+| `PlayNextURI` | Queue next URI | Medium |
+
+#### Playlist Management
+| Command | Description | Priority |
+|---------|-------------|----------|
+| `PlaylistAdd` | Add URI to playlist | Medium |
+| `PlaylistRemove` | Remove item from playlist | Medium |
+| `PlaylistClear` | Clear playlist | Medium |
+| `PlaylistGet` | Get playlist contents | Medium |
+| `PlaylistLoad/Save` | Load/save named playlists | Low |
+| `PlaylistMoveUp/Down` | Reorder playlist | Low |
+
+#### Library
+| Command | Description | Priority |
+|---------|-------------|----------|
+| `LibraryGet` | Browse library | Low |
+| `LibraryPictureByPath/Hash` | Get album art | Low |
+| `LibraryFavorite*` | Favorite management | Low |
+
+#### Display/Transport
+| Command | Description | Priority |
+|---------|-------------|----------|
+| `GetDisplay/SetDisplay` | Display mode (time/remain/total) | Low |
+| `GetTransport/SetTransport` | Transport type selection | Low |
+| `GetInputs` | List available inputs | Medium |
+
+#### Advanced
+| Command | Description | Priority |
+|---------|-------------|----------|
+| `Set20kFilter` | 20kHz lowpass filter toggle | Low |
+| `SetTransportRate` | Transport sample rate | Low |
+| `GetLicense` | License info | Low |
+| `Reset` | Reset HQPlayer | Low |
+| `ConfigurationLoad` | Load config (requires auth) | Low |
+
+#### Authentication (Requires Crypto)
+| Command | Description | Priority |
+|---------|-------------|----------|
+| `SessionAuthentication` | ECDH + Ed25519 handshake | Low |
+| Encrypted commands | ChaCha20-Poly1305 encryption | Low |
+
+## Protocol Details
+
+### List Item Structure
+
+From hqp-control parsing:
+
+```cpp
+// ModesItem: index, name, value (value can be negative, e.g., -1 for [source])
+emit modesItem(index, name, value);
+
+// FiltersItem: index, name, value, arg
+emit filtersItem(index, name, value, arg);
+
+// ShapersItem: index, name, value
+emit shapersItem(index, name, value);
+
+// RatesItem: index, rate (no value field!)
+emit ratesItem(index, rate);
+```
+
+### State Response Fields
+
+The State XML response contains:
+- `filter` - current filter VALUE
+- `filter1x` - 1x filter VALUE (when using split filters)
+- `filterNx` - Nx filter VALUE (when using split filters)
+- `mode` - mode VALUE (can be -1 for [source])
+- `shaper` - shaper VALUE
+- `rate` - rate INDEX (different from others!)
+- `active_rate` - actual sample rate in Hz
+- `volume` - volume in dB
+
+### Key Insight: VALUE vs INDEX
+
+For most list items, HQPlayer has TWO different identifiers:
+1. **index** - Position in the list (0, 1, 2, ...)
+2. **value** - HQPlayer's internal ID (can be non-sequential, e.g., IIR2 has value=57)
+
+Example from filter list:
+```
+index=0, value=0, name=none
+index=1, value=1, name=IIR
+index=2, value=57, name=IIR2  <-- Note: value != index
+index=15, value=53, name=poly-sinc-hb-xs
+index=19, value=15, name=poly-sinc-ext
+```
+
+When setting a filter, you send the VALUE (e.g., 53 for poly-sinc-hb-xs), not the index (15).
+
+**Exception:** SetRate uses the INDEX because RateItem has no value field.
+
+## Testing Verification
+
+After applying the fixes:
+
+```bash
+# Test filter1x change to poly-sinc-hb-xs (value 53)
+curl -X POST http://localhost:8089/hqp/pipeline \
+  -H "Content-Type: application/json" \
+  -d '{"setting":"filter1x","value":53}'
+# Result: {"settings":{"filter1x":{"selected":{"value":"53","label":"poly-sinc-hb-xs"}}}}
+
+# Test shaper change to NS5 (value 7)
+curl -X POST http://localhost:8089/hqp/pipeline \
+  -H "Content-Type: application/json" \
+  -d '{"setting":"shaper","value":7}'
+# Result: {"settings":{"shaper":{"selected":{"value":"7","label":"NS5"}}}}
+
+# Test rate change to 96000
+curl -X POST http://localhost:8089/hqp/pipeline \
+  -H "Content-Type: application/json" \
+  -d '{"setting":"samplerate","value":96000}'
+# Result: {"settings":{"samplerate":{"selected":{"value":"96000","label":"96000"}}}}
+```
+
+## References
+
+- hqp-control v5.2.30 source: `/Users/muness1/src/hqp-control-5230-src/`
+- Protocol documentation: `hqplayer_control_protocol.md`
+- HQPlayer Desktop by Signalyst

--- a/src/adapters/hqplayer.rs
+++ b/src/adapters/hqplayer.rs
@@ -1270,9 +1270,13 @@ impl HqpAdapter {
         let playback_status = self.get_playback_status().await.unwrap_or_default();
 
         // Lazy-load lists if not cached (first request after connect)
+        // Check ALL lists - if any are empty, we need to refresh
         let needs_lists = {
             let cached = self.state.read().await;
             cached.modes.is_empty()
+                || cached.filters.is_empty()
+                || cached.shapers.is_empty()
+                || cached.rates.is_empty()
         };
         if needs_lists {
             self.refresh_lists().await;

--- a/src/adapters/hqplayer.rs
+++ b/src/adapters/hqplayer.rs
@@ -485,12 +485,17 @@ impl HqpAdapter {
 
             if changed {
                 state.connected = false;
-                // Clear cached lists when switching hosts - they're specific to each HQPlayer instance
+                // Clear ALL instance-specific cached data when switching hosts
+                state.info = None;
+                state.last_state = None;
                 state.modes.clear();
                 state.filters.clear();
                 state.shapers.clear();
                 state.rates.clear();
                 state.volume_range = None;
+                state.profiles.clear();
+                state.hidden_fields.clear();
+                state.config_title = None;
             }
             changed
         };

--- a/src/adapters/hqplayer.rs
+++ b/src/adapters/hqplayer.rs
@@ -129,9 +129,9 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 const RESPONSE_TIMEOUT: Duration = Duration::from_secs(3);
 const PROFILE_PATH: &str = "/config/profile/load";
 /// Maximum reconnection attempts before giving up
-const MAX_RECONNECT_ATTEMPTS: u32 = 3;
-/// Delay between reconnection attempts
-const RECONNECT_DELAY: Duration = Duration::from_millis(200);
+const MAX_RECONNECT_ATTEMPTS: u32 = 2;
+/// Delay between reconnection attempts (HQPlayer can be overwhelmed by rapid connections)
+const RECONNECT_DELAY: Duration = Duration::from_secs(1);
 
 /// HQPlayer state information
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/src/adapters/hqplayer.rs
+++ b/src/adapters/hqplayer.rs
@@ -3,6 +3,11 @@
 //! Implements the TCP/XML control protocol on port 4321 for pipeline control.
 //! Also implements HTTP/Digest auth for web UI profile loading (port 8088).
 //! Based on Jussi Laako's hqp-control reference implementation.
+//!
+//! See `docs/hqplayer-protocol-audit.md` for:
+//! - State vs Status semantics (configured vs active values)
+//! - VALUE vs INDEX field usage for Set commands
+//! - Caching strategy to avoid overwhelming HQPlayer
 
 use anyhow::{anyhow, Result};
 use quick_xml::events::{BytesStart, Event};

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1415,6 +1415,12 @@ pub async fn hqp_configure_handler(
     State(state): State<AppState>,
     Json(req): Json<HqpConfigRequest>,
 ) -> impl IntoResponse {
+    // Clear zone links for "default" instance - prevents stale data after host change
+    state
+        .hqp_zone_links
+        .remove_links_for_instance("default")
+        .await;
+
     // Configure the adapter
     state
         .hqplayer

--- a/src/app/pages/hqplayer.rs
+++ b/src/app/pages/hqplayer.rs
@@ -269,6 +269,8 @@ pub fn HqPlayer() -> Element {
             if let Err(e) = api::post_json_no_response("/hqp/pipeline", &req).await {
                 hqp_error.set(Some(format!("Pipeline update failed: {e}")));
             } else {
+                // Server now returns fresh state after setting, so HQPlayer has processed
+                // the change before we refresh
                 pipeline.restart();
             }
             hqp_loading.set(false);
@@ -725,7 +727,8 @@ fn DspSettings(
         .unwrap_or_default();
     let matrix_current = matrix.as_ref().and_then(|m| m.current);
 
-    // Dynamic shaper label
+    // Dynamic shaper label based on mode
+    // SDM/DSD mode = "Modulator", PCM mode = "Shaper" (not "Dither")
     let shaper_label = mode_opts
         .as_ref()
         .and_then(|m| m.selected.as_ref())
@@ -735,7 +738,7 @@ fn DspSettings(
             if lower.contains("sdm") || lower.contains("dsd") {
                 "Modulator"
             } else {
-                "Dither"
+                "Shaper" // PCM mode uses noise shaping, not dithering
             }
         })
         .unwrap_or("Shaper");

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -529,33 +529,16 @@ impl ServerHandler for HifiMcpHandler {
 
                 let result = match args.setting.as_str() {
                     "filter1x" | "filter_1x" => {
-                        if let Some(v) = parse_nonneg(&args.value) {
-                            self.state.hqplayer.set_filter_1x(v).await
-                        } else {
-                            return Self::error_result(
-                                "Invalid filter1x value (expected non-negative integer)".into(),
-                            );
-                        }
+                        // Adapter handles name→value lookup
+                        self.state.hqplayer.set_filter_1x(&args.value).await
                     }
                     "filterNx" | "filter_nx" | "filternx" => {
-                        if let Some(v) = parse_nonneg(&args.value) {
-                            self.state.hqplayer.set_filter_nx(v).await
-                        } else {
-                            return Self::error_result(
-                                "Invalid filterNx value (expected non-negative integer)".into(),
-                            );
-                        }
+                        // Adapter handles name→value lookup
+                        self.state.hqplayer.set_filter_nx(&args.value).await
                     }
                     "shaper" | "dither" => {
-                        // shaper (DSD) and dither (PCM) use the same HQPlayer API
-                        if let Some(v) = parse_nonneg(&args.value) {
-                            self.state.hqplayer.set_shaper(v).await
-                        } else {
-                            return Self::error_result(
-                                "Invalid shaper/dither value (expected non-negative integer)"
-                                    .into(),
-                            );
-                        }
+                        // Adapter handles name→value lookup
+                        self.state.hqplayer.set_shaper(&args.value).await
                     }
                     "rate" | "samplerate" => {
                         if let Some(v) = parse_nonneg(&args.value) {


### PR DESCRIPTION
## Summary

Fixes HQPlayer Set commands (SetMode, SetFilter, SetShaping) which were sending incorrect values due to a misunderstanding of the protocol semantics.

## Root Cause

Despite the hqp-control command-line help saying `--set-filter <index>`, the actual XML protocol's `value` attribute expects the **VALUE field** from list items, not the array **index**. These are different:

| Field | Description | Example |
|-------|-------------|---------|
| index | Position in list | 0, 1, 2, 15, 19 |
| value | HQPlayer internal ID | 0, 1, 57, 53, 15 |

Example from filter list:
```
index=0, value=0, name=none
index=1, value=1, name=IIR
index=2, value=57, name=IIR2  ← Note: value != index
index=15, value=53, name=poly-sinc-hb-xs
index=19, value=15, name=poly-sinc-ext
```

## Changes

### Core Fixes
- `set_mode`: Send VALUE directly (no conversion)
- `set_filter/set_filter_1x/set_filter_nx`: Send VALUE directly
- `set_shaper`: Send VALUE directly
- `set_rate`: Keep index lookup (RateItem has no VALUE field - this one was correct)
- `get_pipeline_status`: Look up filters/shapers by VALUE field, not array index

### API
- Return fresh pipeline state after updates instead of just `{"ok": true}`

### UI
- Fix shaper label to say "Shaper" not "Dither" for PCM mode

### Documentation
- Added comprehensive protocol audit in `docs/hqplayer-protocol-audit.md`
- Documents all implemented vs unimplemented commands
- Explains value vs index semantics
- Lists potential future features with priorities

## Testing

All settings verified working via API:
```bash
# filter1x → poly-sinc-hb-xs (value 53) ✅
# filterNx → sinc-medium (value 49) ✅  
# shaper → NS5 (value 7) ✅
# mode → PCM (value 0) ✅
# samplerate → 96000 ✅
```

## Related

- Fixes #206
- Based on hqp-control v5.2.30 source code analysis

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pipeline updates now return the current pipeline status when available (falls back to acknowledgement).

* **Bug Fixes**
  * Commands now use VALUE semantics and improved samplerate/matrix profile resolution.
  * Tighter connection/retry policy and more robust, lazy caching for control lists and volume range.

* **UI**
  * DSP shaper label clarified to reflect PCM (noise shaping) vs SDM/DSD.

* **Documentation**
  * Added comprehensive HQPlayer protocol audit.

* **Chores**
  * MCP server URL switched to localhost:8089.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->