### PR TITLE
ci: switch to Namespace.so cache volumes and sccache WebDAV

### DIFF
--- a/.github/workflows/api-guard.yml
+++ b/.github/workflows/api-guard.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   check-api-changes:
     name: Check API Changes
-    runs-on: namespace-profile-default
+    runs-on: namespace-profile-cached
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
 
   plan:
     name: Plan
-    runs-on: namespace-profile-default
+    runs-on: namespace-profile-cached
     outputs:
       is_release: ${{ steps.decide.outputs.is_release }}
       build_linux_arm: ${{ steps.decide.outputs.build_linux_arm }}
@@ -335,7 +335,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: namespace-profile-default
+    runs-on: namespace-profile-cached
     steps:
       - uses: actions/checkout@v6
 
@@ -355,12 +355,10 @@ jobs:
         with:
           components: clippy, rustfmt
 
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
+      - name: Cache Rust
+        uses: namespacelabs/nscloud-cache-action@v1
         with:
-          shared-key: "native-build"
-          cache-all-crates: true
-          cache-on-failure: true
+          cache: rust
 
       - name: Check formatting
         run: cargo fmt --check
@@ -370,7 +368,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: namespace-profile-default
+    runs-on: namespace-profile-cached
     steps:
       - uses: actions/checkout@v6
 
@@ -391,14 +389,16 @@ jobs:
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
 
+      - name: Configure Namespace sccache cache
+        run: nsc cache sccache setup --cache_name default >> "$GITHUB_ENV"
+
       - name: Cache Rust
-        uses: Swatinem/rust-cache@v2
+        uses: namespacelabs/nscloud-cache-action@v1
         with:
-          shared-key: "test-build"
+          cache: rust
 
       - name: Run tests
         env:
-          SCCACHE_GHA_ENABLED: "true"
           RUSTC_WRAPPER: "sccache"
         run: cargo test --workspace
 
@@ -407,7 +407,7 @@ jobs:
   # Uses content-based caching to skip build when source unchanged
   build-wasm:
     name: Build WASM Assets
-    runs-on: namespace-profile-default
+    runs-on: namespace-profile-cached
     steps:
       - uses: actions/checkout@v6
 
@@ -449,13 +449,11 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
 
-      - name: Cache Rust dependencies
+      - name: Cache Rust
         if: steps.check-cache.outputs.needs_build == 'true'
-        uses: Swatinem/rust-cache@v2
+        uses: namespacelabs/nscloud-cache-action@v1
         with:
-          shared-key: "wasm-build"
-          cache-all-crates: true
-          cache-on-failure: true
+          cache: rust
 
       - name: Cache Dioxus CLI
         if: steps.check-cache.outputs.needs_build == 'true'
@@ -518,7 +516,7 @@ jobs:
   build-linux-x64:
     name: Build Linux x64
     needs: [plan, build-wasm]
-    runs-on: namespace-profile-default
+    runs-on: namespace-profile-cached
     steps:
       - uses: actions/checkout@v6
 
@@ -528,9 +526,9 @@ jobs:
           targets: x86_64-unknown-linux-musl
 
       - name: Cache Rust
-        uses: Swatinem/rust-cache@v2
+        uses: namespacelabs/nscloud-cache-action@v1
         with:
-          shared-key: zigbuild-x86_64-unknown-linux-musl
+          cache: rust
 
       - name: Install zig
         run: |
@@ -591,7 +589,7 @@ jobs:
   smoke-test:
     name: Smoke Test Binary
     needs: [plan, build-linux-x64]
-    runs-on: namespace-profile-default
+    runs-on: namespace-profile-cached
     steps:
       - name: Download binary
         uses: actions/download-artifact@v7
@@ -734,7 +732,7 @@ jobs:
     name: Build Linux ARM (${{ matrix.arch }})
     needs: [plan, build-wasm]
     if: needs.plan.outputs.build_linux_arm == 'true'
-    runs-on: namespace-profile-default
+    runs-on: namespace-profile-cached
     strategy:
       matrix:
         include:
