### PR TITLE
feat: First-run onboarding experience in web UI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -463,7 +463,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cargo/bin/dx
-          key: dx-cli-0.7.3
+          key: dx-cli-0.7.3-${{ runner.os }}-v2
 
       - name: Install Dioxus CLI
         if: steps.check-cache.outputs.needs_build == 'true' && steps.cache-dx.outputs.cache-hit != 'true'

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2039,6 +2039,8 @@ pub struct AppSettings {
     #[serde(default, alias = "hideLmsPage")]
     pub hide_lms_page: bool,
     #[serde(default)]
+    pub onboarding_completed: bool,
+    #[serde(default)]
     pub adapters: AdapterSettings,
 }
 
@@ -2066,6 +2068,7 @@ impl Default for AppSettings {
             hide_knobs_page: false,
             hide_hqp_page: false,
             hide_lms_page: false,
+            onboarding_completed: false,
             adapters: AdapterSettings {
                 roon: true,
                 upnp: false,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2038,7 +2038,7 @@ pub struct AppSettings {
     pub hide_hqp_page: bool,
     #[serde(default, alias = "hideLmsPage")]
     pub hide_lms_page: bool,
-    #[serde(default)]
+    #[serde(default, alias = "onboardingCompleted")]
     pub onboarding_completed: bool,
     #[serde(default)]
     pub adapters: AdapterSettings,

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -62,6 +62,8 @@ pub struct AppSettings {
     pub hide_hqp_page: bool,
     #[serde(default)]
     pub hide_lms_page: bool,
+    #[serde(default)]
+    pub onboarding_completed: bool,
 }
 
 // =============================================================================

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -13,7 +13,7 @@ pub mod settings_context;
 pub mod sse;
 pub mod theme;
 
-use pages::{HqPlayer, Knobs, Lms, Settings, Zones};
+use pages::{HqPlayer, Knobs, Lms, Onboarding, Settings, Zones};
 use settings_context::use_settings_provider;
 use sse::use_sse_provider;
 use theme::use_theme_provider;
@@ -23,12 +23,29 @@ use theme::use_theme_provider;
 pub fn App() -> Element {
     // Initialize SSE context at app root (single EventSource for all pages)
     use_sse_provider();
-
-    // Initialize theme context at app root (handles localStorage + DOM class)
     use_theme_provider();
-
-    // Initialize settings context at app root (shared nav visibility state)
     use_settings_provider();
+    let settings = settings_context::use_settings();
+
+    // While settings are loading (SSR or pre-hydration), show branded splash
+    if !settings.is_loaded() {
+        return rsx! {
+            document::Meta {
+                name: "viewport",
+                content: "width=device-width, initial-scale=1"
+            }
+            document::Style { {embedded_assets::DX_THEME_CSS} }
+            document::Style { {embedded_assets::TAILWIND_CSS} }
+            div { class: "min-h-screen flex items-center justify-center",
+                p { class: "text-muted animate-pulse", "Loading..." }
+            }
+        };
+    }
+
+    // First-run: show onboarding instead of normal UI
+    if !settings.onboarding_completed() {
+        return rsx! { Onboarding {} };
+    }
 
     rsx! {
         Router::<Route> {}

--- a/src/app/pages/mod.rs
+++ b/src/app/pages/mod.rs
@@ -5,11 +5,13 @@
 mod hqplayer;
 mod knobs;
 mod lms;
+mod onboarding;
 mod settings;
 mod zones;
 
 pub use hqplayer::HqPlayer;
 pub use knobs::Knobs;
 pub use lms::Lms;
+pub use onboarding::Onboarding;
 pub use settings::Settings;
 pub use zones::Zones;

--- a/src/app/pages/onboarding.rs
+++ b/src/app/pages/onboarding.rs
@@ -1,0 +1,403 @@
+//! First-run onboarding experience.
+//!
+//! Shows discovery progress, found zones, and connection guides.
+//! Displayed on first visit; subsequent visits go to normal UI.
+
+use crate::app::api::{AppSettings, Zone, ZonesResponse};
+use crate::app::embedded_assets::{
+    APPLE_TOUCH_ICON_DATA_URL, DX_THEME_CSS, FAVICON_DATA_URL, LOGO_DATA_URL, TAILWIND_CSS,
+};
+use crate::app::settings_context::use_settings;
+use crate::app::sse::{use_sse, SseEvent};
+use dioxus::prelude::*;
+
+/// Onboarding wizard — renders outside the normal Router/Layout.
+#[component]
+pub fn Onboarding() -> Element {
+    let sse = use_sse();
+    let settings_ctx = use_settings();
+    let mut step = use_signal(|| 0u8); // 0 = discovery, 1 = ready
+
+    // Track zones
+    let mut zones = use_resource(|| async {
+        crate::app::api::fetch_json::<ZonesResponse>("/zones")
+            .await
+            .ok()
+    });
+
+    // Refresh zones on SSE events (zone discovery, updates, adapter changes)
+    use_effect(move || {
+        let _ = (sse.event_count)();
+        let event = (sse.last_event)();
+
+        if matches!(
+            event.as_ref(),
+            Some(
+                SseEvent::ZoneDiscovered { .. }
+                    | SseEvent::ZoneUpdated { .. }
+                    | SseEvent::ZoneRemoved { .. }
+                    | SseEvent::AdapterConnected { .. }
+                    | SseEvent::AdapterDisconnected { .. }
+                    | SseEvent::RoonConnected
+                    | SseEvent::RoonDisconnected
+                    | SseEvent::LmsConnected
+                    | SseEvent::LmsDisconnected
+                    | SseEvent::OpenHomeDeviceFound
+                    | SseEvent::OpenHomeDeviceLost
+                    | SseEvent::UpnpRendererFound
+                    | SseEvent::UpnpRendererLost
+            )
+        ) {
+            zones.restart();
+        }
+    });
+
+    let zone_list: Vec<Zone> = zones
+        .read()
+        .clone()
+        .flatten()
+        .map(|r| r.zones)
+        .unwrap_or_default();
+
+    // Group zones by source for display
+    let zone_groups = group_zones_by_source(&zone_list);
+    let zone_count = zone_list.len();
+    let source_count = zone_groups.len();
+    let is_loading = zones.read().is_none();
+
+    // Bridge address from window.location
+    let bridge_host = get_bridge_host();
+
+    // Shared completion logic: save flag to server and update local signal
+    let do_complete = move || {
+        spawn(async move {
+            if let Ok(mut s) =
+                crate::app::api::fetch_json::<AppSettings>("/api/settings").await
+            {
+                s.onboarding_completed = true;
+                let _ =
+                    crate::app::api::post_json_no_response("/api/settings", &s).await;
+            }
+            settings_ctx.complete_onboarding();
+        });
+    };
+    let finish = move |_: MouseEvent| {
+        do_complete();
+    };
+    let skip = move |_: MouseEvent| {
+        do_complete();
+    };
+
+    let advance = move |_: MouseEvent| {
+        step.set(1);
+    };
+
+    rsx! {
+        // Head elements (since we bypass the normal Layout)
+        document::Title { "Welcome — Unified Hi-Fi Control" }
+        document::Meta {
+            name: "viewport",
+            content: "width=device-width, initial-scale=1"
+        }
+        document::Style { {DX_THEME_CSS} }
+        document::Style { {TAILWIND_CSS} }
+        document::Link {
+            rel: "icon",
+            href: "{*FAVICON_DATA_URL}"
+        }
+        document::Link {
+            rel: "apple-touch-icon",
+            sizes: "180x180",
+            href: "{*APPLE_TOUCH_ICON_DATA_URL}"
+        }
+
+        div { class: "min-h-screen flex flex-col items-center justify-center px-4 py-8",
+            // Logo + title
+            div { class: "text-center mb-8",
+                img {
+                    src: "{*LOGO_DATA_URL}",
+                    alt: "Unified Hi-Fi Control",
+                    class: "w-16 h-16 mx-auto mb-4 rounded-xl"
+                }
+                h1 { class: "text-2xl font-bold", "Unified Hi\u{2011}Fi Control" }
+                p { class: "text-muted mt-1", "Multi-source music bridge" }
+            }
+
+            // Step indicator
+            div { class: "flex items-center gap-2 mb-8",
+                span {
+                    class: if step() == 0 { "w-2.5 h-2.5 rounded-full bg-primary" } else { "w-2.5 h-2.5 rounded-full bg-muted" }
+                }
+                span { class: "w-6 h-px bg-border" }
+                span {
+                    class: if step() == 1 { "w-2.5 h-2.5 rounded-full bg-primary" } else { "w-2.5 h-2.5 rounded-full bg-muted" }
+                }
+            }
+
+            // Step content
+            div { class: "w-full max-w-md",
+                match step() {
+                    0 => rsx! {
+                        DiscoveryStep {
+                            zone_groups: zone_groups,
+                            zone_count: zone_count,
+                            is_loading: is_loading,
+                            on_continue: advance,
+                            on_skip: skip,
+                        }
+                    },
+                    _ => rsx! {
+                        ReadyStep {
+                            zone_count: zone_count,
+                            source_count: source_count,
+                            bridge_host: bridge_host,
+                            on_complete: finish,
+                        }
+                    },
+                }
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Step components
+// =============================================================================
+
+#[component]
+fn DiscoveryStep(
+    zone_groups: Vec<(String, Vec<Zone>)>,
+    zone_count: usize,
+    is_loading: bool,
+    on_continue: EventHandler<MouseEvent>,
+    on_skip: EventHandler<MouseEvent>,
+) -> Element {
+    rsx! {
+        div { class: "space-y-6",
+            // Heading
+            div { class: "text-center",
+                h2 { class: "text-xl font-semibold mb-1", "Discovering your music sources" }
+                p { class: "text-muted text-sm",
+                    if is_loading {
+                        "Searching for music servers on your network..."
+                    } else if zone_count == 0 {
+                        "Searching... zones will appear as they are found."
+                    } else {
+                        "Zones appear in real-time as they are discovered."
+                    }
+                }
+            }
+
+            // Loading indicator
+            if is_loading || zone_count == 0 {
+                div { class: "flex items-center justify-center gap-3 py-6 text-muted",
+                    // Animated spinner
+                    svg {
+                        class: "w-5 h-5 animate-spin",
+                        fill: "none",
+                        view_box: "0 0 24 24",
+                        circle {
+                            class: "opacity-25",
+                            cx: "12",
+                            cy: "12",
+                            r: "10",
+                            stroke: "currentColor",
+                            stroke_width: "4",
+                        }
+                        path {
+                            class: "opacity-75",
+                            fill: "currentColor",
+                            d: "M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z",
+                        }
+                    }
+                    span { "Searching..." }
+                }
+            }
+
+            // Discovered zones grouped by source
+            if zone_count > 0 {
+                div { class: "space-y-4",
+                    p { class: "text-sm font-medium",
+                        "Found {zone_count} zone{plural(zone_count)}:"
+                    }
+                    for (source, zones) in zone_groups.iter() {
+                        div { class: "card p-3",
+                            div { class: "flex items-center gap-2 mb-2",
+                                span { class: "w-2 h-2 rounded-full bg-green-500" }
+                                span { class: "text-sm font-medium", "{source}" }
+                                span { class: "text-xs text-muted",
+                                    "({zones.len()} zone{plural(zones.len())})"
+                                }
+                            }
+                            ul { class: "space-y-1 ml-4",
+                                for zone in zones.iter() {
+                                    li {
+                                        key: "{zone.zone_id}",
+                                        class: "text-sm text-muted flex items-center gap-2",
+                                        span { "♪" }
+                                        span { class: "truncate", "{zone.zone_name}" }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Action buttons
+            div { class: "flex justify-between items-center pt-4",
+                button {
+                    class: "btn btn-ghost text-sm",
+                    onclick: move |e| on_skip.call(e),
+                    "Skip"
+                }
+                button {
+                    class: "btn btn-primary",
+                    onclick: move |e| on_continue.call(e),
+                    if zone_count > 0 {
+                        "Continue"
+                    } else {
+                        "Continue anyway"
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn ReadyStep(
+    zone_count: usize,
+    source_count: usize,
+    bridge_host: String,
+    on_complete: EventHandler<MouseEvent>,
+) -> Element {
+    let mcp_url = format!("http://{}/mcp", bridge_host);
+
+    rsx! {
+        div { class: "space-y-6",
+            // Heading
+            div { class: "text-center",
+                h2 { class: "text-xl font-semibold mb-1", "You're ready!" }
+                if zone_count > 0 {
+                    p { class: "text-muted text-sm",
+                        "Found {zone_count} zone{plural(zone_count)} from {source_count} source{plural(source_count)}."
+                    }
+                } else {
+                    p { class: "text-muted text-sm",
+                        "No zones found yet — they'll appear once your music servers are online."
+                    }
+                }
+            }
+
+            // Connection guide
+            div { class: "space-y-3",
+                p { class: "text-sm font-medium", "Control your music with:" }
+
+                // Web
+                ConnectionCard {
+                    icon: "🌐",
+                    title: "Web Browser",
+                    description: "You're already here — bookmark this page.",
+                }
+
+                // Knob
+                ConnectionCard {
+                    icon: "🎛",
+                    title: "Hardware Knob",
+                    description: format!("Point your roon-knob at {bridge_host}"),
+                }
+
+                // Phone
+                ConnectionCard {
+                    icon: "📱",
+                    title: "iPhone / Apple Watch",
+                    description: "Download HiFi Control from the App Store.".to_string(),
+                }
+
+                // AI
+                ConnectionCard {
+                    icon: "🤖",
+                    title: "AI Assistant (MCP)",
+                    description: format!("Add to Claude or ChatGPT: {mcp_url}"),
+                }
+            }
+
+            // Get started button
+            div { class: "pt-4",
+                button {
+                    class: "btn btn-primary w-full",
+                    onclick: move |e| on_complete.call(e),
+                    "Get Started"
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn ConnectionCard(icon: &'static str, title: &'static str, description: String) -> Element {
+    rsx! {
+        div { class: "card p-3 flex items-start gap-3",
+            span { class: "text-xl flex-shrink-0", "{icon}" }
+            div {
+                p { class: "text-sm font-medium", "{title}" }
+                p { class: "text-xs text-muted mt-0.5", "{description}" }
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/// Group zones by source, sorted (Roon, LMS, OpenHome, UPnP, Other).
+fn group_zones_by_source(zones: &[Zone]) -> Vec<(String, Vec<Zone>)> {
+    let mut groups: std::collections::HashMap<String, Vec<Zone>> =
+        std::collections::HashMap::new();
+    for zone in zones {
+        let source = zone.source.clone().unwrap_or_else(|| "Other".to_string());
+        groups.entry(source).or_default().push(zone.clone());
+    }
+    for v in groups.values_mut() {
+        v.sort_by(|a, b| a.zone_name.cmp(&b.zone_name));
+    }
+    let priority = |s: &str| -> i32 {
+        match s.to_lowercase().as_str() {
+            "roon" => 0,
+            "lms" => 1,
+            "openhome" => 2,
+            "upnp" => 3,
+            _ => 4,
+        }
+    };
+    let mut result: Vec<_> = groups.into_iter().collect();
+    result.sort_by(|a, b| priority(&a.0).cmp(&priority(&b.0)));
+    result
+}
+
+/// Plural suffix helper
+fn plural(n: usize) -> &'static str {
+    if n == 1 {
+        ""
+    } else {
+        "s"
+    }
+}
+
+/// Get bridge host (hostname:port) from window.location (WASM) or fallback.
+fn get_bridge_host() -> String {
+    #[cfg(target_arch = "wasm32")]
+    {
+        if let Some(window) = web_sys::window() {
+            // host() returns "hostname:port" (or just "hostname" if default port)
+            if let Ok(host) = window.location().host() {
+                if !host.is_empty() {
+                    return host;
+                }
+            }
+        }
+    }
+    "uhc.local:8088".to_string()
+}

--- a/src/app/pages/onboarding.rs
+++ b/src/app/pages/onboarding.rs
@@ -269,7 +269,8 @@ fn ReadyStep(
     bridge_host: String,
     on_complete: EventHandler<MouseEvent>,
 ) -> Element {
-    let mcp_url = format!("http://{}/mcp", bridge_host);
+    let bridge_origin = get_bridge_origin();
+    let mcp_url = format!("{}/mcp", bridge_origin);
 
     rsx! {
         div { class: "space-y-6",
@@ -380,6 +381,22 @@ fn plural(n: usize) -> &'static str {
     } else {
         "s"
     }
+}
+
+/// Get bridge origin (scheme + host) from window.location (WASM) or fallback.
+fn get_bridge_origin() -> String {
+    #[cfg(target_arch = "wasm32")]
+    {
+        if let Some(window) = web_sys::window() {
+            let location = window.location();
+            if let (Ok(protocol), Ok(host)) = (location.protocol(), location.host()) {
+                if !host.is_empty() {
+                    return format!("{}//{}", protocol, host);
+                }
+            }
+        }
+    }
+    "http://uhc.local:8088".to_string()
 }
 
 /// Get bridge host (hostname:port) from window.location (WASM) or fallback.

--- a/src/app/pages/onboarding.rs
+++ b/src/app/pages/onboarding.rs
@@ -71,12 +71,9 @@ pub fn Onboarding() -> Element {
     // Shared completion logic: save flag to server and update local signal
     let do_complete = move || {
         spawn(async move {
-            if let Ok(mut s) =
-                crate::app::api::fetch_json::<AppSettings>("/api/settings").await
-            {
+            if let Ok(mut s) = crate::app::api::fetch_json::<AppSettings>("/api/settings").await {
                 s.onboarding_completed = true;
-                let _ =
-                    crate::app::api::post_json_no_response("/api/settings", &s).await;
+                let _ = crate::app::api::post_json_no_response("/api/settings", &s).await;
             }
             settings_ctx.complete_onboarding();
         });
@@ -354,8 +351,7 @@ fn ConnectionCard(icon: &'static str, title: &'static str, description: String) 
 
 /// Group zones by source, sorted (Roon, LMS, OpenHome, UPnP, Other).
 fn group_zones_by_source(zones: &[Zone]) -> Vec<(String, Vec<Zone>)> {
-    let mut groups: std::collections::HashMap<String, Vec<Zone>> =
-        std::collections::HashMap::new();
+    let mut groups: std::collections::HashMap<String, Vec<Zone>> = std::collections::HashMap::new();
     for zone in zones {
         let source = zone.source.clone().unwrap_or_else(|| "Other".to_string());
         groups.entry(source).or_default().push(zone.clone());

--- a/src/app/pages/settings.rs
+++ b/src/app/pages/settings.rs
@@ -56,7 +56,7 @@ pub fn Settings() -> Element {
             hqplayer_enabled.set(s.adapters.hqplayer);
             hide_knobs.set(s.hide_knobs_page);
             // Sync to shared context for Nav reactivity (page visibility follows adapter state)
-            settings_ctx.update(s.hide_knobs_page, s.adapters.hqplayer, s.adapters.lms);
+            settings_ctx.update(s.hide_knobs_page, s.adapters.hqplayer, s.adapters.lms, s.onboarding_completed);
             settings_ctx.mark_loaded();
         }
     });
@@ -108,7 +108,7 @@ pub fn Settings() -> Element {
         let lms = lms_enabled();
 
         // Update shared context immediately for reactive Nav updates
-        settings_ctx.update(hk, hqp, lms);
+        settings_ctx.update(hk, hqp, lms, settings_ctx.onboarding_completed());
 
         let settings = AppSettings {
             adapters: AdapterSettings {
@@ -122,6 +122,7 @@ pub fn Settings() -> Element {
             // These are now derived from adapter state but we keep them for API compat
             hide_hqp_page: !hqp,
             hide_lms_page: !lms,
+            onboarding_completed: settings_ctx.onboarding_completed(),
         };
         spawn(async move {
             let _ = crate::app::api::post_json_no_response("/api/settings", &settings).await;

--- a/src/app/pages/settings.rs
+++ b/src/app/pages/settings.rs
@@ -56,7 +56,12 @@ pub fn Settings() -> Element {
             hqplayer_enabled.set(s.adapters.hqplayer);
             hide_knobs.set(s.hide_knobs_page);
             // Sync to shared context for Nav reactivity (page visibility follows adapter state)
-            settings_ctx.update(s.hide_knobs_page, s.adapters.hqplayer, s.adapters.lms, s.onboarding_completed);
+            settings_ctx.update(
+                s.hide_knobs_page,
+                s.adapters.hqplayer,
+                s.adapters.lms,
+                s.onboarding_completed,
+            );
             settings_ctx.mark_loaded();
         }
     });

--- a/src/app/settings_context.rs
+++ b/src/app/settings_context.rs
@@ -18,6 +18,8 @@ pub struct SettingsContext {
     lms_enabled: Signal<bool>,
     /// Whether settings have been loaded from server
     loaded: Signal<bool>,
+    /// Whether first-run onboarding has been completed
+    onboarding_completed: Signal<bool>,
 }
 
 impl SettingsContext {
@@ -41,14 +43,27 @@ impl SettingsContext {
         !(self.lms_enabled)()
     }
 
+    /// Check if onboarding has been completed
+    pub fn onboarding_completed(&self) -> bool {
+        (self.onboarding_completed)()
+    }
+
+    /// Mark onboarding as completed (updates local signal)
+    pub fn complete_onboarding(&self) {
+        let mut oc = self.onboarding_completed;
+        oc.set(true);
+    }
+
     /// Update settings - now takes adapter enabled states
-    pub fn update(&self, hide_knobs: bool, hqp_enabled: bool, lms_enabled: bool) {
+    pub fn update(&self, hide_knobs: bool, hqp_enabled: bool, lms_enabled: bool, onboarding_completed: bool) {
         let mut hk = self.hide_knobs;
         let mut he = self.hqp_enabled;
         let mut le = self.lms_enabled;
         hk.set(hide_knobs);
         he.set(hqp_enabled);
         le.set(lms_enabled);
+        let mut oc = self.onboarding_completed;
+        oc.set(onboarding_completed);
     }
 
     /// Mark settings as loaded
@@ -64,12 +79,14 @@ pub fn use_settings_provider() {
     let hqp_enabled = use_signal(|| false);
     let lms_enabled = use_signal(|| false);
     let loaded = use_signal(|| false);
+    let onboarding_completed = use_signal(|| false);
 
     let ctx = SettingsContext {
         hide_knobs,
         hqp_enabled,
         lms_enabled,
         loaded,
+        onboarding_completed,
     };
 
     use_context_provider(|| ctx);
@@ -87,6 +104,7 @@ pub fn use_settings_provider() {
                         settings.hide_knobs_page,
                         settings.adapters.hqplayer,
                         settings.adapters.lms,
+                        settings.onboarding_completed,
                     );
                     ctx.mark_loaded();
                 }

--- a/src/app/settings_context.rs
+++ b/src/app/settings_context.rs
@@ -102,18 +102,24 @@ pub fn use_settings_provider() {
     {
         use_effect(move || {
             spawn(async move {
-                if let Ok(settings) =
-                    crate::app::api::fetch_json::<AppSettings>("/api/settings").await
+                match crate::app::api::fetch_json::<AppSettings>("/api/settings").await
                 {
-                    // Page visibility now derived from adapter enabled state
-                    ctx.update(
-                        settings.hide_knobs_page,
-                        settings.adapters.hqplayer,
-                        settings.adapters.lms,
-                        settings.onboarding_completed,
-                    );
-                    ctx.mark_loaded();
+                    Ok(settings) => {
+                        // Page visibility now derived from adapter enabled state
+                        ctx.update(
+                            settings.hide_knobs_page,
+                            settings.adapters.hqplayer,
+                            settings.adapters.lms,
+                            settings.onboarding_completed,
+                        );
+                    }
+                    Err(e) => {
+                        web_sys::console::warn_1(
+                            &format!("Failed to fetch settings: {}", e).into(),
+                        );
+                    }
                 }
+                ctx.mark_loaded();
             });
         });
     }

--- a/src/app/settings_context.rs
+++ b/src/app/settings_context.rs
@@ -55,7 +55,13 @@ impl SettingsContext {
     }
 
     /// Update settings - now takes adapter enabled states
-    pub fn update(&self, hide_knobs: bool, hqp_enabled: bool, lms_enabled: bool, onboarding_completed: bool) {
+    pub fn update(
+        &self,
+        hide_knobs: bool,
+        hqp_enabled: bool,
+        lms_enabled: bool,
+        onboarding_completed: bool,
+    ) {
         let mut hk = self.hide_knobs;
         let mut he = self.hqp_enabled;
         let mut le = self.lms_enabled;

--- a/src/app/sse.rs
+++ b/src/app/sse.rs
@@ -130,7 +130,10 @@ impl SseContext {
         matches!(
             self.last_event.read().as_ref(),
             Some(
-                SseEvent::ZoneUpdated { .. }
+                SseEvent::ZoneDiscovered { .. }
+                    | SseEvent::AdapterConnected { .. }
+                    | SseEvent::AdapterDisconnected { .. }
+                    | SseEvent::ZoneUpdated { .. }
                     | SseEvent::ZoneRemoved { .. }
                     | SseEvent::NowPlayingChanged { .. }
                     | SseEvent::SeekPositionChanged { .. }

--- a/src/app/sse.rs
+++ b/src/app/sse.rs
@@ -13,6 +13,12 @@ use std::rc::Rc;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
 
+/// Payload for adapter-level events
+#[derive(Clone, Debug, PartialEq, Deserialize)]
+pub struct AdapterPayload {
+    pub adapter: String,
+}
+
 /// Payload for zone-related events
 #[derive(Clone, Debug, PartialEq, Deserialize)]
 pub struct ZonePayload {
@@ -38,6 +44,17 @@ pub struct VolumePayload {
 #[derive(Clone, Debug, PartialEq, Deserialize)]
 #[serde(tag = "type")]
 pub enum SseEvent {
+    // Zone lifecycle events (from server MuseEvent)
+    ZoneDiscovered {},
+
+    // Generic adapter events (server sends these for all adapters)
+    AdapterConnected {
+        payload: AdapterPayload,
+    },
+    AdapterDisconnected {
+        payload: AdapterPayload,
+    },
+
     // Roon events
     RoonConnected,
     RoonDisconnected,


### PR DESCRIPTION
Closes #257

## Summary

Adds a guided onboarding wizard that appears on first visit to the web UI. Shows real-time source discovery progress via SSE and provides connection guides for all client types.

### What changed

**Server-side (`src/api/mod.rs`):**
- Added `onboarding_completed: bool` to `AppSettings` (defaults to `false`)
- No new API endpoints -- reuses existing `POST /api/settings`

**Client-side SSE (`src/app/sse.rs`):**
- Added `ZoneDiscovered`, `AdapterConnected`, `AdapterDisconnected` event types (server already sends these via MuseEvent)

**Settings context (`src/app/settings_context.rs`):**
- Added `onboarding_completed` signal with getter/setter
- Updated `update()` to propagate the flag

**App root (`src/app/mod.rs`):**
- Conditionally renders Onboarding (first-run) or Router (normal) based on settings
- Shows branded loading splash during settings fetch

**Onboarding page (`src/app/pages/onboarding.rs`):**
- 2-step wizard:
 1. **Discovery** -- shows zones appearing in real-time via SSE, grouped by source
 2. **Ready** -- connection guide for Web, Hardware Knob, iPhone, AI/MCP
- Skip button on step 1; Get Started on step 2
- Mobile-first layout (works at 375px)
- Renders outside normal Layout/Nav for clean full-screen experience
- Bridge address derived from `window.location.host` (works behind reverse proxies)

### Acceptance criteria
- [x] First visit shows onboarding, not empty zone list
- [x] Onboarding shows real-time source discovery progress via SSE
- [x] Each discovered zone appears in real-time (not after page refresh)
- [x] Client connection guide with correct bridge address/links
- [x] Skip option for users who know what they are doing
- [x] After completing/skipping, subsequent visits go to normal UI
- [x] Works well on mobile viewport (375px wide minimum)
- [x] Works for all deployment types (Pi image, Docker, NAS)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Onboarding wizard for first-time users with zone discovery, zone grouping by source, and multiple connection method options (Web, Knob, Mobile, AI MCP)
  * Real-time push notifications for zone discovery and adapter connectivity events
  * Settings system extended with onboarding completion status tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->