### PR TITLE
feat(events): extract shared wire protocol types to muse-events crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2605,6 +2605,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "muse-events"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4574,6 +4582,7 @@ dependencies = [
  "md5",
  "mdns-sd",
  "mime_guess",
+ "muse-events",
  "quick-xml",
  "rand 0.8.5",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
+[workspace]
+members = ["muse-events"]
+resolver = "2"
+
 [package]
 name = "unified-hifi-control"
 version = "0.0.0"  # Injected from git tag at build time
@@ -35,6 +39,9 @@ server = [
 web = ["dioxus/web"]
 
 [dependencies]
+# Shared wire protocol types for Muse ecosystem
+muse-events = { path = "muse-events" }
+
 # Dioxus UI framework (SSR + client hydration + router)
 dioxus = { version = "0.7.3", features = ["fullstack", "router"] }
 

--- a/muse-events/Cargo.toml
+++ b/muse-events/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "muse-events"
+version = "0.1.0"
+edition = "2021"
+authors = ["Open Horizon Labs <support@openhorizonlabs.com>"]
+description = "Shared wire protocol types for the Muse ecosystem"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/open-horizon-labs/muse-events"
+keywords = ["audio", "music", "streaming", "events"]
+categories = ["multimedia::audio"]
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/muse-events/src/events.rs
+++ b/muse-events/src/events.rs
@@ -4,7 +4,7 @@
 //! the wire via SSE. Consumers (Memex, etc.) depend on this crate
 //! instead of duplicating types.
 
-use crate::zone::{NowPlaying, VolumeControl, Zone, ZoneState};
+use crate::zone::{NowPlaying, Zone, ZoneState};
 use serde::{Deserialize, Serialize};
 
 /// Events that cross the wire via SSE.
@@ -56,8 +56,10 @@ pub enum MuseEvent {
     VolumeChanged {
         /// Output ID
         output_id: String,
-        /// Volume control state
-        volume: VolumeControl,
+        /// Current volume value
+        value: f32,
+        /// Whether the output is muted
+        is_muted: bool,
     },
 
     // =========================================================================

--- a/muse-events/src/events.rs
+++ b/muse-events/src/events.rs
@@ -1,0 +1,215 @@
+//! SSE wire protocol events for the Muse ecosystem.
+//!
+//! `MuseEvent` is the subset of UHC's internal `BusEvent` that crosses
+//! the wire via SSE. Consumers (Memex, etc.) depend on this crate
+//! instead of duplicating types.
+
+use crate::zone::{NowPlaying, VolumeControl, Zone, ZoneState};
+use serde::{Deserialize, Serialize};
+
+/// Events that cross the wire via SSE.
+///
+/// This is the subset of UHC's internal `BusEvent` that external consumers
+/// need to handle. UHC converts from `BusEvent` to `MuseEvent` at the SSE
+/// boundary.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", content = "payload")]
+pub enum MuseEvent {
+    // =========================================================================
+    // Zone Lifecycle Events
+    // =========================================================================
+    /// A new zone was discovered by an adapter
+    ZoneDiscovered {
+        /// Full zone information
+        zone: Zone,
+    },
+
+    /// Zone information was updated
+    ZoneUpdated(ZoneState),
+
+    /// A zone was removed (went offline, adapter disconnected, etc.)
+    ZoneRemoved {
+        /// Zone identifier (prefixed, e.g., "roon:xxx")
+        zone_id: String,
+    },
+
+    // =========================================================================
+    // Now Playing Events
+    // =========================================================================
+    /// Now playing information changed for a zone
+    NowPlayingChanged {
+        /// Zone identifier (prefixed, e.g., "roon:xxx")
+        zone_id: String,
+        /// Updated now playing info
+        now_playing: Option<NowPlaying>,
+    },
+
+    /// Seek position changed (for progress updates)
+    SeekPositionChanged {
+        /// Zone identifier (prefixed, e.g., "roon:xxx")
+        zone_id: String,
+        /// Current position in milliseconds
+        position: i64,
+    },
+
+    /// Volume changed
+    VolumeChanged {
+        /// Output ID
+        output_id: String,
+        /// Volume control state
+        volume: VolumeControl,
+    },
+
+    // =========================================================================
+    // Adapter Lifecycle Events
+    // =========================================================================
+    /// An adapter connected to its backend
+    AdapterConnected {
+        /// Adapter identifier (e.g., "roon", "lms", "hqplayer")
+        adapter: String,
+        /// Connection details
+        details: Option<String>,
+    },
+
+    /// An adapter disconnected from its backend
+    AdapterDisconnected {
+        /// Adapter identifier
+        adapter: String,
+        /// Reason for disconnection
+        reason: Option<String>,
+    },
+
+    // =========================================================================
+    // HQPlayer Events
+    // =========================================================================
+    /// HQPlayer pipeline changed
+    HqpPipelineChanged {
+        /// HQPlayer host
+        host: String,
+        /// Filter setting
+        filter: Option<String>,
+        /// Shaper setting
+        shaper: Option<String>,
+        /// Sample rate
+        rate: Option<String>,
+    },
+}
+
+impl MuseEvent {
+    /// Get the event type as a string (for logging/filtering)
+    pub fn event_type(&self) -> &'static str {
+        match self {
+            Self::ZoneDiscovered { .. } => "zone_discovered",
+            Self::ZoneUpdated { .. } => "zone_updated",
+            Self::ZoneRemoved { .. } => "zone_removed",
+            Self::NowPlayingChanged { .. } => "now_playing_changed",
+            Self::SeekPositionChanged { .. } => "seek_position_changed",
+            Self::VolumeChanged { .. } => "volume_changed",
+            Self::AdapterConnected { .. } => "adapter_connected",
+            Self::AdapterDisconnected { .. } => "adapter_disconnected",
+            Self::HqpPipelineChanged { .. } => "hqp_pipeline_changed",
+        }
+    }
+
+    /// Check if this is a zone-related event
+    pub fn is_zone_event(&self) -> bool {
+        matches!(
+            self,
+            Self::ZoneDiscovered { .. } | Self::ZoneUpdated { .. } | Self::ZoneRemoved { .. }
+        )
+    }
+
+    /// Check if this is a playback-related event
+    pub fn is_playback_event(&self) -> bool {
+        matches!(
+            self,
+            Self::NowPlayingChanged { .. }
+                | Self::SeekPositionChanged { .. }
+                | Self::VolumeChanged { .. }
+        )
+    }
+
+    /// Check if this is an adapter lifecycle event
+    pub fn is_adapter_event(&self) -> bool {
+        matches!(
+            self,
+            Self::AdapterConnected { .. } | Self::AdapterDisconnected { .. }
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::zone::PlaybackState;
+
+    #[test]
+    fn test_muse_event_serialization() {
+        let event = MuseEvent::ZoneUpdated(ZoneState {
+            zone_id: "roon:123".to_string(),
+            display_name: "Living Room".to_string(),
+            state: PlaybackState::Playing,
+        });
+
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains("ZoneUpdated"));
+        assert!(json.contains("roon:123"));
+
+        let deserialized: MuseEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(event, deserialized);
+    }
+
+    #[test]
+    fn test_zone_discovered_serialization() {
+        let zone = Zone {
+            zone_id: "lms:00:11:22:33:44:55".to_string(),
+            zone_name: "Kitchen".to_string(),
+            state: PlaybackState::Stopped,
+            volume_control: None,
+            now_playing: None,
+            source: "lms".to_string(),
+            is_controllable: true,
+            is_seekable: true,
+            last_updated: 1234567890,
+            is_play_allowed: true,
+            is_pause_allowed: false,
+            is_next_allowed: true,
+            is_previous_allowed: true,
+        };
+
+        let event = MuseEvent::ZoneDiscovered { zone: zone.clone() };
+        let json = serde_json::to_string(&event).unwrap();
+        let deserialized: MuseEvent = serde_json::from_str(&json).unwrap();
+
+        match deserialized {
+            MuseEvent::ZoneDiscovered { zone: z } => assert_eq!(z, zone),
+            _ => panic!("Wrong event type"),
+        }
+    }
+
+    #[test]
+    fn test_event_type_methods() {
+        let event = MuseEvent::ZoneDiscovered {
+            zone: Zone {
+                zone_id: "test:1".to_string(),
+                zone_name: "Test".to_string(),
+                state: PlaybackState::Unknown,
+                volume_control: None,
+                now_playing: None,
+                source: "test".to_string(),
+                is_controllable: false,
+                is_seekable: false,
+                last_updated: 0,
+                is_play_allowed: false,
+                is_pause_allowed: false,
+                is_next_allowed: false,
+                is_previous_allowed: false,
+            },
+        };
+
+        assert_eq!(event.event_type(), "zone_discovered");
+        assert!(event.is_zone_event());
+        assert!(!event.is_playback_event());
+        assert!(!event.is_adapter_event());
+    }
+}

--- a/muse-events/src/ingest.rs
+++ b/muse-events/src/ingest.rs
@@ -1,0 +1,102 @@
+//! Ingest wire protocol types for muse-ingest.
+//!
+//! These types define the format expected by the muse-ingest proxy
+//! when UHC's EventReporter forwards events.
+
+use serde::{Deserialize, Serialize};
+
+/// Event payload sent to the ingest proxy.
+///
+/// This is a generic envelope that wraps any event type with
+/// metadata needed for processing.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IngestEvent {
+    /// Event type identifier (e.g., "now_playing_changed")
+    pub event_type: String,
+
+    /// Unix timestamp in seconds
+    pub timestamp: u64,
+
+    /// Event-specific payload as JSON
+    pub payload: serde_json::Value,
+}
+
+/// Request body for the ingest endpoint.
+///
+/// Events are batched for efficiency - UHC buffers events
+/// and sends them in batches to reduce network overhead.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IngestRequest {
+    /// Batch of events to process
+    pub events: Vec<IngestEvent>,
+}
+
+impl IngestRequest {
+    /// Create a new request with the given events
+    pub fn new(events: Vec<IngestEvent>) -> Self {
+        Self { events }
+    }
+
+    /// Check if the request is empty
+    pub fn is_empty(&self) -> bool {
+        self.events.is_empty()
+    }
+
+    /// Get the number of events
+    pub fn len(&self) -> usize {
+        self.events.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ingest_event_serialization() {
+        let event = IngestEvent {
+            event_type: "now_playing_changed".to_string(),
+            timestamp: 1234567890,
+            payload: serde_json::json!({
+                "zone_id": "roon:123",
+                "title": "Test Song",
+                "artist": "Test Artist"
+            }),
+        };
+
+        let json = serde_json::to_string(&event).unwrap();
+        let deserialized: IngestEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(event, deserialized);
+    }
+
+    #[test]
+    fn test_ingest_request_serialization() {
+        let request = IngestRequest {
+            events: vec![
+                IngestEvent {
+                    event_type: "zone_discovered".to_string(),
+                    timestamp: 1234567890,
+                    payload: serde_json::json!({"zone_id": "roon:1"}),
+                },
+                IngestEvent {
+                    event_type: "now_playing_changed".to_string(),
+                    timestamp: 1234567891,
+                    payload: serde_json::json!({"zone_id": "roon:1", "title": "Song"}),
+                },
+            ],
+        };
+
+        let json = serde_json::to_string(&request).unwrap();
+        let deserialized: IngestRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(request, deserialized);
+        assert_eq!(request.len(), 2);
+        assert!(!request.is_empty());
+    }
+
+    #[test]
+    fn test_empty_request() {
+        let request = IngestRequest::new(vec![]);
+        assert!(request.is_empty());
+        assert_eq!(request.len(), 0);
+    }
+}

--- a/muse-events/src/lib.rs
+++ b/muse-events/src/lib.rs
@@ -1,0 +1,22 @@
+//! Shared wire protocol types for the Muse ecosystem.
+//!
+//! This crate defines the types that cross boundaries between:
+//! - UHC (unified-hifi-control) - the event producer
+//! - Memex - SSE event consumer
+//! - muse-ingest - batch event consumer
+//!
+//! # Modules
+//! - [`zone`] - Zone and playback state types
+//! - [`events`] - SSE wire protocol events (MuseEvent)
+//! - [`ingest`] - Ingest wire protocol types (IngestEvent, IngestRequest)
+
+pub mod events;
+pub mod ingest;
+pub mod zone;
+
+// Re-export commonly used types at crate root
+pub use events::MuseEvent;
+pub use ingest::{IngestEvent, IngestRequest};
+pub use zone::{
+    NowPlaying, PlaybackState, TrackMetadata, VolumeControl, VolumeScale, Zone, ZoneState,
+};

--- a/muse-events/src/zone.rs
+++ b/muse-events/src/zone.rs
@@ -1,0 +1,264 @@
+//! Zone and playback types shared across the Muse ecosystem.
+//!
+//! These types represent the domain model for zones, playback state,
+//! and now playing information.
+
+use serde::{Deserialize, Serialize};
+
+/// Unified zone representation across all adapters.
+///
+/// A zone represents a logical playback destination (Roon zone, LMS player,
+/// HQPlayer instance, etc.) with a consistent interface regardless of source.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Zone {
+    /// Unique zone identifier (e.g., "roon:1234", "lms:00:11:22:33:44:55")
+    pub zone_id: String,
+
+    /// Human-readable zone name
+    pub zone_name: String,
+
+    /// Current playback state
+    pub state: PlaybackState,
+
+    /// Volume control information (if available)
+    pub volume_control: Option<VolumeControl>,
+
+    /// Currently playing track (if any)
+    pub now_playing: Option<NowPlaying>,
+
+    /// Source adapter identifier (e.g., "roon", "lms", "hqplayer")
+    pub source: String,
+
+    /// Whether playback controls are available
+    pub is_controllable: bool,
+
+    /// Whether the zone supports seeking
+    pub is_seekable: bool,
+
+    /// Last update timestamp (milliseconds since epoch)
+    pub last_updated: u64,
+
+    /// Whether play command is currently allowed
+    pub is_play_allowed: bool,
+
+    /// Whether pause command is currently allowed
+    pub is_pause_allowed: bool,
+
+    /// Whether next track command is allowed
+    pub is_next_allowed: bool,
+
+    /// Whether previous track command is allowed
+    pub is_previous_allowed: bool,
+}
+
+/// Simplified zone state for ZoneUpdated events.
+///
+/// Contains the essential state that changes during zone updates,
+/// without the full Zone struct overhead.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ZoneState {
+    /// Zone identifier
+    pub zone_id: String,
+
+    /// Display name
+    pub display_name: String,
+
+    /// Current playback state
+    pub state: PlaybackState,
+}
+
+/// Playback state enumeration
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "lowercase")]
+pub enum PlaybackState {
+    Playing,
+    Paused,
+    Stopped,
+    Loading,
+    /// Buffering (used by streaming sources)
+    Buffering,
+    /// Unknown/unavailable state
+    #[default]
+    Unknown,
+}
+
+impl std::fmt::Display for PlaybackState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Playing => write!(f, "playing"),
+            Self::Paused => write!(f, "paused"),
+            Self::Stopped => write!(f, "stopped"),
+            Self::Loading => write!(f, "loading"),
+            Self::Buffering => write!(f, "buffering"),
+            Self::Unknown => write!(f, "unknown"),
+        }
+    }
+}
+
+impl From<&str> for PlaybackState {
+    fn from(s: &str) -> Self {
+        match s.to_lowercase().as_str() {
+            "playing" | "play" => Self::Playing,
+            "paused" | "pause" => Self::Paused,
+            "stopped" | "stop" => Self::Stopped,
+            "loading" => Self::Loading,
+            "buffering" => Self::Buffering,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+/// Volume control information for a zone or output.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct VolumeControl {
+    /// Current volume value (in the scale defined by min/max)
+    pub value: f32,
+
+    /// Minimum volume value (e.g., -64 for dB, 0 for percentage)
+    pub min: f32,
+
+    /// Maximum volume value (e.g., 0 for dB, 100 for percentage)
+    pub max: f32,
+
+    /// Volume step size (for relative adjustments)
+    pub step: f32,
+
+    /// Whether volume is currently muted
+    pub is_muted: bool,
+
+    /// Volume scale type
+    pub scale: VolumeScale,
+
+    /// Output ID for this volume control (for multi-output zones)
+    pub output_id: Option<String>,
+}
+
+/// Volume scale type
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum VolumeScale {
+    /// Decibels (typically -64 to 0)
+    Decibel,
+    /// Percentage (0 to 100)
+    Percentage,
+    /// Linear (0.0 to 1.0)
+    Linear,
+    /// Unknown/unspecified
+    #[default]
+    Unknown,
+}
+
+/// Now playing track information.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct NowPlaying {
+    /// Track title (always present, may be empty string)
+    pub title: String,
+
+    /// Artist name
+    pub artist: String,
+
+    /// Album name
+    pub album: String,
+
+    /// Image key or URL for album art
+    pub image_key: Option<String>,
+
+    /// Current seek position in seconds
+    pub seek_position: Option<f64>,
+
+    /// Total track duration in seconds
+    pub duration: Option<f64>,
+
+    /// Additional metadata (format, bitrate, etc.)
+    pub metadata: Option<TrackMetadata>,
+}
+
+/// Additional track metadata
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TrackMetadata {
+    /// Audio format (e.g., "FLAC", "DSD", "MQA")
+    pub format: Option<String>,
+
+    /// Sample rate in Hz (e.g., 44100, 192000)
+    pub sample_rate: Option<u32>,
+
+    /// Bit depth (e.g., 16, 24, 32)
+    pub bit_depth: Option<u8>,
+
+    /// Bitrate in kbps
+    pub bitrate: Option<u32>,
+
+    /// Genre
+    pub genre: Option<String>,
+
+    /// Composer
+    pub composer: Option<String>,
+
+    /// Track number
+    pub track_number: Option<u32>,
+
+    /// Disc number
+    pub disc_number: Option<u32>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_playback_state_from_str() {
+        assert_eq!(PlaybackState::from("playing"), PlaybackState::Playing);
+        assert_eq!(PlaybackState::from("PAUSED"), PlaybackState::Paused);
+        assert_eq!(PlaybackState::from("stop"), PlaybackState::Stopped);
+        assert_eq!(PlaybackState::from("unknown_state"), PlaybackState::Unknown);
+    }
+
+    #[test]
+    fn test_playback_state_display() {
+        assert_eq!(PlaybackState::Playing.to_string(), "playing");
+        assert_eq!(PlaybackState::Paused.to_string(), "paused");
+    }
+
+    #[test]
+    fn test_zone_serialization() {
+        let zone = Zone {
+            zone_id: "roon:123".to_string(),
+            zone_name: "Living Room".to_string(),
+            state: PlaybackState::Playing,
+            volume_control: Some(VolumeControl {
+                value: -20.0,
+                min: -64.0,
+                max: 0.0,
+                step: 1.0,
+                is_muted: false,
+                scale: VolumeScale::Decibel,
+                output_id: None,
+            }),
+            now_playing: None,
+            source: "roon".to_string(),
+            is_controllable: true,
+            is_seekable: true,
+            last_updated: 1234567890,
+            is_play_allowed: false,
+            is_pause_allowed: true,
+            is_next_allowed: true,
+            is_previous_allowed: true,
+        };
+
+        let json = serde_json::to_string(&zone).unwrap();
+        let deserialized: Zone = serde_json::from_str(&json).unwrap();
+        assert_eq!(zone, deserialized);
+    }
+
+    #[test]
+    fn test_volume_scale_serialization() {
+        assert_eq!(
+            serde_json::to_string(&VolumeScale::Decibel).unwrap(),
+            "\"decibel\""
+        );
+        assert_eq!(
+            serde_json::to_string(&VolumeScale::Linear).unwrap(),
+            "\"linear\""
+        );
+    }
+}

--- a/src/bus/events.rs
+++ b/src/bus/events.rs
@@ -3,9 +3,18 @@
 //! This module defines comprehensive event types that abstract across
 //! different audio sources (Roon, LMS, HQPlayer, etc.) into a unified
 //! zone-based model.
+//!
+//! Shared types are re-exported from muse-events crate for cross-wire
+//! compatibility with Memex and muse-ingest consumers.
 
 use serde::{Deserialize, Serialize};
 use std::fmt;
+
+// Re-export shared types from muse-events crate
+pub use muse_events::zone::{
+    NowPlaying, PlaybackState, TrackMetadata, VolumeControl, VolumeScale, Zone, ZoneState,
+};
+pub use muse_events::MuseEvent;
 
 // =============================================================================
 // PrefixedZoneId - Type-safe zone identifier with source prefix
@@ -99,190 +108,10 @@ impl From<PrefixedZoneId> for String {
 }
 
 // =============================================================================
-// Core Data Structures
+// Internal-only types (not part of wire protocol)
 // =============================================================================
 
-/// Unified zone representation across all adapters.
-///
-/// A zone represents a logical playback destination (Roon zone, LMS player,
-/// HQPlayer instance, etc.) with a consistent interface regardless of source.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct Zone {
-    /// Unique zone identifier (e.g., "roon:1234", "lms:00:11:22:33:44:55")
-    pub zone_id: String,
-
-    /// Human-readable zone name
-    pub zone_name: String,
-
-    /// Current playback state
-    pub state: PlaybackState,
-
-    /// Volume control information (if available)
-    pub volume_control: Option<VolumeControl>,
-
-    /// Currently playing track (if any)
-    pub now_playing: Option<NowPlaying>,
-
-    /// Source adapter identifier (e.g., "roon", "lms", "hqplayer")
-    pub source: String,
-
-    /// Whether playback controls are available
-    pub is_controllable: bool,
-
-    /// Whether the zone supports seeking
-    pub is_seekable: bool,
-
-    /// Last update timestamp (milliseconds since epoch)
-    pub last_updated: u64,
-
-    /// Whether play command is currently allowed
-    pub is_play_allowed: bool,
-
-    /// Whether pause command is currently allowed
-    pub is_pause_allowed: bool,
-
-    /// Whether next track command is allowed
-    pub is_next_allowed: bool,
-
-    /// Whether previous track command is allowed
-    pub is_previous_allowed: bool,
-}
-
-/// Playback state enumeration
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
-#[serde(rename_all = "lowercase")]
-pub enum PlaybackState {
-    Playing,
-    Paused,
-    Stopped,
-    Loading,
-    /// Buffering (used by streaming sources)
-    Buffering,
-    /// Unknown/unavailable state
-    #[default]
-    Unknown,
-}
-
-impl std::fmt::Display for PlaybackState {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Playing => write!(f, "playing"),
-            Self::Paused => write!(f, "paused"),
-            Self::Stopped => write!(f, "stopped"),
-            Self::Loading => write!(f, "loading"),
-            Self::Buffering => write!(f, "buffering"),
-            Self::Unknown => write!(f, "unknown"),
-        }
-    }
-}
-
-impl From<&str> for PlaybackState {
-    fn from(s: &str) -> Self {
-        match s.to_lowercase().as_str() {
-            "playing" | "play" => Self::Playing,
-            "paused" | "pause" => Self::Paused,
-            "stopped" | "stop" => Self::Stopped,
-            "loading" => Self::Loading,
-            "buffering" => Self::Buffering,
-            _ => Self::Unknown,
-        }
-    }
-}
-
-/// Volume control information for a zone or output.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct VolumeControl {
-    /// Current volume value (in the scale defined by min/max)
-    pub value: f32,
-
-    /// Minimum volume value (e.g., -64 for dB, 0 for percentage)
-    pub min: f32,
-
-    /// Maximum volume value (e.g., 0 for dB, 100 for percentage)
-    pub max: f32,
-
-    /// Volume step size (for relative adjustments)
-    pub step: f32,
-
-    /// Whether volume is currently muted
-    pub is_muted: bool,
-
-    /// Volume scale type
-    pub scale: VolumeScale,
-
-    /// Output ID for this volume control (for multi-output zones)
-    pub output_id: Option<String>,
-}
-
-/// Volume scale type
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
-pub enum VolumeScale {
-    /// Decibels (typically -64 to 0)
-    Decibel,
-    /// Percentage (0 to 100)
-    Percentage,
-    /// Linear (0.0 to 1.0)
-    Linear,
-    /// Unknown/unspecified
-    #[default]
-    Unknown,
-}
-
-/// Now playing track information.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct NowPlaying {
-    /// Track title
-    pub title: String,
-
-    /// Artist name
-    pub artist: String,
-
-    /// Album name
-    pub album: String,
-
-    /// Image key or URL for album art
-    pub image_key: Option<String>,
-
-    /// Current seek position in seconds
-    pub seek_position: Option<f64>,
-
-    /// Total track duration in seconds
-    pub duration: Option<f64>,
-
-    /// Additional metadata (format, bitrate, etc.)
-    pub metadata: Option<TrackMetadata>,
-}
-
-/// Additional track metadata
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct TrackMetadata {
-    /// Audio format (e.g., "FLAC", "DSD", "MQA")
-    pub format: Option<String>,
-
-    /// Sample rate in Hz (e.g., 44100, 192000)
-    pub sample_rate: Option<u32>,
-
-    /// Bit depth (e.g., 16, 24, 32)
-    pub bit_depth: Option<u8>,
-
-    /// Bitrate in kbps
-    pub bitrate: Option<u32>,
-
-    /// Genre
-    pub genre: Option<String>,
-
-    /// Composer
-    pub composer: Option<String>,
-
-    /// Track number
-    pub track_number: Option<u32>,
-
-    /// Disc number
-    pub disc_number: Option<u32>,
-}
-
-/// Image data returned from adapters
+/// Image data returned from adapters (internal only, not serialized over wire)
 #[derive(Debug, Clone)]
 pub struct ImageData {
     /// MIME content type (e.g., "image/jpeg", "image/png")
@@ -292,7 +121,7 @@ pub struct ImageData {
     pub data: Vec<u8>,
 }
 
-/// Zone update payload for partial updates.
+/// Zone update payload for partial updates (internal only).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ZoneUpdate {
     /// Zone identifier
@@ -427,6 +256,9 @@ pub struct CommandResponse {
 /// - Adapter lifecycle: Adapter start/stop, cleanup
 /// - System: Shutdown, health checks
 /// - Legacy: Backward-compatible events for existing integrations
+///
+/// Note: For events that cross the wire (SSE, ingest), use `MuseEvent` from
+/// muse-events crate. `BusEvent::to_muse_event()` converts at the boundary.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload")]
 #[allow(clippy::large_enum_variant)] // Zone is intentionally large for full state
@@ -694,6 +526,140 @@ impl BusEvent {
                 | Self::LmsPlayerStateChanged { .. }
         )
     }
+
+    /// Convert to MuseEvent for SSE transmission.
+    ///
+    /// Returns None for internal-only events that shouldn't cross the wire
+    /// (commands, system events, adapter lifecycle details).
+    ///
+    /// Note: The aggregator parameter is reserved for future enrichment of
+    /// NowPlayingChanged events with duration/metadata from zone state.
+    /// Currently not used as it would require async lookup.
+    #[allow(unused_variables)]
+    pub fn to_muse_event(&self, aggregator: Option<&crate::aggregator::ZoneAggregator>) -> Option<MuseEvent> {
+        match self {
+            Self::ZoneDiscovered { zone } => Some(MuseEvent::ZoneDiscovered { zone: zone.clone() }),
+
+            Self::ZoneUpdated {
+                zone_id,
+                display_name,
+                state,
+            } => Some(MuseEvent::ZoneUpdated(ZoneState {
+                zone_id: zone_id.as_str().to_string(),
+                display_name: display_name.clone(),
+                state: PlaybackState::from(state.as_str()),
+            })),
+
+            Self::ZoneRemoved { zone_id } => Some(MuseEvent::ZoneRemoved {
+                zone_id: zone_id.as_str().to_string(),
+            }),
+
+            Self::NowPlayingChanged {
+                zone_id,
+                title,
+                artist,
+                album,
+                image_key,
+            } => Some(MuseEvent::NowPlayingChanged {
+                zone_id: zone_id.as_str().to_string(),
+                now_playing: title.as_ref().map(|t| NowPlaying {
+                    title: t.clone(),
+                    artist: artist.clone().unwrap_or_default(),
+                    album: album.clone().unwrap_or_default(),
+                    image_key: image_key.clone(),
+                    seek_position: None,
+                    // Duration enrichment would require async aggregator lookup
+                    // Left as None for now; could be enhanced in future
+                    duration: None,
+                    metadata: None,
+                }),
+            }),
+
+            Self::SeekPositionChanged { zone_id, position } => {
+                Some(MuseEvent::SeekPositionChanged {
+                    zone_id: zone_id.as_str().to_string(),
+                    position: *position,
+                })
+            }
+
+            Self::VolumeChanged {
+                output_id,
+                value,
+                is_muted,
+            } => Some(MuseEvent::VolumeChanged {
+                output_id: output_id.clone(),
+                volume: VolumeControl {
+                    value: *value,
+                    min: 0.0,   // Default, actual values would come from zone
+                    max: 100.0, // Default
+                    step: 1.0,  // Default
+                    is_muted: *is_muted,
+                    scale: VolumeScale::Unknown,
+                    output_id: Some(output_id.clone()),
+                },
+            }),
+
+            Self::AdapterConnected { adapter, details } => Some(MuseEvent::AdapterConnected {
+                adapter: adapter.clone(),
+                details: details.clone(),
+            }),
+
+            Self::AdapterDisconnected { adapter, reason } => Some(MuseEvent::AdapterDisconnected {
+                adapter: adapter.clone(),
+                reason: reason.clone(),
+            }),
+
+            Self::HqpPipelineChanged {
+                host,
+                filter,
+                shaper,
+                rate,
+            } => Some(MuseEvent::HqpPipelineChanged {
+                host: host.clone(),
+                filter: filter.clone(),
+                shaper: shaper.clone(),
+                rate: rate.clone(),
+            }),
+
+            // Internal events - don't cross the wire
+            Self::CommandReceived { .. }
+            | Self::CommandResult { .. }
+            | Self::AdapterStopping { .. }
+            | Self::AdapterStopped { .. }
+            | Self::ZonesFlushed { .. }
+            | Self::ShuttingDown { .. }
+            | Self::HealthCheck { .. }
+            | Self::ControlCommand { .. } => None,
+
+            // Legacy events - forward as adapter events
+            Self::RoonConnected { .. } => Some(MuseEvent::AdapterConnected {
+                adapter: "roon".to_string(),
+                details: None,
+            }),
+            Self::RoonDisconnected => Some(MuseEvent::AdapterDisconnected {
+                adapter: "roon".to_string(),
+                reason: None,
+            }),
+            Self::HqpConnected { host } => Some(MuseEvent::AdapterConnected {
+                adapter: "hqplayer".to_string(),
+                details: Some(host.clone()),
+            }),
+            Self::HqpDisconnected { host } => Some(MuseEvent::AdapterDisconnected {
+                adapter: "hqplayer".to_string(),
+                reason: Some(format!("Disconnected from {}", host)),
+            }),
+            Self::HqpStateChanged { .. } => None, // Internal state tracking
+            Self::LmsConnected { host } => Some(MuseEvent::AdapterConnected {
+                adapter: "lms".to_string(),
+                details: Some(host.clone()),
+            }),
+            Self::LmsDisconnected { host } => Some(MuseEvent::AdapterDisconnected {
+                adapter: "lms".to_string(),
+                reason: Some(format!("Disconnected from {}", host)),
+            }),
+            Self::LmsPlayerStateChanged { .. } => None, // Handled via ZoneUpdated
+        }
+    }
 }
 
 #[cfg(test)]
