### PR TITLE
feat: rich LMS search with unified library + streaming results

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,8 +214,8 @@ MCP (Model Context Protocol) enables AI assistants (Claude, ChatGPT, BoltAI, etc
 | `hifi_zones` | List all playback zones |
 | `hifi_now_playing` | Get current track info |
 | `hifi_control` | Play, pause, next, previous, volume |
-| `hifi_search` | Search library/TIDAL/Qobuz (Roon, LMS) |
-| `hifi_play` | Search and play/queue/radio (Roon, LMS) |
+| `hifi_search` | Search library/streaming with rich metadata (title, artist, album, year, genre, duration, image_url) and _play token |
+| `hifi_play_item` | Play a search result via _play token from hifi_search |
 | `hifi_status` | Bridge connection status |
 | `hifi_hqplayer_status` | HQPlayer pipeline status |
 | `hifi_hqplayer_profiles` | List HQPlayer configs |

--- a/src/adapters/lms.rs
+++ b/src/adapters/lms.rs
@@ -569,6 +569,16 @@ pub struct LmsSearchResult {
     pub url: Option<String>,
     /// String-based item_id for globalsearch results (used with globalsearch playlist)
     pub item_id: Option<String>,
+    /// Release year
+    pub year: Option<u32>,
+    /// Genre
+    pub genre: Option<String>,
+    /// Duration in seconds
+    pub duration: Option<f64>,
+    /// Full image URL (for streaming items or resolved library cover art)
+    pub image_url: Option<String>,
+    /// Cover ID for library items (used to build cover art URL)
+    pub coverid: Option<String>,
 }
 
 /// Action to take when playing search results
@@ -1033,21 +1043,30 @@ impl LmsAdapter {
             .await
     }
 
-    /// Search using LMS globalsearch which includes all providers (library, TIDAL, Qobuz, etc.)
+    /// Build a cover art URL for a library item from its cover ID.
+    async fn library_cover_url(&self, coverid: &str) -> Option<String> {
+        let state = self.state.read().await;
+        let host = state.host.as_ref()?;
+        Some(format!("http://{}:{}/music/{}/cover.jpg", host, state.port, coverid))
+    }
+
+    /// Resolve an image URL: absolute URLs pass through, relative paths get the LMS base prepended.
+    async fn resolve_image_url(&self, url: &str) -> Option<String> {
+        if url.starts_with("http://") || url.starts_with("https://") {
+            return Some(url.to_string());
+        }
+        let state = self.state.read().await;
+        let host = state.host.as_ref()?;
+        Some(format!("http://{}:{}{}", host, state.port, url))
+    }
+
+    /// Unified search across library and streaming services.
     ///
-    /// Uses the LMS JSON-RPC `globalsearch items` command which searches across all
-    /// registered search providers including streaming service plugins.
-    ///
-    /// Globalsearch returns a hierarchy:
-    /// 1. Providers (My Music, TIDAL, Qobuz)
-    /// 2. Categories (Everything, Playlists, Artists, Albums, Songs)
-    /// 3. Actual playable items
-    ///
-    /// This method drills into streaming providers to find playable tracks.
-    ///
-    /// NOTE: globalsearch requires a player_id to determine which apps/providers are available.
-    /// Fallback chain: passed player_id -> any connected player -> library-only search.
-    pub async fn search(
+    /// Returns rich metadata for all results: artist, album, year, genre, duration, image_url.
+    /// Library results come from dedicated `albums`, `tracks`, `artists` endpoints with tags.
+    /// Streaming results come from globalsearch with drill-down into Albums and Songs.
+    /// Results are deduplicated: if a library and streaming result share title+artist, library wins.
+    pub async fn search_unified(
         &self,
         query: &str,
         player_id: Option<&str>,
@@ -1055,66 +1074,226 @@ impl LmsAdapter {
     ) -> Result<Vec<LmsSearchResult>> {
         let limit = limit.unwrap_or(20);
 
-        // globalsearch requires a player_id to work - without it, LMS returns empty response
-        // Fallback chain: passed player_id -> any connected player -> library-only
-        let player_id = match player_id.map(strip_lms_prefix) {
-            Some(id) => id.to_string(),
+        // --- Library search with rich tags ---
+        let mut library_results = Vec::new();
+
+        // Albums: tags a=artist, l=album, y=year, j=artwork_track_id
+        let albums_result = self
+            .rpc
+            .execute(
+                None,
+                vec![
+                    json!("albums"),
+                    json!(0),
+                    json!(10),
+                    json!(format!("search:{}", query)),
+                    json!("tags:alyj"),
+                ],
+            )
+            .await;
+
+        if let Ok(result) = albums_result {
+            if let Some(albums) = result.get("albums_loop").and_then(|v| v.as_array()) {
+                for album in albums.iter().take(10) {
+                    let id = album.get("id").and_then(|v| v.as_i64()).unwrap_or(0);
+                    let title = album.get("album").and_then(|v| v.as_str()).unwrap_or_default();
+                    let artist = album.get("artist").and_then(|v| v.as_str()).map(String::from);
+                    let year = album.get("year").and_then(|v| v.as_u64()).map(|y| y as u32);
+                    let artwork_track_id = album.get("artwork_track_id")
+                        .and_then(|v| v.as_str().map(String::from).or_else(|| v.as_i64().map(|n| n.to_string())));
+                    let image_url = if let Some(ref cid) = artwork_track_id {
+                        self.library_cover_url(cid).await
+                    } else {
+                        None
+                    };
+                    library_results.push(LmsSearchResult {
+                        result_type: LmsSearchResultType::Album,
+                        id,
+                        title: title.to_string(),
+                        artist,
+                        album: None,
+                        url: None,
+                        item_id: None,
+                        year,
+                        genre: None,
+                        duration: None,
+                        image_url,
+                        coverid: artwork_track_id,
+                    });
+                }
+            }
+        }
+
+        // Tracks: tags a=artist, A=albumartist, l=album, s=duration, e=album_id,
+        //         d=duration, t=tracknum, y=year, g=genre, i=disc, j=artwork_track_id, o=type
+        let tracks_result = self
+            .rpc
+            .execute(
+                None,
+                vec![
+                    json!("tracks"),
+                    json!(0),
+                    json!(10),
+                    json!(format!("search:{}", query)),
+                    json!("tags:aAlsedtygijo"),
+                ],
+            )
+            .await;
+
+        if let Ok(result) = tracks_result {
+            if let Some(tracks) = result.get("titles_loop").and_then(|v| v.as_array()) {
+                for track in tracks.iter().take(10) {
+                    let id = track.get("id").and_then(|v| v.as_i64()).unwrap_or(0);
+                    let title = track.get("title").and_then(|v| v.as_str()).unwrap_or_default();
+                    let artist = track.get("artist").and_then(|v| v.as_str()).map(String::from);
+                    let album = track.get("album").and_then(|v| v.as_str()).map(String::from);
+                    let year = track.get("year").and_then(|v| v.as_u64()).map(|y| y as u32);
+                    let genre = track.get("genre").and_then(|v| v.as_str()).map(String::from);
+                    let duration = track.get("duration").and_then(|v| v.as_f64());
+                    let coverid = track.get("coverid")
+                        .and_then(|v| v.as_str().map(String::from).or_else(|| v.as_i64().map(|n| n.to_string())))
+                        .or_else(|| track.get("artwork_track_id")
+                            .and_then(|v| v.as_str().map(String::from).or_else(|| v.as_i64().map(|n| n.to_string()))));
+                    let image_url = if let Some(ref cid) = coverid {
+                        self.library_cover_url(cid).await
+                    } else {
+                        None
+                    };
+                    library_results.push(LmsSearchResult {
+                        result_type: LmsSearchResultType::Track,
+                        id,
+                        title: title.to_string(),
+                        artist,
+                        album,
+                        url: None,
+                        item_id: None,
+                        year,
+                        genre,
+                        duration,
+                        image_url,
+                        coverid,
+                    });
+                }
+            }
+        }
+
+        // Artists
+        let artists_result = self
+            .rpc
+            .execute(
+                None,
+                vec![
+                    json!("artists"),
+                    json!(0),
+                    json!(5),
+                    json!(format!("search:{}", query)),
+                ],
+            )
+            .await;
+
+        if let Ok(result) = artists_result {
+            if let Some(artists) = result.get("contributors_loop").and_then(|v| v.as_array()) {
+                for artist in artists.iter().take(5) {
+                    let id = artist.get("contributor_id")
+                        .or_else(|| artist.get("id"))
+                        .and_then(|v| v.as_i64())
+                        .unwrap_or(0);
+                    let name = artist.get("contributor")
+                        .or_else(|| artist.get("name"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default();
+                    library_results.push(LmsSearchResult {
+                        result_type: LmsSearchResultType::Artist,
+                        id,
+                        title: name.to_string(),
+                        artist: None,
+                        album: None,
+                        url: None,
+                        item_id: None,
+                        year: None,
+                        genre: None,
+                        duration: None,
+                        image_url: None,
+                        coverid: None,
+                    });
+                }
+            }
+        }
+
+        // --- Streaming search via globalsearch ---
+        let mut streaming_results = Vec::new();
+
+        // Resolve player_id for globalsearch (requires one)
+        let player_id_resolved = match player_id.map(strip_lms_prefix) {
+            Some(id) => Some(id.to_string()),
             None => {
-                // Try to get any connected player (drop lock before any await)
-                let any_player = {
-                    let state = self.state.read().await;
-                    state.players.keys().next().cloned()
-                };
-                match any_player {
-                    Some(id) => id,
-                    None => return self.search_library(query, limit).await,
-                }
+                let state = self.state.read().await;
+                state.players.keys().next().cloned()
             }
         };
 
-        // Get top-level providers
-        let result = self.globalsearch_items(&player_id, query, None).await?;
+        if let Some(ref pid) = player_id_resolved {
+            // Get top-level providers
+            if let Ok(result) = self.globalsearch_items(pid, query, None).await {
+                if let Some(items) = Self::get_items_from_result(&result) {
+                    for item in items {
+                        let item_id = item.get("id").and_then(|v| v.as_str());
+                        let has_items = item.get("hasitems").and_then(|v| v.as_i64()).unwrap_or(0) == 1;
+                        let is_audio = item.get("isaudio").and_then(|v| v.as_i64()).unwrap_or(0) == 1
+                            || item.get("type").and_then(|v| v.as_str()) == Some("audio");
 
-        let items = match Self::get_items_from_result(&result) {
-            Some(items) => items,
-            None => return self.search_library(query, limit).await,
-        };
+                        if is_audio {
+                            if let Some(mut r) = self.parse_single_item(item) {
+                                // Resolve relative image URLs
+                                if let Some(ref url) = r.image_url {
+                                    r.image_url = self.resolve_image_url(url).await;
+                                }
+                                streaming_results.push(r);
+                            }
+                            continue;
+                        }
 
-        let mut results = Vec::new();
-
-        // Look for providers and drill into them to find playable items
-        for item in items {
-            if results.len() >= limit {
-                break;
-            }
-
-            let item_id = item.get("id").and_then(|v| v.as_str());
-            let has_items = item.get("hasitems").and_then(|v| v.as_i64()).unwrap_or(0) == 1;
-            let is_audio = item.get("isaudio").and_then(|v| v.as_i64()).unwrap_or(0) == 1
-                || item.get("type").and_then(|v| v.as_str()) == Some("audio");
-
-            // If it's a playable item, add it directly
-            if is_audio {
-                if let Some(result) = self.parse_single_item(item) {
-                    results.push(result);
-                }
-                continue;
-            }
-
-            // Drill into any provider that has sub-items (TIDAL, Qobuz, Spotify, Deezer, etc.)
-            if let Some(item_id) = item_id {
-                if has_items {
-                    if let Ok(songs) = self
-                        .drill_into_songs(&player_id, query, item_id, limit - results.len())
-                        .await
-                    {
-                        results.extend(songs);
+                        // Drill into providers for Albums and Songs categories
+                        if let Some(provider_id) = item_id {
+                            if has_items {
+                                if let Ok(songs) = self
+                                    .drill_into_songs_and_albums(pid, query, provider_id, limit)
+                                    .await
+                                {
+                                    for mut r in songs {
+                                        if let Some(ref url) = r.image_url {
+                                            r.image_url = self.resolve_image_url(url).await;
+                                        }
+                                        streaming_results.push(r);
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }
         }
 
-        // Fallback to library search if no streaming results
+        // --- Merge: library first, then streaming, with dedup ---
+        let mut results = library_results;
+
+        // Deduplicate: skip streaming items whose title+artist match a library item (case-insensitive)
+        for sr in streaming_results {
+            let dominated = results.iter().any(|lr| {
+                lr.title.eq_ignore_ascii_case(&sr.title)
+                    && match (&lr.artist, &sr.artist) {
+                        (Some(a), Some(b)) => a.eq_ignore_ascii_case(b),
+                        _ => false,
+                    }
+            });
+            if !dominated {
+                results.push(sr);
+            }
+        }
+
+        results.truncate(limit);
+
+        // If no results at all, fall back to simple library search
         if results.is_empty() {
             return self.search_library(query, limit).await;
         }
@@ -1122,94 +1301,12 @@ impl LmsAdapter {
         debug!(
             query = query,
             results = results.len(),
-            "LMS globalsearch completed"
+            "LMS unified search completed"
         );
 
         Ok(results)
     }
 
-    /// Raw globalsearch returning unprocessed JSON for LLM consumption.
-    ///
-    /// Unlike `search()` which parses results into typed structs, this returns the raw
-    /// globalsearch responses from all providers (My Music, TIDAL, Qobuz, etc.).
-    /// The LLM can interpret field variations, category names, and metadata directly —
-    /// no information is lost to struct parsing.
-    ///
-    /// Returns a JSON object with provider names as keys and their raw item lists as values.
-    pub async fn search_raw(
-        &self,
-        query: &str,
-        player_id: Option<&str>,
-    ) -> Result<serde_json::Value> {
-        // Same player_id resolution as search()
-        let player_id = match player_id.map(strip_lms_prefix) {
-            Some(id) => id.to_string(),
-            None => {
-                let any_player = {
-                    let state = self.state.read().await;
-                    state.players.keys().next().cloned()
-                };
-                match any_player {
-                    Some(id) => id,
-                    None => return Ok(json!({"error": "No players connected"})),
-                }
-            }
-        };
-
-        // Get top-level providers
-        let result = self.globalsearch_items(&player_id, query, None).await?;
-        let items = match Self::get_items_from_result(&result) {
-            Some(items) => items,
-            None => return Ok(json!({"results": []})),
-        };
-
-        let mut providers = serde_json::Map::new();
-
-        for item in items {
-            let name = item
-                .get("name")
-                .and_then(|v| v.as_str())
-                .unwrap_or("unknown");
-            let item_id = item.get("id").and_then(|v| v.as_str());
-            let has_items = item.get("hasitems").and_then(|v| v.as_i64()).unwrap_or(0) == 1;
-            let is_audio = item.get("isaudio").and_then(|v| v.as_i64()).unwrap_or(0) == 1
-                || item.get("type").and_then(|v| v.as_str()) == Some("audio");
-
-            if is_audio {
-                // Top-level playable item — add under "direct" provider
-                if let Some(arr) = providers
-                    .entry("direct")
-                    .or_insert_with(|| json!([]))
-                    .as_array_mut()
-                {
-                    arr.push(item.clone());
-                }
-                continue;
-            }
-
-            // Drill one level into each provider
-            if let Some(item_id) = item_id {
-                if has_items {
-                    if let Ok(sub_result) = self
-                        .globalsearch_items(&player_id, query, Some(item_id))
-                        .await
-                    {
-                        if let Some(sub_items) = Self::get_items_from_result(&sub_result) {
-                            providers.insert(name.to_string(), json!(sub_items));
-                        }
-                    }
-                }
-            }
-        }
-
-        debug!(
-            query = query,
-            providers = providers.len(),
-            "LMS raw globalsearch completed"
-        );
-
-        Ok(json!({ "providers": providers }))
-    }
 
     /// Execute a globalsearch items query
     async fn globalsearch_items(
@@ -1241,15 +1338,15 @@ impl LmsAdapter {
             .and_then(|v| v.as_array())
     }
 
-    /// Drill into a provider to find the Songs category and return playable items
-    async fn drill_into_songs(
+    /// Drill into a provider to find both Albums and Songs categories.
+    /// Returns albums with hasitems=1 and individual tracks.
+    async fn drill_into_songs_and_albums(
         &self,
         player_id: &str,
         query: &str,
         provider_item_id: &str,
         limit: usize,
     ) -> Result<Vec<LmsSearchResult>> {
-        // Get the provider's categories (Everything, Playlists, Artists, Albums, Songs)
         let result = self
             .globalsearch_items(player_id, query, Some(provider_item_id))
             .await?;
@@ -1261,9 +1358,16 @@ impl LmsAdapter {
 
         let mut results = Vec::new();
 
-        // Prefer "Songs" category over "Everything" — "Everything" contains album
-        // containers (isaudio=1, hasitems=1) that queue entire albums when played.
-        // Try "Songs" first, fall back to "Everything" if no Songs category exists.
+        // Find Albums and Songs category IDs
+        let albums_id = items.iter().find_map(|item| {
+            let name = item.get("name").and_then(|v| v.as_str()).unwrap_or("");
+            let has = item.get("hasitems").and_then(|v| v.as_i64()).unwrap_or(0) == 1;
+            if has && name == "Albums" {
+                item.get("id").and_then(|v| v.as_str())
+            } else {
+                None
+            }
+        });
         let songs_id = items.iter().find_map(|item| {
             let name = item.get("name").and_then(|v| v.as_str()).unwrap_or("");
             let has = item.get("hasitems").and_then(|v| v.as_i64()).unwrap_or(0) == 1;
@@ -1282,10 +1386,8 @@ impl LmsAdapter {
                 None
             }
         });
-        let drill_id = songs_id.or(everything_id);
 
-        // Collect any directly playable items (tracks and album containers alike).
-        // parse_single_item classifies them correctly — callers use category to decide.
+        // Collect directly playable items at this level
         for item in items {
             if results.len() >= limit {
                 break;
@@ -1293,14 +1395,49 @@ impl LmsAdapter {
             let is_audio = item.get("isaudio").and_then(|v| v.as_i64()).unwrap_or(0) == 1
                 || item.get("type").and_then(|v| v.as_str()) == Some("audio");
             if is_audio {
-                if let Some(result) = self.parse_single_item(item) {
-                    results.push(result);
+                if let Some(r) = self.parse_single_item(item) {
+                    results.push(r);
                 }
             }
         }
 
-        // Drill into Songs (or Everything) for more tracks
-        if let Some(drill) = drill_id {
+        // Drill into Albums category
+        if let Some(aid) = albums_id {
+            if let Ok(album_result) = self.globalsearch_items(player_id, query, Some(aid)).await {
+                if let Some(album_items) = Self::get_items_from_result(&album_result) {
+                    for item in album_items.iter().take(5) {
+                        if results.len() >= limit { break; }
+                        let has_items = item.get("hasitems").and_then(|v| v.as_i64()).unwrap_or(0) == 1;
+                        if has_items {
+                            // This is an album container
+                            let string_item_id = item.get("id").and_then(|v| v.as_str()).map(String::from);
+                            let title = item.get("name").or_else(|| item.get("title"))
+                                .and_then(|v| v.as_str()).unwrap_or_default();
+                            let artist = item.get("artist").and_then(|v| v.as_str()).map(String::from);
+                            let image = item.get("image").and_then(|v| v.as_str()).map(String::from);
+                            results.push(LmsSearchResult {
+                                result_type: LmsSearchResultType::Album,
+                                id: 0,
+                                title: title.to_string(),
+                                artist,
+                                album: None,
+                                url: None,
+                                item_id: string_item_id,
+                                year: None,
+                                genre: None,
+                                duration: None,
+                                image_url: image,
+                                coverid: None,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        // Drill into Songs (or Everything) for tracks
+        let songs_drill = songs_id.or(everything_id);
+        if let Some(drill) = songs_drill {
             let songs_result = self
                 .globalsearch_items(player_id, query, Some(drill))
                 .await?;
@@ -1309,8 +1446,8 @@ impl LmsAdapter {
                     if results.len() >= limit {
                         break;
                     }
-                    if let Some(result) = self.parse_single_item(song) {
-                        results.push(result);
+                    if let Some(r) = self.parse_single_item(song) {
+                        results.push(r);
                     }
                 }
             }
@@ -1370,6 +1507,9 @@ impl LmsAdapter {
             LmsSearchResultType::Track
         };
 
+        // Extract image URL for streaming items (globalsearch provides `image` field)
+        let image_url = item.get("image").and_then(|v| v.as_str()).map(String::from);
+
         Some(LmsSearchResult {
             result_type,
             id: numeric_id,
@@ -1381,6 +1521,11 @@ impl LmsAdapter {
             album: item.get("album").and_then(|v| v.as_str()).map(String::from),
             url,
             item_id: string_item_id,
+            year: None,
+            genre: None,
+            duration: item.get("duration").and_then(|v| v.as_f64()),
+            image_url,
+            coverid: None,
         })
     }
 
@@ -1419,6 +1564,11 @@ impl LmsAdapter {
                         album: None,
                         url: None,
                         item_id: None,
+                        year: None,
+                        genre: None,
+                        duration: None,
+                        image_url: None,
+                        coverid: None,
                     });
                 }
             }
@@ -1439,6 +1589,11 @@ impl LmsAdapter {
                         album: None,
                         url: None,
                         item_id: None,
+                        year: None,
+                        genre: None,
+                        duration: None,
+                        image_url: None,
+                        coverid: None,
                     });
                 }
             }
@@ -1465,6 +1620,11 @@ impl LmsAdapter {
                             .map(String::from),
                         url: None,
                         item_id: None,
+                        year: None,
+                        genre: None,
+                        duration: None,
+                        image_url: None,
+                        coverid: None,
                     });
                 }
             }
@@ -1477,125 +1637,6 @@ impl LmsAdapter {
         );
 
         Ok(results)
-    }
-
-    /// Search and play the first matching result
-    ///
-    /// Searches using globalsearch (includes streaming services), finds the first
-    /// playable result, and executes the specified action (play, queue, or insert).
-    /// Uses URL-based playback for streaming items, playlistcontrol for library items.
-    pub async fn search_and_play(
-        &self,
-        query: &str,
-        player_id: &str,
-        action: LmsPlayAction,
-    ) -> Result<String> {
-        let player_id = strip_lms_prefix(player_id);
-
-        // Search for content (uses globalsearch which includes all providers)
-        let results = self.search(query, Some(player_id), Some(10)).await?;
-
-        if results.is_empty() {
-            return Err(anyhow!("No results found for '{}'", query));
-        }
-
-        // Take the first result
-        let result = &results[0];
-
-        // Determine playback method based on item type:
-        // 1. item_id present (globalsearch streaming) -> use "globalsearch playlist play item_id:XXX"
-        // 2. url present (direct URL) -> use "playlist load/add URL"
-        // 3. otherwise (library item) -> use "playlistcontrol" with entity ID
-        if let Some(ref item_id) = result.item_id {
-            // Globalsearch streaming item - use globalsearch playlist command
-            let method = match action {
-                LmsPlayAction::Play => "play",
-                LmsPlayAction::Queue => "add",
-                LmsPlayAction::Insert => "insert",
-            };
-            let item_id_param = format!("item_id:{}", item_id);
-            self.rpc
-                .execute(
-                    Some(player_id),
-                    vec![
-                        json!("globalsearch"),
-                        json!("playlist"),
-                        json!(method),
-                        json!(item_id_param),
-                    ],
-                )
-                .await?;
-        } else if let Some(ref url) = result.url {
-            // Direct URL item - use playlist command with URL
-            let method = match action {
-                LmsPlayAction::Play => "load",
-                LmsPlayAction::Queue => "add",
-                LmsPlayAction::Insert => "insert",
-            };
-            self.rpc
-                .execute(
-                    Some(player_id),
-                    vec![json!("playlist"), json!(method), json!(url)],
-                )
-                .await?;
-        } else if result.id > 0 {
-            // Library item - use playlistcontrol with entity ID
-            let id_param = match result.result_type {
-                LmsSearchResultType::Album => format!("album_id:{}", result.id),
-                LmsSearchResultType::Artist => format!("artist_id:{}", result.id),
-                LmsSearchResultType::Track => format!("track_id:{}", result.id),
-            };
-
-            let cmd_param = format!("cmd:{}", action.to_lms_cmd());
-
-            self.rpc
-                .execute(
-                    Some(player_id),
-                    vec![json!("playlistcontrol"), json!(cmd_param), json!(id_param)],
-                )
-                .await?;
-        } else {
-            // No valid playback handle - this shouldn't happen if parse_single_item works correctly
-            return Err(anyhow!(
-                "No playable result found for '{}' (missing item_id, url, and valid id)",
-                query
-            ));
-        }
-
-        // Build response message
-        let action_verb = match action {
-            LmsPlayAction::Play => "Playing",
-            LmsPlayAction::Queue => "Queued",
-            LmsPlayAction::Insert => "Playing next",
-        };
-
-        let what = match result.result_type {
-            LmsSearchResultType::Album => {
-                if let Some(ref artist) = result.artist {
-                    format!("album \"{}\" by {}", result.title, artist)
-                } else {
-                    format!("album \"{}\"", result.title)
-                }
-            }
-            LmsSearchResultType::Artist => format!("music by {}", result.title),
-            LmsSearchResultType::Track => {
-                if let Some(ref artist) = result.artist {
-                    format!("\"{}\" by {}", result.title, artist)
-                } else {
-                    format!("\"{}\"", result.title)
-                }
-            }
-        };
-
-        info!(
-            action = action_verb,
-            what = what,
-            player_id = player_id,
-            url = result.url.as_deref().unwrap_or("library"),
-            "LMS search_and_play"
-        );
-
-        Ok(format!("{} {}", action_verb, what))
     }
 
     /// Play a specific item by raw JSON fields from search results.

--- a/src/adapters/lms.rs
+++ b/src/adapters/lms.rs
@@ -1047,7 +1047,10 @@ impl LmsAdapter {
     async fn library_cover_url(&self, coverid: &str) -> Option<String> {
         let state = self.state.read().await;
         let host = state.host.as_ref()?;
-        Some(format!("http://{}:{}/music/{}/cover.jpg", host, state.port, coverid))
+        Some(format!(
+            "http://{}:{}/music/{}/cover.jpg",
+            host, state.port, coverid
+        ))
     }
 
     /// Resolve an image URL: absolute URLs pass through, relative paths get the LMS base prepended.
@@ -1096,11 +1099,20 @@ impl LmsAdapter {
             if let Some(albums) = result.get("albums_loop").and_then(|v| v.as_array()) {
                 for album in albums.iter().take(10) {
                     let id = album.get("id").and_then(|v| v.as_i64()).unwrap_or(0);
-                    let title = album.get("album").and_then(|v| v.as_str()).unwrap_or_default();
-                    let artist = album.get("artist").and_then(|v| v.as_str()).map(String::from);
+                    let title = album
+                        .get("album")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default();
+                    let artist = album
+                        .get("artist")
+                        .and_then(|v| v.as_str())
+                        .map(String::from);
                     let year = album.get("year").and_then(|v| v.as_u64()).map(|y| y as u32);
-                    let artwork_track_id = album.get("artwork_track_id")
-                        .and_then(|v| v.as_str().map(String::from).or_else(|| v.as_i64().map(|n| n.to_string())));
+                    let artwork_track_id = album.get("artwork_track_id").and_then(|v| {
+                        v.as_str()
+                            .map(String::from)
+                            .or_else(|| v.as_i64().map(|n| n.to_string()))
+                    });
                     let image_url = if let Some(ref cid) = artwork_track_id {
                         self.library_cover_url(cid).await
                     } else {
@@ -1144,16 +1156,38 @@ impl LmsAdapter {
             if let Some(tracks) = result.get("titles_loop").and_then(|v| v.as_array()) {
                 for track in tracks.iter().take(10) {
                     let id = track.get("id").and_then(|v| v.as_i64()).unwrap_or(0);
-                    let title = track.get("title").and_then(|v| v.as_str()).unwrap_or_default();
-                    let artist = track.get("artist").and_then(|v| v.as_str()).map(String::from);
-                    let album = track.get("album").and_then(|v| v.as_str()).map(String::from);
+                    let title = track
+                        .get("title")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default();
+                    let artist = track
+                        .get("artist")
+                        .and_then(|v| v.as_str())
+                        .map(String::from);
+                    let album = track
+                        .get("album")
+                        .and_then(|v| v.as_str())
+                        .map(String::from);
                     let year = track.get("year").and_then(|v| v.as_u64()).map(|y| y as u32);
-                    let genre = track.get("genre").and_then(|v| v.as_str()).map(String::from);
+                    let genre = track
+                        .get("genre")
+                        .and_then(|v| v.as_str())
+                        .map(String::from);
                     let duration = track.get("duration").and_then(|v| v.as_f64());
-                    let coverid = track.get("coverid")
-                        .and_then(|v| v.as_str().map(String::from).or_else(|| v.as_i64().map(|n| n.to_string())))
-                        .or_else(|| track.get("artwork_track_id")
-                            .and_then(|v| v.as_str().map(String::from).or_else(|| v.as_i64().map(|n| n.to_string()))));
+                    let coverid = track
+                        .get("coverid")
+                        .and_then(|v| {
+                            v.as_str()
+                                .map(String::from)
+                                .or_else(|| v.as_i64().map(|n| n.to_string()))
+                        })
+                        .or_else(|| {
+                            track.get("artwork_track_id").and_then(|v| {
+                                v.as_str()
+                                    .map(String::from)
+                                    .or_else(|| v.as_i64().map(|n| n.to_string()))
+                            })
+                        });
                     let image_url = if let Some(ref cid) = coverid {
                         self.library_cover_url(cid).await
                     } else {
@@ -1194,11 +1228,13 @@ impl LmsAdapter {
         if let Ok(result) = artists_result {
             if let Some(artists) = result.get("contributors_loop").and_then(|v| v.as_array()) {
                 for artist in artists.iter().take(5) {
-                    let id = artist.get("contributor_id")
+                    let id = artist
+                        .get("contributor_id")
                         .or_else(|| artist.get("id"))
                         .and_then(|v| v.as_i64())
                         .unwrap_or(0);
-                    let name = artist.get("contributor")
+                    let name = artist
+                        .get("contributor")
                         .or_else(|| artist.get("name"))
                         .and_then(|v| v.as_str())
                         .unwrap_or_default();
@@ -1238,8 +1274,10 @@ impl LmsAdapter {
                 if let Some(items) = Self::get_items_from_result(&result) {
                     for item in items {
                         let item_id = item.get("id").and_then(|v| v.as_str());
-                        let has_items = item.get("hasitems").and_then(|v| v.as_i64()).unwrap_or(0) == 1;
-                        let is_audio = item.get("isaudio").and_then(|v| v.as_i64()).unwrap_or(0) == 1
+                        let has_items =
+                            item.get("hasitems").and_then(|v| v.as_i64()).unwrap_or(0) == 1;
+                        let is_audio = item.get("isaudio").and_then(|v| v.as_i64()).unwrap_or(0)
+                            == 1
                             || item.get("type").and_then(|v| v.as_str()) == Some("audio");
 
                         if is_audio {
@@ -1306,7 +1344,6 @@ impl LmsAdapter {
 
         Ok(results)
     }
-
 
     /// Execute a globalsearch items query
     async fn globalsearch_items(
@@ -1406,15 +1443,26 @@ impl LmsAdapter {
             if let Ok(album_result) = self.globalsearch_items(player_id, query, Some(aid)).await {
                 if let Some(album_items) = Self::get_items_from_result(&album_result) {
                     for item in album_items.iter().take(5) {
-                        if results.len() >= limit { break; }
-                        let has_items = item.get("hasitems").and_then(|v| v.as_i64()).unwrap_or(0) == 1;
+                        if results.len() >= limit {
+                            break;
+                        }
+                        let has_items =
+                            item.get("hasitems").and_then(|v| v.as_i64()).unwrap_or(0) == 1;
                         if has_items {
                             // This is an album container
-                            let string_item_id = item.get("id").and_then(|v| v.as_str()).map(String::from);
-                            let title = item.get("name").or_else(|| item.get("title"))
-                                .and_then(|v| v.as_str()).unwrap_or_default();
-                            let artist = item.get("artist").and_then(|v| v.as_str()).map(String::from);
-                            let image = item.get("image").and_then(|v| v.as_str()).map(String::from);
+                            let string_item_id =
+                                item.get("id").and_then(|v| v.as_str()).map(String::from);
+                            let title = item
+                                .get("name")
+                                .or_else(|| item.get("title"))
+                                .and_then(|v| v.as_str())
+                                .unwrap_or_default();
+                            let artist = item
+                                .get("artist")
+                                .and_then(|v| v.as_str())
+                                .map(String::from);
+                            let image =
+                                item.get("image").and_then(|v| v.as_str()).map(String::from);
                             results.push(LmsSearchResult {
                                 result_type: LmsSearchResultType::Album,
                                 id: 0,

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -66,65 +66,28 @@ pub struct HifiControlTool {
     pub value: Option<f64>,
 }
 
-/// Search for music
+/// Search for music across library and streaming services.
 #[mcp_tool(
     name = "hifi_search",
-    description = "Search for tracks, albums, or artists. Roon: searches Library, TIDAL, or Qobuz (use source param). LMS: searches all installed providers including streaming plugins (zone_id recommended as different players may have different sources configured).",
+    description = "Search for music across library and streaming services. Returns items with rich metadata (title, artist, album, year, genre, duration, image_url, source) and a _play token for playback via hifi_play_item. Library results include local files with full metadata. Streaming results include TIDAL/Qobuz items. Results are ready to evaluate and play.",
     read_only_hint = true
 )]
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct HifiSearchTool {
     /// Search query (e.g., "Hotel California", "Eagles", "jazz piano")
     pub query: String,
-    /// Zone ID for context-aware results. Recommended for LMS (different players may have different sources).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub zone_id: Option<String>,
-    /// Where to search: "library" (default), "tidal", or "qobuz". Roon only; LMS searches all providers.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub source: Option<String>,
-}
-
-/// Search and play music in one command
-#[mcp_tool(
-    name = "hifi_play",
-    description = "Search and play music. Searches and plays, queues, or starts radio from the first matching result. Use action='queue' to add to queue. action='radio' and source param are Roon-only; LMS searches all providers."
-)]
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
-pub struct HifiPlayTool {
-    /// What to play (e.g., "early Michael Jackson", "Dark Side of the Moon")
-    pub query: String,
-    /// Zone ID to play on (get from hifi_zones)
-    pub zone_id: String,
-    /// Where to search: "library" (default), "tidal", or "qobuz". Roon only; LMS searches all providers.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub source: Option<String>,
-    /// What to do: "play" (default), "queue", or "radio". radio is Roon-only.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub action: Option<String>,
-}
-
-/// Search and return raw adapter results for LLM interpretation.
-#[mcp_tool(
-    name = "hifi_search_raw",
-    description = "Search for music and return raw unprocessed results. Returns adapter-native data including all keys needed to play a specific result via hifi_play_item. For Roon: returns browse items with item_key, hint, session_key. For LMS: returns results with id, item_id, url, result_type. The LLM interprets the results and picks what to play.",
-    read_only_hint = true
-)]
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
-pub struct HifiSearchRawTool {
-    /// Search query
-    pub query: String,
-    /// Zone ID (determines which adapter to search)
+    /// Zone ID (determines which adapter to search). Required.
     pub zone_id: String,
     /// Search source: "library" (default), "tidal", "qobuz". Roon only.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
 }
 
-/// Play a specific item by passing back keys from hifi_search_raw results.
+/// Play a specific item by passing back keys from hifi_search results.
 /// The caller (LLM) decides what to play; the bridge just executes.
 #[mcp_tool(
     name = "hifi_play_item",
-    description = "Play a specific item using keys from a prior hifi_search_raw call. Pass the raw JSON fields back as-is. For Roon: session_key + item_key. For LMS: item_id, url, or id + result_type. The bridge routes to the correct adapter based on zone_id prefix."
+    description = "Play a specific item using keys from a prior hifi_search call. Pass the _play token from search results as the item parameter — do not modify it. The bridge routes to the correct adapter based on zone_id prefix."
 )]
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct HifiPlayItemTool {
@@ -197,8 +160,6 @@ tool_box!(
         HifiNowPlayingTool,
         HifiControlTool,
         HifiSearchTool,
-        HifiPlayTool,
-        HifiSearchRawTool,
         HifiPlayItemTool,
         HifiStatusTool,
         HifiHqplayerStatusTool,
@@ -233,11 +194,6 @@ struct McpNowPlaying {
     is_muted: Option<bool>,
 }
 
-#[derive(Debug, Serialize)]
-struct McpSearchResult {
-    title: String,
-    subtitle: Option<String>,
-}
 
 #[derive(Debug, Serialize)]
 struct McpHqpStatus {
@@ -456,114 +412,6 @@ impl ServerHandler for HifiMcpHandler {
             }
 
             HifiTools::HifiSearchTool(args) => {
-                // Route: explicit lms: prefix → LMS, else try Roon, fall back to LMS if Roon browse unavailable
-                let use_lms = args.zone_id.as_ref().is_some_and(|z| z.starts_with("lms:"))
-                    || !self.state.roon.is_browse_connected().await;
-
-                if use_lms {
-                    // LMS search: return raw globalsearch JSON for LLM interpretation.
-                    // The LLM handles field variations, category names, and metadata
-                    // across providers (library, TIDAL, Qobuz) better than hand-parsing.
-                    match self
-                        .state
-                        .lms
-                        .search_raw(&args.query, args.zone_id.as_deref())
-                        .await
-                    {
-                        Ok(raw) => Ok(Self::json_result(&raw)),
-                        Err(e) => Self::error_result(format!("Search error: {}", e)),
-                    }
-                } else {
-                    // Roon search
-                    use crate::adapters::roon::SearchSource;
-                    let source = match args.source.as_deref() {
-                        Some("tidal") => SearchSource::Tidal,
-                        Some("qobuz") => SearchSource::Qobuz,
-                        _ => SearchSource::Library,
-                    };
-                    let zone_id = args.zone_id.as_deref();
-                    match self
-                        .state
-                        .roon
-                        .search(&args.query, zone_id, Some(10), source)
-                        .await
-                    {
-                        Ok((_session_key, results)) => {
-                            let mcp_results: Vec<McpSearchResult> = results
-                                .into_iter()
-                                .map(|item| McpSearchResult {
-                                    title: item.title,
-                                    subtitle: item.subtitle,
-                                })
-                                .collect();
-                            Ok(Self::json_result(&mcp_results))
-                        }
-                        Err(e) => Self::error_result(format!("Search error: {}", e)),
-                    }
-                }
-            }
-
-            HifiTools::HifiPlayTool(args) => {
-                // Route: explicit lms: prefix → LMS, else try Roon, fall back to LMS if Roon browse unavailable
-                let use_lms = args.zone_id.starts_with("lms:")
-                    || !self.state.roon.is_browse_connected().await;
-
-                if use_lms {
-                    use crate::adapters::lms::LmsPlayAction;
-                    if args.action.as_deref() == Some("radio") {
-                        return Self::error_result(
-                            "Radio mode not supported for LMS. Use 'play' or 'queue'.".into(),
-                        );
-                    }
-
-                    // If zone_id doesn't have lms: prefix (fallback case), pick any LMS player
-                    let zone_id = if args.zone_id.starts_with("lms:") {
-                        args.zone_id.clone()
-                    } else {
-                        let players = self.state.lms.get_cached_players().await;
-                        match players.first() {
-                            Some(p) => format!("lms:{}", p.playerid),
-                            None => {
-                                return Self::error_result(
-                                    "No playback adapters available (Roon browse not connected, no LMS players)".into(),
-                                );
-                            }
-                        }
-                    };
-
-                    let action = LmsPlayAction::parse(args.action.as_deref());
-
-                    match self
-                        .state
-                        .lms
-                        .search_and_play(&args.query, &zone_id, action)
-                        .await
-                    {
-                        Ok(message) => Ok(Self::text_result(message)),
-                        Err(e) => Self::error_result(format!("Play error: {}", e)),
-                    }
-                } else {
-                    // Roon play
-                    use crate::adapters::roon::{PlayAction, SearchSource};
-                    let source = match args.source.as_deref() {
-                        Some("tidal") => SearchSource::Tidal,
-                        Some("qobuz") => SearchSource::Qobuz,
-                        _ => SearchSource::Library,
-                    };
-                    let action = PlayAction::parse(args.action.as_deref().unwrap_or("play"));
-                    match self
-                        .state
-                        .roon
-                        .search_and_play(&args.query, &args.zone_id, source, action)
-                        .await
-                    {
-                        Ok(message) => Ok(Self::text_result(message)),
-                        Err(e) => Self::error_result(format!("Play error: {}", e)),
-                    }
-                }
-            }
-
-            HifiTools::HifiSearchRawTool(args) => {
                 let use_lms = args.zone_id.starts_with("lms:")
                     || !self.state.roon.is_browse_connected().await;
 
@@ -571,7 +419,7 @@ impl ServerHandler for HifiMcpHandler {
                     match self
                         .state
                         .lms
-                        .search(&args.query, Some(&args.zone_id), Some(20))
+                        .search_unified(&args.query, Some(&args.zone_id), Some(20))
                         .await
                     {
                         Ok(items) => {
@@ -587,10 +435,14 @@ impl ServerHandler for HifiMcpHandler {
                                     });
                                     serde_json::json!({
                                         "title": item.title,
-                                        "subtitle": item.artist,
-                                        "category": item.result_type.to_string(),
-                                        "source": if item.item_id.is_some() { "streaming" } else { "library" },
+                                        "artist": item.artist,
                                         "album": item.album,
+                                        "category": item.result_type.to_string(),
+                                        "year": item.year,
+                                        "genre": item.genre,
+                                        "duration": item.duration,
+                                        "image_url": item.image_url,
+                                        "source": if item.item_id.is_some() { "streaming" } else { "library" },
                                         "_play": play,
                                     })
                                 })
@@ -977,10 +829,10 @@ pub fn create_mcp_extension(state: AppState) -> axum::Extension<McpExtState> {
         instructions: Some(
             "Unified Hi-Fi Control MCP Server - Control Your Music System\n\n\
             Use hifi_zones to list available zones, hifi_now_playing to see what's playing, \
-            hifi_control for playback control, hifi_search to find music, and hifi_play to play it.\n\n\
-            Note: hifi_search and hifi_play currently work with Roon and LMS zones only. \
+            hifi_control for playback control, hifi_search to find music, and hifi_play_item to play it.\n\n\
+            Note: hifi_search and hifi_play_item currently work with Roon and LMS zones only. \
             Transport controls (play/pause/next/volume) work with all zones (Roon, LMS, OpenHome, UPnP).\n\n\
-            To build a playlist: call hifi_play multiple times with action='queue'. The first track \
+            To build a playlist: call hifi_search to find tracks, then hifi_play_item for each. The first track \
             can use action='play' to start playback, then subsequent tracks use action='queue' to add to the queue."
                 .into(),
         ),

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -194,7 +194,6 @@ struct McpNowPlaying {
     is_muted: Option<bool>,
 }
 
-
 #[derive(Debug, Serialize)]
 struct McpHqpStatus {
     connected: bool,


### PR DESCRIPTION
## Summary

Consolidate three LMS search tools into a single `hifi_search` that returns rich metadata for LLM evaluation.

### Problem

The bridge had 3 overlapping search tools, none returning useful metadata for LLMs:
- `hifi_search` → returned raw navigation hierarchy (categories like "Artists", "Albums", "Songs") — not playable results
- `hifi_search_raw` → drilled into TIDAL Songs only — returned tracks with **no artist, no album, no year, no image**
- `hifi_play` → search-and-play in one shot, bypassing LLM evaluation entirely

An LLM searching for "Kind of Blue" got back 20 random TIDAL tracks with just titles. No artist names. No album. No way to make an informed choice.

### Solution

**Single `hifi_search` tool** that combines:
1. **Library search** via LMS `albums`/`tracks`/`artists` endpoints with metadata tags — returns artist, album, year, genre, duration, cover art URL
2. **Streaming search** via globalsearch drilling into both Albums AND Songs (was Songs-only) — extracts image URLs
3. **Merge + deduplicate** — library results first, streaming appended, dedup on title+artist

### Result format

```json
{
  "title": "Kind Of Blue",
  "artist": "Miles Davis",
  "album": null,
  "category": "album",
  "year": 1969,
  "genre": "Jazz",
  "image_url": "http://192.168.50.225:9000/music/c75cb89d/cover.jpg",
  "source": "library",
  "_play": {"adapter": "lms", "id": 8, "result_type": "album"}
}
```

### Changes

**MCP tools** (12 → 10):
- Removed `hifi_search` (navigation links, useless)
- Removed `hifi_play` (bypassed LLM evaluation)
- Renamed `hifi_search_raw` → `hifi_search` with rich results
- `hifi_play_item` unchanged — existing playback works

**LMS adapter**:
- New `search_unified()` method
- New `drill_into_songs_and_albums()` (was songs-only)
- Image extraction from globalsearch items
- Cover art URL construction from LMS host:port + coverid
- Removed dead code: `search()`, `search_raw()`, `search_and_play()`, `drill_into_songs()`

**No breaking changes**: `_play` token format and `play_item()` unchanged.

### Testing

- `cargo check` passes clean
- Verified library search returns rich metadata via LMS JSON-RPC
- Verified streaming image URLs are present in globalsearch responses
- Verified `playlistcontrol cmd:load track_id:48` works for library tracks

### Label needed

`api-change-approved` — MCP tool names changed (not REST routes, but following the spirit of the policy)