@@ -753,9 +751,9 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Cache Rust
-        uses: Swatinem/rust-cache@v2
+        uses: namespacelabs/nscloud-cache-action@v1
         with:
-          shared-key: zigbuild-${{ matrix.target }}
+          cache: rust
 
       - name: Install zig
         run: |
@@ -834,10 +832,13 @@ jobs:
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
 
+      - name: Configure Namespace sccache cache
+        run: nsc cache sccache setup --cache_name default >> "$GITHUB_ENV"
+
       - name: Cache Rust
-        uses: Swatinem/rust-cache@v2
+        uses: namespacelabs/nscloud-cache-action@v1
         with:
-          shared-key: macos-x64
+          cache: rust
 
       - name: Download WASM assets
         uses: actions/download-artifact@v7
@@ -858,7 +859,6 @@ jobs:
 
       - name: Build x86_64 (embeds WASM)
         env:
-          SCCACHE_GHA_ENABLED: "true"
           RUSTC_WRAPPER: "sccache"
           UHC_VERSION: ${{ needs.plan.outputs.version }}
           UHC_GIT_SHA: ${{ needs.plan.outputs.git_sha }}
@@ -890,10 +890,13 @@ jobs:
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
 
+      - name: Configure Namespace sccache cache
+        run: nsc cache sccache setup --cache_name default >> "$GITHUB_ENV"
+
       - name: Cache Rust
-        uses: Swatinem/rust-cache@v2
+        uses: namespacelabs/nscloud-cache-action@v1
         with:
-          shared-key: macos-arm64
+          cache: rust
 
       - name: Download WASM assets
         uses: actions/download-artifact@v7
@@ -914,7 +917,6 @@ jobs:
 
       - name: Build aarch64 (embeds WASM)
         env:
-          SCCACHE_GHA_ENABLED: "true"
           RUSTC_WRAPPER: "sccache"
           UHC_VERSION: ${{ needs.plan.outputs.version }}
           UHC_GIT_SHA: ${{ needs.plan.outputs.git_sha }}
@@ -1043,7 +1045,7 @@ jobs:
       always() &&
       needs.plan.outputs.build_lms == 'true' &&
       needs.build-linux-x64.result == 'success'
-    runs-on: namespace-profile-default
+    runs-on: namespace-profile-cached
     steps:
       - uses: actions/checkout@v6
 
@@ -1170,7 +1172,7 @@ jobs:
       always() &&
       needs.plan.outputs.build_synology == 'true' &&
       needs.build-linux-x64.result == 'success'
-    runs-on: namespace-profile-default
+    runs-on: namespace-profile-cached
     strategy:
       fail-fast: false
       matrix:
@@ -1241,7 +1243,7 @@ jobs:
     name: Build QNAP (x64)
     needs: [plan, build-linux-x64]
     if: needs.plan.outputs.build_qnap == 'true'
-    runs-on: namespace-profile-default
+    runs-on: namespace-profile-cached
     steps:
       - uses: actions/checkout@v6
 
@@ -1293,7 +1295,7 @@ jobs:
       always() &&
       needs.plan.outputs.build_qnap_arm == 'true' &&
       needs.build-linux-arm.result == 'success'
-    runs-on: namespace-profile-default
+    runs-on: namespace-profile-cached
     steps:
       - uses: actions/checkout@v6
 
@@ -1347,7 +1349,7 @@ jobs:
       needs.plan.outputs.build_docker == 'true' &&
       needs.plan.outputs.is_release != 'true' &&
       needs.build-linux-x64.result == 'success'
-    runs-on: namespace-profile-default
+    runs-on: namespace-profile-cached
     permissions:
       packages: write
     steps:
@@ -1424,7 +1426,7 @@ jobs:
     name: Build Docker (${{ matrix.arch }})
     needs: [plan, build-linux-x64, build-linux-arm]
     if: needs.plan.outputs.is_release == 'true'
