### PR TITLE
feat: Flashable Pi image with WiFi captive portal provisioning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -543,7 +543,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cargo/bin/cargo-zigbuild
-          key: cargo-zigbuild-0.20
+          key: cargo-zigbuild-0.20.2
 
       - name: Install cargo-zigbuild
         if: steps.cache-zigbuild.outputs.cache-hit != 'true'
@@ -768,7 +768,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cargo/bin/cargo-zigbuild
-          key: cargo-zigbuild-0.20
+          key: cargo-zigbuild-0.20.2
 
       - name: Install cargo-zigbuild
         if: steps.cache-zigbuild.outputs.cache-hit != 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ dist/
 public/tailwind.css
 # Note: public/dx-components-theme.css is hand-authored, NOT generated
 .worktrees/
+
+# Pi image build artifacts
+image/pi-gen/
+image/deploy/

--- a/image/README.md
+++ b/image/README.md
@@ -1,0 +1,163 @@
+# UHC Raspberry Pi Image
+
+Flashable SD card image that turns any Raspberry Pi into a UHC bridge appliance.
+No SSH, no Docker, no Linux knowledge required.
+
+## Supported Hardware
+
+| Model | Architecture | Status |
+|-------|-------------|--------|
+| Pi Zero 2 W | armv7 | Primary target |
+| Pi 2 Model B | armv7 | Supported |
+| Pi 3 Model B/B+ | arm64 | Supported |
+| Pi 4 Model B | arm64 | Supported |
+| Pi 5 | arm64 | Supported |
+
+## Quick Start
+
+### 1. Build the image
+
+```bash
+# arm64 (Pi 3/4/5) - default
+./image/build.sh
+
+# armv7 (Pi Zero 2 W, Pi 2/3)
+./image/build.sh --arch armv7
+
+# Use a pre-built binary from CI
+./image/build.sh --arch arm64 --binary ./path/to/unified-hifi-control
+```
+
+### 2. Flash the SD card
+
+Use [Raspberry Pi Imager](https://www.raspberrypi.com/software/) (recommended):
+1. Open Pi Imager
+2. Choose OS -> "Use custom" -> select `image/deploy/uhc-pi-arm64.img.gz`
+3. Choose storage -> select your SD card
+4. Write
+
+Or use `dd`:
+```bash
+gunzip -c image/deploy/uhc-pi-arm64.img.gz | sudo dd of=/dev/sdX bs=4M status=progress
+sync
+```
+
+### 3. Boot and connect
+
+Insert SD card, power on the Pi. Three scenarios:
+
+**Ethernet connected:** UHC starts automatically.
+Browse to http://uhc.local:8088 within 60 seconds.
+
+**WiFi pre-configured (Pi Imager):** If you set WiFi credentials in Pi Imager's
+settings before flashing, the Pi connects automatically. Browse to http://uhc.local:8088.
+
+**No network configured:** The Pi creates a WiFi hotspot named **UHC-Setup**.
+1. Connect your phone/laptop to "UHC-Setup"
+2. A captive portal opens automatically
+3. Select your WiFi network and enter the password
+4. The Pi connects to your WiFi and starts UHC
+5. Browse to http://uhc.local:8088
+
+## Build Prerequisites
+
+- Docker (pi-gen runs in containers)
+- One of:
+  - `cross` (`cargo install cross`) for automatic cross-compilation
+  - A pre-built UHC binary for the target architecture
+
+## What's in the Image
+
+- **Base:** Raspberry Pi OS Lite (Bookworm) - minimal, headless
+- **UHC binary:** `/usr/bin/unified-hifi-control`
+- **Services:**
+  - `unified-hifi-control.service` - main UHC bridge (auto-starts, auto-restarts)
+  - `wifi-connect.service` - captive portal (runs only when no network configured)
+  - `avahi-daemon.service` - mDNS (advertises `uhc.local` and `_uhc._tcp`)
+- **Network:** NetworkManager (replaces dhcpcd for wifi-connect compatibility)
+- **SSH:** Enabled (user: `uhc`, password: `uhc`)
+- **SD card protection:**
+  - `/var/log`, `/var/tmp`, `/tmp` on tmpfs (RAM)
+  - Journal to RAM only (30MB cap)
+  - noatime on root filesystem
+  - Swap disabled
+  - Reduced dirty writeback frequency
+
+## Default Credentials
+
+| | |
+|---|---|
+| **Hostname** | uhc |
+| **SSH user** | uhc |
+| **SSH password** | uhc |
+| **Web UI** | http://uhc.local:8088 |
+| **WiFi AP** | UHC-Setup (when no network configured) |
+
+> **Change the SSH password** after first login: `passwd`
+
+## Architecture
+
+```
+Power on
+  -> Ethernet? -> UHC starts -> uhc.local:8088 ready
+  -> WiFi pre-configured? -> Connect -> UHC starts -> uhc.local:8088 ready
+  -> No network? -> "UHC-Setup" AP
+      -> Phone connects -> Captive portal
+      -> User picks WiFi -> Pi connects
+      -> UHC starts -> uhc.local:8088 ready
+```
+
+## Troubleshooting
+
+### Can't find uhc.local
+
+mDNS (`.local` addresses) can be flaky on some routers that block multicast.
+Find the Pi's IP address instead:
+- Check your router's DHCP lease table
+- Or from another machine: `avahi-browse -art | grep uhc`
+- Ethernet is always more reliable than WiFi for mDNS
+
+### UHC not starting
+
+SSH in and check:
+```bash
+ssh uhc@uhc.local
+systemctl status unified-hifi-control
+journalctl -u unified-hifi-control -f
+```
+
+### WiFi portal not appearing
+
+The captive portal only starts when no network is configured.
+If the Pi previously connected to WiFi, it remembers the credentials.
+
+To reset WiFi and trigger the portal again:
+```bash
+ssh uhc@uhc.local
+sudo nmcli con delete <connection-name>
+sudo rm -f /var/lib/uhc-wifi-configured
+sudo systemctl restart wifi-connect
+```
+
+## Development
+
+### Clean rebuild
+```bash
+./image/build.sh --clean
+```
+
+### Image structure (pi-gen stages)
+
+| Stage | Contents |
+|-------|----------|
+| stage0-2 | Standard Pi OS Lite (Bookworm) |
+| stage-uhc/00-install-deps | NetworkManager, Avahi, wifi-connect |
+| stage-uhc/01-uhc-binary | UHC binary to /usr/bin |
+| stage-uhc/02-services | systemd services, Avahi mDNS config |
+| stage-uhc/03-hardening | SD card wear mitigation, tmpfs, sysctl |
+
+### Customizing wifi-connect portal
+
+wifi-connect supports a custom React frontend. To brand the captive portal,
+add UI files to `stage-uhc/00-install-deps/files/ui/` and modify `00-run.sh`
+to copy them to `/usr/local/share/wifi-connect/ui/`.

--- a/image/README.md
+++ b/image/README.md
@@ -97,7 +97,7 @@ settings before flashing, the Pi connects automatically. Browse to http://uhc.lo
 
 ## Architecture
 
-```
+```text
 Power on
   -> Ethernet? -> UHC starts -> uhc.local:8088 ready
   -> WiFi pre-configured? -> Connect -> UHC starts -> uhc.local:8088 ready

--- a/image/build.sh
+++ b/image/build.sh
@@ -215,9 +215,11 @@ mkdir -p "$DEPLOY_DIR"
 PIGEN_DEPLOY="$PIGEN_DIR/deploy"
 if [[ -d "$PIGEN_DEPLOY" ]]; then
     # Find the most recent image
-    BUILT_IMAGE=$(find "$PIGEN_DEPLOY" -name "*.img.gz" -o -name "*.img.xz" | sort | tail -1)
+    BUILT_IMAGE=$(find "$PIGEN_DEPLOY" \( -name "*.img.gz" -o -name "*.img.xz" \) | sort | tail -1)
     if [[ -n "$BUILT_IMAGE" ]]; then
-        FINAL_NAME="uhc-pi-${ARCH}.img.gz"
+        # Preserve original compression extension
+        IMG_EXT="${BUILT_IMAGE##*.img.}"
+        FINAL_NAME="uhc-pi-${ARCH}.img.${IMG_EXT}"
         cp "$BUILT_IMAGE" "$DEPLOY_DIR/$FINAL_NAME"
         echo ""
         echo "==> Build complete!"

--- a/image/build.sh
+++ b/image/build.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+#
+# Build a flashable Raspberry Pi image with UHC pre-installed.
+#
+# Usage:
+#   ./image/build.sh [--arch arm64|armv7] [--binary PATH]
+#
+# Prerequisites:
+#   - Docker (pi-gen runs inside containers)
+#   - A pre-built UHC binary for the target architecture
+#     (or it will be built via cross if available)
+#
+# Output:
+#   image/deploy/*.img.gz
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PIGEN_DIR="$SCRIPT_DIR/pi-gen"
+DEPLOY_DIR="$SCRIPT_DIR/deploy"
+
+# Defaults
+ARCH="arm64"
+UHC_BINARY=""
+PIGEN_REPO="https://github.com/RPi-Distro/pi-gen.git"
+PIGEN_BRANCH="bookworm"
+IMAGE_NAME="uhc-pi"
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Build a flashable Raspberry Pi image with UHC pre-installed.
+
+Options:
+  --arch ARCH       Target architecture: arm64 (default) or armv7
+  --binary PATH     Path to pre-built UHC binary (skip cross-compilation)
+  --clean           Remove pi-gen work directories before building
+  -h, --help        Show this help
+
+Examples:
+  # Build arm64 image (Pi 3/4/5)
+  ./image/build.sh --arch arm64
+
+  # Build armv7 image (Pi Zero 2 W, Pi 2/3)
+  ./image/build.sh --arch armv7
+
+  # Use a pre-built binary
+  ./image/build.sh --arch arm64 --binary ./target/aarch64-unknown-linux-musl/release/unified-hifi-control
+EOF
+    exit 0
+}
+
+CLEAN=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --arch)
+            ARCH="$2"
+            shift 2
+            ;;
+        --binary)
+            UHC_BINARY="$2"
+            shift 2
+            ;;
+        --clean)
+            CLEAN=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage
+            ;;
+    esac
+done
+
+# Validate architecture
+case "$ARCH" in
+    arm64|aarch64)
+        ARCH="arm64"
+        CROSS_TARGET="aarch64-unknown-linux-musl"
+        PIGEN_ARCH="arm64"
+        ;;
+    armv7|armhf)
+        ARCH="armv7"
+        CROSS_TARGET="armv7-unknown-linux-musleabihf"
+        PIGEN_ARCH="armhf"
+        ;;
+    *)
+        echo "Error: unsupported architecture '$ARCH'. Use arm64 or armv7." >&2
+        exit 1
+        ;;
+esac
+
+echo "==> Building UHC Pi image"
+echo "    Architecture: $ARCH ($PIGEN_ARCH)"
+echo "    Cross target: $CROSS_TARGET"
+
+# --- Step 1: Obtain UHC binary ---
+
+if [[ -n "$UHC_BINARY" ]]; then
+    if [[ ! -f "$UHC_BINARY" ]]; then
+        echo "Error: binary not found at $UHC_BINARY" >&2
+        exit 1
+    fi
+    echo "==> Using pre-built binary: $UHC_BINARY"
+else
+    BINARY_PATH="$REPO_ROOT/target/$CROSS_TARGET/release/unified-hifi-control"
+    if [[ -f "$BINARY_PATH" ]]; then
+        echo "==> Found existing binary: $BINARY_PATH"
+        UHC_BINARY="$BINARY_PATH"
+    else
+        echo "==> Building UHC binary for $CROSS_TARGET via cross..."
+        if ! command -v cross &>/dev/null; then
+            echo "Error: 'cross' not found. Install with: cargo install cross" >&2
+            echo "Or provide a pre-built binary with --binary PATH" >&2
+            exit 1
+        fi
+        (cd "$REPO_ROOT" && cross build --release --target "$CROSS_TARGET" --no-default-features --features server)
+        UHC_BINARY="$BINARY_PATH"
+    fi
+fi
+
+# Verify the binary is the correct architecture
+if command -v readelf &>/dev/null; then
+    ELF_MACHINE=$(readelf -h "$UHC_BINARY" 2>/dev/null | grep 'Machine:' || true)
+    case "$ARCH" in
+        arm64)
+            if ! echo "$ELF_MACHINE" | grep -qi "AArch64"; then
+                echo "Error: binary is not arm64: $ELF_MACHINE" >&2
+                exit 1
+            fi
+            ;;
+        armv7)
+            if ! echo "$ELF_MACHINE" | grep -qi "ARM"; then
+                echo "Error: binary is not armv7: $ELF_MACHINE" >&2
+                exit 1
+            fi
+            ;;
+    esac
+else
+    echo "WARNING: readelf not available, skipping architecture validation" >&2
+fi
+
+echo "    Binary size: $(du -h "$UHC_BINARY" | cut -f1)"
+
+# --- Step 2: Clone/update pi-gen ---
+
+if [[ ! -d "$PIGEN_DIR" ]]; then
+    echo "==> Cloning pi-gen ($PIGEN_BRANCH)..."
+    git clone --depth 1 --branch "$PIGEN_BRANCH" "$PIGEN_REPO" "$PIGEN_DIR"
+else
+    echo "==> pi-gen already present"
+fi
+
+if [[ "$CLEAN" == "true" ]]; then
+    echo "==> Cleaning pi-gen work directories..."
+    (cd "$PIGEN_DIR" && sudo rm -rf work deploy)
+fi
+
+# --- Step 3: Configure pi-gen ---
+
+# Copy UHC binary to a location accessible during build
+STAGE_DIR="$PIGEN_DIR/stage-uhc"
+rm -rf "$STAGE_DIR"
+cp -r "$SCRIPT_DIR/stage-uhc" "$STAGE_DIR"
+
+# Place binary where the stage can find it
+mkdir -p "$STAGE_DIR/01-uhc-binary/files"
+cp "$UHC_BINARY" "$STAGE_DIR/01-uhc-binary/files/unified-hifi-control"
+chmod 755 "$STAGE_DIR/01-uhc-binary/files/unified-hifi-control"
+
+# Write pi-gen config
+cat > "$PIGEN_DIR/config" <<EOF
+IMG_NAME="$IMAGE_NAME"
+RELEASE="bookworm"
+TARGET_HOSTNAME="uhc"
+FIRST_USER_NAME="uhc"
+FIRST_USER_PASSWORD="uhc"
+ENABLE_SSH="1"
+LOCALE_DEFAULT="en_US.UTF-8"
+KEYBOARD_KEYMAP="us"
+KEYBOARD_LAYOUT="English (US)"
+TIMEZONE_DEFAULT="UTC"
+STAGE_LIST="stage0 stage1 stage2 stage-uhc"
+EOF
+
+# Skip stages 3-5 (desktop, full desktop, testing)
+touch "$PIGEN_DIR/stage3/SKIP" "$PIGEN_DIR/stage4/SKIP" "$PIGEN_DIR/stage5/SKIP"
+touch "$PIGEN_DIR/stage3/SKIP_IMAGES" "$PIGEN_DIR/stage4/SKIP_IMAGES" "$PIGEN_DIR/stage5/SKIP_IMAGES"
+
+# Only generate image at stage-uhc (our final stage)
+touch "$PIGEN_DIR/stage2/SKIP_IMAGES"
+touch "$PIGEN_DIR/stage-uhc/EXPORT_IMAGE"
+
+echo "==> pi-gen configured"
+echo "    Image name: $IMAGE_NAME"
+echo "    Hostname: uhc"
+echo "    Architecture: $PIGEN_ARCH"
+
+# --- Step 4: Build image ---
+
+echo "==> Building image (this may take 15-30 minutes)..."
+(cd "$PIGEN_DIR" && sudo ./build-docker.sh)
+
+# --- Step 5: Collect output ---
+
+mkdir -p "$DEPLOY_DIR"
+
+# pi-gen outputs to deploy/ inside its directory
+PIGEN_DEPLOY="$PIGEN_DIR/deploy"
+if [[ -d "$PIGEN_DEPLOY" ]]; then
+    # Find the most recent image
+    BUILT_IMAGE=$(find "$PIGEN_DEPLOY" -name "*.img.gz" -o -name "*.img.xz" | sort | tail -1)
+    if [[ -n "$BUILT_IMAGE" ]]; then
+        FINAL_NAME="uhc-pi-${ARCH}.img.gz"
+        cp "$BUILT_IMAGE" "$DEPLOY_DIR/$FINAL_NAME"
+        echo ""
+        echo "==> Build complete!"
+        echo "    Image: $DEPLOY_DIR/$FINAL_NAME"
+        echo "    Size:  $(du -h "$DEPLOY_DIR/$FINAL_NAME" | cut -f1)"
+        echo ""
+        echo "Flash with:"
+        echo "    # macOS/Linux"
+        echo "    gunzip -c $DEPLOY_DIR/$FINAL_NAME | sudo dd of=/dev/sdX bs=4M status=progress"
+        echo ""
+        echo "    # Or use Raspberry Pi Imager -> 'Use custom'"
+    else
+        echo "Error: no image file found in $PIGEN_DEPLOY" >&2
+        ls -la "$PIGEN_DEPLOY" >&2
+        exit 1
+    fi
+else
+    echo "Error: pi-gen deploy directory not found" >&2
+    exit 1
+fi