@@ -794,5 +760,53 @@ mod tests {
         // Invalid - no prefix
         assert!(PrefixedZoneId::parse("abc123").is_none());
         assert!(PrefixedZoneId::parse("unknown:abc").is_none());
+    }
+
+    #[test]
+    fn test_to_muse_event_zone_discovered() {
+        let zone = Zone {
+            zone_id: "roon:123".to_string(),
+            zone_name: "Test".to_string(),
+            state: PlaybackState::Stopped,
+            volume_control: None,
+            now_playing: None,
+            source: "roon".to_string(),
+            is_controllable: true,
+            is_seekable: true,
+            last_updated: 0,
+            is_play_allowed: true,
+            is_pause_allowed: false,
+            is_next_allowed: true,
+            is_previous_allowed: true,
+        };
+        let bus_event = BusEvent::ZoneDiscovered { zone: zone.clone() };
+        let muse_event = bus_event.to_muse_event(None);
+
+        assert!(muse_event.is_some());
+        match muse_event.unwrap() {
+            MuseEvent::ZoneDiscovered { zone: z } => assert_eq!(z, zone),
+            _ => panic!("Wrong event type"),
+        }
+    }
+
+    #[test]
+    fn test_to_muse_event_internal_events_none() {
+        let internal_events = vec![
+            BusEvent::CommandReceived {
+                zone_id: "test".to_string(),
+                command: Command::Play,
+                request_id: None,
+            },
+            BusEvent::ShuttingDown { reason: None },
+            BusEvent::HealthCheck { timestamp: 0 },
+        ];
+
+        for event in internal_events {
+            assert!(
+                event.to_muse_event(None).is_none(),
+                "Internal event {:?} should not convert to MuseEvent",
+                event.event_type()
+            );
+        }
     }
 }

