### PR TITLE
fix: include albums in globalsearch results, let callers filter

### DIFF
--- a/src/adapters/lms.rs
+++ b/src/adapters/lms.rs
@@ -1284,16 +1284,15 @@ impl LmsAdapter {
         });
         let drill_id = songs_id.or(everything_id);
 
-        // Also collect any directly playable items (non-container tracks)
+        // Collect any directly playable items (tracks and album containers alike).
+        // parse_single_item classifies them correctly — callers use category to decide.
         for item in items {
             if results.len() >= limit {
                 break;
             }
             let is_audio = item.get("isaudio").and_then(|v| v.as_i64()).unwrap_or(0) == 1
                 || item.get("type").and_then(|v| v.as_str()) == Some("audio");
-            let has_items = item.get("hasitems").and_then(|v| v.as_i64()).unwrap_or(0) == 1;
-            // Skip containers — they're albums/playlists, not individual tracks
-            if is_audio && !has_items {
+            if is_audio {
                 if let Some(result) = self.parse_single_item(item) {
                     results.push(result);
                 }


### PR DESCRIPTION
## Problem

PR #264 correctly classified album containers as `Album` instead of `Track`, but also filtered them out of `drill_into_songs` results with a `!has_items` check. This means `hifi_search_raw` can't find albums at all — "play the album Desperado" returns nothing.

## Fix

Remove the `has_items` skip. All `isaudio=1` items flow through `parse_single_item`, which correctly classifies them:
- `hasitems=1` → `category: "album"`
- `hasitems=0` → `category: "track"`

The bridge classifies. Callers filter. Muse's `muse_playlist_play` already prefers `category == "track"` via three-pass selection. The LLM can use `category: "album"` to intentionally queue a full album when the user asks for it.