--- a/image/stage-uhc/00-install-deps/00-packages
+++ b/image/stage-uhc/00-install-deps/00-packages
@@ -1,0 +1,4 @@
+avahi-daemon
+avahi-utils
+network-manager
+dnsmasq

--- a/image/stage-uhc/00-install-deps/00-run.sh
+++ b/image/stage-uhc/00-install-deps/00-run.sh
@@ -5,11 +5,7 @@
 #
 
 # Determine architecture inside the chroot
-DPKG_ARCH=$(on_chroot printenv DPKG_ARCH 2>/dev/null || echo "")
-if [ -z "$DPKG_ARCH" ]; then
-    # Detect from the rootfs
-    DPKG_ARCH=$(chroot "${ROOTFS_DIR}" dpkg --print-architecture)
-fi
+DPKG_ARCH=$(chroot "${ROOTFS_DIR}" dpkg --print-architecture)
 
 WIFI_CONNECT_VERSION="4.4.6"
 case "$DPKG_ARCH" in

--- a/image/stage-uhc/00-install-deps/00-run.sh
+++ b/image/stage-uhc/00-install-deps/00-run.sh
@@ -1,0 +1,48 @@
+#!/bin/bash -e
+#
+# Install wifi-connect for captive portal WiFi provisioning.
+# https://github.com/balena-os/wifi-connect
+#
+
+# Determine architecture inside the chroot
+DPKG_ARCH=$(on_chroot printenv DPKG_ARCH 2>/dev/null || echo "")
+if [ -z "$DPKG_ARCH" ]; then
+    # Detect from the rootfs
+    DPKG_ARCH=$(chroot "${ROOTFS_DIR}" dpkg --print-architecture)
+fi
+
+WIFI_CONNECT_VERSION="4.4.6"
+case "$DPKG_ARCH" in
+    arm64|aarch64)
+        WIFI_CONNECT_ARCH="aarch64"
+        ;;
+    armhf|armv7l)
+        WIFI_CONNECT_ARCH="rpi"
+        ;;
+    *)
+        echo "WARNING: wifi-connect does not support $DPKG_ARCH, skipping" >&2
+        exit 0
+        ;;
+esac
+
+WIFI_CONNECT_URL="https://github.com/balena-os/wifi-connect/releases/download/v${WIFI_CONNECT_VERSION}/wifi-connect-v${WIFI_CONNECT_VERSION}-linux-${WIFI_CONNECT_ARCH}.tar.gz"
+
+echo "==> Installing wifi-connect ${WIFI_CONNECT_VERSION} (${WIFI_CONNECT_ARCH})"
+
+# Download and extract wifi-connect
+mkdir -p "${ROOTFS_DIR}/usr/local/share/wifi-connect"
+wget -q -O /tmp/wifi-connect.tar.gz "$WIFI_CONNECT_URL"
+tar xzf /tmp/wifi-connect.tar.gz -C "${ROOTFS_DIR}/usr/local/share/wifi-connect"
+rm /tmp/wifi-connect.tar.gz
+
+# Create symlink for the binary
+ln -sf /usr/local/share/wifi-connect/wifi-connect "${ROOTFS_DIR}/usr/local/bin/wifi-connect"
+
+# Disable dhcpcd (NetworkManager replaces it)
+on_chroot <<CHROOT
+systemctl disable dhcpcd.service 2>/dev/null || true
+systemctl mask dhcpcd.service 2>/dev/null || true
+systemctl enable NetworkManager.service
+CHROOT
+
+echo "==> wifi-connect installed"