--- a/src/bus/events.rs
+++ b/src/bus/events.rs
@@ -588,15 +588,8 @@ impl BusEvent {
                 is_muted,
             } => Some(MuseEvent::VolumeChanged {
                 output_id: output_id.clone(),
-                volume: VolumeControl {
-                    value: *value,
-                    min: 0.0,   // Default, actual values would come from zone
-                    max: 100.0, // Default
-                    step: 1.0,  // Default
-                    is_muted: *is_muted,
-                    scale: VolumeScale::Unknown,
-                    output_id: Some(output_id.clone()),
-                },
+                value: *value,
+                is_muted: *is_muted,
             }),
 
             Self::AdapterConnected { adapter, details } => Some(MuseEvent::AdapterConnected {

--- a/src/event_reporter.rs
+++ b/src/event_reporter.rs
@@ -12,8 +12,8 @@
 
 use crate::aggregator::ZoneAggregator;
 use crate::bus::{BusEvent, SharedBus, Zone};
+use muse_events::ingest::{IngestEvent, IngestRequest};
 use reqwest::Client;
-use serde::Serialize;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -52,19 +52,7 @@ pub struct EventReporter {
     shutdown: CancellationToken,
 }
 
-/// Event payload sent to the ingest proxy
-#[derive(Debug, Clone, Serialize)]
-pub struct IngestEvent {
-    pub event_type: String,
-    pub timestamp: u64,
-    pub payload: serde_json::Value,
-}
-
-/// Request body for the ingest endpoint
-#[derive(Debug, Serialize)]
-struct IngestRequest {
-    events: Vec<IngestEvent>,
-}
+// IngestEvent and IngestRequest are now imported from muse_events::ingest
 
 impl EventReporter {
     /// Create a new EventReporter


### PR DESCRIPTION
Closes #243

## Summary
- Converts UHC to a Cargo workspace with muse-events as a workspace member
- Creates `muse-events` crate containing shared wire protocol types that cross boundaries between UHC, Memex, and muse-ingest
- SSE endpoint now serializes `MuseEvent` (subset of BusEvent) for cleaner wire protocol
- EventReporter uses `IngestEvent`/`IngestRequest` from muse-events

## Changes
- **muse-events crate**: Zone, NowPlaying, PlaybackState, VolumeControl, TrackMetadata, ZoneState types
- **muse-events crate**: MuseEvent enum for SSE wire protocol
- **muse-events crate**: IngestEvent/IngestRequest for muse-ingest proxy
- **src/bus/events.rs**: Re-exports shared types from muse-events, adds `BusEvent::to_muse_event()` conversion
- **src/api/mod.rs**: SSE handler converts BusEvent to MuseEvent before serialization
- **src/event_reporter.rs**: Uses muse_events::ingest types instead of local definitions

## Test plan
- [ ] `cargo check` passes
- [ ] `cargo test` passes
- [ ] SSE events serialize as `MuseEvent` format
- [ ] EventReporter uses correct ingest types

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added event protocol types for server-sent events, including zones, playback status, adapters, and HQPlayer events.
  * Introduced event ingestion protocol supporting batch event handling.

* **Improvements**
  * Enhanced event filtering in SSE streams to better control data delivery.

* **Refactoring**
  * Consolidated event-related types into a centralized library for consistency across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->