### PR TITLE
ci: GitHub Actions pipeline for Pi image builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1688,6 +1688,12 @@ jobs:
 
           ### LMS Plugin
           - `lms-unified-hifi-control-*.zip` - Install via LMS Settings > Plugins
+
+          ### Raspberry Pi Images
+          Flashable SD card images (uploaded separately by the Pi Image workflow):
+          - `unified-hifi-control-*-pi-arm64.img.gz` — Pi 3, Pi 4, Pi 5
+          - `unified-hifi-control-*-pi-armhf.img.gz` — Pi Zero 2 W, Pi 2, Pi 3
+          - `.sha256` checksum files included
           EOF
 
       - name: Upload to release

--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -1,0 +1,177 @@
+name: Pi Image
+
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g., v4.1.0)'
+        required: true
+        type: string
+
+concurrency:
+  group: pi-image-${{ github.event.workflow_run.head_branch || inputs.tag }}
+  cancel-in-progress: true
+
+jobs:
+  # =============================================================================
+  # Build flashable Raspberry Pi images using pi-gen
+  # =============================================================================
+  # Triggered automatically after a successful release Build, or manually.
+  # Downloads pre-built ARM binaries (from Build artifacts or release assets),
+  # runs pi-gen in Docker to produce .img.gz files, uploads to GitHub Release.
+
+  build-pi-image:
+    name: Build Pi Image (${{ matrix.arch }})
+    # workflow_run: only when Build succeeded on a release event
+    # workflow_dispatch: always
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'release')
+    runs-on: namespace-profile-default
+    timeout-minutes: 90
+    permissions:
+      contents: write
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arm64
+            binary_name: unified-hifi-linux-arm64
+            artifact_name: binary-aarch64-unknown-linux-musl
+            build_arch: arm64
+          - arch: armhf
+            binary_name: unified-hifi-linux-armv7
+            artifact_name: binary-armv7-unknown-linux-musleabihf
+            build_arch: armv7
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Determine release tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+            # Ensure tag starts with v
+            [[ "$TAG" != v* ]] && TAG="v$TAG"
+          else
+            TAG="${{ github.event.workflow_run.head_branch }}"
+          fi
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "version=${TAG#v}" >> $GITHUB_OUTPUT
+          echo "::notice::Building Pi ${{ matrix.arch }} image for $TAG"
+
+      - name: Download binary from Build workflow
+        if: github.event_name == 'workflow_run'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh run download ${{ github.event.workflow_run.id }} \
+            --name ${{ matrix.artifact_name }} \
+            --dir binary/
+
+      - name: Download binary from release
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download "${{ steps.tag.outputs.tag }}" \
+            --pattern "${{ matrix.binary_name }}" \
+            --dir binary/
+
+      - name: Verify binary
+        run: |
+          ls -la binary/
+          chmod +x binary/${{ matrix.binary_name }}
+          file binary/${{ matrix.binary_name }}
+
+      - name: Set up QEMU user-mode emulation
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64,arm
+
+      - name: Build Pi image
+        run: |
+          ./image/build.sh \
+            --arch ${{ matrix.build_arch }} \
+            --binary binary/${{ matrix.binary_name }}
+
+      - name: Rename and generate SHA256 checksum
+        id: output
+        run: |
+          IMG=$(find image/deploy \( -name '*.img.gz' -o -name '*.img.xz' \) | sort | tail -1)
+          if [ -z "$IMG" ]; then
+            echo "::error::No image file found in image/deploy/"
+            ls -la image/deploy/ 2>/dev/null || echo "deploy dir missing"
+            exit 1
+          fi
+
+          EXT="${IMG##*.img.}"
+          VERSION="${{ steps.tag.outputs.version }}"
+          FINAL="unified-hifi-control-${VERSION}-pi-${{ matrix.arch }}.img.${EXT}"
+          cp "$IMG" "$FINAL"
+
+          SHA256=$(sha256sum "$FINAL" | cut -d' ' -f1)
+          echo "$SHA256  $FINAL" > "${FINAL}.sha256"
+          echo "file=$FINAL" >> $GITHUB_OUTPUT
+          echo "checksum=${FINAL}.sha256" >> $GITHUB_OUTPUT
+
+          echo "::notice::Image: $FINAL ($(du -h "$FINAL" | cut -f1))"
+          echo "::notice::SHA256: $SHA256"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: pi-image-${{ matrix.arch }}
+          path: |
+            ${{ steps.output.outputs.file }}
+            ${{ steps.output.outputs.checksum }}
+          retention-days: 5
+
+      - name: Upload to GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ steps.tag.outputs.tag }}" \
+            "${{ steps.output.outputs.file }}" \
+            "${{ steps.output.outputs.checksum }}" \
+            --clobber
+
+  # =============================================================================
+  # Summary
+  # =============================================================================
+
+  summary:
+    name: Pi Image Summary
+    needs: [build-pi-image]
+    if: always()
+    runs-on: namespace-profile-default
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v7
+        with:
+          path: artifacts/
+        continue-on-error: true
+
+      - name: Display summary
+        run: |
+          echo "## Pi Image Build Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Image | Size | SHA256 |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|------|--------|" >> $GITHUB_STEP_SUMMARY
+          find artifacts -name '*.img.*' ! -name '*.sha256' -type f 2>/dev/null | while read f; do
+            size=$(du -h "$f" | cut -f1)
+            name=$(basename "$f")
+            sha_file="${f}.sha256"
+            if [ -f "$sha_file" ]; then
+              sha=$(cut -d' ' -f1 "$sha_file")
+              sha_short="${sha:0:16}..."
+            else
+              sha_short="(not found)"
+            fi
+            echo "| $name | $size | \`$sha_short\` |" >> $GITHUB_STEP_SUMMARY
+          done || echo "| (none) | - | - |" >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ Then install "Unified Hi-Fi Control" from the plugin list. The plugin automatica
 
 Pre-built binaries available for Linux (x64, arm64, armv7), macOS (x64, arm64), and Windows from [Releases](https://github.com/open-horizon-labs/unified-hifi-control/releases).
 
+### Raspberry Pi
+
+Flashable SD card images turn any Raspberry Pi into a UHC bridge appliance with zero configuration.
+Download from [Releases](https://github.com/open-horizon-labs/unified-hifi-control/releases):
+- `unified-hifi-control-*-pi-arm64.img.gz` — Pi 3, Pi 4, Pi 5
+- `unified-hifi-control-*-pi-armhf.img.gz` — Pi Zero 2 W, Pi 2, Pi 3
+
+Flash with [Raspberry Pi Imager](https://www.raspberrypi.com/software/) (Use custom → select the .img.gz file).
+See [image/README.md](image/README.md) for details.
+
 ## Quick Start (Docker)
 
 ```yaml

--- a/image/README.md
+++ b/image/README.md
@@ -14,8 +14,21 @@ No SSH, no Docker, no Linux knowledge required.
 | Pi 5 | arm64 | Supported |
 
 ## Quick Start
+### 1. Download or build the image
 
-### 1. Build the image
+**Option A: Download pre-built image from GitHub Releases** (recommended)
+
+Download from [Releases](https://github.com/open-horizon-labs/unified-hifi-control/releases):
+- `unified-hifi-control-{version}-pi-arm64.img.gz` — Pi 3, Pi 4, Pi 5
+- `unified-hifi-control-{version}-pi-armhf.img.gz` — Pi Zero 2 W, Pi 2, Pi 3
+
+Each image has a corresponding `.sha256` checksum file. Verify after download:
+
+```bash
+sha256sum -c unified-hifi-control-*-pi-arm64.img.gz.sha256
+```
+
+**Option B: Build locally**
 
 ```bash
 # arm64 (Pi 3/4/5) - default


### PR DESCRIPTION
Closes #258

## Summary

Adds a GitHub Actions workflow (`pi-image.yml`) that automatically builds flashable Raspberry Pi SD card images alongside releases.

### Workflow design

- **Trigger:** `workflow_run` (after Build workflow completes on release) + `workflow_dispatch` (manual, for testing)
- **Matrix:** arm64 (Pi 3/4/5) and armhf (Pi Zero 2 W, Pi 2/3)
- **Binary source:** Downloads pre-built ARM binaries from Build workflow artifacts (automatic) or release assets (manual dispatch)
- **Build:** Runs existing `image/build.sh` which uses pi-gen in Docker with QEMU user-mode emulation
- **Output:** Versioned `.img.gz` files + SHA256 checksums uploaded to GitHub Release

### Changes

| File | Change |
|------|--------|
| `.github/workflows/pi-image.yml` | New workflow: builds arm64 + armhf Pi images |
| `.github/workflows/build.yml` | Release notes now mention Pi image assets |
| `README.md` | New "Raspberry Pi" install section |
| `image/README.md` | Added release download instructions (Option A) alongside existing build instructions |

### Acceptance criteria from #258

- [x] `.github/workflows/pi-image.yml` builds both armhf and arm64 images
- [x] Images uploaded to GitHub Release on tagged releases
- [x] Manual trigger works for testing (`workflow_dispatch`)
- [x] SHA256 checksums published alongside images
- [x] README updated with Pi image download/flash instructions
- [x] 90-minute timeout to prevent stuck builds