--- a/image/stage-uhc/01-uhc-binary/00-run.sh
+++ b/image/stage-uhc/01-uhc-binary/00-run.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+#
+# Install the UHC binary into the image.
+#
+
+echo "==> Installing UHC binary"
+
+# Copy binary (placed here by build.sh)
+install -m 755 "${STAGE_DIR}/01-uhc-binary/files/unified-hifi-control" \
+    "${ROOTFS_DIR}/usr/bin/unified-hifi-control"
+
+# Create data and config directories
+install -d -m 755 "${ROOTFS_DIR}/var/lib/unified-hifi-control"
+install -d -m 755 "${ROOTFS_DIR}/etc/unified-hifi-control"
+
+echo "==> UHC binary installed to /usr/bin/unified-hifi-control"
+echo "    $(ls -lh "${ROOTFS_DIR}/usr/bin/unified-hifi-control" | awk '{print $5}')"

--- a/image/stage-uhc/02-services/00-run.sh
+++ b/image/stage-uhc/02-services/00-run.sh
@@ -1,0 +1,50 @@
+#!/bin/bash -e
+#
+# Install and enable systemd services, Avahi mDNS, and wifi-connect.
+#
+
+echo "==> Installing UHC services"
+
+# Install systemd services
+install -m 644 "${STAGE_DIR}/02-services/files/unified-hifi-control.service" \
+    "${ROOTFS_DIR}/etc/systemd/system/unified-hifi-control.service"
+
+install -m 644 "${STAGE_DIR}/02-services/files/wifi-connect.service" \
+    "${ROOTFS_DIR}/etc/systemd/system/wifi-connect.service"
+
+# Install WiFi check script
+install -m 755 "${STAGE_DIR}/02-services/files/wifi-connect-check.sh" \
+    "${ROOTFS_DIR}/usr/local/bin/wifi-connect-check"
+
+# Install Avahi service file for mDNS discovery
+install -d -m 755 "${ROOTFS_DIR}/etc/avahi/services"
+install -m 644 "${STAGE_DIR}/02-services/files/uhc.service" \
+    "${ROOTFS_DIR}/etc/avahi/services/uhc.service"
+
+# Configure Avahi to advertise uhc.local
+if [ -f "${ROOTFS_DIR}/etc/avahi/avahi-daemon.conf" ]; then
+    # Enable hostname publishing
+    sed -i 's/^#*host-name=.*/host-name=uhc/' \
+        "${ROOTFS_DIR}/etc/avahi/avahi-daemon.conf"
+    sed -i 's/^#*publish-hinfo=.*/publish-hinfo=yes/' \
+        "${ROOTFS_DIR}/etc/avahi/avahi-daemon.conf"
+    sed -i 's/^#*publish-workstation=.*/publish-workstation=no/' \
+        "${ROOTFS_DIR}/etc/avahi/avahi-daemon.conf"
+fi
+
+# Enable services
+on_chroot <<CHROOT
+systemctl enable unified-hifi-control.service
+systemctl enable wifi-connect.service
+systemctl enable avahi-daemon.service
+CHROOT
+
+# Force password change on first SSH login
+on_chroot <<CHROOT
+chage -d 0 uhc
+CHROOT
+
+echo "==> Services installed and enabled"
+echo "    - unified-hifi-control.service (UHC bridge)"
+echo "    - wifi-connect.service (captive portal)"
+echo "    - avahi-daemon.service (mDNS/uhc.local)"

