### PR TITLE
fix: reset seek/duration on track change

### DIFF
--- a/src/aggregator.rs
+++ b/src/aggregator.rs
@@ -65,20 +65,16 @@ impl ZoneAggregator {
                 } => {
                     debug!("Now playing changed: {}", zone_id);
                     if let Some(zone) = self.zones.write().await.get_mut(zone_id.as_str()) {
-                        // Preserve seek_position and duration from existing now_playing
-                        let (seek_position, duration) = zone
-                            .now_playing
-                            .as_ref()
-                            .map(|np| (np.seek_position, np.duration))
-                            .unwrap_or((None, None));
-
+                        // Reset seek/duration — stale values from the previous track
+                        // cause progress bars to show wrong position. SeekPositionChanged
+                        // will fill in correct values on the next adapter poll.
                         zone.now_playing = Some(NowPlaying {
                             title: title.unwrap_or_default(),
                             artist: artist.unwrap_or_default(),
                             album: album.unwrap_or_default(),
                             image_key,
-                            seek_position,
-                            duration,
+                            seek_position: None,
+                            duration: None,
                             metadata: None,
                         });
                     }


### PR DESCRIPTION
## Problem

Aggregator's `NowPlayingChanged` handler preserved `seek_position` and `duration` from the previous track into the new `NowPlaying` entry. This caused the knob progress bar to show the old track's position/length until the next `SeekPositionChanged` event arrived (~2s for LMS poll).

## Fix

Set `seek_position` and `duration` to `None` on track change instead of carrying over stale values. `SeekPositionChanged` fills in correct values on next adapter poll.

## Impact

- Progress bar briefly hidden on track change until seek data arrives (correct behavior)
- No more stuck/wrong progress position after track skip
- Affects all adapters (LMS, Roon, OpenHome, UPnP)