### PR TITLE
chore: remove unused rumqttc dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ server = [
     "dep:tower-http",
     "dep:roon-api",
     "dep:reqwest",
-    "dep:rumqttc",
     "dep:tracing-subscriber",
     "dep:config",
     "dep:image",
@@ -94,9 +93,6 @@ roon-api = { git = "https://github.com/open-horizon-labs/rust-roon-api.git", bra
 
 # HTTP client (server only)
 reqwest = { version = "0.12", default-features = false, features = ["json", "cookies", "rustls-tls"], optional = true }
-
-# MQTT (server only)
-rumqttc = { version = "0.24", optional = true }
 
 # Logging subscriber (server only - needs tokio)
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }


### PR DESCRIPTION
## Summary

Removes the unused `rumqttc` dependency. MQTT support was planned but never implemented - the dependency was included in the `server` feature but no code actually uses it.

This supersedes #213 (dependabot bump for rumqttc).

## Changes

- Remove `rumqttc` from server feature
- Remove `rumqttc` from dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed MQTT support from the server build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->