--- a/image/stage-uhc/02-services/00-run.sh
+++ b/image/stage-uhc/02-services/00-run.sh
@@ -24,11 +24,11 @@ install -m 644 "${STAGE_DIR}/02-services/files/uhc.service" \
 # Configure Avahi to advertise uhc.local
 if [ -f "${ROOTFS_DIR}/etc/avahi/avahi-daemon.conf" ]; then
     # Enable hostname publishing
-    sed -i 's/^#*host-name=.*/host-name=uhc/' \
+    sed -i 's/^[[:space:]]*#*[[:space:]]*host-name=.*/host-name=uhc/' \
         "${ROOTFS_DIR}/etc/avahi/avahi-daemon.conf"
-    sed -i 's/^#*publish-hinfo=.*/publish-hinfo=yes/' \
+    sed -i 's/^[[:space:]]*#*[[:space:]]*publish-hinfo=.*/publish-hinfo=yes/' \
         "${ROOTFS_DIR}/etc/avahi/avahi-daemon.conf"
-    sed -i 's/^#*publish-workstation=.*/publish-workstation=no/' \
+    sed -i 's/^[[:space:]]*#*[[:space:]]*publish-workstation=.*/publish-workstation=no/' \
         "${ROOTFS_DIR}/etc/avahi/avahi-daemon.conf"
 fi
 

