### PR TITLE
fix(docker): update Dockerfile for Tailwind v4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 
 # Copy actual source
 COPY src/ ./src/
-COPY input.css tailwind.config.js ./
+COPY public/ ./public/
 
 # Build Tailwind CSS (downloads standalone CLI if needed)
 RUN make css


### PR DESCRIPTION
## Summary
- Remove stale `COPY input.css tailwind.config.js ./` — Tailwind v4 uses `src/input.css` (already copied via `COPY src/`) with CSS-based config, no JS config file
- Add `COPY public/ ./public/` for static assets

Docker build has been broken since the Tailwind v4 migration (#127/theme PRs) which moved `input.css` to `src/input.css` and dropped `tailwind.config.js`.

## Test plan
- [ ] `docker compose up --build` succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration to copy the entire public/ directory instead of individual files during the build stage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->