### PR TITLE
fix(ci): remove restore-keys to prevent WASM cache corruption

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -421,9 +421,8 @@ jobs:
           # Version is baked in at compile time, but we accept stale version display
           # for PRs in exchange for cache efficiency. Releases change Cargo.toml anyway.
           # Note: Tailwind version pinned in Makefile - update cache key when upgrading
+          # No restore-keys: partial cache restore causes corruption (stale WASM artifacts)
           key: wasm-v3-tw4.1.18-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml', 'Dioxus.toml', 'src/**/*.rs', 'assets/**', 'src/input.css', 'public/dx-components-theme.css') }}
-          restore-keys: |
-            wasm-v3-
 
       - name: Setup Rust
         if: steps.cache-wasm.outputs.cache-hit != 'true'
@@ -514,9 +513,8 @@ jobs:
             target/dx/
             target/wasm32-unknown-unknown/
           # Same cache key as build-wasm job - shares cached artifacts
+          # No restore-keys: partial cache restore causes corruption (stale WASM artifacts)
           key: wasm-v3-tw4.1.18-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml', 'Dioxus.toml', 'src/**/*.rs', 'assets/**', 'src/input.css', 'public/dx-components-theme.css') }}
-          restore-keys: |
-            wasm-v3-
 
       - name: Setup Rust
         if: steps.cache-wasm.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary
- Remove `restore-keys` fallback from WASM cache configuration
- Prevents partial cache restores with incompatible artifacts

## Problem
The `restore-keys: wasm-v3-` fallback was restoring stale WASM artifacts when the content hash changed, causing "cache may be corrupted" errors and requiring manual cache deletion.

## Solution
WASM builds are all-or-nothing - partial restore is worse than clean build. Only use exact cache key matches.

## Trade-off
- Cache miss = full WASM rebuild (~10 min)
- Cache hit = guaranteed correct artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build pipeline stability by refining cache configuration to prevent potential issues with stale build artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->