--- a/image/stage-uhc/02-services/files/uhc.service
+++ b/image/stage-uhc/02-services/files/uhc.service
@@ -1,0 +1,22 @@
+<?xml version="1.0" standalone='no'?>
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+<!--
+  Avahi/mDNS service advertisement for UHC.
+  Advertises uhc.local and the _uhc._tcp service for discovery.
+-->
+<service-group>
+  <name replace-wildcards="yes">UHC on %h</name>
+
+  <service>
+    <type>_uhc._tcp</type>
+    <port>8088</port>
+    <txt-record>version=1</txt-record>
+    <txt-record>path=/api</txt-record>
+  </service>
+
+  <service>
+    <type>_http._tcp</type>
+    <port>8088</port>
+    <txt-record>path=/</txt-record>
+  </service>
+</service-group>

--- a/image/stage-uhc/02-services/files/unified-hifi-control.service
+++ b/image/stage-uhc/02-services/files/unified-hifi-control.service
@@ -1,0 +1,34 @@
+[Unit]
+Description=Unified Hi-Fi Control Bridge
+Documentation=https://github.com/open-horizon-labs/unified-hifi-control
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/var/lib/unified-hifi-control
+ExecStart=/usr/bin/unified-hifi-control
+Restart=always
+RestartSec=5
+
+# Environment
+Environment=PORT=8088
+Environment=CONFIG_DIR=/etc/unified-hifi-control
+Environment=DATA_DIR=/var/lib/unified-hifi-control
+Environment=RUST_LOG=info
+
+# Network capability for mDNS (binding to privileged ports if needed)
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+
+# Security hardening (relaxed vs standard linux service for Pi appliance use)
+NoNewPrivileges=true
+ProtectHome=true
+PrivateTmp=true
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=unified-hifi-control
+
+[Install]
+WantedBy=multi-user.target

