### PR TITLE
Fix LMS polling volume parsing for non-integer values

### DIFF
--- a/src/adapters/lms.rs
+++ b/src/adapters/lms.rs
@@ -372,8 +372,9 @@ impl LmsRpc {
             power: result.get("power").and_then(|v| v.as_i64()).unwrap_or(0) == 1,
             volume: result
                 .get("mixer volume")
-                .and_then(|v| v.as_i64())
-                .unwrap_or(0) as i32,
+                .and_then(|v| v.as_f64())
+                .unwrap_or(0.0)
+                .round() as i32,
             playlist_tracks: result
                 .get("playlist_tracks")
                 .and_then(|v| v.as_u64())
@@ -1560,6 +1561,7 @@ async fn update_players_internal(
             }
             Err(e) => {
                 tracing::warn!("Failed to get status for player {}: {}", player.playerid, e);
+                continue;
             }
         }
 
@@ -2618,5 +2620,39 @@ mod tests {
             }
             _ => panic!("Expected Mixer event, got {:?}", event),
         }
+    }
+
+    // -------------------------------------------------------------------------
+    // Volume Parsing Tests (Issue #299)
+    // -------------------------------------------------------------------------
+
+    /// Helper: extract volume from a JSON "mixer volume" value the same way
+    /// get_player_status does.
+    fn parse_volume(json_value: serde_json::Value) -> i32 {
+        json_value.as_f64().unwrap_or(0.0).round() as i32
+    }
+
+    #[test]
+    fn test_volume_parsing_integer() {
+        assert_eq!(parse_volume(json!(75)), 75);
+        assert_eq!(parse_volume(json!(0)), 0);
+        assert_eq!(parse_volume(json!(100)), 100);
+    }
+
+    #[test]
+    fn test_volume_parsing_float() {
+        // LMS with 2.5-step increments produces these values
+        assert_eq!(parse_volume(json!(52.5)), 53);
+        assert_eq!(parse_volume(json!(57.5)), 58);
+        assert_eq!(parse_volume(json!(50.0)), 50);
+        assert_eq!(parse_volume(json!(99.9)), 100);
+        assert_eq!(parse_volume(json!(0.4)), 0);
+    }
+
+    #[test]
+    fn test_volume_parsing_null_defaults_to_zero() {
+        let val: Option<serde_json::Value> = None;
+        let volume = val.and_then(|v| v.as_f64()).unwrap_or(0.0).round() as i32;
+        assert_eq!(volume, 0);
     }
 }


### PR DESCRIPTION
## Summary
Fix volume parsing in LMS polling path to handle non-integer mixer values (e.g., 52.5) that LMS produces with hardware button/IR 2.5-step increments. Also prevent failed status queries from overwriting cached player data with defaults.

Closes #299

## Problem
When LMS stores a non-integer volume (e.g., 52.5), the polling path's `as_i64()` parser silently fails and defaults to 0, causing erratic volume behavior. Additionally, when `get_player_status()` fails, the player with default volume=0 still gets cached, triggering false volume-change events.

## Solution
**Selected:** Local optimum (two targeted fixes)

1. Parse `"mixer volume"` with `as_f64()` + round instead of `as_i64()` -- handles both integer and float values correctly
2. On failed `get_player_status()`, `continue` to skip cache update, preserving existing cached data

## Acceptance Criteria
- [x] Non-integer mixer volume values (e.g., 52.5) are parsed correctly and rounded to nearest integer
- [x] Failed `get_player_status()` does not overwrite cached player data with defaults
- [x] Existing integer volume values continue to work unchanged
- [x] Unit tests cover float volume parsing

## Test Plan
- [x] Unit test: float volume (52.5) rounds to 53
- [x] Unit test: integer volume (75) still parses correctly
- [x] Unit test: null/missing volume defaults to 0
- [x] `cargo test --workspace` passes
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed volume parsing to correctly handle and round fractional volume values
  * Improved error resilience during player status retrieval to prevent processing interruptions

* **Tests**
  * Added comprehensive volume parsing test coverage including edge cases and null value handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->