### PR TITLE
chore: Point roon-api at ohc/main fork branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3225,7 +3225,7 @@ dependencies = [
 [[package]]
 name = "roon-api"
 version = "0.3.1"
-source = "git+https://github.com/open-horizon-labs/rust-roon-api.git?branch=fix%2Ffractional-volume#06dd807f2b9c09274cc679710e9175d97ca09adf"
+source = "git+https://github.com/open-horizon-labs/rust-roon-api.git?branch=ohc%2Fmain#06dd807f2b9c09274cc679710e9175d97ca09adf"
 dependencies = [
  "futures-util",
  "if-addrs 0.13.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,8 +88,8 @@ tower = { version = "0.5", optional = true }
 tower-http = { version = "0.6", features = ["cors", "compression-gzip", "trace"], optional = true }
 
 # Roon API (server only)
-roon-api = { git = "https://github.com/open-horizon-labs/rust-roon-api.git", branch = "fix/fractional-volume", features = ["transport", "image", "status", "browse"], optional = true }
-# TODO: Switch back to upstream after https://github.com/TheAppgineer/rust-roon-api/pull/1 is merged
+roon-api = { git = "https://github.com/open-horizon-labs/rust-roon-api.git", branch = "ohc/main", features = ["transport", "image", "status", "browse"], optional = true }
+# TODO: Switch back to upstream after TheAppgineer/rust-roon-api#1 and #2 are merged
 
 # HTTP client (server only)
 reqwest = { version = "0.12", default-features = false, features = ["json", "cookies", "rustls-tls"], optional = true }


### PR DESCRIPTION
## Summary

Renames the roon-api fork branch reference from `fix/fractional-volume` to `ohc/main` — an honest name for our rolling fork branch that carries all upstream-pending fixes.

Same commit (`06dd807`), just a cleaner branch reference. Future fixes stack on `ohc/main` and get rebased as upstream merges our PRs.

## Test plan

- [x] `cargo check --features server` passes
- [x] Same commit hash resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Roon API dependency to track the latest development branch, ensuring alignment with ongoing upstream development while maintaining existing functionality and feature support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->