--- a/image/stage-uhc/02-services/files/wifi-connect-check.sh
+++ b/image/stage-uhc/02-services/files/wifi-connect-check.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# Check if WiFi is connected. Used by wifi-connect.service to decide
+# whether captive portal is needed.
+#
+# Exit 0 = no WiFi configured (start captive portal)
+# Exit 1 = WiFi is connected (skip captive portal)
+#
+
+# If ethernet is connected, don't start captive portal
+if nmcli -t -f TYPE,STATE dev | grep -q "ethernet:connected"; then
+    exit 1
+fi
+
+# If WiFi is connected, don't start captive portal
+if nmcli -t -f TYPE,STATE dev | grep -q "wifi:connected"; then
+    exit 1
+fi
+
+# If there are saved WiFi connections, try to connect first
+SAVED_WIFI=$(nmcli -t -f TYPE con show | grep -c "802-11-wireless" || true)
+if [ "$SAVED_WIFI" -gt 0 ]; then
+    # Poll for NetworkManager to auto-connect (up to 15s)
+    for _ in $(seq 1 15); do
+        if nmcli -t -f TYPE,STATE dev | grep -q "wifi:connected"; then
+            exit 1
+        fi
+        sleep 1
+    done
+fi
+
+# No network - start captive portal
+echo "No network connection detected, starting captive portal" >&2
+exit 0