-    runs-on: namespace-profile-default
+    runs-on: namespace-profile-cached
     strategy:
       matrix:
         include:
@@ -1491,7 +1493,7 @@ jobs:
     name: Create Docker Manifest
     needs: [plan, build-docker-release]
     if: needs.plan.outputs.is_release == 'true'
-    runs-on: namespace-profile-default
+    runs-on: namespace-profile-cached
     steps:
       - name: Download digests
         uses: actions/download-artifact@v7
@@ -1545,7 +1547,7 @@ jobs:
       always() &&
       needs.plan.outputs.build_linux_packages == 'true' &&
       needs.build-linux-x64.result == 'success'
-    runs-on: namespace-profile-default
+    runs-on: namespace-profile-cached
     steps:
       - uses: actions/checkout@v6
 
@@ -1637,7 +1639,7 @@ jobs:
     name: Upload to Release
     needs: [plan, build-linux-x64, build-linux-arm, build-macos-universal, build-windows, build-linux-packages, build-lms-universal, build-synology, build-qnap-x64, build-qnap-arm]
     if: needs.plan.outputs.is_release == 'true'
-    runs-on: namespace-profile-default
+    runs-on: namespace-profile-cached
     permissions:
       contents: write
     steps:
@@ -1707,7 +1709,7 @@ jobs:
     name: Update LMS repo.xml
     needs: [plan, upload-release]
     if: needs.plan.outputs.is_release == 'true'
-    runs-on: namespace-profile-default
+    runs-on: namespace-profile-cached
     permissions:
       contents: write
       pull-requests: write
@@ -1793,7 +1795,7 @@ jobs:
     name: Publish to AUR
     needs: [plan, upload-release]
     if: needs.plan.outputs.is_release == 'true'
-    runs-on: namespace-profile-default
+    runs-on: namespace-profile-cached
     steps:
       - uses: actions/checkout@v6
 
@@ -1844,7 +1846,7 @@ jobs:
       - build-docker-release
       - build-linux-packages
     if: always()
-    runs-on: namespace-profile-default
+    runs-on: namespace-profile-cached
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v7
@@ -1884,7 +1886,7 @@ jobs:
     name: Post Artifact Links
     needs: [summary]
     if: always() && github.event_name == 'pull_request'
-    runs-on: namespace-profile-default
+    runs-on: namespace-profile-cached
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -31,7 +31,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.event == 'release')
-    runs-on: namespace-profile-default
+    runs-on: namespace-profile-cached
     timeout-minutes: 90
     permissions:
       contents: write
@@ -149,7 +149,7 @@ jobs:
     name: Pi Image Summary
     needs: [build-pi-image]
     if: always()
-    runs-on: namespace-profile-default
+    runs-on: namespace-profile-cached
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v7


### PR DESCRIPTION
## Summary
- Replace `Swatinem/rust-cache@v2` with `namespacelabs/nscloud-cache-action@v1` — bind-mounted persistent cache volumes instead of tarball download/upload
- Replace `SCCACHE_GHA_ENABLED: "true"` with `nsc cache sccache setup --cache_name default` — co-located WebDAV backend instead of routing through GitHub's cache API
- Switch all Linux Namespace runners from `namespace-profile-default` to `namespace-profile-cached`
- macOS jobs (`namespace-profile-tahoe`) get both sccache WebDAV and nscloud-cache-action
- Windows job (`windows-latest`, GitHub-hosted) left unchanged — nscloud requires Namespace runners

## Test plan
- [ ] Verify lint job passes (nscloud-cache-action replaces Swatinem/rust-cache)
- [ ] Verify test job passes (sccache WebDAV + nscloud-cache-action)
- [ ] Verify build-linux-x64 and smoke test pass
- [ ] Verify build-wasm job passes with conditional cache step
- [ ] Trigger a macOS build (add `build:macos` + `build-me` labels) to verify sccache WebDAV on tahoe runners
- [ ] Verify Windows build still works unchanged with SCCACHE_GHA_ENABLED