### PR TITLE
ci: Allow build:* labels to trigger CI directly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,11 +135,11 @@ jobs:
           INPUT_LINUX_PACKAGES: ${{ inputs.build_linux_packages }}
         run: |
           # Skip if triggered by a non-build label (e.g., arch, coderabbit)
-          # Only the 'build-me' label should trigger builds via labeled event
-          if [[ "$EVENT_ACTION" == "labeled" && "$LABEL_ADDED" != "build-me" ]]; then
-            echo "::notice::Skipping: labeled event for '$LABEL_ADDED' (only 'build-me' triggers builds)"
+          # Allow 'build-me' (all builds) and 'build:*' (specific builds) labels
+          if [[ "$EVENT_ACTION" == "labeled" && "$LABEL_ADDED" != "build-me" && "$LABEL_ADDED" != build:* ]]; then
+            echo "::notice::Skipping: labeled event for '$LABEL_ADDED' (only 'build-me' and 'build:*' trigger builds)"
             echo "### ⏭️ Skipped" >> $GITHUB_STEP_SUMMARY
-            echo "Label \`$LABEL_ADDED\` added - only \`build-me\` triggers builds." >> $GITHUB_STEP_SUMMARY
+            echo "Label \`$LABEL_ADDED\` added - only \`build-me\` and \`build:*\` labels trigger builds." >> $GITHUB_STEP_SUMMARY
             # Set all outputs to false/empty so dependent jobs skip
             echo "is_release=false" >> $GITHUB_OUTPUT
             echo "build_linux_arm=false" >> $GITHUB_OUTPUT
@@ -326,7 +326,7 @@ jobs:
             echo "|-------|--------------|" >> $GITHUB_STEP_SUMMARY
             printf "%s" "$TABLE_ROWS" >> $GITHUB_STEP_SUMMARY
           else
-            echo "_No optional builds enabled. Add \`build:*\` labels then \`build-me\` to trigger._" >> $GITHUB_STEP_SUMMARY
+            echo "_No optional builds enabled. Add \`build:*\` labels to trigger specific builds, or \`build-me\` for defaults._" >> $GITHUB_STEP_SUMMARY
           fi
 
   # =============================================================================
@@ -1844,7 +1844,7 @@ jobs:
             echo "| $name | $size |" >> $GITHUB_STEP_SUMMARY
           done || echo "| (none) | - |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "_Add \`build:*\` labels to configure builds, then add \`build-me\` to trigger. Labels: build:lms, build:synology, build:qnap-arm, build:linux-arm, build:macos, build:windows, build:all_" >> $GITHUB_STEP_SUMMARY
+          echo "_Add \`build:*\` labels to trigger specific builds, or \`build-me\` for defaults. Labels: build:lms, build:synology, build:qnap-arm, build:linux-arm, build:macos, build:windows, build:docker, build:all_" >> $GITHUB_STEP_SUMMARY
 
   # =============================================================================
   # PR Comment with Artifact Links


### PR DESCRIPTION
## Summary

- `build:*` labels (e.g., `build:docker`, `build:synology`) now trigger CI directly via the `labeled` event
- Previously only `build-me` could pass the gate, requiring a two-label dance to get specific builds
- `build-me` still works for triggering default builds

One-line gate change — `build:*` labels were already checked downstream in the plan logic, they just couldn't get past the front door.

## Test plan

- [ ] Adding `build:docker` label to a PR triggers CI and builds Docker image
- [ ] Adding a non-build label (e.g., `coderabbit`) still skips CI
- [ ] `build-me` still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build system to accept both `build-me` and `build:*` labels for triggering builds.
  * Clarified system messages to reflect expanded labeling options, including `build:docker` and `build:all`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->