--- a/image/stage-uhc/02-services/files/wifi-connect.service
+++ b/image/stage-uhc/02-services/files/wifi-connect.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=WiFi Connect - Captive Portal Provisioning
+Documentation=https://github.com/balena-os/wifi-connect
+After=NetworkManager.service
+Wants=NetworkManager.service
+
+[Service]
+Type=simple
+# Only start if no network is available (ethernet or WiFi)
+ExecStartPre=/usr/local/bin/wifi-connect-check
+ExecStart=/usr/local/bin/wifi-connect \
+    --portal-ssid UHC-Setup \
+    --portal-gateway 192.168.42.1 \
+    --portal-listening-port 80 \
+    --activity-timeout 300
+Restart=on-failure
+RestartSec=30
+# Don't restart forever if network is up
+StartLimitIntervalSec=300
+StartLimitBurst=3
+
+# Environment
+Environment=DBUS_SYSTEM_BUS_ADDRESS=unix:path=/var/run/dbus/system_bus_socket
+
+[Install]
+WantedBy=multi-user.target

--- a/image/stage-uhc/02-services/files/wifi-connect.service
+++ b/image/stage-uhc/02-services/files/wifi-connect.service
@@ -7,7 +7,7 @@ Wants=NetworkManager.service
 [Service]
 Type=simple
 # Only start if no network is available (ethernet or WiFi)
-ExecStartPre=/usr/local/bin/wifi-connect-check
+ExecCondition=/usr/local/bin/wifi-connect-check
 ExecStart=/usr/local/bin/wifi-connect \
     --portal-ssid UHC-Setup \
     --portal-gateway 192.168.42.1 \

--- a/image/stage-uhc/03-hardening/00-run.sh
+++ b/image/stage-uhc/03-hardening/00-run.sh
@@ -1,0 +1,79 @@
+#!/bin/bash -e
+#
+# SD card wear mitigation and system hardening for appliance use.
+#
+# Goals:
+# - Minimize writes to extend SD card lifespan
+# - Set up tmpfs for volatile data
+# - Configure journald for RAM-only logging
+# - Set noatime on filesystems
+#
+
+echo "==> Applying SD card wear mitigation"
+
+# --- noatime on root filesystem ---
+# Add noatime to existing root partition entry (before we append tmpfs lines)
+sed -i '/^[^#].*\/.*defaults/ s|defaults|defaults,noatime|' "${ROOTFS_DIR}/etc/fstab"
+
+# --- tmpfs for volatile directories ---
+
+cat >> "${ROOTFS_DIR}/etc/fstab" <<'FSTAB'
+# SD card wear mitigation - volatile data in RAM
+tmpfs /var/log     tmpfs defaults,noatime,nosuid,nodev,noexec,mode=0755,size=50M 0 0
+tmpfs /var/tmp     tmpfs defaults,noatime,nosuid,nodev,noexec,mode=1777,size=50M 0 0
+tmpfs /tmp         tmpfs defaults,noatime,nosuid,nodev,noexec,mode=1777,size=100M 0 0
+FSTAB
+
+# --- journald: log to RAM only, limit size ---
+
+install -d -m 755 "${ROOTFS_DIR}/etc/systemd/journald.conf.d"
+cat > "${ROOTFS_DIR}/etc/systemd/journald.conf.d/uhc-sdcard.conf" <<'JOURNALD'
+[Journal]
+# Store journal in RAM only (no persistent /var/log/journal)
+Storage=volatile
+# Limit RAM usage
+RuntimeMaxUse=30M
+RuntimeMaxFileSize=5M
+# Compress to reduce RAM usage
+Compress=yes
+# Drop old entries rather than blocking
+RateLimitIntervalSec=30s
+RateLimitBurst=1000
+JOURNALD
+
+# --- Disable swap (saves SD writes) ---
+
+on_chroot <<CHROOT
+# Disable dphys-swapfile if present
+systemctl disable dphys-swapfile.service 2>/dev/null || true
+systemctl mask dphys-swapfile.service 2>/dev/null || true
+
+# Remove swap file if it exists
+rm -f /var/swap
+CHROOT
+
+# --- Sysctl tweaks for reduced writes ---
+
+cat > "${ROOTFS_DIR}/etc/sysctl.d/99-uhc-sdcard.conf" <<'SYSCTL'
+# Reduce write frequency
+vm.dirty_writeback_centisecs = 6000
+vm.dirty_expire_centisecs = 6000
+
+# Reduce swappiness (prefer killing over swapping to SD)
+vm.swappiness = 1
+SYSCTL
+
+# --- Disable man-db auto-update (saves writes + CPU on upgrades) ---
+
+on_chroot <<CHROOT
+if [ -f /etc/cron.daily/man-db ] || [ -f /etc/cron.weekly/man-db ]; then
+    rm -f /etc/cron.daily/man-db /etc/cron.weekly/man-db
+fi
+CHROOT
+
+echo "==> SD card hardening complete"
+echo "    - tmpfs for /var/log, /var/tmp, /tmp"
+echo "    - noatime on root filesystem"
+echo "    - journald: volatile (RAM-only), 30MB max"
+echo "    - swap disabled"
+echo "    - reduced dirty writeback frequency"

--- a/image/stage-uhc/03-hardening/00-run.sh
+++ b/image/stage-uhc/03-hardening/00-run.sh
@@ -13,16 +13,20 @@ echo "==> Applying SD card wear mitigation"
 
 # --- noatime on root filesystem ---
 # Add noatime to existing root partition entry (before we append tmpfs lines)
-sed -i '/^[^#].*\/.*defaults/ s|defaults|defaults,noatime|' "${ROOTFS_DIR}/etc/fstab"
+if ! grep -qE '^[^#].*\s+/\s+.*\bnoatime\b' "${ROOTFS_DIR}/etc/fstab"; then
+    sed -i '/^[^#].*\/.*defaults/ s|defaults|defaults,noatime|' "${ROOTFS_DIR}/etc/fstab"
+fi
 
 # --- tmpfs for volatile directories ---
 
+if ! grep -q 'tmpfs /var/log' "${ROOTFS_DIR}/etc/fstab"; then
 cat >> "${ROOTFS_DIR}/etc/fstab" <<'FSTAB'
 # SD card wear mitigation - volatile data in RAM
 tmpfs /var/log     tmpfs defaults,noatime,nosuid,nodev,noexec,mode=0755,size=50M 0 0
 tmpfs /var/tmp     tmpfs defaults,noatime,nosuid,nodev,noexec,mode=1777,size=50M 0 0
 tmpfs /tmp         tmpfs defaults,noatime,nosuid,nodev,noexec,mode=1777,size=100M 0 0
 FSTAB
+fi
 
 # --- journald: log to RAM only, limit size ---
 

--- a/image/stage-uhc/prerun.sh
+++ b/image/stage-uhc/prerun.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+# pi-gen prerun script for stage-uhc
+# This runs before any sub-stages to validate prerequisites
+if [ ! -f "${STAGE_DIR}/01-uhc-binary/files/unified-hifi-control" ]; then
+    echo "ERROR: UHC binary not found. Run build.sh, not pi-gen directly." >&2
+    exit 1
+fi


### PR DESCRIPTION
Closes #256

## Summary

Adds a pi-gen based build system (`image/`) that produces flashable Raspberry Pi SD card images with UHC pre-installed as an appliance.

### Boot flow

1. **Ethernet connected** → UHC starts, `uhc.local:8088` reachable within 60s
2. **WiFi pre-configured** (Pi Imager) → connects, starts UHC
3. **No network** → creates "UHC-Setup" WiFi hotspot → captive portal opens on phone → user picks WiFi → UHC starts

### What is in the image

- **Base:** Pi OS Lite (Bookworm), headless, NetworkManager
- **UHC binary** at `/usr/bin/unified-hifi-control` (musl static)
- **Services:**
 - `unified-hifi-control.service` — auto-start, auto-restart on crash
 - `wifi-connect.service` — captive portal (only when no network configured)
 - `avahi-daemon.service` — mDNS (`uhc.local` + `_uhc._tcp` discovery)
- **SD card protection:** tmpfs for logs, volatile journal (30MB cap), noatime, swap disabled, reduced dirty writeback
- **Security:** SSH enabled, forced password change on first login

### Architecture variants

- `arm64` — Pi 3/4/5 (default)
- `armv7` — Pi Zero 2 W, Pi 2/3

### Usage

```bash
# Build arm64 image (requires Docker)
./image/build.sh

# Build armv7 image
./image/build.sh --arch armv7

# Use pre-built binary from CI
./image/build.sh --arch arm64 --binary ./path/to/binary
```

### Files added

| File | Purpose |
|------|---------|
| `image/build.sh` | Main build script (clones pi-gen, configures, builds) |
| `image/README.md` | Build/flash/troubleshooting docs |
| `image/stage-uhc/` | Custom pi-gen stage with 4 sub-stages |
| `image/stage-uhc/00-install-deps/` | APT packages + wifi-connect binary |
| `image/stage-uhc/01-uhc-binary/` | Install UHC to `/usr/bin` |
| `image/stage-uhc/02-services/` | systemd services, Avahi mDNS, wifi-connect config |
| `image/stage-uhc/03-hardening/` | SD card wear mitigation, tmpfs, sysctl |

### Trade-offs per issue

- Pi OS Lite, not Yocto/Buildroot (larger but standard/maintained)
- wifi-connect over comitup (Rust-based, customizable, NM-native)
- No OTA updates in v1 (reflash or SSH)
- No display support (headless bridge appliance)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Raspberry Pi image build system supporting arm64 and armv7 architectures
  * Integrated captive portal for WiFi configuration during initial device setup
  * Implemented mDNS service discovery for easy device discovery on local networks
  * Added automatic service restart and system hardening with SD card wear mitigation
  * Configured SSH access with secure defaults

* **Documentation**
  * Added comprehensive README with build, flashing, and configuration instructions

* **Chores**
  * Updated .gitignore for build artifacts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->