### PR TITLE
feat(#324): publish adaptive producer documents through the bus and aggregator

### DIFF
--- a/.oh/adaptive-publication.md
+++ b/.oh/adaptive-publication.md
@@ -145,6 +145,11 @@ Two constraints come from that reading rather than from the issue text, and both
 
 ### Recommendation
 
+> **Historical revision 1 — withdrawn.** The separate-broadcast-bus recommendation and its
+> lifecycle decisions below are retained only as the audit trail for why revision 2 was
+> necessary. They are not current design requirements. The authoritative recommendation,
+> decisions, and invariants begin at **“Solution Space — revision 2.”**
+
 **Selected:** Option D — separate internal `AdaptiveBus`, aggregator as sole admission gate
 **Level:** Reframe
 
@@ -166,7 +171,8 @@ out of `admit()`, because no other object of that type exists in the process.
 
 ### The decisions this issue must make explicitly
 
-Five, each recorded here because "an ADR paragraph is not an owner".
+Seven, each recorded here because "an ADR paragraph is not an owner". Decisions 6 and 7 were
+added after dissent review on PR #363.
 
 **1. C1/C2 incoherence → demote, never refuse, never fabricate.**
 
@@ -223,6 +229,80 @@ enforcement would be defence in depth, and is only worth taking if it does not d
 This discharges the obligation `fdc1ca4` recorded at the field, and it can only be done
 here: the prefix vocabulary lives in the server-only bus module, which the shared contract
 layer may not name.
+
+**6. Three more published-and-unapplied invariants. Decision: refuse.**
+
+The same defect class as decision 3 — *the contract published a rule and no code path applied
+it* — found in three more places by dissent review on #363.
+
+| Invariant | Refusal | Why refuse rather than repair |
+|---|---|---|
+| A control publishes one value lane twice | `DuplicateValueLane` | One lane is one reading. Two `desired` lanes make "the staged value" ambiguous, and because `effective_view` resolves a single lane, C1 could be satisfied by one and contradicted by the other in the same document. Picking one invents a disambiguation the producer never made. |
+| The document publishes health for one transport lane twice | `DuplicateLaneHealth` | `LaneWitness` is keyed by lane, so a duplicate is not redundant but unrepresentable. Folding it would silently keep whichever entry came last in a `Vec`. |
+| `Availability` is not well formed | `AvailabilityNotWellFormed` | A consumer that can see "not usable" but not why cannot explain itself, and the user cannot escape the state that caused it. Inventing a reason tells the user something no producer said. |
+| `LaneHealth.last_success` is not RFC 3339 | `LaneTimestampNotRfc3339` | `Timestamp` documents itself as RFC 3339 and every freshness judgement has to parse it. An unparseable value is not a degraded reading but no reading, and admitting one puts a string no consumer can interpret where one it can is expected. Refused on the *first* document too: there is no predecessor to fall back on, so the alternatives are publishing garbage or silently blanking a field, and blanking hides a producer bug only its author can fix. |
+
+**Unrecognized vocabulary members are held to all of these.** Forward compatibility means an
+unknown member stays *representable* — the control is kept, its observed value is kept, the
+unknown state passes through unnormalized — not that structural invariants lapse when a name is
+unfamiliar. An unknown availability state is precisely where a reason matters most, because a
+consumer cannot even fall back on knowing what the state means. This is a narrower reading than
+decision 3 takes of `LaneValue::is_consistent`, and the difference is real rather than an
+inconsistency: that predicate returns `false` *because of* an unrecognized grounding, so
+applying it would refuse a document for using a newer vocabulary, whereas these turn only on
+shapes every version agrees about.
+
+**7. Adapter lifecycle is settled by internal run identity, never by the public bus.**
+
+`crate::bus::BusEvent` and `AdaptiveEvent` are independent broadcast channels drained by one
+`select!` that imposes no order between them. So this interleaving is unremarkable: run *N*
+publishes a document; it sits unread in the adaptive channel; `AdapterStopping` then
+`AdapterConnected` are both processed from the public channel; only then is the document read
+and admitted as current. **Any scheme that treats a public-bus event as the "everything before
+this is stale" marker is defeated by that ordering** — including an epoch tombstone cleared on
+reconnect, which the reconnect disarms before the straggler it exists to stop arrives. The
+mirror case breaks too: a delayed `AdapterStopping` from run *N*, read after run *N+1* has begun
+publishing, would flush a live run's producers.
+
+So identity is carried *in the event* and allocated **synchronously**:
+
+* `AdapterRuns::begin` takes a lock, allocates a monotonic `AdapterRunId`, and records it as
+  that adapter's live run **before returning** — so "run *N+1* is live" is already true before
+  run *N+1* publishes anything.
+* Every ingress `AdaptiveEvent` carries a `PublicationOrigin { adapter, run }`. Publications and
+  removals from a run that is not live are refused (`StaleAdapterRun`) or ignored, however long
+  they sat in a channel and whatever else was processed meanwhile.
+* **Withdrawn:** `AdapterStopping` was treated as a hint that triggered a sweep. Revision 2
+  proved even that destructive sweep unnecessary and unsafe as a source of state removal.
+  Stop events are now informational; ended-run snapshots project `LastKnown`, and only an
+  explicit producer retirement removes state.
+* Ordering therefore comes from a counter under a lock, not from the relative delivery order of
+  two channels — the one thing this design cannot assume.
+
+**Run identity is not producer epoch, and the two lifecycles stay apart.**
+
+| | Whose | Meaning |
+|---|---|---|
+| `AdapterRunId` | ours | one connection attempt by one adapter in this process |
+| `ProducerEpoch` | the producer's | its own restart counter, which only it can bump |
+
+An adapter reconnecting to an unchanged engine is a **new run at the same epoch and must be able
+to republish** — so adapter lifecycle never writes an epoch bar, which is what stranded that
+case. A new run's first publication also *supersedes* the previous run's snapshot rather than
+being ordered against it, because an ended run's view is no longer evidence of anything and
+comparing revisions across the boundary would refuse a reconnect that legitimately sees a lower
+counter. Lane witnesses survive: those are aggregator-observed and belong to the lane, not to our
+connection.
+
+An explicit `ProducerRemoved` is the *other* lifecycle and keeps its own rule: the producer said
+it is gone, so only the producer can contradict that, with a strictly higher `ProducerEpoch`. No
+adapter reconnect clears it.
+
+**Residual, recorded rather than mitigated.** An adapter that dies without ending its run leaves
+that run live, so its stragglers stay admissible until something begins a new run for the same
+adapter — `begin` supersedes unconditionally, so one reconnect is enough. Already-admitted
+producers of a crashed adapter linger until a stop hint or a new run arrives; nothing times them
+out, because the aggregator holds no clock.
 
 ### The reshaping window — decision, not deferral
 
@@ -498,14 +578,178 @@ Five mutations, each verified to have applied first: stop recursing into `cfg_at
 the derive allowlist; drop `UseTree::Rename`; accept `any(...)` as a server gate; swallow
 parse errors. Each is detected.
 
+## Solution Space: lifecycle soundness (revision 2)
+**Updated:** 2026-07-31
+**Supersedes:** the `AdapterStopping`/`AdapterConnected` tombstone lifecycle recorded in
+decision 7 above. That design is withdrawn, not amended.
+
+**Problem:** aggregator-owned adaptive state must be non-regressing, non-resurrectable,
+lifecycle-correct and recoverable under concurrency, crash/cancel, reconnect and
+bounded-channel lag — with `BusEvent`/HTTP frozen and unadmitted documents internal.
+
+**Key constraint:** lifecycle authority was distributed across two independent async channels
+plus a lock-free registry, and every decision read state at a moment unrelated to when it
+acted. No patch to a *rule* fixes that; it is a shape problem.
+
+### Root causes behind the nine dissent findings
+
+| Root cause | Findings |
+|---|---|
+| **R1. Decision and mutation are not atomic** — registry `Mutex` and store `RwLock` are separate; liveness is checked before `store.write().await` | 1, 7 |
+| **R2. Lifecycle facts travel as lossy, unordered, under-addressed events** — `broadcast` drops on lag; two channels have no mutual order; retirement carries no key or epoch. Documents survive loss (idempotent snapshots); *transitions* do not | 3, 5 |
+| **R3. Ownership and ordering are inferred, not recorded** — cleanup string-matches `producer_type`/id prefix; refusals carry no origin; a new run discards ordering instead of rebasing it; dead runs are never reaped and presence trusts the producer's own flag | 2, 4, 6 |
+| **R4. Validation coverage is incomplete** — orthogonal to lifecycle, needed under every candidate | 8, 9 |
+
+Two reframes drove the candidate set. **Commands are not notifications:** publish and retire
+must not be lost, must be ordered, and deserve a verdict; admitted/refused are fan-out and
+losing one is harmless because a reader can re-read. One lossy fan-out carried both, and that
+conflation *is* R2. **Watermarks, not tombstones:** a tombstone is a negative record you must
+remember and can fail to create (finding 5); a monotonic watermark keyed on producer identity
+makes resurrection unrepresentable, covers keys never seen, and survives reconnect because it
+is not keyed on the adapter run.
+
+### Candidates Considered
+
+| Option | Level | Approach | Trade-off |
+|---|---|---|---|
+| A | Local Optimum | Atomic run-registry/store locking; explicit rebase rule replacing `previous = None` | Closes R1 and finding 2; R2/R3 untouched; lock discipline is an unenforceable convention |
+| B | Reframe | Single-consumer bounded mpsc command ingress; `broadcast` for admitted/refused egress only | Backpressure replaces loss; needs a queue policy per command kind |
+| C | Reframe | Synchronous aggregator command API; adapters await a verdict | Inverts the adapter→aggregator dependency the architecture forbids |
+| D | Redesign | Durable journal, per-run sequence, replay | Gap detection and restart recovery; introduces persistence #327 owns |
+| E | Redesign | Single-writer actor, bounded mpsc inbox with oneshot replies, watermark ledger keyed on producer identity, RAII run leases, read-only snapshot handle, lossy egress broadcast | Largest change; read projection still needs a short shared lock, while mutation authority stays with one actor |
+
+### Evaluation
+
+**A — atomic locking.** Partial. Closes findings 1, 7 and (with a rebase rule) 2; leaves 3, 4,
+5, 6. "Never check liveness outside the store lock" is not expressible in the type system, so
+the next inserted `.await` silently reopens finding 1. Couples publication throughput to
+lifecycle churn. Subsumed by E.
+
+**B — bounded mpsc ingress.** Substantial. One consumer means no concurrent mutation, so R1
+dissolves rather than being guarded; bounded mpsc replaces loss with backpressure (finding 3);
+total ingress order removes the "two channels, no mutual order" premise, so `AdapterStopping`
+can stop being an input. Needs an explicit per-kind queue policy. Does not by itself fix 2, 4,
+5, 6.
+
+**C — synchronous command API.** Mechanically sufficient, disqualified on dependency direction:
+adapters would hold the aggregator, which `docs/ARCHITECTURE.md` and `AGENTS.md` forbid — this
+is Option E of the original analysis, rejected then for the same reason. It also serialises
+adapter poll loops against the aggregator. Its one desirable half — a synchronous verdict — is
+recoverable inside E via a oneshot reply, because the publisher then holds only a sender.
+
+**D — journal + sequence + replay.** Right answer to a question #324 was not asked. Durability
+is #327's, and a journal breaks #324's cleanly-revertible property ("a plain revert; no data
+migration, nothing persists a producer document"). The journal and explicit per-run sequence
+remain deferred together; the bounded inbox provides the in-process order #324 requires.
+
+**E — actor + watermark ledger + RAII leases.** Addresses R1, R2 and R3 as one shape rather
+than three patch sets: exclusive write ownership plus one run/store linearization guard kills both TOCTOU classes; bounded lossless inbox
+kills finding 3; a watermark ledger outliving snapshots kills 2 and 5 including unseen keys;
+recorded origins kill 6 and 7's refusal clearing; RAII leases plus read-time presence kill 4.
+Cost: the read path becomes a snapshot handle backed by a short read lock, which is an API
+decision for #326 rather than an implementation detail.
+
+### Recommendation
+
+**Selected:** Option **E**, absorbing A's atomicity through an explicit run/store guard, B's
+channel split as its ingress, and C's oneshot verdict as an option on commands. D's journal and
+sequence layer remain deferred with durability to #327.
+**Level:** Redesign.
+
+Seven of nine findings are consequences of three structural facts. Patching them individually
+is what produced the withdrawn design: each fix was locally correct and the composition was
+not. A single writer plus a guard held from liveness decision through store commit makes the
+check/act race unrepresentable; a watermark ledger makes resurrection unrepresentable; recorded
+origins make ownership a fact rather than a guess.
+
+**Accepted trade-offs.** The read path changes shape. Watermarks grow with distinct producer
+identities and nothing evicts them within a process. Backpressure becomes observable to
+publishers — the correct failure mode, but a new one. RAII covers cancel, task abort, and
+panic-unwind, but not `mem::forget`, process abort, or `panic = "abort"`; unconditional
+supersession on `begin` stays as the backstop.
+
+### Decisions fixed for #324 (owner-confirmed)
+
+1. Publishers **may await** bounded backpressure.
+2. **No document coalescing.** Every ingress command is lossless and ordered.
+3. Retirement is scoped `producer_id` + `epoch` + `origin` and **must cover unseen keys**.
+   The explicit epoch is the sole new retirement authority: rejected documents identify keys
+   to clear but their claimed epochs never raise a floor.
+4. Watermarks stay **in memory**; durable journal/replay deferred to **#327**.
+5. `AdapterStopping` is **not** an authoritative ingress path — run leases are. Ended runs
+   remain visible as `LastKnown`; only explicit producer retirement removes snapshots.
+6. Presence **degrades to `LastKnown`** whenever the admitting run is no longer live.
+7. Reads go through a **read-only snapshot/watch handle**, not synchronous aggregator calls.
+8. Frozen `BusEvent`/HTTP/API contracts maintained.
+
+### Invariants
+
+- **I1 Serialization.** No `.await` between reading lifecycle state and committing the mutation
+  it authorises. One actor owns ingress writes, and the run guard remains held through the
+  synchronous store mutation; read projections acquire locks in the same run-then-store order.
+- **I2 Watermark monotonicity.** Per key, `high_(epoch, revisions)` and
+  `retired_through_epoch` never decrease — including across explicit retirement. A refused
+  document changes neither; the applied retirement floor is the explicit request or a higher
+  floor already retained, and egress reports that applied value.
+- **I3 No resurrection.** Admitted only if `epoch > retired_through_epoch` **and**
+  `(epoch, revisions)` does not regress against the watermark — regardless of run, and
+  regardless of whether the key was ever seen. Retirement through epoch *N* removes only
+  snapshots and diagnostics at epoch *N* or lower; a newer admitted restart remains visible.
+- **I4 Run authority has an explicit linearization point.** Publications are checked against
+  run liveness in the same synchronous turn as store mutation. Retirement reserves bounded
+  capacity and commits authority while the lease is live; once committed, dropping the lease
+  cannot revoke the queued retirement. A stale lease returns `StaleAdapterRun` before enqueue.
+- **I5 Ownership enforced at the trusted internal namespace boundary.** Every
+  publication/retirement must use an allocator-issued live lease whose adapter matches the
+  producer-id namespace. Origins cannot be synthesized through the public API; a wrong-owner
+  command failure is returned/emitted but never occupies the producer's retained document-
+  refusal slot. No cleanup path matches `producer_type`, and the adapter/producer prefix
+  convention remains trusted internal input.
+- **I6 Retirement is total and lossless through its floor.** Retiring *P* through epoch *N*
+  removes every known key/diagnostic of *P* at *N* or lower and installs a producer-wide floor
+  covering unseen keys, without removing a newer restart. It cannot be dropped by channel
+  pressure and returns an explicit committed, applied, or stale-run outcome.
+- **I7 Command losslessness.** No ingress command is dropped. A non-lossy cancellation token
+  closes ingress only after producing adapters stop, then drains accepted commands before the
+  composition root joins the actor. SSE uses a separate early-cancellation token. Wrong-owner
+  commands fail synchronously before queueing (including detached publication), so they never
+  depend on a lossy hint. Only state-change egress notifications may be lost; consumers recover
+  by re-reading the view.
+- **I8 Presence honesty.** `Live` only if the admitting run is live, evaluated at read time so
+  it does not depend on a cleanup command having been delivered.
+- **I9 Timestamp validity.** Every `Timestamp` in an admitted document parses as RFC 3339 —
+  all fields, not only `LaneHealth.last_success`.
+- **I10 Alias closure.** No second name for internal-event types under any type syntax, and no
+  exported root function, const/static, struct/union field, enum payload, trait associated
+  item, trait/impl/generic bound, inherent-method signature, private type/import alias chain,
+  forbidden glob, impl target, or exported/re-exported macro can launder contract/publication
+  types.
+
+### Unresolved assumptions
+
+- Watermarks are unevicted within a process. Fine for #324; revisit jointly with #327 if they
+  must survive restart.
+- Retirement is producer-scoped, so it cannot retire one target of a multi-target producer.
+  Target-granular retirement remains deferred to #325.
+- Presence degradation on a dead run is a semantic #326's consumers have not been told about.
+- `AdapterStopping` is informational only. Last-known snapshots remain until explicit producer
+  retirement; that retirement emits an egress invalidation hint.
+- Direct aggregator helpers remain available in ordinary **debug-profile** builds because Rust
+  integration tests compile the library as a dependency and do not activate its `cfg(test)`.
+  This is an explicit compatibility seam, not a test-only claim. Release builds structurally
+  omit the re-export and direct methods; the actor-only guarantee is a release-artifact
+  guarantee. `cargo test --release --test adaptive_publication` consequently does not compile,
+  while the release library/application check does.
+
 ## Ship
-**Updated:** 2026-07-30
-**Status:** staged (draft PR, nothing merged, deployed or marked ready)
+**Updated:** 2026-07-31
+**Status:** implementation and local gates green; exact-head review/dissent and push pending;
+draft PR only
 
 **Delivery path.** PR #363 (draft) → base `feat/issue-323-adaptive-producer-contract`
-(PR #362, also draft) → #362 merges to `v3` → #363 retargets to `v3` → CI → maintainer
-review → squash merge. Two hops, because this is a stacked PR and the prerequisite is not
-merged.
+(PR #362, draft/CLEAN) → base `fix/issue-338-rust-1-97-lint` (PR #339, draft) → `v3` →
+retarget each dependent PR as its base merges → CI on the `v3`-targeting hop → maintainer
+review → squash merge. Three stacked hops; neither prerequisite is merged.
 
 **Delivery-path tax, measured rather than guessed:**
 
@@ -520,24 +764,28 @@ merged.
    `tests/fixtures/api_routes.txt` differs from the base. It does not, so the job takes the
    `api_changed=false` branch and reports "No API contract changes detected". No label is
    needed and none must be added.
-3. **A pre-existing `v3` lint failure blocks merge**, not caused here:
-   `src/app/pages/zones.rs:269` trips `clippy::unnecessary_sort_by` on CI's newer
-   toolchain. Owned by #338 ("CI: restore the v3 lint baseline under Rust 1.97"), which is
-   open. #362 hit the same wall.
+3. **The pre-existing `v3` Rust 1.97 lint repair is now the bottom stack.** #338 is represented
+   by draft PR #339 (`fix/issue-338-rust-1-97-lint` → `v3`); #362 currently targets that branch
+   and GitHub reports it CLEAN. This branch still cannot reach `v3` until both prerequisites
+   move.
 4. **`docker.yml` is `master`-only**, so a `v3` merge publishes no image. Release artifacts
    only on tag `v*` or a published release.
-5. **PR #362 is `BLOCKED`** on GitHub's own mergeability check, so the first hop is not
-   currently available regardless of this branch's state.
+5. **The stack, not a merge conflict, is the current gate.** PR #362 is draft/CLEAN, while
+   bottom PR #339 remains draft; no hop is authorized to merge automatically.
 
 **Rollback.** A plain revert. `src/producers/` is referenced from exactly two places outside
 itself — `pub mod producers;` in `src/lib.rs` and the construct-and-spawn in `src/main.rs` —
-and nothing publishes to it, so reverting removes a task that subscribes to two channels and
-waits. No data migration: nothing persists a producer document. The one caveat is
+and nothing publishes to it, so reverting removes the bounded actor and its shutdown
+subscription. No data migration: nothing persists a producer document. The one caveat is
 `ReasonCode::ControlRemoved` and `control_removed_after_advance.json`, which are contract
 surface: reverting those after #325 maps onto them would be a compatibility break, so this
 rollback is clean only while this branch is the tip.
 
-**Verified rather than asserted:** `tests/fixtures/api_routes.txt` byte-identical to
-`origin/v3`; zero `.route(` lines added or removed in `src/main.rs`; `src/api/` and
-`src/bus/` untouched; PR #363 carries no labels; worktree clean; every commit
-forward-only, no force push.
+**Latest local evidence:** the full all-features suite, focused lifecycle 25/25 (also 25/25 in
+the release profile), publication 107/107, contract isolation 57/57,
+`cargo clippy --lib --all-features -- -D warnings`, and
+`cargo check --release --all-features` all pass after the final dissent round.
+`tests/fixtures/api_routes.txt`
+remains byte-identical to `origin/v3`; zero `.route(` lines were added or removed in
+`src/main.rs`; `src/api/` and `src/bus/` are untouched; PR #363 carries no labels. The worktree
+is intentionally dirty until the reviewed checkpoint is committed; no force push is used.

--- a/.oh/adaptive-publication.md
+++ b/.oh/adaptive-publication.md
@@ -390,6 +390,91 @@ exactly that way. That is now three consecutive rounds in this epic where the de
 record was a lint reporting success on a violation, and the third where external review
 found it before the internal gates did.
 
+## Solution checkpoint: the boundary lints
+**Updated:** 2026-07-30
+
+Raised after the seventh escape from the hand-written scanner in
+`tests/adaptive_publication_lint.rs`. The escapes, in order, each found by an external
+reviewer and each failing in the direction that reports success:
+
+| # | Escape | Found by |
+|---|---|---|
+| 1 | only the nearest `#[derive(` was inspected | CodeRabbit |
+| 2 | an attribute wrapped across lines was cleared by its own continuation line | CodeRabbit |
+| 3 | `use serde::Serialize as EventWire;` — no literal `Serialize` | CodeRabbit |
+| 4 | a crate-local `pub use` re-export — no literal `serde` in the file | CodeRabbit |
+| 5 | `r##"… " … ] …"##` — string mode left at the embedded quote | CodeRabbit |
+| 6 | `pub use` — the boundary rule rejected exactly that one visibility form | Codex |
+| 7 | `'\''` — the char lexer stopped at the escaped apostrophe | Codex |
+| 8 | `#[allow(unused_imports)] use …;` — an attribute is not a statement boundary | Codex |
+
+Eight commits, 1,982 lines, 56 helper functions, and the escape rate was not falling.
+
+### Candidates
+
+| Option | Approach | Trade-off |
+|---|---|---|
+| A | Continue the shared lexer: lex identifier tokens outside comments and literals, as Codex first suggested | Fixes escape 8 and probably 9. Each round has produced a *new* class rather than a repeat, so the fix is another special case in an incrementally hand-written Rust lexer living in a test file |
+| B | Parse with `syn`, inspect the AST | Escapes stop being detected and become unrepresentable. Costs a parse-failure path and knows nothing about names |
+
+### Evaluation
+
+**A — continue scanning.** Solves the stated problem: for the reported instance, yes; for
+the class, no. Cost: low per round, unbounded in aggregate. Second-order: the file had
+become a Rust lexer written by defect report, in a test, maintained by whoever last got
+reviewed. The recurring shape is the argument — *a text scanner approximates a parser, and
+every approximation has a boundary an adversary finds before its author does.*
+
+**B — `syn` AST.** Solves the stated problem: yes, structurally. Cost: one rewrite, zero
+new dependency — `syn = { version = "2", features = ["full", "parsing", "visit"] }` is
+already a direct dev-dependency, and six sibling lints already call `syn::parse_file`
+(`await_in_lock_lint`, `spawn_cancellation_lint`, `ignored_send_lint`, `oneshot_leak_lint`,
+`arbitrary_find_lint`, `unbounded_channel_lint`). Second-order: attributes become a
+`Vec<Attribute>` on the item however they were formatted; `UseTree::Rename` becomes a
+variant rather than a spelling; visibility and attributes become fields of `ItemUse`
+rather than characters preceding it; and lexing raw strings and char literals correctly
+becomes the parser's job by definition. Every one of the eight escapes above is closed by
+the representation rather than by a check.
+
+### Recommendation
+
+**Selected: B.** The ad-hoc lexer is deleted rather than kept alongside — `code_only`,
+`join_wrapped_attributes`, `attributes_in`, `string_literal_end`, `char_literal_end`,
+`starts_a_use_statement`, `imports_in`, `derive_tokens`, `collapse_whitespace`,
+`split_top_level`. Keeping both would claim a joint sufficiency neither has.
+
+The module gates moved to `syn` too: `ItemMod` with structured `Meta`, so
+`any(feature = "server", feature = "web")` is rejected by having no accepting arm rather
+than by a string test for `any(`.
+
+1,982 lines → 887. 34 tests → 17, because the probes became table-driven corpora rather
+than one test per spelling; assertion count rose.
+
+### Contrary case
+
+**`syn` resolves no names.** `use crate::wire::EventWire;` is an import of *something*;
+that it is `serde::Serialize` re-exported lives in another file, and a parser will never
+know. If the guarantee had been "detect serialization", B would fail exactly where A did.
+
+It does not fail, because the guarantee is an **allowlist**: parsing makes enumeration
+exact, and the allowlist decides without needing to know what a name means. That is the
+load-bearing pairing — either alone is insufficient, and the previous rounds failed
+precisely because they tried detection alone.
+
+**Residual, unfixed by either architecture:** items produced by macro *expansion* are
+invisible to a parse of pre-expansion source. Macro *invocations* are visited and their
+token streams checked — exact, because tokens are post-lexing — but a macro assembling an
+`impl` from fragments escapes A and B alike. Recorded rather than papered over.
+
+### Evidence
+
+All eight escapes replayed against the new architecture as source snippets through the
+production helpers, plus four replayed against the real `src/producers/event.rs` with the
+build confirmed clean each time (three fail the allowlists, one fails the derive list).
+Five mutations, each verified to have applied first: stop recursing into `cfg_attr`; widen
+the derive allowlist; drop `UseTree::Rename`; accept `any(...)` as a server gate; swallow
+parse errors. Each is detected.
+
 ## Ship
 **Updated:** 2026-07-30
 **Status:** staged (draft PR, nothing merged, deployed or marked ready)

--- a/.oh/adaptive-publication.md
+++ b/.oh/adaptive-publication.md
@@ -461,10 +461,23 @@ exact, and the allowlist decides without needing to know what a name means. That
 load-bearing pairing — either alone is insufficient, and the previous rounds failed
 precisely because they tried detection alone.
 
-**Residual, unfixed by either architecture:** items produced by macro *expansion* are
-invisible to a parse of pre-expansion source. Macro *invocations* are visited and their
-token streams checked — exact, because tokens are post-lexing — but a macro assembling an
-`impl` from fragments escapes A and B alike. Recorded rather than papered over.
+**The residual I first recorded was not one.** I wrote that macro-generated items escape
+both architectures and accepted it. Codex rejected that: `#[event_wire] pub enum
+AdaptiveEvent {}` and `make_event_wire!(AdaptiveEvent);` are live false passes, and they
+close the same way everything else here did — by permission, not detection. Two more
+allowlists: `AdaptiveEvent` may carry only `derive` and `doc`; every macro invocation in
+`src/producers/event.rs` must be on a list holding only `tracing::trace`.
+
+The reviewer then caught a second-order error in my first attempt at that closure: I
+collected only `Item::Macro`, while Rust permits a statement-position macro to expand to
+item definitions and a trait impl is valid wherever written. The escape simply moved one
+level down into a function body — and the module's real `tracing::trace!` call sits there,
+which is why an empty allowlist had passed. Replaced with a `syn::visit::Visit` collector
+over every `syn::Macro` at any depth.
+
+**What genuinely remains:** an *allowlisted* macro could expand to anything, and expansion
+is not in this source. That is why the lists are minimal rather than convenient — the
+guarantee is that nothing generative is permitted, not that generation is understood.
 
 ### Evidence
 

--- a/.oh/adaptive-publication.md
+++ b/.oh/adaptive-publication.md
@@ -226,7 +226,7 @@ layer may not name.
 
 ### The reshaping window — decision, not deferral
 
-#323's ship-gate dissent asked this issue to decide, before any outside-repository
+The ship-gate dissent on #323 asked this issue to decide, before any outside-repository
 consumer exists, whether v1's shape is right. **Decision: the window stays open, and this
 issue deliberately does not close it.** #324 publishes to in-repo consumers only; no HTTP,
 SSE, MCP or device surface is added. The evidence that would justify reshaping — which

--- a/.oh/adaptive-publication.md
+++ b/.oh/adaptive-publication.md
@@ -367,3 +367,69 @@ PR #363.
 **Verification gap:** `dx` is not installed here, so the WASM/fullstack build is proved only
 by CI's `build-wasm` job. `lint_producers_module_is_server_gated` is the host-runnable proxy
 and is the reason the module is gated at all.
+
+### Review remediation
+
+| Source | Finding | Fixed |
+|---|---|---|
+| execute review (3/6) | canonical fixture published an illegal outcome transition | `12a8e07` |
+| execute review (3/6) | lane witness ordered timestamps lexicographically | `56cd0a9` |
+| execute review (3/6) | surface lint enumerated six dirs, missed `src/mqtt` | `56cd0a9` |
+| execute review (3/6) | coherence invariant test covered 3 of 4 cases | `56cd0a9` |
+| execute review (3/6) | a refusal outlived the producer it named | `6a2ad99` |
+| execute dissent (4/6) | fixed point argued, not checked → `IrreparableIntent` | `f34f28b` |
+| execute dissent (4/6) | module doc overclaimed the structural guarantee | `f34f28b` |
+| execute dissent (4/6) | "refusal is safe" untrue for a first document | `f34f28b` |
+| execute dissent (4/6) | `ProducerRemoved` cannot retire one target of many | `f34f28b` |
+| **CodeRabbit** | `is_server_gate` accepted `any(feature="server", …)` | `f098202` |
+| **CodeRabbit** | surface sweep missed `use crate::{adaptive, producers};` | `f098202` |
+
+Both CodeRabbit findings were in the lints, both were reachable, and the second was
+reachable *using this repository's own import style* — `src/main.rs` groups its imports
+exactly that way. That is now three consecutive rounds in this epic where the defect of
+record was a lint reporting success on a violation, and the third where external review
+found it before the internal gates did.
+
+## Ship
+**Updated:** 2026-07-30
+**Status:** staged (draft PR, nothing merged, deployed or marked ready)
+
+**Delivery path.** PR #363 (draft) → base `feat/issue-323-adaptive-producer-contract`
+(PR #362, also draft) → #362 merges to `v3` → #363 retargets to `v3` → CI → maintainer
+review → squash merge. Two hops, because this is a stacked PR and the prerequisite is not
+merged.
+
+**Delivery-path tax, measured rather than guessed:**
+
+1. **This branch has no CI at all.** `build.yml` triggers on pull requests targeting
+   `master`/`v3` and on pushes to `v3` or `feature/**`. This branch is `feat/…` and the PR
+   targets `feat/issue-323-…`, so **no workflow has run on any commit here**
+   (`gh run list --branch feat/issue-324-adaptive-publication` is empty). Everything green
+   is green on a laptop. The first CI signal arrives only when the base becomes `v3`.
+2. **`api-guard` will trigger once retargeted, and this PR touches one of its paths.**
+   It watches `src/main.rs`, `src/api/**` and `tests/fixtures/api_routes.txt`; `src/main.rs`
+   changed. Read rather than assumed: the job's only assertion is whether
+   `tests/fixtures/api_routes.txt` differs from the base. It does not, so the job takes the
+   `api_changed=false` branch and reports "No API contract changes detected". No label is
+   needed and none must be added.
+3. **A pre-existing `v3` lint failure blocks merge**, not caused here:
+   `src/app/pages/zones.rs:269` trips `clippy::unnecessary_sort_by` on CI's newer
+   toolchain. Owned by #338 ("CI: restore the v3 lint baseline under Rust 1.97"), which is
+   open. #362 hit the same wall.
+4. **`docker.yml` is `master`-only**, so a `v3` merge publishes no image. Release artifacts
+   only on tag `v*` or a published release.
+5. **PR #362 is `BLOCKED`** on GitHub's own mergeability check, so the first hop is not
+   currently available regardless of this branch's state.
+
+**Rollback.** A plain revert. `src/producers/` is referenced from exactly two places outside
+itself — `pub mod producers;` in `src/lib.rs` and the construct-and-spawn in `src/main.rs` —
+and nothing publishes to it, so reverting removes a task that subscribes to two channels and
+waits. No data migration: nothing persists a producer document. The one caveat is
+`ReasonCode::ControlRemoved` and `control_removed_after_advance.json`, which are contract
+surface: reverting those after #325 maps onto them would be a compatibility break, so this
+rollback is clean only while this branch is the tip.
+
+**Verified rather than asserted:** `tests/fixtures/api_routes.txt` byte-identical to
+`origin/v3`; zero `.route(` lines added or removed in `src/main.rs`; `src/api/` and
+`src/bus/` untouched; PR #363 carries no labels; worktree clean; every commit
+forward-only, no force push.

--- a/.oh/adaptive-publication.md
+++ b/.oh/adaptive-publication.md
@@ -1,0 +1,284 @@
+# Adaptive Producer Publication (UHC #324)
+
+Session for GitHub issue #324 — *Adaptive control: publish producer documents through the
+bus and aggregator*. Parent epic #312. Prerequisite #323 / PR #362, consumed at exact head
+`2f185938ec18d542e424448afb3f65d499977569`.
+
+## Aim
+
+The aggregator owns every current adaptive producer document, admits them under one gate
+that no path bypasses, and serves atomic snapshots to in-repo consumers — while nothing
+about this contract becomes visible outside the repository, and no HTTP route, SSE payload
+or request/response schema changes.
+
+Out of scope for #324: HQPlayer mapping (#325), matcher/manifest composition (#326),
+persisted bindings (#327), catalog provenance (#343), and **any** consumer-facing exposure
+(HTTP, SSE, MCP, device). See "The reshaping window" below for why the last one is a
+decision rather than an omission.
+
+## Solution Space
+
+**Updated:** 2026-07-30
+
+**Problem:** Adapters must publish versioned producer documents and the aggregator must own
+them as authoritative state — but the obvious carrier for "publish an event" in this
+codebase is `BusEvent`, and `BusEvent` *is* a public wire payload.
+
+**Key constraint (binding, and it is not the one the issue title implies):**
+`src/api/mod.rs:1210` serializes **every** `BusEvent` verbatim into the `GET /events` SSE
+stream. `docs/ARCHITECTURE.md:96` documents that stream as consumable by "any HTTP client
+(curl, ESP32, etc.)". Therefore *adding a variant to `BusEvent` is a response-schema change
+to an existing public endpoint, and it publishes the v1 contract to consumers outside this
+repository* — two of this issue's hard prohibitions, tripped by the single most idiomatic
+move available. Every candidate below is scored first on whether it trips that wire.
+
+**Success looks like:**
+
+* An incoherent document cannot reach a consumer, because the only object a consumer can
+  obtain is one the gate produced.
+* `tests/fixtures/api_routes.txt` byte-identical; `cargo test --test api_contract` green;
+  the SSE payload set unchanged, proved rather than asserted.
+* Multiple producers, restart (epoch), reconnect (lane health), removal, out-of-order
+  delivery, unknown additive fields, and live-command isolation each have a
+  consumer-expectation test that failed before its implementation existed.
+
+### Situated knowledge
+
+RNA MCP (`oh_search_context`) is **not connected** in this session, so no repo-local metis
+or guardrails were retrieved. Prior-art substitute, read directly: `.oh/`,
+`docs/architecture/adaptive-producer-contract-v1.md`, `docs/adr/003-*`, `docs/ARCHITECTURE.md`,
+`tests/architecture_lint.rs`, `tests/aggregator_lint.rs`, `tests/adaptive_dependency_lint.rs`,
+and the #362 remediation commits `1577948`, `fdc1ca4`, `2f18593`.
+
+Two constraints come from that reading rather than from the issue text, and both bind:
+
+1. **`fdc1ca4` assigned zone-prefix validation to this issue.** `ProducerTarget.zone_id` is
+   a plain `String`; `PrefixedZoneId` is `#[serde(transparent)]` so its derived `Deserialize`
+   never calls `parse`. The field's own doc comment (`src/adaptive/document.rs:241`) says
+   validation "belongs to whoever admits the document into the aggregator (#324), where the
+   vocabulary of valid prefixes lives."
+2. **`pub mod bus` is `#[cfg(feature = "server")]`** (`src/lib.rs:46`) while `pub mod adaptive`
+   is deliberately shared. Any publication layer that touches both is server-only by
+   construction, and may not live inside `src/adaptive/`.
+
+### Candidates Considered
+
+| Option | Level | Approach | Trade-off |
+|--------|-------|----------|-----------|
+| A | Band-Aid | `BusEvent::AdaptiveProducerPublished`; store documents in `ZoneAggregator` | Fastest; changes the `/events` payload set and publishes v1 outside the repo |
+| B | Local Optimum | New `BusEvent` variants + a denylist filter in `events_handler` | Keeps SSE stable *if the filter is maintained*; raw unvalidated documents still reach every bus subscriber |
+| C | Local Optimum | Adapters publish a tiny "revision advanced" event; aggregator pulls the document from the adapter | Small events; but this *is* aggregator-queries-adapter, and the pull races the next poll so snapshots stop being atomic |
+| D | Reframe | Separate internal `AdaptiveBus`; the aggregator is the sole admission gate and the sole holder of an admitted document | Two buses to explain; a lint must prove the second one never reaches the wire |
+| E | Reframe | No bus: adapters hold `Arc<ProducerAggregator>` and call `publish()` directly | Simplest path, synchronous refusal back to the adapter; inverts the adapter→aggregator dependency the architecture forbids |
+| F | Redesign | Generalize `ZoneAggregator` into a typed snapshot store keyed by `(domain, identity)` and migrate zones onto it | The uniform end state; rewrites the drop-in-compatible zone path during an additive contract issue |
+
+### Evaluation
+
+**Option A — `BusEvent` variant + `ZoneAggregator`**
+- Solves stated problem: No.
+- Implementation cost: Low.
+- Maintenance burden: High.
+- Second-order effects: Disqualifying on three counts, any one of which is fatal.
+  `events_handler` would emit a new SSE message type to every connected knob, iOS client
+  and browser — a response-schema change to `GET /events` without approval, and
+  out-of-repo exposure of a contract this issue is explicitly told to keep internal. It
+  also puts producer state into a zone-shaped aggregator whose `run()` loop and
+  `AdapterStopping` flush are zone-specific, and it leaves the C1/C2 gate as a match arm
+  rather than a chokepoint. Rejected.
+
+**Option B — `BusEvent` variants + SSE denylist**
+- Solves stated problem: Partially.
+- Implementation cost: Low-medium.
+- Maintenance burden: Medium-high.
+- Second-order effects: The SSE payload set can be held stable, but only by a negative
+  rule someone must remember. Worse, the *unvalidated* document is on the public bus, so
+  "an incoherent document never reaches a consumer" degrades from a structural property
+  to a convention: any future subscriber that reads the ingress event bypasses the gate,
+  and nothing stops it. A denylist also cannot prevent the enum from being *serializable*
+  with adaptive payloads — one `serde_json::to_string(&event)` anywhere re-exports the
+  contract. Rejected, but its SSE-stability test is worth keeping.
+
+**Option C — revision-advanced event, aggregator pulls**
+- Solves stated problem: No.
+- Implementation cost: Medium.
+- Maintenance burden: High.
+- Second-order effects: Directly contradicts `docs/ARCHITECTURE.md` ("UI talks to
+  aggregator only", "adapters are event publishers") and `AGENTS.md:165` ("Don't bypass
+  the aggregator to query adapters directly") — inverted, but the same coupling. The pull
+  also races the producer's next poll, so the aggregator can compose a snapshot that
+  never existed, defeating the atomicity requirement that motivated the whole contract.
+  Rejected.
+
+**Option D — internal `AdaptiveBus`, aggregator as sole admission gate**
+- Solves stated problem: Yes.
+- Implementation cost: Medium.
+- Maintenance burden: Low.
+- Second-order effects: `BusEvent` is untouched, so the SSE payload set cannot change —
+  not because a filter suppresses adaptive events, but because no adaptive type is
+  reachable from the serialized enum. The architecture is preserved exactly: adapters
+  publish, the aggregator owns, nobody queries an adapter. Because the gate is the only
+  writer *and* the only thing that ever holds an admitted document, "incoherent documents
+  never reach consumers" becomes checkable as an invariant over the store rather than a
+  property of a code path. Costs: a second channel to document, and a lint owed to prove
+  the separation is real rather than intended.
+
+**Option E — direct `Arc<ProducerAggregator>` handle**
+- Solves stated problem: Yes, mechanically.
+- Implementation cost: Low.
+- Maintenance burden: Medium.
+- Second-order effects: Inverts the dependency — adapters would import the aggregator,
+  which is the coupling `tests/architecture_lint.rs` exists to prevent, and it forecloses
+  multi-consumer fan-out without re-adding a bus later. Rejected. **One idea salvaged:**
+  its synchronous `Result` means the adapter learns its document was refused. Option D
+  loses that, so refusals must be made observable another way — see "Refusals are
+  observable" below.
+
+**Option F — generalized snapshot store**
+- Solves stated problem: Yes, and best for the epic's end state.
+- Implementation cost: High *here*.
+- Maintenance burden: Low.
+- Second-order effects: Rewrites `ZoneAggregator`, which backs the API surface
+  `tests/client_harness.rs` pins as a drop-in replacement for the Node.js server. Doing
+  that inside an additive contract issue spends the issue's risk budget on a refactor
+  nobody asked for. Deferred, not rejected; Option D leaves it available because the
+  producer store is a separate type that could later be one instantiation of it.
+
+### Recommendation
+
+**Selected:** Option D — separate internal `AdaptiveBus`, aggregator as sole admission gate
+**Level:** Reframe
+
+**Rationale:** The reframe is *what kind of thing `BusEvent` is*. Reading it as "the event
+bus" makes A and B look idiomatic; reading it as what it actually is — a public,
+serialized wire payload with out-of-repo consumers — disqualifies both immediately. Once
+the carrier is internal, the second reframe follows for free: the aggregator stops being a
+store that happens to validate and becomes an **admission gate that happens to store**, so
+the safety property is structural. A consumer cannot obtain a document that did not come
+out of `admit()`, because no other object of that type exists in the process.
+
+**Accepted trade-offs:**
+- Two buses. Mitigated by a lint that proves the internal one is unreachable from the
+  serialized enum and from `src/api/`, and by the internal one carrying no `Serialize`
+  derive at all — it cannot be written to a wire even by accident.
+- No synchronous refusal to the publishing adapter. Mitigated below.
+- The producer store is a second store rather than a generalization of the first
+  (Option F). Recorded as the deferred end state.
+
+### The decisions this issue must make explicitly
+
+Five, each recorded here because "an ADR paragraph is not an owner".
+
+**1. C1/C2 incoherence → demote, never refuse, never fabricate.**
+
+| Violation | Publication policy | Why |
+|---|---|---|
+| `MissingDesiredLane`, `DesiredLaneDisagrees` (C1) | demote entry to `RequiresProducerValidation` | The only repair that would preserve `valid` is inventing a `desired` lane — fabricating intent the user never staged. Demotion blocks apply and makes the effective projection advisory, which is exactly what spec §6 tells consumers to do with a non-`valid` entry. |
+| `MultipleValidDrafts` (C2) | demote **every** claiming entry to `Conflicts` | The aggregator cannot know which draft the user meant. Keeping one `valid` would silently authorize an apply nobody confirmed, and any "keep the first" rule is a function of `Vec` order, which is producer-arbitrary. Demoting all is order-independent and satisfies C2 literally — "at most one valid" is satisfied by zero. |
+| `UnknownControl` | demote to `DraftInvalid` with reason `control_removed` | Required to be *distinct and visible*: users must see "this control no longer exists", not the generic "needs producer validation". |
+
+Demotion only ever lowers validity. It never adds a lane, never edits a value, never
+touches a control. That is testable as a byte-level assertion — the repaired document must
+differ from the published one in `change_sets[..].entries[..].validity` and nowhere else —
+and it is the mechanical form of "never fabricate desired intent".
+
+**2. Envelope violations → refuse the whole document.**
+
+Unsupported major, unparsable/missing version, malformed body, `ConstraintTooComplex`,
+revision regression, epoch regression, duplicate revision, invalid zone-id prefix, and the
+two new invariants below. Refusal is safe *specifically because the aggregator retains the
+last admitted snapshot*: a refused document does not blank a producer, it fails to advance
+one. That asymmetry is the whole reason envelope problems can be strict while intent
+problems must be lenient.
+
+**3. New invariant — `LaneValue` consistency. Decision: refuse.**
+
+`LaneValue::is_consistent` (`src/adaptive/value.rs:411`) is published as a rule and called
+by nothing on the admission path. A deserialized document may therefore assert `grounded`
+with no value, or `ungrounded` with one — simultaneously "I have no reading" and a
+reading. This is the same defect class `fdc1ca4` fixed three times over: *the contract
+published a rule and no code path applied it*.
+
+Refuse rather than repair, because every repair picks a side. Dropping the value discards
+producer data; flipping the grounding fabricates a reading. Neither is the aggregator's
+call.
+
+**4. New invariant — deserialized operation-history legality. Decision: refuse.**
+
+`OperationRecord::transition` enforces `CommandOutcome::may_transition_to`, but
+`history: Vec<OutcomeTransition>` deserializes unchecked, so an admitted document can carry
+an outcome chain the contract calls impossible. Refuse the document rather than repair it:
+the alternative repairs are dropping illegal transitions or truncating the chain, and both
+destroy audit history that spec §7 declares append-only and that "a new operation cannot
+erase". A corrupt audit trail must be visible as a refusal, not silently tidied.
+
+Both 3 and 4 are enforced at the publication gate. Whether they also belong in
+`admit_document` is an execute-gate question: the gate must hold for typed documents that
+never passed through JSON, so gate enforcement is necessary regardless; contract-layer
+enforcement would be defence in depth, and is only worth taking if it does not disturb #323.
+
+**5. Zone identity is validated at admission.**
+
+`ProducerTarget.zone_id`, when present, must parse as a prefixed zone id
+(`roon:` / `lms:` / `openhome:` / `upnp:` / `hqplayer:`) via `bus::events::PrefixedZoneId`.
+This discharges the obligation `fdc1ca4` recorded at the field, and it can only be done
+here: the prefix vocabulary lives in the server-only bus module, which the shared contract
+layer may not name.
+
+### The reshaping window — decision, not deferral
+
+#323's ship-gate dissent asked this issue to decide, before any outside-repository
+consumer exists, whether v1's shape is right. **Decision: the window stays open, and this
+issue deliberately does not close it.** #324 publishes to in-repo consumers only; no HTTP,
+SSE, MCP or device surface is added. The evidence that would justify reshaping — which
+constructs a real producer actually populates — is #325's to produce, and #325 is blocked
+by this issue. Committing v1's shape now would be committing it on no evidence.
+
+One reshaping is taken, and it is minimal: **`ReasonCode::ControlRemoved`** is added,
+because decision 1 requires a removed control to be distinguishable from a control awaiting
+validation, and no existing member carries that meaning. It is additive, and
+`every_vocabulary_member_has_a_worked_example` will force the fixture that #324's own
+acceptance criteria already demand — a change set whose base predates a control-plane
+advance that removed its target. `CONSUMER_SCHEMA_VERSION` is **not** bumped: 1.0 has never
+been released outside this repository, so this completes 1.0 rather than adding to it.
+
+### Implementation Notes
+
+1. `src/producers/` — new, `#[cfg(feature = "server")]`, because it necessarily touches
+   both `crate::bus` and `crate::adaptive`.
+   - `event.rs` — `AdaptiveEvent` lifecycle: discovered / updated / removed, plus the
+     gate's own admitted / refused outcomes. **No `Serialize`/`Deserialize` derive**, so it
+     cannot reach a wire even by accident.
+   - `admission.rs` — pure functions: `admit(previous, incoming) -> Admission`. No tokio,
+     no locks, directly unit-testable.
+   - `aggregator.rs` — `ProducerAggregator`: owns `BTreeMap<ProducerKey, ProducerEntry>`,
+     subscribes to `AdaptiveBus` for ingress and to the public bus for `AdapterStopping` /
+     `ShuttingDown` only.
+2. `src/aggregator.rs` is **not** moved or restructured: `tests/aggregator_lint.rs` reads
+   it by literal path.
+3. `ProducerKey { producer_id, role, zone_id }`, ordered, so snapshots are deterministic.
+4. Ordering: epoch dominates. Higher epoch → accept unconditionally (revisions are
+   incomparable across epochs). Same epoch → `DocumentRevisions::regresses_from` refuses.
+   Equal revisions → refuse as a duplicate; lane-health changes are document state and
+   must bump `state`. Lower epoch → refuse as out-of-order.
+5. Per-lane last-good is aggregator-observed history kept **beside** the document, never
+   merged into it: `LaneWitness { state, last_success, last_error, at }`, where
+   `last_success` is monotonic across admissions. Editing the producer's own words would be
+   the same fabrication C1 forbids.
+6. Atomic snapshots: `ProducerSnapshot { document: Arc<ProducerDocument>, lanes, presence,
+   repairs, admitted_at }`, produced under one read lock.
+7. **Refusals are observable**, replacing what Option E would have returned synchronously:
+   retained per key as `last_refusal`, queryable from the aggregator, emitted on the
+   internal bus, and logged with `tracing::warn!`. A refusal that only appears in a log
+   line is not observable to a test.
+8. `recv()` must handle `RecvError::Lagged` by continuing, not by exiting. `ZoneAggregator`
+   uses `while let Ok(event) = rx.recv().await`, which terminates the loop on lag; the new
+   loop must not copy that. (Pre-existing, out of scope, worth reporting.)
+9. Live-command isolation is structural: the aggregator mutates producer state on adaptive
+   ingress only. Every other bus event is inert, and the test asserts a staged change set is
+   byte-identical after a stream of `CommandReceived` / `ControlCommand` / `VolumeChanged` /
+   `HqpPipelineChanged`.
+10. Lints owed: no adaptive type reachable from `BusEvent`; `src/api/` never names
+    `crate::producers`; `api_routes.txt` unchanged; the internal event type derives no
+    serde.
+11. No route changes. `tests/fixtures/api_routes.txt` untouched, `api-change-approved` never
+    applied.

--- a/.oh/adaptive-publication.md
+++ b/.oh/adaptive-publication.md
@@ -282,3 +282,88 @@ been released outside this repository, so this completes 1.0 rather than adding 
     serde.
 11. No route changes. `tests/fixtures/api_routes.txt` untouched, `api-change-approved` never
     applied.
+
+## Execute
+**Updated:** 2026-07-30
+**Status:** complete
+
+Prerequisite #323 was remediated twice during this session. This branch was merged
+forward-only onto `d6da952` at `49a55ed`; reports 1/6 and 2/6 were re-anchored there.
+
+**TDD evidence.** `tests/adaptive_publication.rs` was written first against a deliberately
+naive stub (admit everything, store blindly). RED: **29 failed, 24 passed**. After the real
+gate and aggregator: **53 passed, 0 failed**. Full suite 408 → **472 passed, 0 failed**
+across 24 binaries. `cargo fmt --check` clean; `cargo clippy --lib` clean.
+
+### What the two new invariants found on day one
+
+Enforcing decision 4 immediately refused a **canonical #323 fixture**.
+`command_outcomes.json` recorded `disconnected -> indeterminate` on `op-provisional-9001`,
+which `CommandOutcome::may_transition_to` forbids — nothing may regress into an unresolved
+state — and which contradicted the same operation's `write_attempt:
+acknowledged_provisional`, since `disconnected` means the transport was down *before* the
+write was attempted. Nothing may legally transition *into* `indeterminate`, so that
+operation's history is correctly empty.
+
+The defect was load-bearing for a passing test:
+`a_new_operation_cannot_erase_the_audit_trail` asserted `history` was non-empty and that
+some transition had `to == Indeterminate`, which only the illegal entry could satisfy. It is
+retargeted at `op-divergent-9015` and asserts `from == Indeterminate`, which is what the
+comment above it always claimed to be testing.
+
+This is the argument for the invariant, not an argument against it: a rule the contract
+published and no code path applied had already produced a wrong fixture and a test shaped
+around it.
+
+### Decisions taken during execution
+
+* **Equal revisions (obligation A4).** Neither binary. A republication at the same revision
+  whose difference is confined to `lanes`/`stale` is admitted as `HealthRefresh`; anything
+  else at the same revision is refused as `NotAdvanced`. Demanding a `state` bump for lane
+  transitions would invalidate every open change set on every lane flap, because drafts are
+  validated against the state revision. Checked by rebuilding the incoming document with the
+  held lane health and comparing for equality.
+* **Lane-value predicate (obligation A3).** `LaneValue::is_consistent` is **not** used at the
+  door: it returns `false` for `Grounding::Unrecognized`, so admission would refuse a
+  forward-compatible document wholesale. The gate refuses only recognized-grounding defects.
+  `CommandOutcome::may_transition_to` needs no such narrowing — it already returns `true` for
+  unrecognized outcomes, so decision 4 is forward-compatible as written.
+* **C2 demotes both claimants (D2).** `draft_policy.on_conflict` is deliberately not
+  consulted: it governs staging, and #324 implements no staging path. Tested with a document
+  declaring `last_actor_takeover`.
+* **`ReasonCode::ControlRemoved`** added, forced by the requirement that a removed control be
+  distinguishable from one awaiting validation. `every_vocabulary_member_has_a_worked_example`
+  then forced the fixture #324's acceptance criteria already demanded:
+  `control_removed_after_advance.json`, a draft whose base predates the advance that removed
+  its target. No `CONSUMER_SCHEMA_VERSION` bump: 1.0 has never left this repository.
+
+### Obligations discharged
+
+| # | Where |
+|---|---|
+| A1, A8 | `tests/adaptive_publication_lint.rs` — 11 tests, bidirectional probes |
+| A2 | `ProducerAggregator::run` handles `Lagged` and continues; `record_lag`; `a_lagging_aggregator_keeps_running_rather_than_exiting` |
+| A3 | `first_lane_defect`; `an_unrecognized_grounding_from_a_newer_minor_is_admitted_not_refused` |
+| A4 | `ordering()` health-refresh branch; two `envelope::republishing_*` tests |
+| A5, P2-2 | demotion keyed on `(change_set, control)`; `one_draft_holding_one_control_on_two_apply_lanes_is_left_alone` |
+| A6 | every `AdmissionRefusal` names its offender; asserted in the envelope and lane-value tests |
+| A7 | every test document originates from a canonical #323 fixture |
+| D2 | `a_declared_last_actor_takeover_policy_does_not_change_publication_time_repair` |
+| D4 | `apply_demotions` writes only `entry.validity`; `repair_changes_validity_and_nothing_else` |
+| D5 | `IllegalOutcomeHistory` names operation and transition pair; `tracing::warn!` on refusal |
+| D6 | `poll_loop::a_sequence_of_polls_always_serves_exactly_one_published_document` |
+
+D1, D3, D7 are records rather than code and are discharged in this file and ADR 003.
+
+**The probe earned its keep immediately.** `gate_scanner_detects_a_gate_it_must_not_miss`
+failed on first run: `is_server_gate` compared against the spaced spelling only, so
+`#[cfg(feature="server")]` read as absent — the same whitespace blind spot `1577948` fixed
+in the sibling lint, caught here before it shipped rather than by a later review.
+
+**Drift check:** none. `tests/fixtures/api_routes.txt` byte-identical to `v3`; zero `.route(`
+lines added or removed in `src/main.rs`; `src/api/` and `src/bus/` untouched; no label on
+PR #363.
+
+**Verification gap:** `dx` is not installed here, so the WASM/fullstack build is proved only
+by CI's `build-wasm` job. `lint_producers_module_is_server_gated` is the host-runnable proxy
+and is the reason the module is gated at all.

--- a/.oh/adaptive-publication.md
+++ b/.oh/adaptive-publication.md
@@ -475,9 +475,19 @@ level down into a function body — and the module's real `tracing::trace!` call
 which is why an empty allowlist had passed. Replaced with a `syn::visit::Visit` collector
 over every `syn::Macro` at any depth.
 
-**What genuinely remains:** an *allowlisted* macro could expand to anything, and expansion
-is not in this source. That is why the lists are minimal rather than convenient — the
-guarantee is that nothing generative is permitted, not that generation is understood.
+A third round found the closure still too narrow. The checks audited `AdaptiveEvent`'s own
+attributes, but a proc macro emits arbitrary *items* rather than only code about what it
+annotates — so `#[generate_event_wire] fn helper() {}` or
+`#[derive(GenerateAdaptiveWire)] struct Helper;` elsewhere in the module can emit
+`impl Serialize for AdaptiveEvent` with the enum's attrs, the imports, the `ItemImpl` list
+and the macro allowlist all clean. Closed with a location-aware module-wide policy: `doc`
+anywhere, `derive` only on `enum AdaptiveEvent` and only holding `Debug`/`Clone`, nothing
+else anywhere. That is now the production gate; the enum-specific checks are kept only
+because they name an offender more precisely.
+
+**What genuinely remains:** an *allowlisted* macro or derive could expand to anything, and
+expansion is not in this source. That is why the lists are minimal rather than convenient —
+the guarantee is that nothing generative is permitted, not that generation is understood.
 
 ### Evidence
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4587,6 +4587,7 @@ dependencies = [
  "md5",
  "mdns-sd",
  "mime_guess",
+ "proc-macro2",
  "quick-xml",
  "rand 0.8.5",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,6 +149,10 @@ required-features = ["server"]
 tokio-test = "0.4"
 serial_test = "3"
 syn = { version = "2", features = ["full", "parsing", "visit"] }
+# Token-level inspection for tests/adaptive_publication_lint.rs. Already in the lock
+# graph as a transitive dependency of syn; declared so the lint can walk TokenTree
+# without stringifying a macro body, which made string literals fabricate matches.
+proc-macro2 = "1"
 walkdir = "2"
 tempfile = "3"
 

--- a/docs/adr/003-adaptive-producer-document-v1.md
+++ b/docs/adr/003-adaptive-producer-document-v1.md
@@ -129,6 +129,28 @@ adapter code — re-coupling surfaces to backends, which is what the epic remove
   `recovery_required` / `divergent` outcomes, multi-revision plan boundaries, the
   `in_range` / `is_grounded` / `not_eq` / `any` operators, and `held` values on producers
   with no settings interface.
+
+  **Rule for the window while it is open (added by #324).** "The window is open" was too
+  loose to govern anything: #324 declared it open and then added to v1 in the same
+  document. What actually governs, stated so the next issue does not have to re-derive it:
+
+  1. An **addition** is permitted when an acceptance criterion of an issue in the #312
+     graph forces it. Nothing else is.
+  2. A **removal** or a semantic change to an existing member is not permitted, window or
+     no window. §8 of the specification is additive-only and a compatibility rule cannot
+     carry a private exception for its own authors.
+  3. Every addition taken under (1) is recorded here with the criterion that forced it.
+
+  Additions taken so far:
+
+  | Addition | Forced by | Issue |
+  |---|---|---|
+  | `ReasonCode::ControlRemoved` | "`IntentIncoherence::UnknownControl` is treated as a distinct, user-visible state … users should see *this control no longer exists*, not the generic *needs producer validation*" | #324 |
+  | `tests/fixtures/adaptive/control_removed_after_advance.json` | "add a fixture and test for a change set whose base predates a control-plane advance that **removed** a targeted control" — and then required by `every_vocabulary_member_has_a_worked_example` once the reason code existed | #324 |
+
+  Neither is free. A canonical fixture path is additive-only per §8, so registering a sixth
+  one narrows the window it was added under. That is the cost of rule (1) and it is why
+  rule (1) is bounded by an acceptance criterion rather than by judgment.
 * Non-Rust consumers get canonical fixtures and normative prose now; a generated JSON
   Schema is owed to the first issue that needs it (#314 or #326).
 * Consumers must handle an `Unrecognized` arm for every vocabulary. That is the cost of

--- a/src/adaptive/control.rs
+++ b/src/adaptive/control.rs
@@ -197,6 +197,15 @@ semantic_enum! {
         Superseded => "superseded",
         /// Retention expired before this could be applied.
         Expired => "expired",
+        /// The control this refers to is no longer described by the document.
+        ///
+        /// Reachable whenever a control-plane advance removes a control an open draft
+        /// still targets. Deliberately distinct from `draft_invalid` and from
+        /// `EntryValidity::RequiresProducerValidation`: a user must be told "this control
+        /// no longer exists" rather than "this needs validating", because no amount of
+        /// revalidation will bring it back. Applied at publication by #324's admission
+        /// gate, from [`super::IntentIncoherence::UnknownControl`].
+        ControlRemoved => "control_removed",
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,3 +59,7 @@ pub mod knobs;
 pub mod mcp;
 #[cfg(feature = "server")]
 pub mod mdns;
+// Adaptive producer publication: internal bus + aggregator-owned state (#324).
+// Server-only: it necessarily touches both `crate::bus` and `crate::adaptive`.
+#[cfg(feature = "server")]
+pub mod producers;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@
 mod server {
     use unified_hifi_control::{
         adapters, aggregator, api, app, bus, config, coordinator, embedded, firmware, knobs, mcp,
-        mdns,
+        mdns, producers,
     };
 
     // Import Startable trait for adapter lifecycle methods
@@ -316,6 +316,26 @@ mod server {
             aggregator_for_spawn.run().await;
         });
         tracing::info!("ZoneAggregator started");
+
+        // Initialize the adaptive producer publication path (#324).
+        //
+        // The internal bus is deliberately separate from `bus`: `GET /events` serializes
+        // every BusEvent verbatim, so carrying producer documents there would change a
+        // public endpoint's payload and publish the v1 contract outside this repository.
+        // `adaptive_bus` is handed to producing adapters by #325; nothing publishes on it
+        // yet, and no surface reads the aggregator yet (#326). It is wired now so that
+        // ownership of producer state lives in one place from the first producer onward,
+        // rather than being retrofitted around one.
+        let adaptive_bus = producers::create_adaptive_bus();
+        let producer_aggregator = Arc::new(producers::ProducerAggregator::new(
+            bus.clone(),
+            adaptive_bus.clone(),
+        ));
+        let producers_for_spawn = producer_aggregator.clone();
+        tokio::spawn(async move {
+            producers_for_spawn.run().await;
+        });
+        tracing::info!("ProducerAggregator started");
 
         // Clone Roon adapter for shutdown access (cheap - just Arc clones)
         let roon_for_shutdown = roon.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -306,6 +306,27 @@ mod server {
             upnp.clone(),
         ];
 
+        // Fail before starting adapters or the adaptive actor if the public socket cannot be
+        // acquired. After this point every fallible server exit goes through explicit teardown.
+        let addr = SocketAddr::from(([0, 0, 0, 0], config.port));
+        let listener = tokio::net::TcpListener::bind(addr).await?;
+
+        // SSE closes as soon as graceful HTTP shutdown begins. Adaptive ingress remains open
+        // until producing adapters have stopped, then drains under its own non-lossy token.
+        let shutdown_token = CancellationToken::new();
+        let producer_shutdown_token = CancellationToken::new();
+
+        // Construct the bounded command actor before any producer can publish. The handle is
+        // retained for the process lifetime and will be handed to producing adapters by #325;
+        // the read-only view is consumed by #326. No adaptive payload enters the public
+        // BusEvent/SSE contract.
+        let (_adaptive_handle, producer_actor, _adaptive_view) =
+            producers::AdaptiveRuntime::build(producer_shutdown_token.clone(), 1024);
+        let producer_actor_task = tokio::spawn(async move {
+            producer_actor.run().await;
+        });
+        tracing::info!("ProducerActor started");
+
         // Single loop to start all enabled adapters
         coord.start_all_enabled(&startable_adapters).await;
 
@@ -317,31 +338,8 @@ mod server {
         });
         tracing::info!("ZoneAggregator started");
 
-        // Initialize the adaptive producer publication path (#324).
-        //
-        // The internal bus is deliberately separate from `bus`: `GET /events` serializes
-        // every BusEvent verbatim, so carrying producer documents there would change a
-        // public endpoint's payload and publish the v1 contract outside this repository.
-        // `adaptive_bus` is handed to producing adapters by #325; nothing publishes on it
-        // yet, and no surface reads the aggregator yet (#326). It is wired now so that
-        // ownership of producer state lives in one place from the first producer onward,
-        // rather than being retrofitted around one.
-        let adaptive_bus = producers::create_adaptive_bus();
-        let producer_aggregator = Arc::new(producers::ProducerAggregator::new(
-            bus.clone(),
-            adaptive_bus.clone(),
-        ));
-        let producers_for_spawn = producer_aggregator.clone();
-        tokio::spawn(async move {
-            producers_for_spawn.run().await;
-        });
-        tracing::info!("ProducerAggregator started");
-
         // Clone Roon adapter for shutdown access (cheap - just Arc clones)
         let roon_for_shutdown = roon.clone();
-
-        // Create shutdown token for graceful SSE termination (fixes #73)
-        let shutdown_token = CancellationToken::new();
 
         // Build application state (clone Arcs so we can access adapters for shutdown)
         let state = api::AppState::new(
@@ -577,7 +575,6 @@ mod server {
         };
 
         // Start server with graceful shutdown
-        let addr = SocketAddr::from(([0, 0, 0, 0], config.port));
         tracing::info!("Listening on http://{}", addr);
 
         // Advertise via mDNS for knob discovery
@@ -613,8 +610,6 @@ mod server {
             None
         };
 
-        let listener = tokio::net::TcpListener::bind(addr).await?;
-
         // Create shutdown future that cancels token before graceful shutdown (fixes #73)
         let graceful_shutdown = {
             let token = shutdown_token.clone();
@@ -636,12 +631,16 @@ mod server {
             }
         };
 
-        axum::serve(
+        let server_result = axum::serve(
             listener,
             router.into_make_service_with_connect_info::<SocketAddr>(),
         )
         .with_graceful_shutdown(graceful_shutdown)
-        .await?;
+        .await;
+
+        // Graceful signal handling already cancels this token. Cancel again unconditionally so
+        // an Axum error closes SSE streams too.
+        shutdown_token.cancel();
 
         // Cleanup: publish ShuttingDown event and stop adapters
         tracing::info!("Shutting down adapters...");
@@ -651,9 +650,6 @@ mod server {
             reason: Some("User requested shutdown".to_string()),
         });
 
-        // Give listeners a moment to react to ShuttingDown
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-
         // Stop adapters
         roon_for_shutdown.stop().await;
         if let Some(ref fw) = firmware_service {
@@ -662,8 +658,18 @@ mod server {
         lms.stop().await;
         openhome.stop().await;
         upnp.stop().await;
+
+        // No producer remains after adapters stop. Close ingress, drain every command already
+        // accepted by the bounded actor, and join it. Public-bus listeners are independently
+        // responsible for their own shutdown; no arbitrary sleep can prove they observed a
+        // broadcast.
+        producer_shutdown_token.cancel();
+        if let Err(error) = producer_actor_task.await {
+            tracing::warn!(%error, "ProducerActor exited with a join error");
+        }
         tracing::info!("Shutdown complete");
 
+        server_result?;
         Ok(())
     }
 

--- a/src/producers/admission.rs
+++ b/src/producers/admission.rs
@@ -33,6 +33,13 @@ use crate::adaptive::{
 };
 use crate::bus::PrefixedZoneId;
 
+/// Catalog key rendered when a staged entry targets a control that no longer exists.
+///
+/// Named once because two places must agree on it: this module and the canonical
+/// `control_removed_after_advance` fixture consumers are built against. Catalog *text* is
+/// governed by #343; only the key is fixed here.
+pub const CONTROL_REMOVED_TEXT_KEY: &str = "reason.control_no_longer_exists";
+
 /// Stable aggregator key for one producer document.
 ///
 /// Deliberately carries no serde derives. It is aggregator-internal addressing, and the
@@ -436,6 +443,12 @@ fn repair_intent(mut document: ProducerDocument) -> (ProducerDocument, Vec<Inten
                 change_set,
             } => {
                 let mut reason = Reason::draft(ReasonCode::ControlRemoved);
+                // Both fields, and they are not interchangeable. `detail` names the specific
+                // control for a log reader; `display_text_key` is what a consumer can
+                // actually render to a user, because catalog keys localise and English
+                // diagnostic prose does not. Emitting only `detail` would leave the user
+                // with either untranslated text or nothing at all.
+                reason.display_text_key = Some(CONTROL_REMOVED_TEXT_KEY.to_string());
                 reason.detail = Some(format!(
                     "control {control} is no longer described by this producer document"
                 ));

--- a/src/producers/admission.rs
+++ b/src/producers/admission.rs
@@ -20,16 +20,21 @@
 //!
 //! ## Order of checks
 //!
-//! Version, then constraint bounds, then zone identity, then lane values, then history,
-//! then coherence repair, then ordering. Repair runs **before** the ordering comparison so
+//! Version, then constraint bounds, then zone identity, then lane values, then all timestamp
+//! fields, then document shape, then history, then coherence repair, then ordering. Repair runs **before** the
+//! ordering comparison so
 //! that both sides of that comparison are repaired: the stored document is post-repair, and
 //! comparing a raw incoming document against it would report a spurious difference and
 //! refuse an identical republication as [`AdmissionRefusal::NotAdvanced`].
 
+use chrono::DateTime;
+use std::collections::BTreeSet;
+
+use super::run::AdapterRunId;
 use crate::adaptive::{
-    ChangeSetId, CommandOutcome, ControlId, DocumentRevisions, EntryValidity, Grounding,
-    IntentIncoherence, OperationId, ProducerDocument, ProducerEpoch, Reason, ReasonCode, Refusal,
-    TargetRole, ValueLane, CONSUMER_SCHEMA_VERSION,
+    AvailabilityState, ChangeSetId, CommandOutcome, ControlId, DocumentRevisions, EntryValidity,
+    Grounding, IntentIncoherence, OperationId, ProducerDocument, ProducerEpoch, Reason, ReasonCode,
+    Refusal, TargetRole, TransportLane, ValueLane, CONSUMER_SCHEMA_VERSION,
 };
 use crate::bus::PrefixedZoneId;
 
@@ -125,6 +130,98 @@ pub enum AdmissionRefusal {
     IrreparableIntent {
         /// What survived the repair.
         violations: Vec<IntentIncoherence>,
+    },
+    /// The publishing adapter run is no longer live.
+    ///
+    /// Adapter lifecycle rather than producer identity, and the two are deliberately separate:
+    /// this says *our* connection that sent the document has been replaced or ended, not that
+    /// the engine behind it is gone. Decided from the synchronously-maintained run registry, so
+    /// it holds however long the document sat in the channel and whatever public-bus events
+    /// were processed meanwhile. See [`super::run`].
+    StaleAdapterRun {
+        /// The adapter.
+        adapter: String,
+        /// The run that published it.
+        published_by: AdapterRunId,
+        /// The run that is live now, if any.
+        active: Option<AdapterRunId>,
+    },
+    /// The adapter tried to speak for a producer outside its namespace.
+    ProducerOwnershipMismatch {
+        /// Adapter that attempted the publication.
+        adapter: String,
+        /// Producer id it does not own.
+        producer_id: String,
+    },
+    /// The producer was retired, and this document does not announce a restart.
+    ///
+    /// Lifecycle rather than document coherence, so it is decided by the aggregator and never
+    /// by [`admit`]: the gate is pure and sees one document, while "this producer has been
+    /// retired" is a fact about the store. Raised when a publication is delivered after an
+    /// explicit actor retirement retired its key — and *only* then. Adapter lifecycle does not
+    /// reach this variant; that is [`AdmissionRefusal::StaleAdapterRun`], because an adapter
+    /// stopping says nothing about whether the engine behind it still exists. A strictly newer
+    /// [`ProducerEpoch`] is a restart and is admitted instead.
+    ProducerRetired {
+        /// The epoch the producer held when it was retired.
+        retired_at: ProducerEpoch,
+        /// The epoch offered by the late document.
+        incoming: ProducerEpoch,
+    },
+    /// A control publishes the same value lane twice.
+    ///
+    /// One lane is one reading. Two `desired` lanes make "the staged value" ambiguous, and
+    /// `effective_view` resolves a single lane, so C1 coherence could be satisfied by one
+    /// entry and contradicted by the other in the same document.
+    DuplicateValueLane {
+        /// The control carrying it.
+        control: ControlId,
+        /// The lane published twice.
+        lane: ValueLane,
+    },
+    /// The document publishes health for the same transport lane twice.
+    ///
+    /// [`super::LaneWitness`] is keyed by lane, so a duplicate is not merely redundant - it
+    /// is unrepresentable, and folding it would silently keep whichever entry happened to
+    /// come last in a `Vec`.
+    DuplicateLaneHealth {
+        /// The lane published twice.
+        lane: TransportLane,
+    },
+    /// Some [`crate::adaptive::Timestamp`] in the document is not an RFC 3339 instant.
+    ///
+    /// Every timestamp field, not only a lane's `last_success`: the type documents itself as
+    /// RFC 3339 and consumers parse all of them. `field` is a dotted path so a producer author
+    /// is told which one, since a document carries many.
+    TimestampNotRfc3339 {
+        /// Dotted path to the offending field.
+        field: String,
+        /// The offending value, quoted back so the author can see what was published.
+        value: String,
+    },
+    /// A lane's `last_success` is not an RFC 3339 instant.
+    ///
+    /// [`crate::adaptive::Timestamp`] documents itself as RFC 3339, and every consumer that judges freshness
+    /// has to parse it. An unparseable value is not a degraded reading but no reading at all,
+    /// and admitting one puts a string no consumer can interpret where one it can is expected.
+    /// Refused rather than dropped, because silently blanking the field would hide a producer
+    /// bug that only its author can fix.
+    LaneTimestampNotRfc3339 {
+        /// The lane carrying it.
+        lane: TransportLane,
+        /// The offending value, quoted back so the author can see what was published.
+        value: String,
+    },
+    /// A control is unavailable, deprecated or unknown without saying why.
+    ///
+    /// `Availability::is_well_formed` is published as a rule by the contract and was called
+    /// by nothing on this path. A consumer that can see "disabled" but not why cannot
+    /// explain itself, and the user cannot escape the state that caused it.
+    AvailabilityNotWellFormed {
+        /// The control carrying it.
+        control: ControlId,
+        /// The state asserted with no reason.
+        state: AvailabilityState,
     },
     /// A recorded outcome transition the contract calls impossible.
     IllegalOutcomeHistory {
@@ -229,6 +326,12 @@ pub fn admit(previous: Option<&ProducerDocument>, incoming: ProducerDocument) ->
     if let Some(refusal) = first_lane_defect(&incoming) {
         return Admission::Refused(refusal);
     }
+    if let Some(refusal) = first_timestamp_defect(&incoming) {
+        return Admission::Refused(refusal);
+    }
+    if let Some(refusal) = first_shape_defect(&incoming) {
+        return Admission::Refused(refusal);
+    }
     if let Some(refusal) = first_illegal_transition(&incoming) {
         return Admission::Refused(refusal);
     }
@@ -262,6 +365,95 @@ pub fn admit(previous: Option<&ProducerDocument>, incoming: ProducerDocument) ->
         repairs,
         kind,
     })
+}
+
+fn first_timestamp_defect(document: &ProducerDocument) -> Option<AdmissionRefusal> {
+    fn invalid(field: String, timestamp: &crate::adaptive::Timestamp) -> Option<AdmissionRefusal> {
+        if DateTime::parse_from_rfc3339(timestamp.as_str()).is_ok() {
+            return None;
+        }
+        Some(AdmissionRefusal::TimestampNotRfc3339 {
+            field,
+            value: timestamp.as_str().to_string(),
+        })
+    }
+
+    for (lane_index, health) in document.lanes.iter().enumerate() {
+        if let Some(timestamp) = &health.freshness.observed_at {
+            if let Some(refusal) = invalid(
+                format!("lanes[{lane_index}].freshness.observed_at"),
+                timestamp,
+            ) {
+                return Some(refusal);
+            }
+        }
+    }
+    for (control_index, control) in document.controls.iter().enumerate() {
+        for (value_index, value) in control.values.iter().enumerate() {
+            if let Some(timestamp) = &value.freshness.observed_at {
+                if let Some(refusal) = invalid(
+                    format!(
+                        "controls[{control_index}].values[{value_index}].freshness.observed_at"
+                    ),
+                    timestamp,
+                ) {
+                    return Some(refusal);
+                }
+            }
+        }
+        for (divergence_index, divergence) in control.divergences.iter().enumerate() {
+            if let Some(timestamp) = &divergence.detected_at {
+                if let Some(refusal) = invalid(
+                    format!(
+                        "controls[{control_index}].divergences[{divergence_index}].detected_at"
+                    ),
+                    timestamp,
+                ) {
+                    return Some(refusal);
+                }
+            }
+        }
+    }
+    if let Some(policy) = &document.draft_policy {
+        if let Some(timestamp) = &policy.retention.expires_at {
+            if let Some(refusal) = invalid("draft_policy.retention.expires_at".into(), timestamp) {
+                return Some(refusal);
+            }
+        }
+    }
+    for (change_set_index, change_set) in document.change_sets.iter().enumerate() {
+        if let Some(refusal) = invalid(
+            format!("change_sets[{change_set_index}].created_at"),
+            &change_set.created_at,
+        ) {
+            return Some(refusal);
+        }
+        if let Some(refusal) = invalid(
+            format!("change_sets[{change_set_index}].updated_at"),
+            &change_set.updated_at,
+        ) {
+            return Some(refusal);
+        }
+        if let Some(timestamp) = &change_set.retention.expires_at {
+            if let Some(refusal) = invalid(
+                format!("change_sets[{change_set_index}].retention.expires_at"),
+                timestamp,
+            ) {
+                return Some(refusal);
+            }
+        }
+    }
+    for (operation_index, operation) in document.operations.iter().enumerate() {
+        for (history_index, transition) in operation.history.iter().enumerate() {
+            if let Some(refusal) = invalid(
+                format!("operations[{operation_index}].history[{history_index}].at"),
+                &transition.at,
+            ) {
+                return Some(refusal);
+            }
+        }
+    }
+    None
 }
 
 /// How `incoming` relates to `held`, or why it may not replace it.
@@ -345,6 +537,76 @@ fn first_lane_defect(document: &ProducerDocument) -> Option<AdmissionRefusal> {
             }
         }
     }
+    None
+}
+
+/// The first structural defect in the document's lane health or controls, if any.
+///
+/// Four more rules the contract states — three with a published predicate — that had no code
+/// path applying them: the defect class decision 3 of `.oh/adaptive-publication.md` names
+/// outright. All four refuse rather than repair, because none has a repair that does not invent
+/// something: choosing between two lanes with the same name picks one of two readings the
+/// producer never disambiguated, inventing a reason for an unexplained unavailability tells the
+/// user something no producer said, and guessing at a malformed instant fabricates a freshness
+/// claim.
+///
+/// **Every rule here applies to unrecognized members too, and that is deliberate.** Forward
+/// compatibility means an unknown member stays *representable* — the control is kept, its
+/// observed value is kept, and the unknown state passes through unnormalized. It does not mean
+/// structural invariants lapse when a name is unfamiliar:
+///
+/// * A duplicate lane is ambiguous whether or not this build knows the lane's name, and
+///   [`super::LaneWitness`] is keyed by `TransportLane` including its `Unrecognized` arm, so a
+///   duplicate genuinely collides.
+/// * `Availability::is_well_formed` is true for `available` and requires at least one reason
+///   for *every* other state, `Unrecognized` included. An unknown state is the case where that
+///   reason matters most, because a consumer cannot even fall back on knowing what the state
+///   means — exempting it would make the invariant weakest exactly where it is needed.
+///
+/// This is a narrower reading than [`first_lane_defect`] takes, and the difference is real
+/// rather than an inconsistency: there, `LaneValue::is_consistent` returns `false` *because of*
+/// an unrecognized grounding, so applying it would refuse a document for using a newer
+/// vocabulary. Here the predicate is indifferent to the state's name and turns only on whether
+/// a reason is present, which is a shape every version agrees on.
+fn first_shape_defect(document: &ProducerDocument) -> Option<AdmissionRefusal> {
+    let mut lanes_seen: BTreeSet<&TransportLane> = BTreeSet::new();
+    for health in &document.lanes {
+        if !lanes_seen.insert(&health.lane) {
+            return Some(AdmissionRefusal::DuplicateLaneHealth {
+                lane: health.lane.clone(),
+            });
+        }
+        // Checked here rather than trusted downstream, so no unparseable instant is ever
+        // stored, served, or compared. `chrono` is the same parser the aggregator's witness
+        // uses, which is what makes "admitted implies comparable" true rather than hopeful.
+        if let Some(last_success) = &health.last_success {
+            if DateTime::parse_from_rfc3339(last_success.as_str()).is_err() {
+                return Some(AdmissionRefusal::LaneTimestampNotRfc3339 {
+                    lane: health.lane.clone(),
+                    value: last_success.as_str().to_string(),
+                });
+            }
+        }
+    }
+
+    for control in &document.controls {
+        let mut value_lanes: BTreeSet<&ValueLane> = BTreeSet::new();
+        for value in &control.values {
+            if !value_lanes.insert(&value.lane) {
+                return Some(AdmissionRefusal::DuplicateValueLane {
+                    control: control.id.clone(),
+                    lane: value.lane.clone(),
+                });
+            }
+        }
+        if !control.availability.is_well_formed() {
+            return Some(AdmissionRefusal::AvailabilityNotWellFormed {
+                control: control.id.clone(),
+                state: control.availability.state.clone(),
+            });
+        }
+    }
+
     None
 }
 

--- a/src/producers/admission.rs
+++ b/src/producers/admission.rs
@@ -26,8 +26,6 @@
 //! comparing a raw incoming document against it would report a spurious difference and
 //! refuse an identical republication as [`AdmissionRefusal::NotAdvanced`].
 
-use serde::{Deserialize, Serialize};
-
 use crate::adaptive::{
     ChangeSetId, CommandOutcome, ControlId, DocumentRevisions, EntryValidity, Grounding,
     IntentIncoherence, OperationId, ProducerDocument, ProducerEpoch, Reason, ReasonCode, Refusal,
@@ -36,7 +34,11 @@ use crate::adaptive::{
 use crate::bus::PrefixedZoneId;
 
 /// Stable aggregator key for one producer document.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+///
+/// Deliberately carries no serde derives. It is aggregator-internal addressing, and the
+/// less of this module is serializable the less of it can be exposed by accident. #327 may
+/// need to persist a binding keyed on this; that issue can add the derive with a reason.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ProducerKey {
     /// Stable semantic producer id.
     pub producer_id: String,

--- a/src/producers/admission.rs
+++ b/src/producers/admission.rs
@@ -1,0 +1,459 @@
+//! The publication admission gate.
+//!
+//! [`admit`] is the only door into [`super::ProducerAggregator`], and the aggregator is the
+//! only holder of an admitted document. That is what turns "an incoherent document never
+//! reaches a consumer" from a property of a code path into a property of the process.
+//!
+//! ## Two policies, and why they differ
+//!
+//! **Envelope problems refuse the whole document.** There is no partially-usable reading of
+//! a document stamped with an unsupported major, addressed to an unparseable zone, or
+//! carrying a lane that asserts both a reading and no reading. Refusal is safe here
+//! *because the aggregator retains the last admitted snapshot*: a refused document fails to
+//! advance a producer rather than blanking one. That asymmetry is the entire reason
+//! envelope handling can be strict.
+//!
+//! **Published-intent incoherence demotes instead.** The only repair that would preserve a
+//! `valid` entry is inventing the `desired` lane it is missing, and that fabricates intent
+//! the user never staged. Demotion lowers validity and touches nothing else — enforced
+//! structurally by [`apply_demotions`], whose only write is to `entry.validity`.
+//!
+//! ## Order of checks
+//!
+//! Version, then constraint bounds, then zone identity, then lane values, then history,
+//! then coherence repair, then ordering. Repair runs **before** the ordering comparison so
+//! that both sides of that comparison are repaired: the stored document is post-repair, and
+//! comparing a raw incoming document against it would report a spurious difference and
+//! refuse an identical republication as [`AdmissionRefusal::NotAdvanced`].
+
+use serde::{Deserialize, Serialize};
+
+use crate::adaptive::{
+    ChangeSetId, CommandOutcome, ControlId, DocumentRevisions, EntryValidity, Grounding,
+    IntentIncoherence, OperationId, ProducerDocument, ProducerEpoch, Reason, ReasonCode, Refusal,
+    TargetRole, ValueLane, CONSUMER_SCHEMA_VERSION,
+};
+use crate::bus::PrefixedZoneId;
+
+/// Stable aggregator key for one producer document.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct ProducerKey {
+    /// Stable semantic producer id.
+    pub producer_id: String,
+    /// The role this document's controls act in.
+    pub role: TargetRole,
+    /// The prefixed zone id, when the producer is bound to a zone.
+    pub zone_id: Option<String>,
+}
+
+impl ProducerKey {
+    /// The key a document belongs under.
+    pub fn of(document: &ProducerDocument) -> Self {
+        Self {
+            producer_id: document.producer.producer_id.clone(),
+            role: document.target.role.clone(),
+            zone_id: document.target.zone_id.clone(),
+        }
+    }
+}
+
+/// Which way a lane value contradicts itself.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LaneDefect {
+    /// `grounding: grounded` with no value.
+    GroundedWithoutValue,
+    /// `grounding: ungrounded` carrying a value.
+    UngroundedWithValue,
+    /// `grounding: ungrounded` with no reason.
+    UngroundedWithoutReason,
+}
+
+/// Why a document was not admitted.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AdmissionRefusal {
+    /// The contract layer refused it.
+    Contract(Refusal),
+    /// `target.zone_id` is not a prefixed zone id.
+    ZoneIdNotPrefixed {
+        /// The offending value.
+        zone_id: String,
+    },
+    /// The epoch went backwards.
+    EpochRegressed {
+        /// Epoch currently held.
+        previous: ProducerEpoch,
+        /// Epoch offered.
+        incoming: ProducerEpoch,
+    },
+    /// A revision went backwards within one epoch.
+    RevisionRegressed {
+        /// Revisions currently held.
+        previous: DocumentRevisions,
+        /// Revisions offered.
+        incoming: DocumentRevisions,
+    },
+    /// Same revisions, different content.
+    NotAdvanced {
+        /// The revisions both documents claim.
+        at: DocumentRevisions,
+    },
+    /// A lane value asserts both a reading and no reading.
+    LaneValueInconsistent {
+        /// The control carrying it.
+        control: ControlId,
+        /// The lane.
+        lane: ValueLane,
+        /// Which way.
+        detail: LaneDefect,
+    },
+    /// A recorded outcome transition the contract calls impossible.
+    IllegalOutcomeHistory {
+        /// The operation.
+        operation: OperationId,
+        /// Recorded source outcome.
+        from: CommandOutcome,
+        /// Recorded target outcome.
+        to: CommandOutcome,
+    },
+}
+
+/// One demotion applied to keep published intent coherent.
+#[derive(Debug, Clone, PartialEq)]
+pub struct IntentRepair {
+    /// The violation that forced it.
+    pub violation: IntentIncoherence,
+    /// The draft holding the entry.
+    pub change_set: ChangeSetId,
+    /// The control the entry targets.
+    pub control: ControlId,
+    /// Validity before.
+    pub from: EntryValidity,
+    /// Validity after.
+    pub to: EntryValidity,
+}
+
+/// How a document related to the one it replaced.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AdmissionKind {
+    /// First document for this key, or the first of a new epoch.
+    Fresh,
+    /// A revision advance.
+    Advanced,
+    /// Same revisions, lane health only.
+    HealthRefresh,
+}
+
+/// A document that passed the gate.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AdmittedDocument {
+    /// The document as it will be served, after any coherence repair.
+    pub document: ProducerDocument,
+    /// What was demoted, and why.
+    pub repairs: Vec<IntentRepair>,
+    /// How it related to its predecessor.
+    pub kind: AdmissionKind,
+}
+
+/// The gate's verdict.
+#[derive(Debug, Clone, PartialEq)]
+// The admitted variant *is* the document, and admission happens on every publication of
+// every producer. Boxing it would trade a stack move for a heap allocation on that path to
+// shrink a value that is immediately consumed. `BusEvent` carries the same allow for the
+// same reason (`src/bus/events.rs`, "Zone is intentionally large for full state").
+#[allow(clippy::large_enum_variant)]
+pub enum Admission {
+    /// Admitted, possibly repaired.
+    Admitted(AdmittedDocument),
+    /// Refused. The previous snapshot, if any, stands.
+    Refused(AdmissionRefusal),
+}
+
+/// Admit `incoming`, given whatever is currently held for the same key.
+///
+/// Pure: no clock, no I/O, no lock. The aggregator supplies the predecessor and stores the
+/// result, which keeps every ordering and coherence rule unit-testable without a runtime.
+pub fn admit(previous: Option<&ProducerDocument>, incoming: ProducerDocument) -> Admission {
+    // The typed path must apply the same version policy as `admit_document`. A document can
+    // reach this gate as a typed value that never passed through JSON — relayed, or built
+    // by an adapter — so the check cannot live only in the deserializer.
+    if let Some(refusal) = incoming
+        .schema_version
+        .compatibility_for(CONSUMER_SCHEMA_VERSION)
+        .refusal()
+    {
+        return Admission::Refused(AdmissionRefusal::Contract(refusal.clone()));
+    }
+
+    // Same argument for the published expression bounds.
+    for constraint in &incoming.constraints {
+        if let Err(limit) = constraint.validate() {
+            return Admission::Refused(AdmissionRefusal::Contract(Refusal::ConstraintTooComplex {
+                constraint: constraint.id.clone(),
+                limit,
+            }));
+        }
+    }
+
+    // The obligation #323 recorded at `ProducerTarget::zone_id`: `PrefixedZoneId` is
+    // `#[serde(transparent)]`, so its derived `Deserialize` never calls `parse`, and the
+    // prefix vocabulary lives in this server-only module rather than in the shared
+    // contract layer.
+    if let Some(zone_id) = &incoming.target.zone_id {
+        if PrefixedZoneId::parse(zone_id).is_none() {
+            return Admission::Refused(AdmissionRefusal::ZoneIdNotPrefixed {
+                zone_id: zone_id.clone(),
+            });
+        }
+    }
+
+    if let Some(refusal) = first_lane_defect(&incoming) {
+        return Admission::Refused(refusal);
+    }
+    if let Some(refusal) = first_illegal_transition(&incoming) {
+        return Admission::Refused(refusal);
+    }
+
+    let (document, repairs) = repair_intent(incoming);
+
+    let kind = match previous {
+        None => AdmissionKind::Fresh,
+        Some(held) => match ordering(held, &document) {
+            Ok(kind) => kind,
+            Err(refusal) => return Admission::Refused(refusal),
+        },
+    };
+
+    Admission::Admitted(AdmittedDocument {
+        document,
+        repairs,
+        kind,
+    })
+}
+
+/// How `incoming` relates to `held`, or why it may not replace it.
+fn ordering(
+    held: &ProducerDocument,
+    incoming: &ProducerDocument,
+) -> Result<AdmissionKind, AdmissionRefusal> {
+    let previous_epoch = held.producer.epoch;
+    let incoming_epoch = incoming.producer.epoch;
+
+    if incoming_epoch < previous_epoch {
+        return Err(AdmissionRefusal::EpochRegressed {
+            previous: previous_epoch,
+            incoming: incoming_epoch,
+        });
+    }
+    if incoming_epoch > previous_epoch {
+        // Revisions are only comparable within one epoch, so a restart legitimately
+        // arrives with lower counters. Comparing them across the boundary would refuse
+        // every document a restarted producer ever publishes.
+        return Ok(AdmissionKind::Fresh);
+    }
+
+    if incoming.revisions.regresses_from(&held.revisions) {
+        return Err(AdmissionRefusal::RevisionRegressed {
+            previous: held.revisions,
+            incoming: incoming.revisions,
+        });
+    }
+    if incoming.revisions != held.revisions {
+        return Ok(AdmissionKind::Advanced);
+    }
+
+    // Equal revisions. Two readings are possible and they have opposite consequences, so
+    // the gate distinguishes them rather than picking one.
+    //
+    // Demanding a `state` bump for a lane transition would be simpler, but a change set is
+    // validated against the state revision, so every lane flap would invalidate every open
+    // draft on the producer. Admitting a health-only refresh keeps drafts alive and still
+    // updates the lane witness. Anything else at the same revision is a producer bug: two
+    // different documents cannot share one revision without destroying the meaning of
+    // "one revision is one atomic snapshot".
+    let mut probe = incoming.clone();
+    probe.lanes.clone_from(&held.lanes);
+    probe.stale = held.stale;
+    if probe == *held {
+        Ok(AdmissionKind::HealthRefresh)
+    } else {
+        Err(AdmissionRefusal::NotAdvanced { at: held.revisions })
+    }
+}
+
+/// The first lane value that contradicts itself, if any.
+///
+/// Deliberately **not** [`crate::adaptive::LaneValue::is_consistent`], which returns `false`
+/// for an unrecognized grounding. That is right for a consumer — an unrecognized grounding
+/// must not be treated as authoritative — but using it here would refuse a
+/// forward-compatible document from a newer minor version wholesale, which the compatibility
+/// policy in §8 of the specification forbids. Unknown members degrade; they never abort.
+fn first_lane_defect(document: &ProducerDocument) -> Option<AdmissionRefusal> {
+    for control in &document.controls {
+        for value in &control.values {
+            let detail = match value.grounding {
+                Grounding::Grounded if value.value.is_none() => {
+                    Some(LaneDefect::GroundedWithoutValue)
+                }
+                Grounding::Ungrounded if value.value.is_some() => {
+                    Some(LaneDefect::UngroundedWithValue)
+                }
+                Grounding::Ungrounded if value.ungrounded_reason.is_none() => {
+                    Some(LaneDefect::UngroundedWithoutReason)
+                }
+                _ => None,
+            };
+            if let Some(detail) = detail {
+                return Some(AdmissionRefusal::LaneValueInconsistent {
+                    control: control.id.clone(),
+                    lane: value.lane.clone(),
+                    detail,
+                });
+            }
+        }
+    }
+    None
+}
+
+/// The first recorded outcome transition the contract calls impossible, if any.
+///
+/// Only per-transition legality is checked, using the contract's own predicate. Chain
+/// continuity — that each transition's `from` equals the previous `to` — is true by
+/// construction of `OperationRecord::transition`, but the contract publishes no predicate
+/// for it, and inventing one at the door would refuse documents on a rule their author was
+/// never told about.
+fn first_illegal_transition(document: &ProducerDocument) -> Option<AdmissionRefusal> {
+    for operation in &document.operations {
+        for transition in &operation.history {
+            if !transition.from.may_transition_to(&transition.to) {
+                return Some(AdmissionRefusal::IllegalOutcomeHistory {
+                    operation: operation.id.clone(),
+                    from: transition.from.clone(),
+                    to: transition.to.clone(),
+                });
+            }
+        }
+    }
+    None
+}
+
+/// One entry validity to lower, and the violation that forced it.
+struct Demotion {
+    change_set: ChangeSetId,
+    control: ControlId,
+    to: EntryValidity,
+    violation: IntentIncoherence,
+}
+
+/// Bring a document's published intent into coherence by lowering validity only.
+fn repair_intent(mut document: ProducerDocument) -> (ProducerDocument, Vec<IntentRepair>) {
+    let violations = document.intent_coherence_violations();
+    if violations.is_empty() {
+        return (document, Vec::new());
+    }
+
+    let mut demotions: Vec<Demotion> = Vec::new();
+    for violation in violations {
+        match &violation {
+            // C1. The entry claims to be applicable but the document publishes no matching
+            // staged value, so `effective_view` would silently fall back to `observed` and
+            // every constraint over the control would evaluate against the running engine.
+            // Apply is blocked; the producer must republish coherently.
+            IntentIncoherence::MissingDesiredLane {
+                control,
+                change_set,
+            }
+            | IntentIncoherence::DesiredLaneDisagrees {
+                control,
+                change_set,
+            } => {
+                let mut reason = Reason::draft(ReasonCode::DraftInvalid);
+                reason.detail = Some(
+                    "published entry has no matching grounded desired lane (contract C1)"
+                        .to_string(),
+                );
+                demotions.push(Demotion {
+                    change_set: change_set.clone(),
+                    control: control.clone(),
+                    to: EntryValidity::RequiresProducerValidation { reason },
+                    violation: violation.clone(),
+                });
+            }
+            // C2. Both claimants lose validity, not one. A single `desired` lane cannot
+            // represent two drafts, the document carries no arrival order to break the tie
+            // with, and keeping one `valid` would authorize an apply nobody confirmed.
+            // "At most one valid" is satisfied by zero, and zero is the only answer that
+            // does not depend on `Vec` order. `draft_policy.on_conflict` is not consulted:
+            // it governs staging, and #324 implements no staging path.
+            IntentIncoherence::MultipleValidDrafts {
+                control,
+                change_set,
+                also_claimed_by,
+            } => {
+                for claimant in [change_set, also_claimed_by] {
+                    demotions.push(Demotion {
+                        change_set: claimant.clone(),
+                        control: control.clone(),
+                        to: EntryValidity::Conflicts {
+                            with: vec![control.clone()],
+                        },
+                        violation: violation.clone(),
+                    });
+                }
+            }
+            // A control-plane advance removed a control an open draft still targets. This
+            // must stay distinguishable from "needs producer validation": no amount of
+            // revalidation brings a removed control back, and a user told to wait for
+            // validation will wait forever.
+            IntentIncoherence::UnknownControl {
+                control,
+                change_set,
+            } => {
+                let mut reason = Reason::draft(ReasonCode::ControlRemoved);
+                reason.detail = Some(format!(
+                    "control {control} is no longer described by this producer document"
+                ));
+                demotions.push(Demotion {
+                    change_set: change_set.clone(),
+                    control: control.clone(),
+                    to: EntryValidity::DraftInvalid { reason },
+                    violation: violation.clone(),
+                });
+            }
+        }
+    }
+
+    let repairs = apply_demotions(&mut document, &demotions);
+    (document, repairs)
+}
+
+/// Apply demotions. **The only field this function writes is `entry.validity`.**
+///
+/// That is the mechanical form of "never fabricate desired intent". Every violation names a
+/// `(change_set, control)` pair, every valid entry for that pair is lowered, and violations
+/// only ever arise from entries that are currently `Valid` — so one pass is a fixed point
+/// and no second sweep can find anything left to repair.
+fn apply_demotions(document: &mut ProducerDocument, demotions: &[Demotion]) -> Vec<IntentRepair> {
+    let mut repairs = Vec::new();
+    for change_set in &mut document.change_sets {
+        for entry in &mut change_set.entries {
+            if entry.validity != EntryValidity::Valid {
+                continue;
+            }
+            let Some(demotion) = demotions.iter().find(|candidate| {
+                candidate.change_set == change_set.id && candidate.control == entry.control
+            }) else {
+                continue;
+            };
+            let from = entry.validity.clone();
+            entry.validity = demotion.to.clone();
+            repairs.push(IntentRepair {
+                violation: demotion.violation.clone(),
+                change_set: change_set.id.clone(),
+                control: entry.control.clone(),
+                from,
+                to: demotion.to.clone(),
+            });
+        }
+    }
+    repairs
+}

--- a/src/producers/admission.rs
+++ b/src/producers/admission.rs
@@ -108,6 +108,17 @@ pub enum AdmissionRefusal {
         /// Which way.
         detail: LaneDefect,
     },
+    /// Coherence repair did not converge.
+    ///
+    /// Unreachable while every [`IntentIncoherence`] arises from an entry that is currently
+    /// `Valid`, because demoting all of those is a fixed point. It exists so that if a
+    /// later minor version of the contract adds a violation kind that does not have that
+    /// property, the document is refused rather than served incoherent — the failure this
+    /// whole gate exists to prevent, arriving by a route this branch cannot foresee.
+    IrreparableIntent {
+        /// What survived the repair.
+        violations: Vec<IntentIncoherence>,
+    },
     /// A recorded outcome transition the contract calls impossible.
     IllegalOutcomeHistory {
         /// The operation.
@@ -216,6 +227,20 @@ pub fn admit(previous: Option<&ProducerDocument>, incoming: ProducerDocument) ->
     }
 
     let (document, repairs) = repair_intent(incoming);
+
+    // The repair is a fixed point *given* that every violation arises from an entry that is
+    // currently `Valid` — which is true of today's `intent_coherence_violations`. That is a
+    // property of a function in another module, owned by another issue, and a later minor
+    // version could add a violation kind that arises from a non-`Valid` entry. Rather than
+    // rely on reasoning that this branch cannot enforce, the result is re-checked: if
+    // anything survived the repair, the document is refused instead of served incoherent.
+    // Costs one extra pass on a path that already clones.
+    let survivors = document.intent_coherence_violations();
+    if !survivors.is_empty() {
+        return Admission::Refused(AdmissionRefusal::IrreparableIntent {
+            violations: survivors,
+        });
+    }
 
     let kind = match previous {
         None => AdmissionKind::Fresh,

--- a/src/producers/aggregator.rs
+++ b/src/producers/aggregator.rs
@@ -408,9 +408,18 @@ impl ProducerAggregator {
 
 /// Fold a document's lane health into the witness map.
 ///
-/// `last_success` only ever advances. That is the whole point: a poll that fails publishes a
-/// lane with no success timestamp, and forgetting the previous one would blank exactly the
-/// information a user needs to judge how stale the reading is.
+/// A `last_success` is retained until the producer publishes a newer one. A poll that fails
+/// publishes a lane with no success timestamp, and forgetting the previous one would blank
+/// exactly the information a user needs to judge how stale a reading is.
+///
+/// **Ordering comes from admission, not from comparing timestamps.** An earlier draft
+/// advanced `last_success` only when the incoming string sorted after the held one, which
+/// looked like a monotonicity guard and was in fact a bug: [`Timestamp`] is documented as
+/// RFC 3339 but its format is not pinned, so `…:21.500Z` sorts *before* `…:21Z` (`.` is
+/// 0x2E, `Z` is 0x5A) and a `+00:00` offset does not compare with a `Z` at all. The guard
+/// was also unnecessary — [`admit`] refuses any document that regresses in epoch or
+/// revision, so an admitted document is never older than the one it replaces. Taking the
+/// producer's latest word is both simpler and correct.
 fn witness_lanes(
     witnesses: &mut BTreeMap<TransportLane, LaneWitness>,
     document: &ProducerDocument,
@@ -426,15 +435,9 @@ fn witness_lanes(
                 observed_in_epoch: document.producer.epoch,
             });
         witness.state = health.state.clone();
-        if let Some(success) = &health.last_success {
-            let advances = witness
-                .last_success
-                .as_ref()
-                .is_none_or(|held| success.as_str() > held.as_str());
-            if advances {
-                witness.last_success = Some(success.clone());
-                witness.observed_in_epoch = document.producer.epoch;
-            }
+        if health.last_success.is_some() {
+            witness.last_success.clone_from(&health.last_success);
+            witness.observed_in_epoch = document.producer.epoch;
         }
         if health.last_error.is_some() {
             witness.last_error.clone_from(&health.last_error);

--- a/src/producers/aggregator.rs
+++ b/src/producers/aggregator.rs
@@ -1,9 +1,9 @@
 //! Aggregator-owned adaptive producer state.
 //!
 //! The aggregator is the single owner of every current producer document, exactly as it is
-//! for zones (`docs/ARCHITECTURE.md`). Adapters publish on the internal
-//! [`super::AdaptiveBus`]; nothing queries an adapter; every read is served from an
-//! admitted snapshot.
+//! for zones (`docs/ARCHITECTURE.md`). Adapters publish through the bounded
+//! [`super::AdaptiveHandle`]; nothing queries an adapter; every read is served from an admitted
+//! snapshot.
 //!
 //! Three properties are worth stating because they are not obvious from the types:
 //!
@@ -12,22 +12,22 @@
 //! * **Lane history lives beside the document, never inside it.** [`LaneWitness`] is
 //!   aggregator-observed and labelled as such. Merging a remembered timestamp into the
 //!   producer's own `lanes` would put words in its mouth.
-//! * **A refusal is retained, not merely logged.** Publication is asynchronous, so the
-//!   publishing adapter gets no return value; if a refusal were only a log line, a producer
-//!   author would have no way to learn its documents were being dropped.
+//! * **A refusal is retained, not merely logged.** A publisher may request an immediate actor
+//!   verdict, but retained diagnostics remain necessary for detached publication and operators.
 
+use chrono::{DateTime, FixedOffset};
 use std::collections::BTreeMap;
-use std::sync::Arc;
-use tokio::sync::broadcast::error::RecvError;
-use tokio::sync::RwLock;
-use tracing::{debug, info, warn};
+use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use tracing::warn;
 
 use super::admission::{admit, Admission, AdmissionRefusal, IntentRepair, ProducerKey};
 use super::event::{AdaptiveEvent, SharedAdaptiveBus};
+use super::run::{AdapterRuns, PublicationOrigin};
 use crate::adaptive::{
     LaneState, ProducerDocument, ProducerEpoch, Reason, Timestamp, TransportLane,
 };
-use crate::bus::{BusEvent, SharedBus};
+#[cfg(debug_assertions)]
+use crate::bus::BusEvent;
 
 /// What the aggregator has ever observed about one transport lane.
 ///
@@ -41,17 +41,26 @@ pub struct LaneWitness {
     pub lane: TransportLane,
     /// Its state in the most recently admitted document.
     pub state: LaneState,
-    /// The newest success ever seen for this lane. Monotonic: never regresses, so a failing
-    /// poll cannot erase the evidence that the lane worked five seconds ago.
+    /// The newest success ever seen for this lane. Monotonic **as an instant**: never
+    /// regresses, so neither a failing poll nor an advancing document that happens to report
+    /// an older instant can erase the evidence that the lane worked five seconds ago.
+    ///
+    /// Compared with `chrono`, not as a string and not by arrival order — see
+    /// [`witness_lanes`] for why each of those was tried and is wrong.
     pub last_success: Option<Timestamp>,
     /// The most recent error seen for this lane.
     pub last_error: Option<Reason>,
-    /// The epoch `last_success` was observed in.
+    /// The epoch in which the **currently retained** `last_success` was observed.
     ///
-    /// Carrying a last-good timestamp across a producer restart is honest only if a
-    /// consumer can tell that it predates the restart. Resetting it instead would discard
-    /// true information; presenting it unqualified would imply it was observed by the
-    /// process now running.
+    /// Not "the epoch of the last document that mentioned this lane". The two differ exactly
+    /// when a restart reports an instant older than one already witnessed: the older-instant
+    /// document is ignored, and this keeps naming the epoch that actually observed the value
+    /// still being shown. The pair moves together or not at all.
+    ///
+    /// Carrying a last-good timestamp across a producer restart is honest only if a consumer
+    /// can tell that it predates the restart. Resetting it instead would discard true
+    /// information; presenting it unqualified would imply it was observed by the process now
+    /// running.
     pub observed_in_epoch: ProducerEpoch,
 }
 
@@ -81,13 +90,6 @@ pub struct ProducerSnapshot {
     pub presence: ProducerPresence,
     /// Coherence demotions applied to the document being served.
     pub repairs: Vec<IntentRepair>,
-    /// Updates dropped because the internal bus lagged.
-    ///
-    /// Channel-global rather than per-producer: `broadcast` reports a receiver's shortfall,
-    /// not which messages were lost. Non-zero means some revision was skipped; because
-    /// documents are whole snapshots rather than deltas, the store converges on the next
-    /// publication and the count is a staleness hint, not a corruption warning.
-    pub missed_updates: u64,
     /// The most recent refusal for this producer, retained across later successes.
     pub last_refusal: Option<AdmissionRefusal>,
 }
@@ -96,6 +98,11 @@ struct Entry {
     document: Arc<ProducerDocument>,
     lanes: BTreeMap<TransportLane, LaneWitness>,
     repairs: Vec<IntentRepair>,
+    /// The adapter run this document was admitted under, if it arrived through one.
+    ///
+    /// Presence is projected from this exact origin at read time. Public-bus stop events never
+    /// flush adaptive state, so an ended run remains honestly visible as last-known.
+    run: Option<PublicationOrigin>,
 }
 
 /// Producers plus the refusals that did not become producers.
@@ -108,178 +115,303 @@ struct Entry {
 struct Store {
     producers: BTreeMap<ProducerKey, Entry>,
     refusals: BTreeMap<ProducerKey, RefusalRecord>,
-    missed_updates: u64,
+    tombstones: BTreeMap<ProducerKey, Tombstone>,
+    producer_tombstones: BTreeMap<String, ProducerEpoch>,
+    watermarks: BTreeMap<ProducerKey, Watermark>,
 }
 
-/// A retained refusal, with the identity of the adapter that published it.
+/// A retained refusal, with the exact adapter run that published it when one exists.
 ///
-/// The producer type is kept beside the refusal because a first-publication refusal never
-/// creates a producer entry, and an `AdapterStopping` flush derives its victims from the
-/// producer map. Without this, a refusal for a producer that never existed outlived the
-/// adapter that caused it. Found by CodeRabbit at `9c53079`.
+/// Public-bus stop hints are informational and never clear adaptive diagnostics. The origin is
+/// retained solely to keep a delayed stale-run refusal from overwriting a newer live-run
+/// refusal for the same key.
 struct RefusalRecord {
     refusal: AdmissionRefusal,
-    producer_type: String,
+    /// The rejected document's claimed epoch scopes diagnostic cleanup only. It is never used
+    /// to advance a retirement floor or watermark.
+    claimed_epoch: ProducerEpoch,
+    origin: Option<PublicationOrigin>,
+}
+
+/// A producer retired by an explicit `ProducerRemoved`, and the epoch it held.
+///
+/// **Producer-epoch retirement only.** Adapter lifecycle does not create these, and nothing
+/// clears them but the producer itself announcing a restart with a strictly higher epoch. An
+/// earlier draft also set them on `AdapterStopping` and cleared them on `AdapterConnected`,
+/// which was unsound twice over: the clear could be processed before a straggler that the
+/// tombstone existed to stop, and requiring a higher epoch stranded any adapter that
+/// reconnected to an engine that had never restarted. Adapter staleness is now
+/// [`super::run`]'s job, and this is only about the producer's own identity.
+struct Tombstone {
+    /// Documents at this epoch or lower are refused; the producer said it was gone.
+    epoch: ProducerEpoch,
+}
+
+/// Monotonic ordering evidence retained even when the visible snapshot is swept.
+#[derive(Clone, Copy)]
+struct Watermark {
+    epoch: ProducerEpoch,
+    revisions: crate::adaptive::DocumentRevisions,
+}
+
+impl Store {
+    /// Keep the newest run's diagnostic for a key. A delayed stale run may be observed later,
+    /// but it must not overwrite the current run's refusal and then erase its evidence.
+    fn record_refusal(&mut self, key: ProducerKey, incoming: RefusalRecord) {
+        let owner = key.producer_id.split_once(':').map(|(owner, _)| owner);
+        let authority = |origin: &Option<PublicationOrigin>| match origin {
+            Some(origin) if Some(origin.adapter.as_str()) == owner => 2_u8,
+            None => 1,
+            Some(_) => 0,
+        };
+        let replace = self.refusals.get(&key).is_none_or(|held| {
+            match authority(&incoming.origin).cmp(&authority(&held.origin)) {
+                std::cmp::Ordering::Greater => true,
+                std::cmp::Ordering::Less => false,
+                std::cmp::Ordering::Equal => match (&held.origin, &incoming.origin) {
+                    (Some(held), Some(incoming)) if held.adapter == incoming.adapter => {
+                        incoming.run >= held.run
+                    }
+                    // Diagnostics from two non-owning adapters have equal lack of authority;
+                    // keep the first rather than letting a process-global run id arbitrate.
+                    (Some(_), Some(_)) => false,
+                    (Some(_), None) => false,
+                    (None, _) => true,
+                },
+            }
+        });
+        if replace {
+            self.refusals.insert(key, incoming);
+        }
+    }
+
+    /// Whether a document may proceed to admission, given what has been retired.
+    ///
+    /// `Err(epoch)` is a document for a producer that said it was gone. A strictly newer epoch
+    /// is a restart and passes the retained floor. The floor remains monotonic evidence so a
+    /// later straggler under this or another target key is still refused.
+    fn admit_past_retirement(
+        &self,
+        key: &ProducerKey,
+        incoming: ProducerEpoch,
+    ) -> Result<(), ProducerEpoch> {
+        let key_epoch = self.tombstones.get(key).map(|t| t.epoch);
+        let producer_epoch = self.producer_tombstones.get(&key.producer_id).copied();
+        let retired_at = match (key_epoch, producer_epoch) {
+            (Some(a), Some(b)) => Some(a.max(b)),
+            (a, b) => a.or(b),
+        };
+        let Some(retired_at) = retired_at else {
+            return Ok(());
+        };
+        if incoming <= retired_at {
+            return Err(retired_at);
+        }
+        // Floors are monotonic evidence, not gates to consume. A higher-epoch restart passes,
+        // but cannot erase the floor for a later straggler under this or an unseen target key.
+        Ok(())
+    }
+
+    /// Retire `key` at `epoch`, keeping the highest epoch if it is already retired.
+    ///
+    /// Highest wins so that a later retirement cannot lower the bar a straggler has to clear.
+    fn retire(&mut self, key: ProducerKey, epoch: ProducerEpoch) {
+        let tombstone = self.tombstones.entry(key).or_insert(Tombstone { epoch });
+        if epoch > tombstone.epoch {
+            tombstone.epoch = epoch;
+        }
+    }
+
+    fn retire_producer_through(
+        &mut self,
+        producer_id: &str,
+        epoch: ProducerEpoch,
+    ) -> ProducerEpoch {
+        let retired = self
+            .producer_tombstones
+            .entry(producer_id.to_string())
+            .or_insert(epoch);
+        if epoch > *retired {
+            *retired = epoch;
+        }
+        *retired
+    }
+
+    fn watermark_refusal(
+        &self,
+        key: &ProducerKey,
+        epoch: ProducerEpoch,
+        revisions: crate::adaptive::DocumentRevisions,
+    ) -> Option<AdmissionRefusal> {
+        let watermark = self.watermarks.get(key)?;
+        if epoch < watermark.epoch {
+            return Some(AdmissionRefusal::EpochRegressed {
+                previous: watermark.epoch,
+                incoming: epoch,
+            });
+        }
+        if epoch == watermark.epoch && revisions.regresses_from(&watermark.revisions) {
+            return Some(AdmissionRefusal::RevisionRegressed {
+                previous: watermark.revisions,
+                incoming: revisions,
+            });
+        }
+        None
+    }
+
+    fn observe_watermark(
+        &mut self,
+        key: ProducerKey,
+        epoch: ProducerEpoch,
+        revisions: crate::adaptive::DocumentRevisions,
+    ) {
+        let replace = self.watermarks.get(&key).is_none_or(|held| {
+            epoch > held.epoch || (epoch == held.epoch && revisions.advances_over(&held.revisions))
+        });
+        if replace {
+            self.watermarks.insert(key, Watermark { epoch, revisions });
+        }
+    }
+
+    fn admitted_epoch_of_producer(&self, producer_id: &str) -> Option<ProducerEpoch> {
+        self.producers
+            .iter()
+            .filter(|(key, _)| key.producer_id == producer_id)
+            .map(|(_, entry)| entry.document.producer.epoch)
+            .max()
+    }
 }
 
 /// Owns every current adaptive producer document.
 pub struct ProducerAggregator {
     store: Arc<RwLock<Store>>,
-    bus: Option<SharedBus>,
-    adaptive: Option<SharedAdaptiveBus>,
+    adaptive: SharedAdaptiveBus,
+    /// The same registry publishers allocate runs from, so staleness is judged against
+    /// synchronously-maintained state rather than event arrival order.
+    runs: Arc<AdapterRuns>,
 }
 
 impl ProducerAggregator {
-    /// Construct wired to the public bus (for lifecycle) and the internal bus (for
-    /// producer documents).
-    pub fn new(bus: SharedBus, adaptive: SharedAdaptiveBus) -> Self {
-        Self {
-            store: Arc::new(RwLock::new(Store::default())),
-            bus: Some(bus),
-            adaptive: Some(adaptive),
-        }
-    }
-
     /// Construct with no bus, for callers that drive [`ProducerAggregator::ingest`]
     /// directly.
+    #[cfg(debug_assertions)]
     pub fn detached() -> Self {
+        Self::detached_with_runs(Arc::new(AdapterRuns::default()))
+    }
+
+    #[cfg(debug_assertions)]
+    pub(super) fn detached_with_runs(runs: Arc<AdapterRuns>) -> Self {
+        Self::detached_with_runs_and_events(runs, super::event::create_adaptive_bus())
+    }
+
+    pub(super) fn detached_with_runs_and_events(
+        runs: Arc<AdapterRuns>,
+        adaptive: SharedAdaptiveBus,
+    ) -> Self {
         Self {
             store: Arc::new(RwLock::new(Store::default())),
-            bus: None,
-            adaptive: None,
-        }
-    }
-
-    /// Event loop. Spawn this; it returns on `ShuttingDown` or when both buses close.
-    ///
-    /// The loop is here rather than inside a `tokio::spawn` block so that
-    /// `tests/spawn_cancellation_lint.rs` sees a cancellable shape, matching
-    /// `ZoneAggregator::run`.
-    pub async fn run(&self) {
-        let (Some(adaptive), Some(bus)) = (self.adaptive.as_ref(), self.bus.as_ref()) else {
-            return;
-        };
-        let mut adaptive_rx = adaptive.subscribe();
-        let mut bus_rx = bus.subscribe();
-
-        info!("ProducerAggregator started");
-
-        loop {
-            tokio::select! {
-                received = adaptive_rx.recv() => match received {
-                    Ok(event) => self.apply_adaptive_event(event).await,
-                    // Lag must not end the loop. `while let Ok(..) = rx.recv().await`
-                    // treats `Lagged` as termination, which would permanently stop
-                    // producer state after one burst - see `ZoneAggregator::run`. Because
-                    // documents are whole snapshots, a dropped update is recovered by the
-                    // next publication, but only if this loop is still consuming.
-                    Err(RecvError::Lagged(missed)) => self.record_lag(missed).await,
-                    Err(RecvError::Closed) => break,
-                },
-                received = bus_rx.recv() => match received {
-                    Ok(event) => {
-                        if self.apply_bus_event(event).await {
-                            break;
-                        }
-                    }
-                    Err(RecvError::Lagged(missed)) => {
-                        debug!("ProducerAggregator lagged {missed} public bus events");
-                    }
-                    Err(RecvError::Closed) => break,
-                },
-            }
-        }
-
-        info!("ProducerAggregator stopped");
-    }
-
-    /// Handle one internal-bus event.
-    async fn apply_adaptive_event(&self, event: AdaptiveEvent) {
-        match event {
-            AdaptiveEvent::ProducerPublished { document } => {
-                self.ingest(*document).await;
-            }
-            AdaptiveEvent::ProducerRemoved { producer_id } => {
-                let removed = self.remove(&producer_id).await;
-                debug!("Producer removed: {producer_id} ({removed} targets)");
-            }
-            // The aggregator's own egress. Consuming it would be a loop.
-            AdaptiveEvent::SnapshotAdmitted { .. } | AdaptiveEvent::SnapshotRefused { .. } => {}
+            adaptive,
+            runs,
         }
     }
 
     /// Handle one public-bus event. Returns whether the loop should stop.
     ///
-    /// Only lifecycle events do anything. Every command, volume and pipeline event is inert
-    /// **by construction**, which is how "immediate/live commands cannot read, clear or
-    /// flush staged intent" is guaranteed rather than merely intended: there is no code path
-    /// from a live command to producer state.
+    /// Public-bus events are informational only for adaptive state.
+    ///
+    /// Retained as a debug-profile seam for the frozen bus-isolation probes. Release lifecycle
+    /// authority is exclusively the actor command channel and run leases; see the explicit
+    /// profile boundary on the re-export in [`super`].
+    #[cfg(debug_assertions)]
     pub async fn apply_bus_event(&self, event: BusEvent) -> bool {
-        match event {
-            BusEvent::AdapterStopping { adapter, .. } => {
-                let removed = self.flush_adapter(&adapter).await;
-                if removed > 0 {
-                    info!("Flushed {removed} producers for adapter {adapter}");
-                }
-                false
-            }
-            BusEvent::ShuttingDown { .. } => true,
-            _ => false,
-        }
+        matches!(event, BusEvent::ShuttingDown { .. })
     }
 
-    /// Admit a document into the store.
+    /// Admit a document with no adapter-run context.
     ///
+    /// The direct path, for callers that drive the aggregator themselves rather than through
+    /// the debug test seam. Run staleness cannot be judged without an origin, so this skips that
+    /// check — every other rule still applies. Production ingress goes through
+    /// [`super::AdaptiveHandle`].
+    #[cfg(debug_assertions)]
+    pub async fn ingest(&self, document: ProducerDocument) -> Admission {
+        self.admit_document(None, document).await
+    }
+
+    /// Admit a document published by a known adapter run.
+    ///
+    /// Refuses anything from a run the registry no longer considers live, which is what makes
+    /// a straggler harmless however long it sat in the channel. See [`super::run`].
+    pub async fn ingest_from(
+        &self,
+        origin: &PublicationOrigin,
+        document: ProducerDocument,
+    ) -> Admission {
+        self.admit_document(Some(origin), document).await
+    }
+
     /// The whole read-modify-write runs under one write guard with no `.await` inside it:
     /// [`admit`] is pure and synchronous, so there is no lock-across-await, and no window in
     /// which a concurrent publication could be compared against a predecessor that is about
     /// to be replaced.
-    pub async fn ingest(&self, document: ProducerDocument) -> Admission {
+    async fn admit_document(
+        &self,
+        origin: Option<&PublicationOrigin>,
+        document: ProducerDocument,
+    ) -> Admission {
         let key = ProducerKey::of(&document);
-        let producer_type = document.producer.producer_type.clone();
-        let admission = {
-            let mut store = self.store.write().await;
-            let previous = store
-                .producers
-                .get(&key)
-                .map(|entry| entry.document.clone());
-            let admission = admit(previous.as_deref(), document);
-
-            match &admission {
-                Admission::Admitted(admitted) => {
-                    let mut lanes = store
-                        .producers
-                        .get(&key)
-                        .map(|entry| entry.lanes.clone())
-                        .unwrap_or_default();
-                    witness_lanes(&mut lanes, &admitted.document);
-                    store.producers.insert(
-                        key.clone(),
-                        Entry {
-                            document: Arc::new(admitted.document.clone()),
-                            lanes,
-                            repairs: admitted.repairs.clone(),
-                        },
-                    );
-                }
-                Admission::Refused(refusal) => {
-                    // Retained rather than replacing anything. The previously admitted
-                    // document, if there is one, keeps being served. The publishing
-                    // adapter's identity is retained with it, because a refusal on a first
-                    // publication has no producer entry to be flushed alongside.
-                    store.refusals.insert(
-                        key.clone(),
-                        RefusalRecord {
-                            refusal: refusal.clone(),
-                            producer_type: producer_type.clone(),
-                        },
-                    );
-                }
+        let claimed_epoch = document.producer.epoch;
+        if let Some(origin) = origin {
+            if !origin.owns(&key.producer_id) {
+                let refusal = AdmissionRefusal::ProducerOwnershipMismatch {
+                    adapter: origin.adapter.clone(),
+                    producer_id: key.producer_id.clone(),
+                };
+                // This is a command-authority failure by another adapter, not a defect in the
+                // named producer's document. Return it and emit an egress hint, but never attach
+                // it to the owner's retained diagnostic slot.
+                warn!(
+                    adapter = %origin.adapter,
+                    producer = %key.producer_id,
+                    "adapter attempted to publish outside its producer namespace"
+                );
+                self.emit(AdaptiveEvent::SnapshotRefused {
+                    key,
+                    refusal: refusal.clone(),
+                });
+                return Admission::Refused(refusal);
             }
-            admission
+        }
+        let admission = match origin {
+            Some(origin) => match self
+                .runs
+                .with_active(origin, || self.admit_active(Some(origin), document))
+            {
+                Ok(admission) => admission,
+                Err(active) => {
+                    let refusal = AdmissionRefusal::StaleAdapterRun {
+                        adapter: origin.adapter.clone(),
+                        published_by: origin.run,
+                        active,
+                    };
+                    warn!(
+                        adapter = %origin.adapter,
+                        published_by = ?origin.run,
+                        "document published by an adapter run that is no longer live; refused"
+                    );
+                    self.retain_refusal(
+                        key.clone(),
+                        refusal.clone(),
+                        claimed_epoch,
+                        Some(origin.clone()),
+                    );
+                    Admission::Refused(refusal)
+                }
+            },
+            None => self.admit_active(None, document),
         };
 
-        // Reporting happens after the guard is released.
+        // Reporting happens after both the lifecycle and store guards are released.
         match &admission {
             Admission::Admitted(admitted) => {
                 if !admitted.repairs.is_empty() {
@@ -311,124 +443,317 @@ impl ProducerAggregator {
         admission
     }
 
-    /// Remove every target of one producer. Returns how many entries went.
+    /// Apply one admission after lifecycle authority has been established.
     ///
-    /// Removal is not disconnection. A producer that has lost its transport keeps
-    /// publishing documents marked `stale`, and those stay visible as last-known.
-    ///
-    /// The retained refusal goes with the producer. Refusals outlive *successes*, so a
-    /// producer author can see that its documents were dropped even after one lands — but
-    /// outliving the producer itself would make `refusals()` name something that no longer
-    /// exists, and a surface listing "producers with problems" would show a ghost.
-    pub async fn remove(&self, producer_id: &str) -> usize {
-        let mut store = self.store.write().await;
-        let doomed: Vec<ProducerKey> = store
-            .producers
-            .keys()
-            .filter(|key| key.producer_id == producer_id)
-            .cloned()
-            .collect();
-        for key in &doomed {
-            store.producers.remove(key);
+    /// For run-stamped ingress this is called *inside* [`AdapterRuns::with_active`], so the
+    /// liveness decision and this complete read-modify-write are one linearizable turn.
+    fn admit_active(
+        &self,
+        origin: Option<&PublicationOrigin>,
+        document: ProducerDocument,
+    ) -> Admission {
+        let key = ProducerKey::of(&document);
+        let incoming_epoch = document.producer.epoch;
+        let mut store = self.write_store();
+
+        if let Err(retired_at) = store.admit_past_retirement(&key, incoming_epoch) {
+            let refusal = AdmissionRefusal::ProducerRetired {
+                retired_at,
+                incoming: incoming_epoch,
+            };
+            store.record_refusal(
+                key,
+                RefusalRecord {
+                    refusal: refusal.clone(),
+                    claimed_epoch: incoming_epoch,
+                    origin: origin.cloned(),
+                },
+            );
+            return Admission::Refused(refusal);
         }
-        store
-            .refusals
-            .retain(|key, _| key.producer_id != producer_id);
-        doomed.len()
+
+        if let Some(refusal) = store.watermark_refusal(&key, incoming_epoch, document.revisions) {
+            store.record_refusal(
+                key,
+                RefusalRecord {
+                    refusal: refusal.clone(),
+                    claimed_epoch: incoming_epoch,
+                    origin: origin.cloned(),
+                },
+            );
+            return Admission::Refused(refusal);
+        }
+
+        // Adapter reconnect is not a producer revision. Compare against the held document
+        // even when the publishing run changed, otherwise a reconnect could change content
+        // under the same epoch/revision and make downstream revision caches lie.
+        let previous = store
+            .producers
+            .get(&key)
+            .map(|entry| entry.document.clone());
+        let admission = admit(previous.as_deref(), document);
+
+        match &admission {
+            Admission::Admitted(admitted) => {
+                store.observe_watermark(
+                    key.clone(),
+                    admitted.document.producer.epoch,
+                    admitted.document.revisions,
+                );
+                let mut lanes = store
+                    .producers
+                    .get(&key)
+                    .map(|entry| entry.lanes.clone())
+                    .unwrap_or_default();
+                witness_lanes(&mut lanes, &admitted.document);
+                store.producers.insert(
+                    key.clone(),
+                    Entry {
+                        document: Arc::new(admitted.document.clone()),
+                        lanes,
+                        repairs: admitted.repairs.clone(),
+                        run: origin.cloned(),
+                    },
+                );
+            }
+            Admission::Refused(refusal) => {
+                store.record_refusal(
+                    key,
+                    RefusalRecord {
+                        refusal: refusal.clone(),
+                        claimed_epoch: incoming_epoch,
+                        origin: origin.cloned(),
+                    },
+                );
+            }
+        }
+        admission
     }
 
-    /// Drop every producer belonging to an adapter that is stopping.
-    ///
-    /// Matched on `producer_type` or on the `adapter:` id prefix, mirroring how
-    /// `ZoneAggregator` flushes zones, so a stopped adapter cannot leave ghost producers
-    /// that no longer correspond to anything running.
-    async fn flush_adapter(&self, adapter: &str) -> usize {
-        let prefix = format!("{adapter}:");
-        let mut store = self.store.write().await;
-        let doomed: Vec<ProducerKey> = store
-            .producers
-            .iter()
-            .filter(|(key, entry)| {
-                entry.document.producer.producer_type == adapter
-                    || key.producer_id.starts_with(&prefix)
-            })
-            .map(|(key, _)| key.clone())
-            .collect();
-        for key in &doomed {
-            store.producers.remove(key);
-        }
-        // A refusal must not outlive the adapter that caused it, and a first-publication
-        // refusal has no producer entry to be found among `doomed`. Matched the same way
-        // the producers are: by producer type, or by the `adapter:` id prefix.
-        store.refusals.retain(|key, record| {
-            !(doomed.iter().any(|gone| gone == key)
-                || record.producer_type == adapter
-                || key.producer_id.starts_with(&prefix))
-        });
-        doomed.len()
-    }
-
-    async fn record_lag(&self, missed: u64) {
-        {
-            let mut store = self.store.write().await;
-            store.missed_updates = store.missed_updates.saturating_add(missed);
-        }
-        warn!(
-            missed,
-            "internal adaptive bus lagged; producer revisions were skipped. Documents are \
-             whole snapshots, so the store converges on the next publication"
+    fn retain_refusal(
+        &self,
+        key: ProducerKey,
+        refusal: AdmissionRefusal,
+        claimed_epoch: ProducerEpoch,
+        origin: Option<PublicationOrigin>,
+    ) {
+        self.write_store().record_refusal(
+            key,
+            RefusalRecord {
+                refusal,
+                claimed_epoch,
+                origin,
+            },
         );
     }
 
-    fn emit(&self, event: AdaptiveEvent) {
-        if let Some(adaptive) = self.adaptive.as_ref() {
-            adaptive.publish(event);
-        }
+    /// Remove every target of one producer, with no adapter-run context.
+    ///
+    /// Debug-test direct path; production retirement goes through [`super::AdaptiveHandle`].
+    #[cfg(debug_assertions)]
+    pub async fn remove(&self, producer_id: &str) -> usize {
+        self.retire_producer(None, producer_id, None).await.0
     }
 
-    fn project(&self, store: &Store, key: &ProducerKey, entry: &Entry) -> ProducerSnapshot {
+    /// Remove every target of one producer, as retired by a known adapter run.
+    ///
+    /// A removal from a run that is no longer live does nothing: it is as stale as a
+    /// publication from that run, and acting on it would retire a producer belonging to the
+    /// run that replaced it.
+    #[cfg(debug_assertions)]
+    pub async fn remove_from(&self, origin: &PublicationOrigin, producer_id: &str) -> usize {
+        self.retire_producer(Some(origin), producer_id, None)
+            .await
+            .0
+    }
+
+    /// Apply a retirement whose run authority was committed atomically with queue insertion.
+    pub(super) fn retire_committed(
+        &self,
+        origin: &PublicationOrigin,
+        producer_id: &str,
+        epoch: ProducerEpoch,
+    ) -> usize {
+        debug_assert!(origin.owns(producer_id));
+        let (removed, applied_floor) = self.retire_active(producer_id, Some(epoch));
+        self.emit(AdaptiveEvent::ProducerRetired {
+            producer_id: producer_id.to_string(),
+            retired_through: applied_floor.unwrap_or(epoch),
+            removed,
+        });
+        removed
+    }
+
+    /// Retire a producer by identity. Returns how many entries went.
+    ///
+    /// Removal is not disconnection. A producer that has lost its transport keeps publishing
+    /// documents marked `stale`, and those stay visible as last-known.
+    ///
+    /// **This is producer-epoch retirement, and it is the only thing that writes a tombstone.**
+    /// The producer said it is gone, so only the producer can contradict that, by announcing a
+    /// restart with a strictly higher epoch. Adapter lifecycle is a separate question answered
+    /// by [`super::run`], and deliberately cannot clear this: an adapter reconnecting does not
+    /// speak for whether a producer still exists.
+    ///
+    /// The retained refusal goes with the producer. Refusals outlive *successes*, so a producer
+    /// author can see that its documents were dropped even after one lands — but outliving the
+    /// producer itself would make `refusals()` name something that no longer exists, and a
+    /// surface listing "producers with problems" would show a ghost.
+    #[cfg(debug_assertions)]
+    async fn retire_producer(
+        &self,
+        origin: Option<&PublicationOrigin>,
+        producer_id: &str,
+        explicit_epoch: Option<ProducerEpoch>,
+    ) -> (usize, Option<ProducerEpoch>) {
+        if let Some(origin) = origin {
+            return self
+                .runs
+                .with_active(origin, || self.retire_active(producer_id, explicit_epoch))
+                .unwrap_or((0, None));
+        }
+        self.retire_active(producer_id, explicit_epoch)
+    }
+
+    fn retire_active(
+        &self,
+        producer_id: &str,
+        explicit_epoch: Option<ProducerEpoch>,
+    ) -> (usize, Option<ProducerEpoch>) {
+        let mut store = self.write_store();
+        let retired_through =
+            explicit_epoch.or_else(|| store.admitted_epoch_of_producer(producer_id));
+        let applied_floor =
+            retired_through.map(|epoch| store.retire_producer_through(producer_id, epoch));
+        let remove_all = explicit_epoch.is_none();
+        let producer_keys: Vec<ProducerKey> = store
+            .producers
+            .iter()
+            .filter(|(key, entry)| {
+                key.producer_id == producer_id
+                    && (remove_all
+                        || applied_floor
+                            .is_some_and(|floor| entry.document.producer.epoch <= floor))
+            })
+            .map(|(key, _)| key.clone())
+            .collect();
+        let refusal_keys: Vec<ProducerKey> = store
+            .refusals
+            .iter()
+            .filter(|(key, record)| {
+                key.producer_id == producer_id
+                    && (remove_all
+                        || applied_floor.is_some_and(|floor| record.claimed_epoch <= floor))
+            })
+            .map(|(key, _)| key.clone())
+            .collect();
+        let mut removed = 0usize;
+        for key in &producer_keys {
+            if store.producers.remove(key).is_some() {
+                removed += 1;
+            }
+            if let Some(epoch) = applied_floor {
+                store.retire(key.clone(), epoch);
+            }
+        }
+        for key in refusal_keys {
+            store.refusals.remove(&key);
+            if let Some(epoch) = applied_floor {
+                store.retire(key, epoch);
+            }
+        }
+        (removed, applied_floor)
+    }
+
+    /// The run registry this aggregator judges publications against.
+    ///
+    /// Exposed so a publisher wired to a detached aggregator, and the tests that stand in for
+    /// one, allocate runs from the same registry rather than a parallel one.
+    #[cfg(debug_assertions)]
+    pub fn runs(&self) -> &Arc<AdapterRuns> {
+        &self.runs
+    }
+
+    fn emit(&self, event: AdaptiveEvent) {
+        self.adaptive.publish(event);
+    }
+
+    fn project(
+        &self,
+        store: &Store,
+        key: &ProducerKey,
+        entry: &Entry,
+        run_is_live: bool,
+    ) -> ProducerSnapshot {
         ProducerSnapshot {
             key: key.clone(),
             document: entry.document.clone(),
             lanes: entry.lanes.clone(),
-            presence: if entry.document.stale {
+            presence: if entry.document.stale || !run_is_live {
                 ProducerPresence::LastKnown
             } else {
                 ProducerPresence::Live
             },
             repairs: entry.repairs.clone(),
-            missed_updates: store.missed_updates,
             last_refusal: store.refusals.get(key).map(|r| r.refusal.clone()),
         }
     }
 
     /// One producer's snapshot, read under a single guard so it cannot be a mixture.
+    #[cfg(debug_assertions)]
     pub async fn snapshot(&self, key: &ProducerKey) -> Option<ProducerSnapshot> {
-        let store = self.store.read().await;
-        store
-            .producers
-            .get(key)
-            .map(|entry| self.project(&store, key, entry))
+        self.snapshot_now(key)
     }
 
     /// Every producer's snapshot, in deterministic key order.
+    #[cfg(debug_assertions)]
     pub async fn snapshots(&self) -> Vec<ProducerSnapshot> {
-        let store = self.store.read().await;
-        store
-            .producers
-            .iter()
-            .map(|(key, entry)| self.project(&store, key, entry))
-            .collect()
+        self.snapshots_now()
     }
 
     /// How many producer entries are held.
+    #[cfg(debug_assertions)]
     pub async fn producer_count(&self) -> usize {
-        self.store.read().await.producers.len()
+        self.read_store().producers.len()
     }
 
     /// Every retained refusal, in deterministic key order.
+    #[cfg(debug_assertions)]
     pub async fn refusals(&self) -> Vec<(ProducerKey, AdmissionRefusal)> {
-        let store = self.store.read().await;
+        self.refusals_now()
+    }
+
+    pub(super) fn snapshot_now(&self, key: &ProducerKey) -> Option<ProducerSnapshot> {
+        self.runs.with_liveness(|live| {
+            let store = self.read_store();
+            store.producers.get(key).map(|entry| {
+                let run_is_live = entry
+                    .run
+                    .as_ref()
+                    .is_none_or(|origin| live.get(&origin.adapter).copied() == Some(origin.run));
+                self.project(&store, key, entry, run_is_live)
+            })
+        })
+    }
+
+    pub(super) fn snapshots_now(&self) -> Vec<ProducerSnapshot> {
+        self.runs.with_liveness(|live| {
+            let store = self.read_store();
+            store
+                .producers
+                .iter()
+                .map(|(key, entry)| {
+                    let run_is_live = entry.run.as_ref().is_none_or(|origin| {
+                        live.get(&origin.adapter).copied() == Some(origin.run)
+                    });
+                    self.project(&store, key, entry, run_is_live)
+                })
+                .collect()
+        })
+    }
+
+    pub(super) fn refusals_now(&self) -> Vec<(ProducerKey, AdmissionRefusal)> {
+        let store = self.read_store();
         store
             .refusals
             .iter()
@@ -436,26 +761,49 @@ impl ProducerAggregator {
             .collect()
     }
 
-    /// Updates dropped to internal-bus lag since start.
-    pub async fn missed_updates(&self) -> u64 {
-        self.store.read().await.missed_updates
+    fn read_store(&self) -> RwLockReadGuard<'_, Store> {
+        self.store
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn write_store(&self) -> RwLockWriteGuard<'_, Store> {
+        self.store
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 }
 
 /// Fold a document's lane health into the witness map.
 ///
-/// A `last_success` is retained until the producer publishes a newer one. A poll that fails
-/// publishes a lane with no success timestamp, and forgetting the previous one would blank
-/// exactly the information a user needs to judge how stale a reading is.
+/// A `last_success` is retained until the producer publishes a **genuinely newer instant**. A
+/// poll that fails publishes a lane with no success timestamp, and forgetting the previous one
+/// would blank exactly the information a user needs to judge how stale a reading is.
 ///
-/// **Ordering comes from admission, not from comparing timestamps.** An earlier draft
-/// advanced `last_success` only when the incoming string sorted after the held one, which
-/// looked like a monotonicity guard and was in fact a bug: [`Timestamp`] is documented as
-/// RFC 3339 but its format is not pinned, so `…:21.500Z` sorts *before* `…:21Z` (`.` is
-/// 0x2E, `Z` is 0x5A) and a `+00:00` offset does not compare with a `Z` at all. The guard
-/// was also unnecessary — [`admit`] refuses any document that regresses in epoch or
-/// revision, so an admitted document is never older than the one it replaces. Taking the
-/// producer's latest word is both simpler and correct.
+/// **Instants are compared as instants, never as strings, and never merely by arrival order.**
+/// Two earlier drafts each got one half of this wrong:
+///
+/// * Comparing the raw strings looked like a monotonicity guard and was a bug. [`Timestamp`]
+///   is documented as RFC 3339 but its spelling is not pinned, so `…:21.500Z` sorts *before*
+///   `…:21Z` (`.` is 0x2E, `Z` is 0x5A) despite being 500ms later, and a `+02:00` offset does
+///   not compare against a `Z` at all.
+/// * Taking the producer's latest word unconditionally fixed that and broke the documented
+///   contract instead. [`admit`] orders *documents* by epoch and revision, which says nothing
+///   about the instants inside them: a producer that polls its lanes on separate schedules,
+///   or re-reports a cached success, routinely publishes an advancing document carrying an
+///   older `last_success`. "Newest ever seen" then quietly became "most recently mentioned".
+///
+/// So the comparison is `chrono`'s. It lives here rather than on [`Timestamp`] because
+/// `src/adaptive/` is lint-enforced (`tests/adaptive_dependency_lint.rs`) to depend on nothing
+/// but `serde`, `serde_json` and `std`, and this is server-side interpretation of a producer's
+/// claim rather than part of the contract's shape.
+///
+/// **Unparseable instants never get here.** [`admit`] refuses any document carrying a
+/// `last_success` that is not RFC 3339, so "admitted implies comparable" is an invariant rather
+/// than a hope, and the witness never holds a value a consumer cannot interpret. The defensive
+/// arms in [`supersedes`] are kept as belt-and-braces: they make the failure mode "keep what we
+/// have" rather than "silently regress" if that guarantee is ever weakened, and there is
+/// deliberately no lexical fallback, which is the first bug above.
 fn witness_lanes(
     witnesses: &mut BTreeMap<TransportLane, LaneWitness>,
     document: &ProducerDocument,
@@ -471,12 +819,39 @@ fn witness_lanes(
                 observed_in_epoch: document.producer.epoch,
             });
         witness.state = health.state.clone();
-        if health.last_success.is_some() {
-            witness.last_success.clone_from(&health.last_success);
-            witness.observed_in_epoch = document.producer.epoch;
+        if let Some(offered) = &health.last_success {
+            if supersedes(offered, witness.last_success.as_ref()) {
+                witness.last_success = Some(offered.clone());
+                // Moved together with the value, never independently: the epoch's whole job
+                // is to say which process observed *this* instant. Advancing it while keeping
+                // an older instant would claim the new process saw something it never did.
+                witness.observed_in_epoch = document.producer.epoch;
+            }
         }
         if health.last_error.is_some() {
             witness.last_error.clone_from(&health.last_error);
         }
     }
+}
+
+/// Whether `offered` is a strictly later instant than `held`.
+///
+/// `None` held means anything offered is an improvement on knowing nothing. The unparseable
+/// arms are unreachable for any admitted document — [`admit`] refuses those — and are written
+/// to fail safe rather than to be relied on: an instant that cannot be parsed cannot be shown
+/// to be newer, so a known-good value stands.
+fn supersedes(offered: &Timestamp, held: Option<&Timestamp>) -> bool {
+    let Some(held) = held else {
+        return true;
+    };
+    match (instant(offered), instant(held)) {
+        (Some(offered), Some(held)) => offered > held,
+        (Some(_), None) => true,
+        (None, _) => false,
+    }
+}
+
+/// One [`Timestamp`] as an instant, or `None` if it is not RFC 3339.
+fn instant(timestamp: &Timestamp) -> Option<DateTime<FixedOffset>> {
+    DateTime::parse_from_rfc3339(timestamp.as_str()).ok()
 }

--- a/src/producers/aggregator.rs
+++ b/src/producers/aggregator.rs
@@ -1,0 +1,443 @@
+//! Aggregator-owned adaptive producer state.
+//!
+//! The aggregator is the single owner of every current producer document, exactly as it is
+//! for zones (`docs/ARCHITECTURE.md`). Adapters publish on the internal
+//! [`super::AdaptiveBus`]; nothing queries an adapter; every read is served from an
+//! admitted snapshot.
+//!
+//! Three properties are worth stating because they are not obvious from the types:
+//!
+//! * **Snapshots are atomic.** One snapshot is one whole published document. A consumer can
+//!   never see a mode read at revision 41 beside an enumeration read at revision 43.
+//! * **Lane history lives beside the document, never inside it.** [`LaneWitness`] is
+//!   aggregator-observed and labelled as such. Merging a remembered timestamp into the
+//!   producer's own `lanes` would put words in its mouth.
+//! * **A refusal is retained, not merely logged.** Publication is asynchronous, so the
+//!   publishing adapter gets no return value; if a refusal were only a log line, a producer
+//!   author would have no way to learn its documents were being dropped.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use tokio::sync::broadcast::error::RecvError;
+use tokio::sync::RwLock;
+use tracing::{debug, info, warn};
+
+use super::admission::{admit, Admission, AdmissionRefusal, IntentRepair, ProducerKey};
+use super::event::{AdaptiveEvent, SharedAdaptiveBus};
+use crate::adaptive::{
+    LaneState, ProducerDocument, ProducerEpoch, Reason, Timestamp, TransportLane,
+};
+use crate::bus::{BusEvent, SharedBus};
+
+/// What the aggregator has ever observed about one transport lane.
+///
+/// Kept beside the document rather than merged into it. A producer that fails to reach its
+/// persistence path publishes a lane with no `last_success`; the aggregator remembers when
+/// that lane last worked, which is what "retain last-good per-lane state instead of blanking
+/// the producer" actually requires — without rewriting what the producer said.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LaneWitness {
+    /// Which lane.
+    pub lane: TransportLane,
+    /// Its state in the most recently admitted document.
+    pub state: LaneState,
+    /// The newest success ever seen for this lane. Monotonic: never regresses, so a failing
+    /// poll cannot erase the evidence that the lane worked five seconds ago.
+    pub last_success: Option<Timestamp>,
+    /// The most recent error seen for this lane.
+    pub last_error: Option<Reason>,
+    /// The epoch `last_success` was observed in.
+    ///
+    /// Carrying a last-good timestamp across a producer restart is honest only if a
+    /// consumer can tell that it predates the restart. Resetting it instead would discard
+    /// true information; presenting it unqualified would imply it was observed by the
+    /// process now running.
+    pub observed_in_epoch: ProducerEpoch,
+}
+
+/// Whether a snapshot is current or last-known.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProducerPresence {
+    /// The producer is publishing and does not mark itself stale.
+    Live,
+    /// Last-known data. Never presented as current.
+    ///
+    /// Driven by the producer's own `stale` flag rather than by the aggregator inferring it
+    /// from lane health: whole-document staleness is an assertion only the producer can
+    /// make, and per-lane degradation is already visible through [`LaneWitness`].
+    LastKnown,
+}
+
+/// One producer's state, served atomically.
+#[derive(Debug, Clone)]
+pub struct ProducerSnapshot {
+    /// Which producer.
+    pub key: ProducerKey,
+    /// The admitted document, shared rather than copied per reader.
+    pub document: Arc<ProducerDocument>,
+    /// Per-lane last-good history, observed by the aggregator.
+    pub lanes: BTreeMap<TransportLane, LaneWitness>,
+    /// Current or last-known.
+    pub presence: ProducerPresence,
+    /// Coherence demotions applied to the document being served.
+    pub repairs: Vec<IntentRepair>,
+    /// Updates dropped because the internal bus lagged.
+    ///
+    /// Channel-global rather than per-producer: `broadcast` reports a receiver's shortfall,
+    /// not which messages were lost. Non-zero means some revision was skipped; because
+    /// documents are whole snapshots rather than deltas, the store converges on the next
+    /// publication and the count is a staleness hint, not a corruption warning.
+    pub missed_updates: u64,
+    /// The most recent refusal for this producer, retained across later successes.
+    pub last_refusal: Option<AdmissionRefusal>,
+}
+
+struct Entry {
+    document: Arc<ProducerDocument>,
+    lanes: BTreeMap<TransportLane, LaneWitness>,
+    repairs: Vec<IntentRepair>,
+}
+
+/// Producers plus the refusals that did not become producers.
+///
+/// One lock over both, so a reader cannot observe a refusal recorded against a producer
+/// whose document has not landed yet. Refusals are stored separately because the first
+/// document for a key can be refused, and that is exactly the case where a silent drop
+/// would be least diagnosable — there is no entry to hang the record on.
+#[derive(Default)]
+struct Store {
+    producers: BTreeMap<ProducerKey, Entry>,
+    refusals: BTreeMap<ProducerKey, AdmissionRefusal>,
+    missed_updates: u64,
+}
+
+/// Owns every current adaptive producer document.
+pub struct ProducerAggregator {
+    store: Arc<RwLock<Store>>,
+    bus: Option<SharedBus>,
+    adaptive: Option<SharedAdaptiveBus>,
+}
+
+impl ProducerAggregator {
+    /// Construct wired to the public bus (for lifecycle) and the internal bus (for
+    /// producer documents).
+    pub fn new(bus: SharedBus, adaptive: SharedAdaptiveBus) -> Self {
+        Self {
+            store: Arc::new(RwLock::new(Store::default())),
+            bus: Some(bus),
+            adaptive: Some(adaptive),
+        }
+    }
+
+    /// Construct with no bus, for callers that drive [`ProducerAggregator::ingest`]
+    /// directly.
+    pub fn detached() -> Self {
+        Self {
+            store: Arc::new(RwLock::new(Store::default())),
+            bus: None,
+            adaptive: None,
+        }
+    }
+
+    /// Event loop. Spawn this; it returns on `ShuttingDown` or when both buses close.
+    ///
+    /// The loop is here rather than inside a `tokio::spawn` block so that
+    /// `tests/spawn_cancellation_lint.rs` sees a cancellable shape, matching
+    /// `ZoneAggregator::run`.
+    pub async fn run(&self) {
+        let (Some(adaptive), Some(bus)) = (self.adaptive.as_ref(), self.bus.as_ref()) else {
+            return;
+        };
+        let mut adaptive_rx = adaptive.subscribe();
+        let mut bus_rx = bus.subscribe();
+
+        info!("ProducerAggregator started");
+
+        loop {
+            tokio::select! {
+                received = adaptive_rx.recv() => match received {
+                    Ok(event) => self.apply_adaptive_event(event).await,
+                    // Lag must not end the loop. `while let Ok(..) = rx.recv().await`
+                    // treats `Lagged` as termination, which would permanently stop
+                    // producer state after one burst - see `ZoneAggregator::run`. Because
+                    // documents are whole snapshots, a dropped update is recovered by the
+                    // next publication, but only if this loop is still consuming.
+                    Err(RecvError::Lagged(missed)) => self.record_lag(missed).await,
+                    Err(RecvError::Closed) => break,
+                },
+                received = bus_rx.recv() => match received {
+                    Ok(event) => {
+                        if self.apply_bus_event(event).await {
+                            break;
+                        }
+                    }
+                    Err(RecvError::Lagged(missed)) => {
+                        debug!("ProducerAggregator lagged {missed} public bus events");
+                    }
+                    Err(RecvError::Closed) => break,
+                },
+            }
+        }
+
+        info!("ProducerAggregator stopped");
+    }
+
+    /// Handle one internal-bus event.
+    async fn apply_adaptive_event(&self, event: AdaptiveEvent) {
+        match event {
+            AdaptiveEvent::ProducerPublished { document } => {
+                self.ingest(*document).await;
+            }
+            AdaptiveEvent::ProducerRemoved { producer_id } => {
+                let removed = self.remove(&producer_id).await;
+                debug!("Producer removed: {producer_id} ({removed} targets)");
+            }
+            // The aggregator's own egress. Consuming it would be a loop.
+            AdaptiveEvent::SnapshotAdmitted { .. } | AdaptiveEvent::SnapshotRefused { .. } => {}
+        }
+    }
+
+    /// Handle one public-bus event. Returns whether the loop should stop.
+    ///
+    /// Only lifecycle events do anything. Every command, volume and pipeline event is inert
+    /// **by construction**, which is how "immediate/live commands cannot read, clear or
+    /// flush staged intent" is guaranteed rather than merely intended: there is no code path
+    /// from a live command to producer state.
+    pub async fn apply_bus_event(&self, event: BusEvent) -> bool {
+        match event {
+            BusEvent::AdapterStopping { adapter, .. } => {
+                let removed = self.flush_adapter(&adapter).await;
+                if removed > 0 {
+                    info!("Flushed {removed} producers for adapter {adapter}");
+                }
+                false
+            }
+            BusEvent::ShuttingDown { .. } => true,
+            _ => false,
+        }
+    }
+
+    /// Admit a document into the store.
+    ///
+    /// The whole read-modify-write runs under one write guard with no `.await` inside it:
+    /// [`admit`] is pure and synchronous, so there is no lock-across-await, and no window in
+    /// which a concurrent publication could be compared against a predecessor that is about
+    /// to be replaced.
+    pub async fn ingest(&self, document: ProducerDocument) -> Admission {
+        let key = ProducerKey::of(&document);
+        let admission = {
+            let mut store = self.store.write().await;
+            let previous = store
+                .producers
+                .get(&key)
+                .map(|entry| entry.document.clone());
+            let admission = admit(previous.as_deref(), document);
+
+            match &admission {
+                Admission::Admitted(admitted) => {
+                    let mut lanes = store
+                        .producers
+                        .get(&key)
+                        .map(|entry| entry.lanes.clone())
+                        .unwrap_or_default();
+                    witness_lanes(&mut lanes, &admitted.document);
+                    store.producers.insert(
+                        key.clone(),
+                        Entry {
+                            document: Arc::new(admitted.document.clone()),
+                            lanes,
+                            repairs: admitted.repairs.clone(),
+                        },
+                    );
+                }
+                Admission::Refused(refusal) => {
+                    // Retained rather than replacing anything. The previously admitted
+                    // document, if there is one, keeps being served.
+                    store.refusals.insert(key.clone(), refusal.clone());
+                }
+            }
+            admission
+        };
+
+        // Reporting happens after the guard is released.
+        match &admission {
+            Admission::Admitted(admitted) => {
+                if !admitted.repairs.is_empty() {
+                    warn!(
+                        producer = %key.producer_id,
+                        repairs = admitted.repairs.len(),
+                        "producer document published incoherent intent; entries demoted"
+                    );
+                }
+                self.emit(AdaptiveEvent::SnapshotAdmitted {
+                    key,
+                    revisions: admitted.document.revisions,
+                    repairs: admitted.repairs.len(),
+                });
+            }
+            Admission::Refused(refusal) => {
+                warn!(
+                    producer = %key.producer_id,
+                    refusal = ?refusal,
+                    "producer document refused; the previous snapshot stands"
+                );
+                self.emit(AdaptiveEvent::SnapshotRefused {
+                    key,
+                    refusal: refusal.clone(),
+                });
+            }
+        }
+
+        admission
+    }
+
+    /// Remove every target of one producer. Returns how many entries went.
+    ///
+    /// Removal is not disconnection. A producer that has lost its transport keeps
+    /// publishing documents marked `stale`, and those stay visible as last-known.
+    pub async fn remove(&self, producer_id: &str) -> usize {
+        let mut store = self.store.write().await;
+        let doomed: Vec<ProducerKey> = store
+            .producers
+            .keys()
+            .filter(|key| key.producer_id == producer_id)
+            .cloned()
+            .collect();
+        for key in &doomed {
+            store.producers.remove(key);
+        }
+        doomed.len()
+    }
+
+    /// Drop every producer belonging to an adapter that is stopping.
+    ///
+    /// Matched on `producer_type` or on the `adapter:` id prefix, mirroring how
+    /// `ZoneAggregator` flushes zones, so a stopped adapter cannot leave ghost producers
+    /// that no longer correspond to anything running.
+    async fn flush_adapter(&self, adapter: &str) -> usize {
+        let prefix = format!("{adapter}:");
+        let mut store = self.store.write().await;
+        let doomed: Vec<ProducerKey> = store
+            .producers
+            .iter()
+            .filter(|(key, entry)| {
+                entry.document.producer.producer_type == adapter
+                    || key.producer_id.starts_with(&prefix)
+            })
+            .map(|(key, _)| key.clone())
+            .collect();
+        for key in &doomed {
+            store.producers.remove(key);
+        }
+        doomed.len()
+    }
+
+    async fn record_lag(&self, missed: u64) {
+        {
+            let mut store = self.store.write().await;
+            store.missed_updates = store.missed_updates.saturating_add(missed);
+        }
+        warn!(
+            missed,
+            "internal adaptive bus lagged; producer revisions were skipped. Documents are \
+             whole snapshots, so the store converges on the next publication"
+        );
+    }
+
+    fn emit(&self, event: AdaptiveEvent) {
+        if let Some(adaptive) = self.adaptive.as_ref() {
+            adaptive.publish(event);
+        }
+    }
+
+    fn project(&self, store: &Store, key: &ProducerKey, entry: &Entry) -> ProducerSnapshot {
+        ProducerSnapshot {
+            key: key.clone(),
+            document: entry.document.clone(),
+            lanes: entry.lanes.clone(),
+            presence: if entry.document.stale {
+                ProducerPresence::LastKnown
+            } else {
+                ProducerPresence::Live
+            },
+            repairs: entry.repairs.clone(),
+            missed_updates: store.missed_updates,
+            last_refusal: store.refusals.get(key).cloned(),
+        }
+    }
+
+    /// One producer's snapshot, read under a single guard so it cannot be a mixture.
+    pub async fn snapshot(&self, key: &ProducerKey) -> Option<ProducerSnapshot> {
+        let store = self.store.read().await;
+        store
+            .producers
+            .get(key)
+            .map(|entry| self.project(&store, key, entry))
+    }
+
+    /// Every producer's snapshot, in deterministic key order.
+    pub async fn snapshots(&self) -> Vec<ProducerSnapshot> {
+        let store = self.store.read().await;
+        store
+            .producers
+            .iter()
+            .map(|(key, entry)| self.project(&store, key, entry))
+            .collect()
+    }
+
+    /// How many producer entries are held.
+    pub async fn producer_count(&self) -> usize {
+        self.store.read().await.producers.len()
+    }
+
+    /// Every retained refusal, in deterministic key order.
+    pub async fn refusals(&self) -> Vec<(ProducerKey, AdmissionRefusal)> {
+        let store = self.store.read().await;
+        store
+            .refusals
+            .iter()
+            .map(|(key, refusal)| (key.clone(), refusal.clone()))
+            .collect()
+    }
+
+    /// Updates dropped to internal-bus lag since start.
+    pub async fn missed_updates(&self) -> u64 {
+        self.store.read().await.missed_updates
+    }
+}
+
+/// Fold a document's lane health into the witness map.
+///
+/// `last_success` only ever advances. That is the whole point: a poll that fails publishes a
+/// lane with no success timestamp, and forgetting the previous one would blank exactly the
+/// information a user needs to judge how stale the reading is.
+fn witness_lanes(
+    witnesses: &mut BTreeMap<TransportLane, LaneWitness>,
+    document: &ProducerDocument,
+) {
+    for health in &document.lanes {
+        let witness = witnesses
+            .entry(health.lane.clone())
+            .or_insert_with(|| LaneWitness {
+                lane: health.lane.clone(),
+                state: health.state.clone(),
+                last_success: None,
+                last_error: None,
+                observed_in_epoch: document.producer.epoch,
+            });
+        witness.state = health.state.clone();
+        if let Some(success) = &health.last_success {
+            let advances = witness
+                .last_success
+                .as_ref()
+                .is_none_or(|held| success.as_str() > held.as_str());
+            if advances {
+                witness.last_success = Some(success.clone());
+                witness.observed_in_epoch = document.producer.epoch;
+            }
+        }
+        if health.last_error.is_some() {
+            witness.last_error.clone_from(&health.last_error);
+        }
+    }
+}

--- a/src/producers/aggregator.rs
+++ b/src/producers/aggregator.rs
@@ -295,6 +295,11 @@ impl ProducerAggregator {
     ///
     /// Removal is not disconnection. A producer that has lost its transport keeps
     /// publishing documents marked `stale`, and those stay visible as last-known.
+    ///
+    /// The retained refusal goes with the producer. Refusals outlive *successes*, so a
+    /// producer author can see that its documents were dropped even after one lands — but
+    /// outliving the producer itself would make `refusals()` name something that no longer
+    /// exists, and a surface listing "producers with problems" would show a ghost.
     pub async fn remove(&self, producer_id: &str) -> usize {
         let mut store = self.store.write().await;
         let doomed: Vec<ProducerKey> = store
@@ -306,6 +311,9 @@ impl ProducerAggregator {
         for key in &doomed {
             store.producers.remove(key);
         }
+        store
+            .refusals
+            .retain(|key, _| key.producer_id != producer_id);
         doomed.len()
     }
 
@@ -329,6 +337,10 @@ impl ProducerAggregator {
         for key in &doomed {
             store.producers.remove(key);
         }
+        // Same reasoning as `remove`: a refusal must not outlive the producer it names.
+        store
+            .refusals
+            .retain(|key, _| !doomed.iter().any(|gone| gone == key));
         doomed.len()
     }
 

--- a/src/producers/aggregator.rs
+++ b/src/producers/aggregator.rs
@@ -107,8 +107,19 @@ struct Entry {
 #[derive(Default)]
 struct Store {
     producers: BTreeMap<ProducerKey, Entry>,
-    refusals: BTreeMap<ProducerKey, AdmissionRefusal>,
+    refusals: BTreeMap<ProducerKey, RefusalRecord>,
     missed_updates: u64,
+}
+
+/// A retained refusal, with the identity of the adapter that published it.
+///
+/// The producer type is kept beside the refusal because a first-publication refusal never
+/// creates a producer entry, and an `AdapterStopping` flush derives its victims from the
+/// producer map. Without this, a refusal for a producer that never existed outlived the
+/// adapter that caused it. Found by CodeRabbit at `9c53079`.
+struct RefusalRecord {
+    refusal: AdmissionRefusal,
+    producer_type: String,
 }
 
 /// Owns every current adaptive producer document.
@@ -225,6 +236,7 @@ impl ProducerAggregator {
     /// to be replaced.
     pub async fn ingest(&self, document: ProducerDocument) -> Admission {
         let key = ProducerKey::of(&document);
+        let producer_type = document.producer.producer_type.clone();
         let admission = {
             let mut store = self.store.write().await;
             let previous = store
@@ -252,8 +264,16 @@ impl ProducerAggregator {
                 }
                 Admission::Refused(refusal) => {
                     // Retained rather than replacing anything. The previously admitted
-                    // document, if there is one, keeps being served.
-                    store.refusals.insert(key.clone(), refusal.clone());
+                    // document, if there is one, keeps being served. The publishing
+                    // adapter's identity is retained with it, because a refusal on a first
+                    // publication has no producer entry to be flushed alongside.
+                    store.refusals.insert(
+                        key.clone(),
+                        RefusalRecord {
+                            refusal: refusal.clone(),
+                            producer_type: producer_type.clone(),
+                        },
+                    );
                 }
             }
             admission
@@ -337,10 +357,14 @@ impl ProducerAggregator {
         for key in &doomed {
             store.producers.remove(key);
         }
-        // Same reasoning as `remove`: a refusal must not outlive the producer it names.
-        store
-            .refusals
-            .retain(|key, _| !doomed.iter().any(|gone| gone == key));
+        // A refusal must not outlive the adapter that caused it, and a first-publication
+        // refusal has no producer entry to be found among `doomed`. Matched the same way
+        // the producers are: by producer type, or by the `adapter:` id prefix.
+        store.refusals.retain(|key, record| {
+            !(doomed.iter().any(|gone| gone == key)
+                || record.producer_type == adapter
+                || key.producer_id.starts_with(&prefix))
+        });
         doomed.len()
     }
 
@@ -374,7 +398,7 @@ impl ProducerAggregator {
             },
             repairs: entry.repairs.clone(),
             missed_updates: store.missed_updates,
-            last_refusal: store.refusals.get(key).cloned(),
+            last_refusal: store.refusals.get(key).map(|r| r.refusal.clone()),
         }
     }
 
@@ -408,7 +432,7 @@ impl ProducerAggregator {
         store
             .refusals
             .iter()
-            .map(|(key, refusal)| (key.clone(), refusal.clone()))
+            .map(|(key, record)| (key.clone(), record.refusal.clone()))
             .collect()
     }
 

--- a/src/producers/event.rs
+++ b/src/producers/event.rs
@@ -33,7 +33,15 @@ pub enum AdaptiveEvent {
     /// A producer is gone. Distinct from a disconnected producer, which keeps publishing
     /// documents marked stale.
     ProducerRemoved {
-        /// Stable producer id; every target of that producer is removed.
+        /// Stable producer id.
+        ///
+        /// **Known limit, recorded for #325.** This removes *every* target of that
+        /// producer. A producer that publishes several documents — say an `instance`-scoped
+        /// one and a `dsp_engine` one bound to a zone — cannot retire one target and keep
+        /// another, because the event carries no [`ProducerKey`]. Not fixed here: no
+        /// producer has more than one target yet, and adding a key to the event without a
+        /// caller that needs it would be guessing at the shape. #325 will meet this first,
+        /// and the fix is additive (a variant carrying a key).
         producer_id: String,
     },
     /// The aggregator admitted a document. Carries a pointer, never a payload: a consumer

--- a/src/producers/event.rs
+++ b/src/producers/event.rs
@@ -1,0 +1,106 @@
+//! The internal adaptive bus.
+//!
+//! Deliberately **not** [`crate::bus::BusEvent`]. `src/api/mod.rs` serializes every
+//! `BusEvent` verbatim into the `GET /events` SSE stream, which `docs/ARCHITECTURE.md`
+//! documents as consumable by any HTTP client including ESP32 firmware. Adding a producer
+//! document to that enum would be a response-schema change to a public endpoint *and*
+//! publication of the v1 contract outside this repository — neither of which #324 is
+//! scoped to do.
+//!
+//! [`AdaptiveEvent`] therefore derives no `Serialize`/`Deserialize`. The existing SSE
+//! projection cannot carry it, and any future exposure has to be a new, deliberate code
+//! path rather than an accident of adding a variant.
+
+use std::sync::Arc;
+use tokio::sync::broadcast;
+
+use super::admission::{AdmissionRefusal, ProducerKey};
+use crate::adaptive::{DocumentRevisions, ProducerDocument};
+
+/// Producer lifecycle on the internal bus.
+///
+/// Ingress variants are written by adapters and read only by the aggregator. Egress
+/// variants are written by the aggregator so an in-repository consumer can learn that
+/// something changed without being handed an unadmitted document.
+#[derive(Debug, Clone)]
+pub enum AdaptiveEvent {
+    /// An adapter published a producer document. Not yet admitted.
+    ProducerPublished {
+        /// The published document. Boxed: a document is large relative to the other
+        /// variants and this enum travels through a broadcast channel.
+        document: Box<ProducerDocument>,
+    },
+    /// A producer is gone. Distinct from a disconnected producer, which keeps publishing
+    /// documents marked stale.
+    ProducerRemoved {
+        /// Stable producer id; every target of that producer is removed.
+        producer_id: String,
+    },
+    /// The aggregator admitted a document. Carries a pointer, never a payload: a consumer
+    /// that wants the content must read the snapshot from the aggregator.
+    SnapshotAdmitted {
+        /// Which producer.
+        key: ProducerKey,
+        /// Where it now is.
+        revisions: DocumentRevisions,
+        /// How many change-set entries had to be demoted for coherence.
+        repairs: usize,
+    },
+    /// The aggregator refused a document. The previous snapshot, if any, is retained.
+    SnapshotRefused {
+        /// Which producer.
+        key: ProducerKey,
+        /// Why.
+        refusal: AdmissionRefusal,
+    },
+}
+
+/// A broadcast channel for [`AdaptiveEvent`].
+pub struct AdaptiveBus {
+    sender: broadcast::Sender<AdaptiveEvent>,
+}
+
+impl AdaptiveBus {
+    /// Create a bus with the given capacity.
+    pub fn new(capacity: usize) -> Self {
+        let (sender, _) = broadcast::channel(capacity);
+        Self { sender }
+    }
+
+    /// Publish an event.
+    ///
+    /// The send result is inspected rather than discarded: `tests/ignored_send_lint.rs`
+    /// allowlists `bus/mod.rs` only, and a silent drop here is precisely the failure a
+    /// producer author would have no way to diagnose.
+    pub fn publish(&self, event: AdaptiveEvent) {
+        if self.sender.send(event).is_err() {
+            tracing::trace!("adaptive bus has no subscribers; event dropped");
+        }
+    }
+
+    /// Subscribe to producer lifecycle events.
+    pub fn subscribe(&self) -> broadcast::Receiver<AdaptiveEvent> {
+        self.sender.subscribe()
+    }
+
+    /// Current subscriber count.
+    pub fn subscriber_count(&self) -> usize {
+        self.sender.receiver_count()
+    }
+}
+
+impl Default for AdaptiveBus {
+    fn default() -> Self {
+        // Larger than the public bus's 256: a producer document is published on every poll
+        // of every producer, and the aggregator is the only consumer that matters.
+        Self::new(1024)
+    }
+}
+
+/// Shared handle to the internal adaptive bus.
+pub type SharedAdaptiveBus = Arc<AdaptiveBus>;
+
+/// Create a shared internal adaptive bus.
+pub fn create_adaptive_bus() -> SharedAdaptiveBus {
+    Arc::new(AdaptiveBus::default())
+}

--- a/src/producers/event.rs
+++ b/src/producers/event.rs
@@ -15,35 +15,14 @@ use std::sync::Arc;
 use tokio::sync::broadcast;
 
 use super::admission::{AdmissionRefusal, ProducerKey};
-use crate::adaptive::{DocumentRevisions, ProducerDocument};
+use crate::adaptive::{DocumentRevisions, ProducerEpoch};
 
-/// Producer lifecycle on the internal bus.
+/// Aggregator egress notifications on the internal bus.
 ///
-/// Ingress variants are written by adapters and read only by the aggregator. Egress
-/// variants are written by the aggregator so an in-repository consumer can learn that
-/// something changed without being handed an unadmitted document.
+/// This enum deliberately has no producer ingress variants. Adapters can only publish through
+/// [`super::AdaptiveHandle`], whose bounded command channel cannot silently lag or drop state.
 #[derive(Debug, Clone)]
 pub enum AdaptiveEvent {
-    /// An adapter published a producer document. Not yet admitted.
-    ProducerPublished {
-        /// The published document. Boxed: a document is large relative to the other
-        /// variants and this enum travels through a broadcast channel.
-        document: Box<ProducerDocument>,
-    },
-    /// A producer is gone. Distinct from a disconnected producer, which keeps publishing
-    /// documents marked stale.
-    ProducerRemoved {
-        /// Stable producer id.
-        ///
-        /// **Known limit, recorded for #325.** This removes *every* target of that
-        /// producer. A producer that publishes several documents — say an `instance`-scoped
-        /// one and a `dsp_engine` one bound to a zone — cannot retire one target and keep
-        /// another, because the event carries no [`ProducerKey`]. Not fixed here: no
-        /// producer has more than one target yet, and adding a key to the event without a
-        /// caller that needs it would be guessing at the shape. #325 will meet this first,
-        /// and the fix is additive (a variant carrying a key).
-        producer_id: String,
-    },
     /// The aggregator admitted a document. Carries a pointer, never a payload: a consumer
     /// that wants the content must read the snapshot from the aggregator.
     SnapshotAdmitted {
@@ -61,9 +40,21 @@ pub enum AdaptiveEvent {
         /// Why.
         refusal: AdmissionRefusal,
     },
+    /// A committed producer retirement changed the read-only view.
+    ProducerRetired {
+        /// Stable producer id whose targets are no longer visible.
+        producer_id: String,
+        /// Producer epoch retired through.
+        retired_through: ProducerEpoch,
+        /// Number of visible target snapshots removed.
+        removed: usize,
+    },
 }
 
-/// A broadcast channel for [`AdaptiveEvent`].
+/// Broadcast egress for admitted/refused notifications.
+///
+/// Lag here can only make a consumer re-read the current [`super::AdaptiveView`]; it cannot
+/// lose producer state because this channel is never used for ingress.
 pub struct AdaptiveBus {
     sender: broadcast::Sender<AdaptiveEvent>,
 }
@@ -80,7 +71,7 @@ impl AdaptiveBus {
     /// The send result is inspected rather than discarded: `tests/ignored_send_lint.rs`
     /// allowlists `bus/mod.rs` only, and a silent drop here is precisely the failure a
     /// producer author would have no way to diagnose.
-    pub fn publish(&self, event: AdaptiveEvent) {
+    pub(super) fn publish(&self, event: AdaptiveEvent) {
         if self.sender.send(event).is_err() {
             tracing::trace!("adaptive bus has no subscribers; event dropped");
         }
@@ -99,8 +90,8 @@ impl AdaptiveBus {
 
 impl Default for AdaptiveBus {
     fn default() -> Self {
-        // Larger than the public bus's 256: a producer document is published on every poll
-        // of every producer, and the aggregator is the only consumer that matters.
+        // Egress is only a re-read hint, but a generous buffer avoids needless lag recovery
+        // when several consumers briefly fall behind a burst of producer polls.
         Self::new(1024)
     }
 }
@@ -109,6 +100,6 @@ impl Default for AdaptiveBus {
 pub type SharedAdaptiveBus = Arc<AdaptiveBus>;
 
 /// Create a shared internal adaptive bus.
-pub fn create_adaptive_bus() -> SharedAdaptiveBus {
+pub(super) fn create_adaptive_bus() -> SharedAdaptiveBus {
     Arc::new(AdaptiveBus::default())
 }

--- a/src/producers/mod.rs
+++ b/src/producers/mod.rs
@@ -15,9 +15,16 @@
 //! ## Why the aggregator is a gate rather than a store
 //!
 //! [`admit`] is the only way a [`crate::adaptive::ProducerDocument`] enters
-//! [`ProducerAggregator`], and the aggregator is the only holder of an admitted one. That
-//! makes "an incoherent document never reaches a consumer" a property of the store rather
-//! than of a code path: there is no other object of that type in the process to obtain.
+//! [`ProducerAggregator`], so every document the aggregator serves has passed the gate, and
+//! the aggregator is the only thing in this repository that holds producer state.
+//!
+//! Stated precisely, because the loose version is the kind of claim that survives into the
+//! next issue's assumptions: this does **not** mean an unadmitted document cannot exist.
+//! `ProducerDocument` is a public type in a shared module and
+//! [`crate::adaptive::admit_document_str`] hands one to any caller. What is true is that a
+//! consumer reading state *from the aggregator* cannot receive one — and since no surface
+//! may reach an adapter (`docs/ARCHITECTURE.md`, `tests/architecture_lint.rs`), the
+//! aggregator is the only place to read it from.
 //!
 //! Two policies split the work, and the split is the load-bearing decision:
 //!
@@ -26,6 +33,13 @@
 //!   inconsistent lane value, an illegal recorded outcome transition. Refusal is safe
 //!   *because the previous snapshot is retained*: it fails to advance a producer rather
 //!   than blanking one.
+//!
+//!   That argument holds from the **second** document onward. On a producer's first
+//!   document there is nothing to retain, and every refusal reason is reachable there — an
+//!   unprefixed zone id most obviously — so a refusal means the producer never appears at
+//!   all. This is accepted rather than mitigated: a producer whose very first document is
+//!   malformed has nothing correct to show, and the refusal is retained and queryable via
+//!   [`ProducerAggregator::refusals`] precisely so that case is diagnosable.
 //! * **Published-intent incoherence demotes, never refuses** — because the only repair
 //!   that preserves `valid` would be inventing a `desired` lane, and that fabricates
 //!   intent the user never staged. Demotion lowers validity and touches nothing else.

--- a/src/producers/mod.rs
+++ b/src/producers/mod.rs
@@ -50,7 +50,7 @@ pub mod event;
 
 pub use admission::{
     admit, Admission, AdmissionKind, AdmissionRefusal, AdmittedDocument, IntentRepair, LaneDefect,
-    ProducerKey,
+    ProducerKey, CONTROL_REMOVED_TEXT_KEY,
 };
 pub use aggregator::{LaneWitness, ProducerAggregator, ProducerPresence, ProducerSnapshot};
 pub use event::{create_adaptive_bus, AdaptiveBus, AdaptiveEvent, SharedAdaptiveBus};

--- a/src/producers/mod.rs
+++ b/src/producers/mod.rs
@@ -10,7 +10,8 @@
 //! consumable by any HTTP client, ESP32 firmware included. Putting a producer document in
 //! that enum would be a response-schema change to a public endpoint *and* publication of
 //! the v1 contract outside this repository. #324 is scoped to do neither, so producer
-//! lifecycle rides a separate internal [`AdaptiveBus`] whose event type derives no serde.
+//! lifecycle rides a bounded actor command channel. Its optional admitted/refused notification
+//! channel derives no serde and never carries ingress state.
 //!
 //! ## Why the aggregator is a gate rather than a store
 //!
@@ -45,12 +46,28 @@
 //!   intent the user never staged. Demotion lowers validity and touches nothing else.
 
 pub mod admission;
-pub mod aggregator;
+mod aggregator;
 pub mod event;
+pub mod run;
+pub mod runtime;
 
 pub use admission::{
     admit, Admission, AdmissionKind, AdmissionRefusal, AdmittedDocument, IntentRepair, LaneDefect,
     ProducerKey, CONTROL_REMOVED_TEXT_KEY,
 };
-pub use aggregator::{LaneWitness, ProducerAggregator, ProducerPresence, ProducerSnapshot};
-pub use event::{create_adaptive_bus, AdaptiveBus, AdaptiveEvent, SharedAdaptiveBus};
+/// Debug-profile compatibility seam for the direct integration-test harness.
+///
+/// This is intentionally broader than `cfg(test)`: integration tests compile the library as a
+/// dependency and therefore cannot see library `cfg(test)` items. Ordinary debug builds expose
+/// the seam; release builds expose adaptive mutation only through the actor. Do not treat a
+/// debug profile as an actor-boundary proof.
+#[cfg(debug_assertions)]
+#[doc(hidden)]
+pub use aggregator::ProducerAggregator;
+pub use aggregator::{LaneWitness, ProducerPresence, ProducerSnapshot};
+pub use event::AdaptiveEvent;
+pub use run::{AdapterRun, AdapterRunId, AdapterRuns, PublicationOrigin};
+pub use runtime::{
+    AdaptiveHandle, AdaptivePublishError, AdaptiveRuntime, AdaptiveRuntimeClosed, AdaptiveView,
+    ProducerActor, RetirementOutcome,
+};

--- a/src/producers/mod.rs
+++ b/src/producers/mod.rs
@@ -1,0 +1,42 @@
+//! Adaptive producer publication: the internal bus and the aggregator that owns state.
+//!
+//! #323 defined the v1 producer document. This module is the first thing that ever holds
+//! one, and it is deliberately the *only* thing that does.
+//!
+//! ## Why this is not on the public bus
+//!
+//! `src/api/mod.rs` serializes every [`crate::bus::BusEvent`] verbatim into the
+//! `GET /events` SSE stream, and `docs/ARCHITECTURE.md` documents that stream as
+//! consumable by any HTTP client, ESP32 firmware included. Putting a producer document in
+//! that enum would be a response-schema change to a public endpoint *and* publication of
+//! the v1 contract outside this repository. #324 is scoped to do neither, so producer
+//! lifecycle rides a separate internal [`AdaptiveBus`] whose event type derives no serde.
+//!
+//! ## Why the aggregator is a gate rather than a store
+//!
+//! [`admit`] is the only way a [`crate::adaptive::ProducerDocument`] enters
+//! [`ProducerAggregator`], and the aggregator is the only holder of an admitted one. That
+//! makes "an incoherent document never reaches a consumer" a property of the store rather
+//! than of a code path: there is no other object of that type in the process to obtain.
+//!
+//! Two policies split the work, and the split is the load-bearing decision:
+//!
+//! * **Envelope problems refuse the whole document** — unsupported major, unparsable
+//!   constraint bounds, an unprefixed zone id, a regressed revision or epoch, an
+//!   inconsistent lane value, an illegal recorded outcome transition. Refusal is safe
+//!   *because the previous snapshot is retained*: it fails to advance a producer rather
+//!   than blanking one.
+//! * **Published-intent incoherence demotes, never refuses** — because the only repair
+//!   that preserves `valid` would be inventing a `desired` lane, and that fabricates
+//!   intent the user never staged. Demotion lowers validity and touches nothing else.
+
+pub mod admission;
+pub mod aggregator;
+pub mod event;
+
+pub use admission::{
+    admit, Admission, AdmissionKind, AdmissionRefusal, AdmittedDocument, IntentRepair, LaneDefect,
+    ProducerKey,
+};
+pub use aggregator::{LaneWitness, ProducerAggregator, ProducerPresence, ProducerSnapshot};
+pub use event::{create_adaptive_bus, AdaptiveBus, AdaptiveEvent, SharedAdaptiveBus};

--- a/src/producers/run.rs
+++ b/src/producers/run.rs
@@ -1,0 +1,233 @@
+//! Adapter run identity, and why no bus event can supply it.
+//!
+//! An adapter starts, publishes producer documents, stops, and may start again. The aggregator
+//! must distinguish "from the run that is currently live" from "from a run that has ended",
+//! because admitting the latter resurrects state nothing stands behind.
+//!
+//! ## Why a public-bus event cannot be the boundary
+//!
+//! [`crate::bus::BusEvent`] is a broadcast channel independent of the aggregator's command
+//! inbox, so nothing orders the two. A publication from run *N* can be read after any number of
+//! public lifecycle events, and an `AdapterStopping` belonging to run *N* can be read after run
+//! *N+1* is already publishing. Every scheme that treats a public event as "everything before
+//! this is stale" is defeated by one of those two orderings.
+//!
+//! ## What is authoritative
+//!
+//! Identity allocated **synchronously** and carried *in the command*. [`AdapterRuns::begin`]
+//! takes a lock, allocates a monotonically increasing [`AdapterRunId`], and records it as that
+//! adapter's live run before it returns — so "run *N+1* is live" is already true before run
+//! *N+1* enqueues anything. Ordering comes from a counter under a lock, never from the relative
+//! delivery order of two channels.
+//!
+//! ## Liveness is a lease, and it is RAII
+//!
+//! [`AdapterRun`] ends its run when dropped, which is what makes cancellation and panic safe: a
+//! `tokio::spawn`ed adapter that is aborted or unwinds runs `Drop` without cooperating. `Drop`
+//! cannot `await`, so it performs the one operation correctness requires:
+//!
+//! It marks the run ended in the registry **synchronously**. A reader immediately projects the
+//! run's producers as last-known, and a queued command from it is refused at application time.
+//!
+//! `Drop` deliberately sends no cleanup command: it cannot await bounded capacity, and
+//! `try_send` would turn a lossless lifecycle into a best-effort one. Diagnostics are retained;
+//! the store prevents an older run's late refusal from replacing a newer run's evidence. The
+//! lease holds no sender, so a live lease cannot keep the actor's inbox open after every
+//! publisher handle is gone.
+//!
+//! RAII covers task cancellation/abort and panic-unwind, because those drop the future holding
+//! the lease. It cannot cover `std::mem::forget`, process termination, or `panic = "abort"`.
+//! [`AdapterRuns::begin`] therefore supersedes the previous run unconditionally as the backstop:
+//! an adapter that died without dropping its lease cannot keep its old run live past reconnect.
+//!
+//! ## Run identity is not producer epoch
+//!
+//! Two lifecycles, deliberately apart:
+//!
+//! * [`AdapterRunId`] is **ours** — one connection attempt by one adapter in this process. It
+//!   says nothing about the engine on the other side.
+//! * `ProducerEpoch` is the **producer's** — its own restart counter, which only it can bump.
+//!
+//! An adapter reconnecting to an unchanged engine is a new run at the *same* epoch and must be
+//! able to republish, so adapter lifecycle never bars an epoch. A producer that genuinely
+//! restarted announces a higher one.
+
+use std::collections::BTreeMap;
+use std::sync::{Mutex, MutexGuard};
+
+/// Identity of one run of one adaptive publisher.
+///
+/// Monotonic across the process rather than per adapter, so two ids are never equal for
+/// different runs even if an adapter name is reused.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct AdapterRunId(u64);
+
+/// Where one command came from.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PublicationOrigin {
+    /// The publishing adapter, matching `BusEvent`'s `adapter` spelling.
+    pub(crate) adapter: String,
+    /// Which run of it.
+    pub(crate) run: AdapterRunId,
+}
+
+impl PublicationOrigin {
+    /// The publishing adapter.
+    pub fn adapter(&self) -> &str {
+        &self.adapter
+    }
+
+    /// The allocator-issued run identity.
+    pub fn run(&self) -> AdapterRunId {
+        self.run
+    }
+
+    /// Whether this adapter namespace owns `producer_id`.
+    pub(crate) fn owns(&self, producer_id: &str) -> bool {
+        producer_id
+            .split_once(':')
+            .is_some_and(|(namespace, local)| namespace == self.adapter && !local.is_empty())
+    }
+}
+
+/// A live lease on one run of one adapter.
+///
+/// Deliberately **not** `Clone`: a clone would end the run when the first copy dropped. Held by
+/// the publisher for the lifetime of its connection; dropping it ends the run.
+#[derive(Debug)]
+pub struct AdapterRun {
+    origin: PublicationOrigin,
+    runs: std::sync::Arc<AdapterRuns>,
+}
+
+impl AdapterRun {
+    /// The origin to stamp commands with.
+    pub fn origin(&self) -> &PublicationOrigin {
+        &self.origin
+    }
+
+    /// Which adapter.
+    pub fn adapter(&self) -> &str {
+        &self.origin.adapter
+    }
+
+    /// Which run.
+    pub fn id(&self) -> AdapterRunId {
+        self.origin.run
+    }
+}
+
+impl Drop for AdapterRun {
+    fn drop(&mut self) {
+        // Synchronous and unconditional. Cleanup is a projection concern; Drop must never
+        // turn the lossless command inbox into a best-effort path.
+        self.runs.mark_ended(&self.origin);
+    }
+}
+
+#[derive(Debug, Default)]
+struct RunState {
+    next: u64,
+    live: BTreeMap<String, AdapterRunId>,
+}
+
+/// Allocates adapter runs and tracks which one is live per adapter.
+///
+/// Read by the aggregator inside a single turn, with no `.await` between the read and the
+/// mutation it authorises — which is why the check-then-act race the previous design had cannot
+/// be expressed here.
+#[derive(Debug, Default)]
+pub struct AdapterRuns {
+    state: Mutex<RunState>,
+}
+
+impl AdapterRuns {
+    /// Begin a run for `adapter`, live before this returns.
+    ///
+    /// Supersedes any previous run for the same adapter without requiring it to have ended: an
+    /// adapter that died without cleanup must not keep its old run live, or its stragglers
+    /// would stay admissible forever.
+    pub fn begin(self: &std::sync::Arc<Self>, adapter: &str) -> AdapterRun {
+        assert!(
+            !adapter.is_empty() && !adapter.contains(':'),
+            "adapter namespace must be non-empty and contain no colon"
+        );
+        let run = {
+            let mut state = self.lock();
+            state.next = state.next.wrapping_add(1);
+            assert_ne!(state.next, 0, "adapter run identity space exhausted");
+            let run = AdapterRunId(state.next);
+            state.live.insert(adapter.to_string(), run);
+            run
+        };
+        AdapterRun {
+            origin: PublicationOrigin {
+                adapter: adapter.to_string(),
+                run,
+            },
+            runs: self.clone(),
+        }
+    }
+
+    /// End `run` if it is still the live run of its adapter.
+    pub fn end(&self, run: &AdapterRun) -> bool {
+        self.mark_ended(run.origin())
+    }
+
+    /// The live run for `adapter`, if it has one.
+    pub fn active(&self, adapter: &str) -> Option<AdapterRunId> {
+        self.lock().live.get(adapter).copied()
+    }
+
+    /// Whether `origin` names the live run of its adapter.
+    pub fn is_active(&self, origin: &PublicationOrigin) -> bool {
+        self.active(&origin.adapter) == Some(origin.run)
+    }
+
+    /// Execute one store mutation while the origin's liveness decision cannot change.
+    ///
+    /// The closure must be synchronous. Holding this guard across the entire mutation is the
+    /// linearization boundary: `begin` and `Drop` cannot interleave between check and commit.
+    pub(super) fn with_active<R>(
+        &self,
+        origin: &PublicationOrigin,
+        apply: impl FnOnce() -> R,
+    ) -> Result<R, Option<AdapterRunId>> {
+        let state = self.lock();
+        let active = state.live.get(&origin.adapter).copied();
+        if active != Some(origin.run) {
+            return Err(active);
+        }
+        Ok(apply())
+    }
+
+    /// Read projected state while adapter liveness is stable.
+    pub(super) fn with_liveness<R>(
+        &self,
+        project: impl FnOnce(&BTreeMap<String, AdapterRunId>) -> R,
+    ) -> R {
+        let state = self.lock();
+        project(&state.live)
+    }
+
+    /// End the run named by `origin`, but only if it is still the live one.
+    ///
+    /// The guard that makes late cleanup harmless: an end belonging to run *N*, applied after
+    /// run *N+1* has begun, finds *N* is not live and does nothing.
+    pub fn mark_ended(&self, origin: &PublicationOrigin) -> bool {
+        let mut state = self.lock();
+        if state.live.get(&origin.adapter) == Some(&origin.run) {
+            state.live.remove(&origin.adapter);
+            return true;
+        }
+        false
+    }
+
+    fn lock(&self) -> MutexGuard<'_, RunState> {
+        // The guarded value is a counter and a map; a panic cannot leave either torn, so
+        // recovering beats propagating a panic into the aggregator's event loop.
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}

--- a/src/producers/runtime.rs
+++ b/src/producers/runtime.rs
@@ -1,0 +1,347 @@
+//! Lossless, single-owner runtime for adaptive producer ingress.
+
+use std::fmt;
+use std::sync::Arc;
+
+use tokio::sync::{broadcast, mpsc, oneshot};
+use tokio_util::sync::CancellationToken;
+
+use super::aggregator::{ProducerAggregator, ProducerSnapshot};
+use super::event::{create_adaptive_bus, AdaptiveEvent, SharedAdaptiveBus};
+use super::run::{AdapterRun, AdapterRuns, PublicationOrigin};
+use super::{Admission, AdmissionRefusal, ProducerKey};
+use crate::adaptive::{ProducerDocument, ProducerEpoch};
+
+/// The adaptive actor is no longer accepting commands.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AdaptiveRuntimeClosed;
+
+impl fmt::Display for AdaptiveRuntimeClosed {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("adaptive producer runtime is closed")
+    }
+}
+
+impl std::error::Error for AdaptiveRuntimeClosed {}
+
+/// A detached publication was not accepted for queueing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AdaptivePublishError {
+    /// The actor no longer accepts ingress.
+    RuntimeClosed,
+    /// The supplied lease does not own the document's producer namespace.
+    ProducerOwnershipMismatch {
+        origin: PublicationOrigin,
+        producer_id: String,
+    },
+}
+
+impl fmt::Display for AdaptivePublishError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::RuntimeClosed => f.write_str("adaptive producer runtime is closed"),
+            Self::ProducerOwnershipMismatch {
+                origin,
+                producer_id,
+            } => write!(
+                f,
+                "adapter {} does not own producer {producer_id}",
+                origin.adapter()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for AdaptivePublishError {}
+
+/// Result of attempting producer retirement through an adapter-run lease.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RetirementOutcome {
+    /// The bounded inbox committed the retirement; a detached caller need not wait further.
+    Committed,
+    /// The actor applied the committed retirement and removed this many visible targets.
+    Retired { removed: usize },
+    /// The supplied lease had already been superseded or ended before queue commitment.
+    StaleAdapterRun {
+        origin: PublicationOrigin,
+        active: Option<super::AdapterRunId>,
+    },
+    /// The live adapter lease does not own the producer id's namespace.
+    ProducerOwnershipMismatch {
+        origin: PublicationOrigin,
+        producer_id: String,
+    },
+}
+
+pub(super) enum ProducerCommand {
+    Publish {
+        origin: PublicationOrigin,
+        document: Box<ProducerDocument>,
+        verdict: Option<oneshot::Sender<Admission>>,
+    },
+    Retire {
+        origin: PublicationOrigin,
+        producer_id: String,
+        epoch: ProducerEpoch,
+        applied: Option<oneshot::Sender<usize>>,
+    },
+}
+
+/// Cloneable producer-side handle. It can enqueue commands but cannot read or mutate state.
+#[derive(Clone)]
+pub struct AdaptiveHandle {
+    commands: mpsc::Sender<ProducerCommand>,
+    runs: Arc<AdapterRuns>,
+}
+
+impl AdaptiveHandle {
+    /// Begin a synchronously registered adapter run.
+    pub fn begin_run(&self, adapter: &str) -> AdapterRun {
+        self.runs.begin(adapter)
+    }
+
+    /// Publish and wait for the aggregator's admission verdict.
+    pub async fn publish(
+        &self,
+        run: &AdapterRun,
+        document: ProducerDocument,
+    ) -> Result<Admission, AdaptiveRuntimeClosed> {
+        if !run.origin().owns(&document.producer.producer_id) {
+            return Ok(Admission::Refused(
+                AdmissionRefusal::ProducerOwnershipMismatch {
+                    adapter: run.adapter().to_string(),
+                    producer_id: document.producer.producer_id,
+                },
+            ));
+        }
+        let (verdict_tx, verdict_rx) = oneshot::channel();
+        self.commands
+            .send(ProducerCommand::Publish {
+                origin: run.origin().clone(),
+                document: Box::new(document),
+                verdict: Some(verdict_tx),
+            })
+            .await
+            .map_err(|_| AdaptiveRuntimeClosed)?;
+        verdict_rx.await.map_err(|_| AdaptiveRuntimeClosed)
+    }
+
+    /// Publish losslessly without waiting for a verdict.
+    pub async fn publish_detached(
+        &self,
+        run: &AdapterRun,
+        document: ProducerDocument,
+    ) -> Result<(), AdaptivePublishError> {
+        if !run.origin().owns(&document.producer.producer_id) {
+            return Err(AdaptivePublishError::ProducerOwnershipMismatch {
+                origin: run.origin().clone(),
+                producer_id: document.producer.producer_id,
+            });
+        }
+        self.publish_detached_at(run.origin(), document)
+            .await
+            .map_err(|_| AdaptivePublishError::RuntimeClosed)
+    }
+
+    /// Publish for a recorded origin after the public lease-based method captured it.
+    async fn publish_detached_at(
+        &self,
+        origin: &PublicationOrigin,
+        document: ProducerDocument,
+    ) -> Result<(), AdaptiveRuntimeClosed> {
+        self.commands
+            .send(ProducerCommand::Publish {
+                origin: origin.clone(),
+                document: Box::new(document),
+                verdict: None,
+            })
+            .await
+            .map_err(|_| AdaptiveRuntimeClosed)
+    }
+
+    /// Retire every target of a producer through `epoch`.
+    pub async fn retire_detached(
+        &self,
+        run: &AdapterRun,
+        producer_id: &str,
+        epoch: ProducerEpoch,
+    ) -> Result<RetirementOutcome, AdaptiveRuntimeClosed> {
+        if !run.origin().owns(producer_id) {
+            return Ok(RetirementOutcome::ProducerOwnershipMismatch {
+                origin: run.origin().clone(),
+                producer_id: producer_id.to_string(),
+            });
+        }
+        let permit = self
+            .commands
+            .reserve()
+            .await
+            .map_err(|_| AdaptiveRuntimeClosed)?;
+        let origin = run.origin().clone();
+        match self.runs.with_active(&origin, || {
+            permit.send(ProducerCommand::Retire {
+                origin: origin.clone(),
+                producer_id: producer_id.to_string(),
+                epoch,
+                applied: None,
+            })
+        }) {
+            Ok(()) => Ok(RetirementOutcome::Committed),
+            Err(active) => Ok(RetirementOutcome::StaleAdapterRun { origin, active }),
+        }
+    }
+
+    /// Retire and wait until the actor has applied the command.
+    pub async fn retire(
+        &self,
+        run: &AdapterRun,
+        producer_id: &str,
+        epoch: ProducerEpoch,
+    ) -> Result<RetirementOutcome, AdaptiveRuntimeClosed> {
+        if !run.origin().owns(producer_id) {
+            return Ok(RetirementOutcome::ProducerOwnershipMismatch {
+                origin: run.origin().clone(),
+                producer_id: producer_id.to_string(),
+            });
+        }
+        let (applied_tx, applied_rx) = oneshot::channel();
+        let permit = self
+            .commands
+            .reserve()
+            .await
+            .map_err(|_| AdaptiveRuntimeClosed)?;
+        let origin = run.origin().clone();
+        if let Err(active) = self.runs.with_active(&origin, || {
+            permit.send(ProducerCommand::Retire {
+                origin: origin.clone(),
+                producer_id: producer_id.to_string(),
+                epoch,
+                applied: Some(applied_tx),
+            })
+        }) {
+            return Ok(RetirementOutcome::StaleAdapterRun { origin, active });
+        }
+        let removed = applied_rx.await.map_err(|_| AdaptiveRuntimeClosed)?;
+        Ok(RetirementOutcome::Retired { removed })
+    }
+}
+
+/// Read-only projection of actor-owned state.
+#[derive(Clone)]
+pub struct AdaptiveView {
+    aggregator: Arc<ProducerAggregator>,
+    events: SharedAdaptiveBus,
+}
+
+impl AdaptiveView {
+    pub fn snapshot(&self, key: &ProducerKey) -> Option<ProducerSnapshot> {
+        self.aggregator.snapshot_now(key)
+    }
+
+    pub fn snapshots(&self) -> Vec<ProducerSnapshot> {
+        self.aggregator.snapshots_now()
+    }
+
+    pub fn refusals(&self) -> Vec<(ProducerKey, AdmissionRefusal)> {
+        self.aggregator.refusals_now()
+    }
+
+    /// Subscribe to admitted/refused hints. Payloads remain readable only through this view.
+    pub fn subscribe(&self) -> broadcast::Receiver<AdaptiveEvent> {
+        self.events.subscribe()
+    }
+}
+
+/// Exclusive command consumer. All ingress mutations happen in this task.
+pub struct ProducerActor {
+    commands: mpsc::Receiver<ProducerCommand>,
+    shutdown: CancellationToken,
+    aggregator: Arc<ProducerAggregator>,
+}
+
+impl ProducerActor {
+    pub async fn run(mut self) {
+        loop {
+            tokio::select! {
+                command = self.commands.recv() => match command {
+                    Some(command) => self.apply(command).await,
+                    None => break,
+                },
+                () = self.shutdown.cancelled() => {
+                    self.drain_accepted().await;
+                    break;
+                },
+            }
+        }
+    }
+
+    /// Stop new sends and apply everything for which bounded ingress already returned success.
+    async fn drain_accepted(&mut self) {
+        self.commands.close();
+        while let Some(command) = self.commands.recv().await {
+            self.apply(command).await;
+        }
+    }
+
+    async fn apply(&self, command: ProducerCommand) {
+        match command {
+            ProducerCommand::Publish {
+                origin,
+                document,
+                verdict,
+            } => {
+                let admission = self.aggregator.ingest_from(&origin, *document).await;
+                if let Some(verdict) = verdict {
+                    if verdict.send(admission).is_err() {
+                        tracing::trace!("adaptive publisher dropped before receiving its verdict");
+                    }
+                }
+            }
+            ProducerCommand::Retire {
+                origin,
+                producer_id,
+                epoch,
+                applied,
+            } => {
+                let removed = self
+                    .aggregator
+                    .retire_committed(&origin, &producer_id, epoch);
+                if let Some(applied) = applied {
+                    if applied.send(removed).is_err() {
+                        tracing::trace!("adaptive publisher dropped before retirement completed");
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Constructs the handle/actor/view split in one ready-before-publish operation.
+pub struct AdaptiveRuntime;
+
+impl AdaptiveRuntime {
+    pub fn build(
+        shutdown: CancellationToken,
+        capacity: usize,
+    ) -> (AdaptiveHandle, ProducerActor, AdaptiveView) {
+        assert!(capacity > 0, "adaptive ingress capacity must be non-zero");
+        let (commands_tx, commands_rx) = mpsc::channel(capacity);
+        let runs = Arc::new(AdapterRuns::default());
+        let events = create_adaptive_bus();
+        let aggregator = Arc::new(ProducerAggregator::detached_with_runs_and_events(
+            runs.clone(),
+            events.clone(),
+        ));
+        let handle = AdaptiveHandle {
+            commands: commands_tx,
+            runs,
+        };
+        let actor = ProducerActor {
+            commands: commands_rx,
+            shutdown,
+            aggregator: aggregator.clone(),
+        };
+        let view = AdaptiveView { aggregator, events };
+        (handle, actor, view)
+    }
+}

--- a/tests/adaptive_contract.rs
+++ b/tests/adaptive_contract.rs
@@ -224,6 +224,12 @@ mod fixtures {
         "hqplayer_degraded_lanes",
         "staged_intent_multi_surface",
         "command_outcomes",
+        // Added by #324: a draft whose base predates a control-plane advance that removed
+        // the control it targets. This is the *post-repair* state a consumer actually
+        // sees, which is why the entry is `draft_invalid` rather than `valid` — the
+        // publication gate demotes it, and the reason must stay distinguishable from
+        // "needs producer validation".
+        "control_removed_after_advance",
     ];
 
     pub fn raw(name: &str) -> serde_json::Value {
@@ -1437,7 +1443,14 @@ mod outcomes {
 
     #[test]
     fn a_new_operation_cannot_erase_the_audit_trail() {
-        let mut record = operation("op-provisional-9001");
+        // Retargeted from `op-provisional-9001` by #324. That operation's history recorded
+        // `disconnected -> indeterminate`, which `CommandOutcome::may_transition_to`
+        // forbids — nothing may regress into an unresolved state — and which contradicted
+        // its own `write_attempt: acknowledged_provisional`, since `disconnected` means the
+        // transport was down *before* the write was attempted. Nothing may legally
+        // transition *into* `indeterminate`, so that operation's history is correctly
+        // empty; `op-divergent-9015` is the worked example of a resolved indeterminate.
+        let mut record = operation("op-divergent-9015");
         let original = record.history.clone();
         assert!(!original.is_empty());
         record
@@ -1458,7 +1471,7 @@ mod outcomes {
         assert!(record
             .history
             .iter()
-            .any(|transition| transition.to == CommandOutcome::Indeterminate));
+            .any(|transition| transition.from == CommandOutcome::Indeterminate));
     }
 
     #[test]

--- a/tests/adaptive_lifecycle.rs
+++ b/tests/adaptive_lifecycle.rs
@@ -1,0 +1,940 @@
+//! Lifecycle counterexamples that require the single-owner actor API (#324, revision 2).
+//!
+//! Every test here is deterministic by construction rather than by timing. The actor drains a
+//! bounded command channel, so a test enqueues commands in the order it wants, *then* runs the
+//! actor to completion. There is no sleep, no yield and no race to lose — the interleaving the
+//! design has to survive is expressed directly as queue order.
+
+use unified_hifi_control::adaptive::{
+    admit_document_str, DocumentRevisions, ProducerDocument, ProducerEpoch, Timestamp,
+};
+use unified_hifi_control::producers::{AdaptiveRuntime, Admission, ProducerKey, ProducerPresence};
+
+fn fixture(name: &str) -> ProducerDocument {
+    let path = format!(
+        "{}/tests/fixtures/adaptive/{name}.json",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    let raw = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"));
+    match admit_document_str(&raw) {
+        Ok(document) => document,
+        Err(refusal) => panic!("canonical fixture {name} is not admissible: {refusal}"),
+    }
+}
+
+fn pipeline() -> ProducerDocument {
+    fixture("hqplayer_pipeline_v1")
+}
+
+fn at(document: &ProducerDocument, epoch: u64, state: u64) -> ProducerDocument {
+    let mut next = document.clone();
+    next.producer.epoch = ProducerEpoch(epoch);
+    next.revisions = DocumentRevisions::new(12, state);
+    next
+}
+
+#[test]
+#[should_panic(expected = "adapter namespace must be non-empty and contain no colon")]
+fn an_adapter_run_cannot_use_an_unownable_namespace() {
+    let (handle, _actor, _view) =
+        AdaptiveRuntime::build(tokio_util::sync::CancellationToken::new(), 1);
+    let _ = handle.begin_run("bad:namespace");
+}
+
+/// Drain the actor to completion, asserting it finishes rather than hanging.
+async fn drain(actor: unified_hifi_control::producers::ProducerActor) {
+    tokio::time::timeout(std::time::Duration::from_secs(5), actor.run())
+        .await
+        .expect("the actor must finish draining once its command channel closes");
+}
+
+// =============================================================================
+// I1: decision and mutation are one turn. Expressed as queue order.
+// =============================================================================
+
+#[tokio::test]
+async fn a_publish_queued_before_its_run_ended_is_refused_when_drained_after() {
+    // The TOCTOU the previous design could not close: the liveness check and the store
+    // mutation were separated by an `.await`, so a run could end in between. Here the publish
+    // is *already enqueued* when the run ends and a successor starts — the most hostile
+    // ordering — and the actor still refuses it, because it evaluates liveness in the same
+    // turn as the mutation it authorises.
+    let (handle, actor, view) =
+        AdaptiveRuntime::build(tokio_util::sync::CancellationToken::new(), 32);
+
+    let first = handle.begin_run("hqplayer");
+    let document = pipeline();
+    let key = ProducerKey::of(&document);
+    handle
+        .publish_detached(&first, document)
+        .await
+        .expect("enqueued");
+
+    // Nothing has drained yet. The run ends and a successor begins.
+    drop(first);
+    let _second = handle.begin_run("hqplayer");
+
+    drop(handle);
+    drain(actor).await;
+
+    assert!(
+        view.snapshot(&key).is_none(),
+        "a publish enqueued before its run ended was admitted after a successor started"
+    );
+    assert!(
+        matches!(
+            view.refusals().as_slice(),
+            [(
+                _,
+                unified_hifi_control::producers::AdmissionRefusal::StaleAdapterRun { .. }
+            )]
+        ),
+        "a stale-run refusal was not retained for detached publication: {:?}",
+        view.refusals()
+    );
+}
+
+#[tokio::test]
+async fn a_replacement_run_cannot_change_content_without_advancing_revision() {
+    let (handle, actor, view) =
+        AdaptiveRuntime::build(tokio_util::sync::CancellationToken::new(), 32);
+    let worker = tokio::spawn(async move { actor.run().await });
+
+    let first = handle.begin_run("hqplayer");
+    let original = pipeline();
+    let key = ProducerKey::of(&original);
+    assert!(matches!(
+        handle
+            .publish(&first, original.clone())
+            .await
+            .expect("verdict"),
+        Admission::Admitted(_)
+    ));
+    drop(first);
+
+    let second = handle.begin_run("hqplayer");
+    let mut contradictory = original.clone();
+    contradictory.producer.product_version = Some("changed-without-revision".to_string());
+    let verdict = handle
+        .publish(&second, contradictory)
+        .await
+        .expect("verdict");
+    assert!(
+        matches!(
+            verdict,
+            Admission::Refused(
+                unified_hifi_control::producers::AdmissionRefusal::NotAdvanced { .. }
+            )
+        ),
+        "a replacement run changed content under the same revision: {verdict:?}"
+    );
+    assert_eq!(
+        view.snapshot(&key)
+            .expect("the original snapshot stands")
+            .document
+            .producer
+            .product_version,
+        original.producer.product_version
+    );
+
+    drop(second);
+    drop(handle);
+    worker.await.expect("actor");
+}
+
+#[tokio::test]
+async fn a_removal_queued_before_its_run_ended_cannot_retire_the_successors_producer() {
+    let (handle, actor, view) =
+        AdaptiveRuntime::build(tokio_util::sync::CancellationToken::new(), 32);
+
+    let first = handle.begin_run("hqplayer");
+    let document = pipeline();
+    let key = ProducerKey::of(&document);
+
+    // Beginning the successor supersedes the still-held first lease.
+    let second = handle.begin_run("hqplayer");
+    handle
+        .publish_detached(&second, document.clone())
+        .await
+        .expect("enqueued");
+    // A retirement attempted from that stale lease is rejected before queue commitment.
+    let retirement = handle
+        .retire_detached(&first, &document.producer.producer_id, ProducerEpoch(7))
+        .await
+        .expect("runtime open");
+    assert!(matches!(
+        retirement,
+        unified_hifi_control::producers::RetirementOutcome::StaleAdapterRun { .. }
+    ));
+
+    drop(handle);
+    drain(actor).await;
+
+    assert!(
+        view.snapshot(&key).is_some(),
+        "a removal from a dead run retired the successor run's producer"
+    );
+    drop(first);
+    drop(second);
+}
+
+#[tokio::test]
+async fn a_retirement_committed_while_live_is_not_lost_when_the_lease_drops() {
+    let (handle, actor, view) =
+        AdaptiveRuntime::build(tokio_util::sync::CancellationToken::new(), 32);
+    let first = handle.begin_run("hqplayer");
+    let document = pipeline();
+    let key = ProducerKey::of(&document);
+
+    // The bounded inbox accepts the retirement while run N is authoritative. It must remain
+    // committed even if the lease drops before the actor gets CPU time.
+    handle
+        .retire_detached(&first, &document.producer.producer_id, ProducerEpoch(7))
+        .await
+        .expect("runtime open");
+    drop(first);
+
+    let successor = handle.begin_run("hqplayer");
+    handle
+        .publish_detached(&successor, document)
+        .await
+        .expect("successor publication accepted");
+    drop(handle);
+    drain(actor).await;
+
+    assert!(
+        view.snapshot(&key).is_none(),
+        "a retirement accepted while live disappeared when its lease dropped"
+    );
+    drop(successor);
+}
+
+#[tokio::test]
+async fn one_adapter_cannot_retire_another_adapters_producer_namespace() {
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    let (handle, actor, view) = AdaptiveRuntime::build(shutdown, 32);
+    let worker = tokio::spawn(async move { actor.run().await });
+    let hqp = handle.begin_run("hqplayer");
+    let roon = handle.begin_run("roon");
+    let document = pipeline();
+    let key = ProducerKey::of(&document);
+
+    handle
+        .publish(&hqp, document.clone())
+        .await
+        .expect("verdict");
+    let outcome = handle
+        .retire(
+            &roon,
+            &document.producer.producer_id,
+            document.producer.epoch,
+        )
+        .await
+        .expect("runtime open");
+    assert!(
+        !matches!(
+            outcome,
+            unified_hifi_control::producers::RetirementOutcome::Committed
+                | unified_hifi_control::producers::RetirementOutcome::Retired { .. }
+        ),
+        "cross-adapter retirement was not refused: {outcome:?}"
+    );
+    assert!(view.snapshot(&key).is_some());
+
+    drop(roon);
+    drop(hqp);
+    drop(handle);
+    worker.await.expect("actor");
+}
+
+// =============================================================================
+// I7: no ingress command is lost, even at capacity.
+// =============================================================================
+
+#[tokio::test]
+async fn a_full_inbox_applies_backpressure_rather_than_losing_a_retirement() {
+    // Capacity 1, deliberately. The publishes fill it and the retirement has to wait; nothing
+    // is dropped and nothing is coalesced, so the retirement is applied in order.
+    let (handle, actor, view) =
+        AdaptiveRuntime::build(tokio_util::sync::CancellationToken::new(), 1);
+
+    let run = handle.begin_run("hqplayer");
+    let document = pipeline();
+    let key = ProducerKey::of(&document);
+
+    let sender = handle.clone();
+    let producer_id = document.producer.producer_id.clone();
+    let feeder = tokio::spawn(async move {
+        for step in 0..32_u64 {
+            sender
+                .publish_detached(&run, at(&pipeline(), 7, 4193 + step))
+                .await
+                .expect("enqueued under backpressure");
+        }
+        sender
+            .retire(&run, &producer_id, ProducerEpoch(7))
+            .await
+            .expect("the retirement must not be dropped by a full inbox");
+        drop(run);
+        drop(sender);
+    });
+
+    let worker = tokio::spawn(async move { actor.run().await });
+    tokio::time::timeout(std::time::Duration::from_secs(5), feeder)
+        .await
+        .expect("the feeder must finish")
+        .expect("the feeder must not panic");
+    drop(handle);
+    tokio::time::timeout(std::time::Duration::from_secs(5), worker)
+        .await
+        .expect("the actor must finish")
+        .expect("the actor must not panic");
+
+    assert!(
+        view.snapshot(&key).is_none(),
+        "a retirement queued behind a full inbox was lost"
+    );
+}
+
+#[tokio::test]
+async fn a_restart_on_one_target_cannot_clear_retirement_for_an_unseen_target() {
+    let (handle, actor, view) =
+        AdaptiveRuntime::build(tokio_util::sync::CancellationToken::new(), 8);
+    let worker = tokio::spawn(async move { actor.run().await });
+    let run = handle.begin_run("hqplayer");
+    let base = pipeline();
+
+    handle
+        .retire(&run, &base.producer.producer_id, ProducerEpoch(7))
+        .await
+        .expect("retirement applied");
+
+    let restarted = handle
+        .publish(&run, at(&base, 8, 1))
+        .await
+        .expect("restart verdict");
+    assert!(matches!(restarted, Admission::Admitted(_)));
+
+    let mut unseen_straggler = at(&base, 7, 9999);
+    unseen_straggler.target.role = unified_hifi_control::adaptive::TargetRole::Instance;
+    unseen_straggler.target.zone_id = None;
+    let refused = handle
+        .publish(&run, unseen_straggler)
+        .await
+        .expect("straggler verdict");
+    assert!(
+        matches!(refused, Admission::Refused(_)),
+        "a restart on one target cleared the producer-wide floor: {refused:?}"
+    );
+    assert!(
+        matches!(
+            view.refusals().as_slice(),
+            [(
+                _,
+                unified_hifi_control::producers::AdmissionRefusal::ProducerRetired { .. }
+            )]
+        ),
+        "a producer-retired refusal was not retained: {:?}",
+        view.refusals()
+    );
+
+    drop(run);
+    drop(handle);
+    worker.await.expect("actor");
+}
+
+#[tokio::test]
+async fn a_refused_future_epoch_cannot_raise_an_explicit_retirement_floor() {
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    let (handle, actor, view) = AdaptiveRuntime::build(shutdown, 32);
+    let worker = tokio::spawn(async move { actor.run().await });
+    let run = handle.begin_run("hqplayer");
+    let base = pipeline();
+    let key = ProducerKey::of(&base);
+
+    assert!(matches!(
+        handle
+            .publish(&run, base.clone())
+            .await
+            .expect("initial verdict"),
+        Admission::Admitted(_)
+    ));
+
+    let mut malformed_future = at(&base, 99, 1);
+    malformed_future.target.zone_id = Some("not-prefixed".to_string());
+    assert!(matches!(
+        handle
+            .publish(&run, malformed_future)
+            .await
+            .expect("refusal verdict"),
+        Admission::Refused(_)
+    ));
+
+    handle
+        .retire(&run, &base.producer.producer_id, ProducerEpoch(7))
+        .await
+        .expect("retirement applied");
+
+    let restart = handle
+        .publish(&run, at(&base, 8, 1))
+        .await
+        .expect("restart verdict");
+    assert!(
+        matches!(restart, Admission::Admitted(_)),
+        "a refused epoch raised the explicit retirement floor: {restart:?}"
+    );
+    assert_eq!(
+        view.snapshot(&key)
+            .expect("corrected restart admitted")
+            .document
+            .producer
+            .epoch,
+        ProducerEpoch(8)
+    );
+
+    drop(run);
+    drop(handle);
+    worker.await.expect("actor");
+}
+
+#[tokio::test]
+async fn a_delayed_lower_epoch_retirement_cannot_remove_a_newer_restart() {
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    let (handle, actor, view) = AdaptiveRuntime::build(shutdown, 32);
+    let worker = tokio::spawn(async move { actor.run().await });
+    let run = handle.begin_run("hqplayer");
+    let restarted = at(&pipeline(), 9, 1);
+    let key = ProducerKey::of(&restarted);
+
+    assert!(matches!(
+        handle
+            .publish(&run, restarted.clone())
+            .await
+            .expect("restart verdict"),
+        Admission::Admitted(_)
+    ));
+    handle
+        .retire(&run, &restarted.producer.producer_id, ProducerEpoch(7))
+        .await
+        .expect("delayed retirement applied");
+
+    assert_eq!(
+        view.snapshot(&key)
+            .expect("newer restart must remain")
+            .document
+            .producer
+            .epoch,
+        ProducerEpoch(9),
+        "retirement through epoch 7 removed epoch-9 state"
+    );
+
+    drop(run);
+    drop(handle);
+    worker.await.expect("actor");
+}
+
+#[tokio::test]
+async fn a_cross_namespace_refusal_cannot_poison_another_producers_retirement_floor() {
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    let (handle, actor, view) = AdaptiveRuntime::build(shutdown, 32);
+    let worker = tokio::spawn(async move { actor.run().await });
+    let hqp = handle.begin_run("hqplayer");
+    let roon = handle.begin_run("roon");
+    let base = pipeline();
+    let key = ProducerKey::of(&base);
+
+    assert!(matches!(
+        handle
+            .publish(&hqp, base.clone())
+            .await
+            .expect("initial verdict"),
+        Admission::Admitted(_)
+    ));
+    assert!(matches!(
+        handle
+            .publish(&roon, at(&base, 999, 1))
+            .await
+            .expect("ownership verdict"),
+        Admission::Refused(
+            unified_hifi_control::producers::AdmissionRefusal::ProducerOwnershipMismatch { .. }
+        )
+    ));
+
+    handle
+        .retire(&hqp, &base.producer.producer_id, ProducerEpoch(7))
+        .await
+        .expect("retirement applied");
+    let restart = handle
+        .publish(&hqp, at(&base, 8, 1))
+        .await
+        .expect("restart verdict");
+    assert!(
+        matches!(restart, Admission::Admitted(_)),
+        "another adapter's refused epoch poisoned retirement authority: {restart:?}"
+    );
+    assert_eq!(
+        view.snapshot(&key)
+            .expect("corrected restart admitted")
+            .document
+            .producer
+            .epoch,
+        ProducerEpoch(8)
+    );
+
+    drop(roon);
+    drop(hqp);
+    drop(handle);
+    worker.await.expect("actor");
+}
+
+#[tokio::test]
+async fn a_wrong_owner_cannot_replace_the_owning_adapters_refusal() {
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    let (handle, actor, view) = AdaptiveRuntime::build(shutdown, 32);
+    let worker = tokio::spawn(async move { actor.run().await });
+    let hqp = handle.begin_run("hqplayer");
+
+    let mut owner_bad = pipeline();
+    owner_bad.lanes[0].last_success = Some(Timestamp::new("not-an-instant"));
+    assert!(matches!(
+        handle
+            .publish(&hqp, owner_bad)
+            .await
+            .expect("owner refusal"),
+        Admission::Refused(
+            unified_hifi_control::producers::AdmissionRefusal::LaneTimestampNotRfc3339 { .. }
+        )
+    ));
+
+    // This later run has a numerically newer process-global id, but it does not own the
+    // hqplayer namespace and therefore cannot displace the owner's diagnostic.
+    let roon = handle.begin_run("roon");
+    assert!(matches!(
+        handle
+            .publish(&roon, at(&pipeline(), 999, 1))
+            .await
+            .expect("ownership refusal"),
+        Admission::Refused(
+            unified_hifi_control::producers::AdmissionRefusal::ProducerOwnershipMismatch { .. }
+        )
+    ));
+    assert!(matches!(
+        view.refusals().as_slice(),
+        [(
+            _,
+            unified_hifi_control::producers::AdmissionRefusal::LaneTimestampNotRfc3339 { .. }
+        )]
+    ));
+
+    drop(roon);
+    drop(hqp);
+    drop(handle);
+    worker.await.expect("actor");
+}
+
+#[tokio::test]
+async fn a_wrong_owner_diagnostic_does_not_attach_to_the_owners_later_snapshot() {
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    let (handle, actor, view) = AdaptiveRuntime::build(shutdown, 32);
+    let worker = tokio::spawn(async move { actor.run().await });
+    let roon = handle.begin_run("roon");
+    let hqp = handle.begin_run("hqplayer");
+    let document = pipeline();
+    let key = ProducerKey::of(&document);
+
+    assert!(matches!(
+        handle
+            .publish(&roon, document.clone())
+            .await
+            .expect("ownership verdict"),
+        Admission::Refused(
+            unified_hifi_control::producers::AdmissionRefusal::ProducerOwnershipMismatch { .. }
+        )
+    ));
+    assert!(matches!(
+        handle.publish(&hqp, document).await.expect("owner verdict"),
+        Admission::Admitted(_)
+    ));
+
+    assert!(
+        view.snapshot(&key)
+            .expect("owner snapshot")
+            .last_refusal
+            .is_none(),
+        "a command-authority failure was attached to the producer as a document refusal"
+    );
+    assert!(view.refusals().is_empty());
+
+    drop(hqp);
+    drop(roon);
+    drop(handle);
+    worker.await.expect("actor");
+}
+
+#[tokio::test]
+async fn a_detached_wrong_owner_publication_fails_before_queueing() {
+    let (handle, actor, view) =
+        AdaptiveRuntime::build(tokio_util::sync::CancellationToken::new(), 32);
+    let roon = handle.begin_run("roon");
+    let result = handle.publish_detached(&roon, pipeline()).await;
+    assert!(matches!(
+        result,
+        Err(
+            unified_hifi_control::producers::AdaptivePublishError::ProducerOwnershipMismatch { .. }
+        )
+    ));
+
+    drop(roon);
+    drop(handle);
+    drain(actor).await;
+    assert!(view.snapshots().is_empty());
+    assert!(view.refusals().is_empty());
+}
+
+// =============================================================================
+// I8: presence degrades when the admitting run is gone, at read time.
+// =============================================================================
+
+#[tokio::test]
+async fn a_producer_whose_run_was_dropped_projects_last_known() {
+    let (handle, actor, view) =
+        AdaptiveRuntime::build(tokio_util::sync::CancellationToken::new(), 32);
+
+    let run = handle.begin_run("hqplayer");
+    let document = pipeline();
+    let key = ProducerKey::of(&document);
+    handle
+        .publish_detached(&run, document)
+        .await
+        .expect("enqueued");
+    drop(handle);
+    drain(actor).await;
+
+    assert_eq!(
+        view.snapshot(&key).expect("admitted").presence,
+        ProducerPresence::Live,
+        "a producer of a live run must be Live"
+    );
+
+    // The lease is dropped with no cleanup command drained afterwards.
+    drop(run);
+
+    assert_eq!(
+        view.snapshot(&key).expect("still last-known").presence,
+        ProducerPresence::LastKnown,
+        "a producer whose admitting run is gone must not be presented as Live"
+    );
+}
+
+#[tokio::test]
+async fn a_producer_whose_run_task_was_aborted_projects_last_known() {
+    let (handle, actor, view) =
+        AdaptiveRuntime::build(tokio_util::sync::CancellationToken::new(), 32);
+
+    let document = pipeline();
+    let key = ProducerKey::of(&document);
+    let publisher = handle.clone();
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+    let worker = tokio::spawn(async move { actor.run().await });
+
+    let task = tokio::spawn(async move {
+        let run = publisher.begin_run("hqplayer");
+        let admission = publisher.publish(&run, pipeline()).await.expect("verdict");
+        assert!(matches!(admission, Admission::Admitted(_)), "admitted");
+        ready_tx.send(()).expect("receiver alive");
+        // Hold the lease until aborted.
+        std::future::pending::<()>().await;
+    });
+
+    ready_rx.await.expect("the publisher reached its park");
+    task.abort();
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), task).await;
+
+    drop(handle);
+    tokio::time::timeout(std::time::Duration::from_secs(5), worker)
+        .await
+        .expect("the actor must finish")
+        .expect("the actor must not panic");
+
+    assert_eq!(
+        view.snapshot(&key).expect("admitted").presence,
+        ProducerPresence::LastKnown,
+        "an aborted publisher's producer was still presented as Live"
+    );
+}
+
+#[tokio::test]
+async fn a_producer_whose_run_task_panicked_projects_last_known() {
+    let (handle, actor, view) =
+        AdaptiveRuntime::build(tokio_util::sync::CancellationToken::new(), 32);
+
+    let document = pipeline();
+    let key = ProducerKey::of(&document);
+    let publisher = handle.clone();
+    let worker = tokio::spawn(async move { actor.run().await });
+
+    let task = tokio::spawn(async move {
+        let run = publisher.begin_run("hqplayer");
+        let admission = publisher.publish(&run, pipeline()).await.expect("verdict");
+        assert!(matches!(admission, Admission::Admitted(_)), "admitted");
+        panic!("the adapter fell over");
+    });
+    let outcome = tokio::time::timeout(std::time::Duration::from_secs(5), task)
+        .await
+        .expect("the task must finish");
+    assert!(outcome.is_err(), "the task was expected to panic");
+
+    drop(handle);
+    tokio::time::timeout(std::time::Duration::from_secs(5), worker)
+        .await
+        .expect("the actor must finish")
+        .expect("the actor must not panic");
+
+    assert_eq!(
+        view.snapshot(&key).expect("admitted").presence,
+        ProducerPresence::LastKnown,
+        "a panicked publisher's producer was still presented as Live"
+    );
+}
+
+// =============================================================================
+// I5: cleanup and refusals are isolated by exact origin.
+// =============================================================================
+
+#[tokio::test]
+async fn ending_a_dead_run_cannot_clear_the_live_runs_refusal() {
+    let (handle, actor, view) =
+        AdaptiveRuntime::build(tokio_util::sync::CancellationToken::new(), 32);
+
+    let dead = handle.begin_run("hqplayer");
+    drop(dead);
+
+    let live = handle.begin_run("hqplayer");
+    let mut bad = pipeline();
+    bad.target.zone_id = Some("not-prefixed".to_string());
+    handle.publish_detached(&live, bad).await.expect("enqueued");
+
+    drop(handle);
+    drain(actor).await;
+
+    assert_eq!(
+        view.refusals().len(),
+        1,
+        "a dead run's cleanup cleared the live run's refusal: {:?}",
+        view.refusals()
+    );
+    drop(live);
+}
+
+#[tokio::test]
+async fn a_stale_run_cannot_overwrite_the_live_runs_refusal() {
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    let (handle, actor, view) = AdaptiveRuntime::build(shutdown, 32);
+    let worker = tokio::spawn(async move { actor.run().await });
+    let old = handle.begin_run("hqplayer");
+    let live = handle.begin_run("hqplayer");
+
+    let mut live_bad = at(&pipeline(), 7, 4194);
+    live_bad.lanes[0].last_success = Some(Timestamp::new("not-an-instant"));
+    handle.publish(&live, live_bad).await.expect("live verdict");
+
+    handle
+        .publish_detached(&old, pipeline())
+        .await
+        .expect("stale command enqueued");
+
+    // Wait for the queued detached refusal without using timing.
+    let mut advanced = at(&pipeline(), 7, 4195);
+    advanced.lanes[0].last_success = Some(Timestamp::new("still-not-an-instant"));
+    handle
+        .publish(&live, advanced)
+        .await
+        .expect("barrier verdict");
+    let refusals = view.refusals();
+    assert!(
+        matches!(
+            refusals.as_slice(),
+            [(
+                _,
+                unified_hifi_control::producers::AdmissionRefusal::LaneTimestampNotRfc3339 { .. }
+            )]
+        ),
+        "stale run displaced the live refusal: {refusals:?}"
+    );
+
+    drop(old);
+    drop(live);
+    drop(handle);
+    worker.await.expect("actor");
+}
+
+#[tokio::test]
+async fn a_verdict_is_returned_to_the_publisher_that_asked_for_one() {
+    // The one desirable half of a synchronous API, without the dependency inversion: the
+    // publisher holds a sender, not the aggregator, and still learns the outcome.
+    let (handle, actor, _view) =
+        AdaptiveRuntime::build(tokio_util::sync::CancellationToken::new(), 32);
+    let worker = tokio::spawn(async move { actor.run().await });
+
+    let run = handle.begin_run("hqplayer");
+    let admission = handle
+        .publish(&run, pipeline())
+        .await
+        .expect("the verdict must come back");
+    assert!(
+        matches!(admission, Admission::Admitted(_)),
+        "expected an admission verdict, got {admission:?}"
+    );
+
+    let mut bad = pipeline();
+    bad.target.zone_id = Some("not-prefixed".to_string());
+    let refused = handle.publish(&run, bad).await.expect("verdict");
+    assert!(
+        matches!(refused, Admission::Refused(_)),
+        "expected a refusal verdict, got {refused:?}"
+    );
+
+    drop(run);
+    drop(handle);
+    tokio::time::timeout(std::time::Duration::from_secs(5), worker)
+        .await
+        .expect("the actor must stop when its channel closes")
+        .expect("the actor must not panic");
+}
+
+#[tokio::test]
+async fn admitted_and_refused_notifications_are_egress_only_hints() {
+    let (handle, actor, view) =
+        AdaptiveRuntime::build(tokio_util::sync::CancellationToken::new(), 32);
+    let mut events = view.subscribe();
+    let worker = tokio::spawn(async move { actor.run().await });
+    let run = handle.begin_run("hqplayer");
+
+    handle.publish(&run, pipeline()).await.expect("verdict");
+    assert!(matches!(
+        events.recv().await.expect("admitted hint"),
+        unified_hifi_control::producers::AdaptiveEvent::SnapshotAdmitted { .. }
+    ));
+
+    let mut bad = at(&pipeline(), 7, 4194);
+    bad.target.zone_id = Some("not-prefixed".to_string());
+    handle.publish(&run, bad).await.expect("verdict");
+    assert!(matches!(
+        events.recv().await.expect("refused hint"),
+        unified_hifi_control::producers::AdaptiveEvent::SnapshotRefused { .. }
+    ));
+
+    drop(run);
+    drop(handle);
+    worker.await.expect("actor");
+}
+
+#[tokio::test]
+async fn retirement_emits_a_view_invalidation_hint() {
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    let (handle, actor, view) = AdaptiveRuntime::build(shutdown, 32);
+    let mut events = view.subscribe();
+    let worker = tokio::spawn(async move { actor.run().await });
+    let run = handle.begin_run("hqplayer");
+    let document = pipeline();
+
+    handle
+        .publish(&run, document.clone())
+        .await
+        .expect("publish");
+    events.recv().await.expect("admission hint");
+    handle
+        .retire(
+            &run,
+            &document.producer.producer_id,
+            document.producer.epoch,
+        )
+        .await
+        .expect("retire");
+    let event = tokio::time::timeout(std::time::Duration::from_secs(1), events.recv())
+        .await
+        .expect("retirement changed the view without an egress hint")
+        .expect("egress open");
+    assert!(matches!(
+        event,
+        unified_hifi_control::producers::AdaptiveEvent::ProducerRetired { .. }
+    ));
+
+    drop(run);
+    drop(handle);
+    worker.await.expect("actor");
+}
+
+#[tokio::test]
+async fn retirement_egress_reports_the_authoritative_applied_floor() {
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    let (handle, actor, view) = AdaptiveRuntime::build(shutdown, 32);
+    let mut events = view.subscribe();
+    let worker = tokio::spawn(async move { actor.run().await });
+    let run = handle.begin_run("hqplayer");
+    let producer_id = pipeline().producer.producer_id;
+
+    handle
+        .retire(&run, &producer_id, ProducerEpoch(9))
+        .await
+        .expect("initial retirement");
+    events.recv().await.expect("initial retirement hint");
+
+    handle
+        .retire(&run, &producer_id, ProducerEpoch(7))
+        .await
+        .expect("lower retirement request");
+    let event = events.recv().await.expect("retirement hint");
+    assert!(matches!(
+        event,
+        unified_hifi_control::producers::AdaptiveEvent::ProducerRetired {
+            retired_through: ProducerEpoch(9),
+            ..
+        }
+    ));
+
+    drop(run);
+    drop(handle);
+    worker.await.expect("actor");
+}
+
+#[tokio::test]
+async fn the_actor_stops_on_shutting_down() {
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    let (handle, actor, _view) = AdaptiveRuntime::build(shutdown.clone(), 32);
+    let worker = tokio::spawn(async move { actor.run().await });
+
+    shutdown.cancel();
+
+    tokio::time::timeout(std::time::Duration::from_secs(5), worker)
+        .await
+        .expect("the actor must stop on ShuttingDown")
+        .expect("the actor must not panic");
+    drop(handle);
+}
+
+#[tokio::test]
+async fn shutdown_drains_commands_accepted_before_the_signal() {
+    // Repeat to cover both select branch orders without relying on sleeps or scheduler timing.
+    for _ in 0..32 {
+        let shutdown = tokio_util::sync::CancellationToken::new();
+        let (handle, actor, view) = AdaptiveRuntime::build(shutdown.clone(), 32);
+        let run = handle.begin_run("hqplayer");
+        let document = pipeline();
+        let key = ProducerKey::of(&document);
+
+        handle
+            .publish_detached(&run, document)
+            .await
+            .expect("accepted before shutdown");
+        shutdown.cancel();
+        actor.run().await;
+
+        assert!(
+            view.snapshot(&key).is_some(),
+            "shutdown discarded a command that ingress had already accepted"
+        );
+        drop(run);
+        drop(handle);
+    }
+}

--- a/tests/adaptive_publication.rs
+++ b/tests/adaptive_publication.rs
@@ -1,0 +1,1389 @@
+//! Consumer-expectation tests for adaptive producer publication (issue #324).
+//!
+//! Written before the implementation, per `AGENTS.md`. Each test states what a *consumer*
+//! of the aggregator is entitled to assume, not what the implementation happens to do.
+//!
+//! The load-bearing expectation, from which most of the others follow: **a consumer cannot
+//! obtain a producer document that did not come out of the admission gate.** Everything
+//! about coherence, monotonicity and zone identity is therefore checkable as a property of
+//! the store rather than of a code path.
+
+use std::collections::BTreeMap;
+
+use unified_hifi_control::adaptive::{
+    admit_document_str, ApplyLane, ChangeSetId, CommandOutcome, ControlId, ControlValue,
+    DocumentRevisions, EntryValidity, Grounding, IntentIncoherence, LaneValue, OperationId,
+    OutcomeTransition, ProducerDocument, ProducerEpoch, Provenance, Reason, ReasonCode, TargetRole,
+    Timestamp, TransportLane, ValueLane,
+};
+use unified_hifi_control::producers::{
+    admit, Admission, AdmissionKind, AdmissionRefusal, LaneDefect, ProducerAggregator, ProducerKey,
+    ProducerPresence,
+};
+
+// =============================================================================
+// Fixtures and helpers
+// =============================================================================
+
+/// Load a canonical #323 fixture through the contract's own admission path.
+///
+/// Deliberately the canonical fixtures rather than bespoke test documents: the publication
+/// path should be exercised by the contract's own worked examples, so a disagreement
+/// between #323's idea of a valid document and #324's is a test failure rather than a
+/// discovery made by #325.
+fn fixture(name: &str) -> ProducerDocument {
+    let path = format!(
+        "{}/tests/fixtures/adaptive/{name}.json",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    let raw = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"));
+    match admit_document_str(&raw) {
+        Ok(document) => document,
+        Err(refusal) => panic!("canonical fixture {name} is not admissible: {refusal}"),
+    }
+}
+
+fn pipeline() -> ProducerDocument {
+    fixture("hqplayer_pipeline_v1")
+}
+
+fn staged() -> ProducerDocument {
+    fixture("staged_intent_multi_surface")
+}
+
+fn degraded() -> ProducerDocument {
+    fixture("hqplayer_degraded_lanes")
+}
+
+fn outcomes() -> ProducerDocument {
+    fixture("command_outcomes")
+}
+
+fn ts(raw: &str) -> Timestamp {
+    Timestamp::new(raw)
+}
+
+/// Admit with no predecessor.
+fn admit_fresh(document: ProducerDocument) -> Admission {
+    admit(None, document)
+}
+
+fn expect_admitted(admission: Admission) -> unified_hifi_control::producers::AdmittedDocument {
+    match admission {
+        Admission::Admitted(admitted) => admitted,
+        Admission::Refused(refusal) => panic!("expected admission, got refusal: {refusal:?}"),
+    }
+}
+
+fn expect_refused(admission: Admission) -> AdmissionRefusal {
+    match admission {
+        Admission::Refused(refusal) => refusal,
+        Admission::Admitted(admitted) => panic!(
+            "expected refusal, document was admitted at {:?}",
+            admitted.document.revisions
+        ),
+    }
+}
+
+// =============================================================================
+// Envelope admission: version, identity, ordering
+// =============================================================================
+
+mod envelope {
+    use super::*;
+
+    #[test]
+    fn every_canonical_fixture_is_admissible_by_the_publication_gate() {
+        // If the gate refuses a document #323 calls canonical, one of the two is wrong and
+        // #325 would be the one to find out.
+        for name in [
+            "hqplayer_pipeline_v1",
+            "hqplayer_degraded_lanes",
+            "staged_intent_multi_surface",
+            "command_outcomes",
+            "forward_compatible_additions",
+        ] {
+            let document = fixture(name);
+            let admission = admit_fresh(document);
+            assert!(
+                matches!(admission, Admission::Admitted(_)),
+                "canonical fixture {name} was refused by the publication gate: {admission:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_document_stamped_with_an_unsupported_major_is_refused() {
+        // The typed path must apply the same version policy as the JSON path: a document
+        // can reach the gate as a typed value that never passed through admit_document.
+        let mut document = pipeline();
+        document.schema_version = unified_hifi_control::adaptive::SchemaVersion::new(2, 0);
+        let refusal = expect_refused(admit_fresh(document));
+        assert!(
+            matches!(refusal, AdmissionRefusal::Contract(_)),
+            "expected a contract refusal for major 2, got {refusal:?}"
+        );
+    }
+
+    #[test]
+    fn a_newer_minor_is_admitted_rather_than_refused() {
+        let mut document = pipeline();
+        document.schema_version = unified_hifi_control::adaptive::SchemaVersion::new(1, 9);
+        expect_admitted(admit_fresh(document));
+    }
+
+    #[test]
+    fn a_zone_id_without_a_known_prefix_is_refused_and_names_the_offender() {
+        // #323 left this to #324 deliberately: PrefixedZoneId is #[serde(transparent)], so
+        // deserialization never validates, and the prefix vocabulary lives in the
+        // server-only bus module the contract layer may not name.
+        let mut document = pipeline();
+        document.target.zone_id = Some("1601bb42ed14351b99c2926214f6cbb80724".to_string());
+        match expect_refused(admit_fresh(document)) {
+            AdmissionRefusal::ZoneIdNotPrefixed { zone_id } => {
+                assert_eq!(zone_id, "1601bb42ed14351b99c2926214f6cbb80724");
+            }
+            other => panic!("expected ZoneIdNotPrefixed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_unknown_prefix_is_refused_even_though_it_looks_prefixed() {
+        let mut document = pipeline();
+        document.target.zone_id = Some("spotify:abc123".to_string());
+        assert!(matches!(
+            expect_refused(admit_fresh(document)),
+            AdmissionRefusal::ZoneIdNotPrefixed { .. }
+        ));
+    }
+
+    #[test]
+    fn an_absent_zone_id_is_fine_for_an_instance_scoped_producer() {
+        let mut document = pipeline();
+        document.target.role = TargetRole::Instance;
+        document.target.zone_id = None;
+        expect_admitted(admit_fresh(document));
+    }
+
+    #[test]
+    fn a_regressing_state_revision_is_refused() {
+        let previous = pipeline();
+        let mut incoming = pipeline();
+        incoming.revisions = DocumentRevisions::new(12, 4192);
+        match expect_refused(admit(Some(&previous), incoming)) {
+            AdmissionRefusal::RevisionRegressed {
+                previous: p,
+                incoming: i,
+            } => {
+                assert_eq!(p, DocumentRevisions::new(12, 4193));
+                assert_eq!(i, DocumentRevisions::new(12, 4192));
+            }
+            other => panic!("expected RevisionRegressed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_regressing_control_plane_revision_is_refused_even_when_state_advances() {
+        let previous = pipeline();
+        let mut incoming = pipeline();
+        incoming.revisions = DocumentRevisions::new(11, 9999);
+        assert!(matches!(
+            expect_refused(admit(Some(&previous), incoming)),
+            AdmissionRefusal::RevisionRegressed { .. }
+        ));
+    }
+
+    #[test]
+    fn a_regressing_epoch_is_refused_as_an_out_of_order_delivery() {
+        let previous = pipeline();
+        let mut incoming = pipeline();
+        incoming.producer.epoch = ProducerEpoch(6);
+        incoming.revisions = DocumentRevisions::new(99, 99999);
+        match expect_refused(admit(Some(&previous), incoming)) {
+            AdmissionRefusal::EpochRegressed {
+                previous: p,
+                incoming: i,
+            } => {
+                assert_eq!(p, ProducerEpoch(7));
+                assert_eq!(i, ProducerEpoch(6));
+            }
+            other => panic!("expected EpochRegressed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_higher_epoch_is_admitted_even_though_its_revisions_are_lower() {
+        // A restart resets revisions. They are only comparable within one epoch, so the
+        // monotonicity rule must not fire across an epoch boundary.
+        let previous = pipeline();
+        let mut incoming = pipeline();
+        incoming.producer.epoch = ProducerEpoch(8);
+        incoming.revisions = DocumentRevisions::new(1, 1);
+        let admitted = expect_admitted(admit(Some(&previous), incoming));
+        assert_eq!(admitted.kind, AdmissionKind::Fresh);
+    }
+
+    #[test]
+    fn republishing_the_same_revision_with_different_content_is_refused() {
+        let previous = pipeline();
+        let mut incoming = pipeline();
+        incoming.controls.truncate(3);
+        match expect_refused(admit(Some(&previous), incoming)) {
+            AdmissionRefusal::NotAdvanced { at } => {
+                assert_eq!(at, DocumentRevisions::new(12, 4193));
+            }
+            other => panic!("expected NotAdvanced, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn republishing_the_same_revision_with_only_lane_health_changed_is_admitted() {
+        // The alternative — demanding a state bump for a lane transition — invalidates
+        // every open change set on every lane flap, because a change set is validated
+        // against the state revision. Admitting a health-only refresh keeps drafts alive
+        // and still updates the lane witness.
+        let previous = pipeline();
+        let mut incoming = pipeline();
+        if let Some(lane) = incoming
+            .lanes
+            .iter_mut()
+            .find(|l| l.lane == TransportLane::Persistent)
+        {
+            lane.state = unified_hifi_control::adaptive::LaneState::Disconnected;
+            lane.last_error = Some(Reason::observed(ReasonCode::RequiresConnection));
+        }
+        let admitted = expect_admitted(admit(Some(&previous), incoming));
+        assert_eq!(admitted.kind, AdmissionKind::HealthRefresh);
+    }
+
+    #[test]
+    fn an_identical_republication_is_admitted_as_a_health_refresh_and_changes_nothing() {
+        let previous = pipeline();
+        let incoming = pipeline();
+        let admitted = expect_admitted(admit(Some(&previous), incoming));
+        assert_eq!(admitted.kind, AdmissionKind::HealthRefresh);
+        assert_eq!(admitted.document, previous);
+    }
+}
+
+// =============================================================================
+// Invariant: LaneValue consistency (decision 3)
+// =============================================================================
+
+mod lane_value_invariant {
+    use super::*;
+
+    fn first_control_lane(document: &mut ProducerDocument) -> &mut LaneValue {
+        let control = document
+            .controls
+            .iter_mut()
+            .find(|c| !c.values.is_empty())
+            .expect("a canonical fixture has at least one control with a lane");
+        control
+            .values
+            .first_mut()
+            .expect("checked non-empty just above")
+    }
+
+    #[test]
+    fn a_grounded_lane_with_no_value_is_refused_and_names_control_and_lane() {
+        let mut document = pipeline();
+        let (control_id, lane) = {
+            let value = first_control_lane(&mut document);
+            value.grounding = Grounding::Grounded;
+            value.value = None;
+            (None::<ControlId>, value.lane.clone())
+        };
+        let _ = control_id;
+        match expect_refused(admit_fresh(document)) {
+            AdmissionRefusal::LaneValueInconsistent {
+                lane: got, detail, ..
+            } => {
+                assert_eq!(got, lane);
+                assert_eq!(detail, LaneDefect::GroundedWithoutValue);
+            }
+            other => panic!("expected LaneValueInconsistent, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_ungrounded_lane_carrying_a_value_is_refused() {
+        let mut document = pipeline();
+        {
+            let value = first_control_lane(&mut document);
+            value.grounding = Grounding::Ungrounded;
+            value.ungrounded_reason = Some(ReasonCode::Unobservable);
+            value.value = Some(ControlValue::Bool(true));
+        }
+        match expect_refused(admit_fresh(document)) {
+            AdmissionRefusal::LaneValueInconsistent { detail, .. } => {
+                assert_eq!(detail, LaneDefect::UngroundedWithValue);
+            }
+            other => panic!("expected LaneValueInconsistent, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_ungrounded_lane_without_a_reason_is_refused() {
+        let mut document = pipeline();
+        {
+            let value = first_control_lane(&mut document);
+            value.grounding = Grounding::Ungrounded;
+            value.value = None;
+            value.ungrounded_reason = None;
+        }
+        match expect_refused(admit_fresh(document)) {
+            AdmissionRefusal::LaneValueInconsistent { detail, .. } => {
+                assert_eq!(detail, LaneDefect::UngroundedWithoutReason);
+            }
+            other => panic!("expected LaneValueInconsistent, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_unrecognized_grounding_from_a_newer_minor_is_admitted_not_refused() {
+        // The whole point of the compatibility policy. `LaneValue::is_consistent` returns
+        // false here — correctly, for a *consumer*, which must not treat the payload as
+        // authoritative — but using that predicate at the door would refuse a
+        // forward-compatible document wholesale, which §8 forbids.
+        let mut document = pipeline();
+        {
+            let value = first_control_lane(&mut document);
+            value.grounding = Grounding::Unrecognized("provisional".to_string());
+        }
+        expect_admitted(admit_fresh(document));
+    }
+}
+
+// =============================================================================
+// Invariant: deserialized operation-history legality (decision 4)
+// =============================================================================
+
+mod history_legality {
+    use super::*;
+
+    #[test]
+    fn an_illegal_recorded_transition_refuses_the_document_and_names_it() {
+        // `applied` is terminal, so nothing may follow it. Deserialization never checks
+        // this, because `history` is a plain Vec.
+        let mut document = outcomes();
+        let operation = document
+            .operations
+            .first_mut()
+            .expect("command_outcomes publishes operations");
+        let id = operation.id.clone();
+        operation.history.push(OutcomeTransition {
+            from: CommandOutcome::Applied,
+            to: CommandOutcome::Indeterminate,
+            at: ts("2026-07-30T11:20:00Z"),
+            observed: None,
+            reason: None,
+        });
+        match expect_refused(admit_fresh(document)) {
+            AdmissionRefusal::IllegalOutcomeHistory {
+                operation,
+                from,
+                to,
+            } => {
+                assert_eq!(operation, id);
+                assert_eq!(from, CommandOutcome::Applied);
+                assert_eq!(to, CommandOutcome::Indeterminate);
+            }
+            other => panic!("expected IllegalOutcomeHistory, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_transition_involving_an_unrecognized_outcome_is_admitted() {
+        // `may_transition_to` permits these deliberately: refusing would drop audit history
+        // a v1.0 consumer cannot read. The gate must not be stricter than the predicate.
+        let mut document = outcomes();
+        let operation = document
+            .operations
+            .first_mut()
+            .expect("command_outcomes publishes operations");
+        operation.history.push(OutcomeTransition {
+            from: CommandOutcome::Applied,
+            to: CommandOutcome::Unrecognized("quarantined".to_string()),
+            at: ts("2026-07-30T11:20:00Z"),
+            observed: None,
+            reason: None,
+        });
+        expect_admitted(admit_fresh(document));
+    }
+
+    #[test]
+    fn a_legal_recorded_transition_is_admitted() {
+        let mut document = outcomes();
+        let operation = document
+            .operations
+            .first_mut()
+            .expect("command_outcomes publishes operations");
+        operation.history.push(OutcomeTransition {
+            from: CommandOutcome::Indeterminate,
+            to: CommandOutcome::Applied,
+            at: ts("2026-07-30T11:20:00Z"),
+            observed: None,
+            reason: None,
+        });
+        expect_admitted(admit_fresh(document));
+    }
+}
+
+// =============================================================================
+// Published-intent coherence: C1, C2 and the removed control
+// =============================================================================
+
+mod intent_coherence {
+    use super::*;
+
+    fn valid_entry_control(document: &ProducerDocument) -> (ChangeSetId, ControlId) {
+        for change_set in &document.change_sets {
+            for entry in &change_set.entries {
+                if entry.validity == EntryValidity::Valid {
+                    return (change_set.id.clone(), entry.control.clone());
+                }
+            }
+        }
+        panic!("staged_intent_multi_surface must publish a valid entry")
+    }
+
+    #[test]
+    fn a_coherent_document_is_admitted_with_no_repairs() {
+        let admitted = expect_admitted(admit_fresh(staged()));
+        assert!(
+            admitted.repairs.is_empty(),
+            "canonical staged-intent fixture should need no repair, got {:?}",
+            admitted.repairs
+        );
+    }
+
+    #[test]
+    fn no_admitted_document_ever_carries_an_intent_incoherence() {
+        // The invariant a consumer relies on, stated over the store rather than over a
+        // code path. Every mutation below is a distinct way to break C1 or C2.
+        let mut broken = Vec::new();
+
+        let mut missing_lane = staged();
+        let (_, control) = valid_entry_control(&missing_lane);
+        for descriptor in &mut missing_lane.controls {
+            if descriptor.id == control {
+                descriptor.values.retain(|v| v.lane != ValueLane::Desired);
+            }
+        }
+        broken.push(missing_lane);
+
+        let mut disagreeing = staged();
+        let (_, control) = valid_entry_control(&disagreeing);
+        for descriptor in &mut disagreeing.controls {
+            if descriptor.id == control {
+                for value in &mut descriptor.values {
+                    if value.lane == ValueLane::Desired {
+                        value.value = Some(ControlValue::choice("something-else"));
+                    }
+                }
+            }
+        }
+        broken.push(disagreeing);
+
+        let mut unknown_control = staged();
+        let (_, control) = valid_entry_control(&unknown_control);
+        unknown_control.controls.retain(|c| c.id != control);
+        broken.push(unknown_control);
+
+        for document in broken {
+            let admitted = expect_admitted(admit_fresh(document));
+            assert!(
+                admitted.document.intent_coherence_violations().is_empty(),
+                "an incoherent document reached a consumer: {:?}",
+                admitted.document.intent_coherence_violations()
+            );
+            assert!(
+                !admitted.repairs.is_empty(),
+                "a repaired document must report what was repaired"
+            );
+        }
+    }
+
+    #[test]
+    fn a_missing_desired_lane_demotes_to_requires_producer_validation_not_to_valid() {
+        let mut document = staged();
+        let (change_set, control) = valid_entry_control(&document);
+        for descriptor in &mut document.controls {
+            if descriptor.id == control {
+                descriptor.values.retain(|v| v.lane != ValueLane::Desired);
+            }
+        }
+        let admitted = expect_admitted(admit_fresh(document));
+        let repair = admitted
+            .repairs
+            .iter()
+            .find(|r| r.control == control && r.change_set == change_set)
+            .expect("the offending entry must be reported");
+        assert!(matches!(
+            repair.violation,
+            IntentIncoherence::MissingDesiredLane { .. }
+        ));
+        assert!(matches!(
+            repair.to,
+            EntryValidity::RequiresProducerValidation { .. }
+        ));
+    }
+
+    #[test]
+    fn a_valid_entry_for_a_removed_control_is_distinctly_visible_as_control_removed() {
+        // The issue is explicit: users must see "this control no longer exists", not the
+        // generic "needs producer validation" that a fail-closed rule would produce.
+        let mut document = staged();
+        let (change_set, control) = valid_entry_control(&document);
+        document.controls.retain(|c| c.id != control);
+        document.revisions = DocumentRevisions::new(13, 4194);
+
+        let admitted = expect_admitted(admit_fresh(document));
+        let repair = admitted
+            .repairs
+            .iter()
+            .find(|r| r.control == control && r.change_set == change_set)
+            .expect("the entry targeting the removed control must be reported");
+        assert!(matches!(
+            repair.violation,
+            IntentIncoherence::UnknownControl { .. }
+        ));
+        match &repair.to {
+            EntryValidity::DraftInvalid { reason } => {
+                assert_eq!(
+                    reason.code,
+                    ReasonCode::ControlRemoved,
+                    "a removed control must be distinguishable from an unvalidated one"
+                );
+            }
+            other => panic!("expected DraftInvalid(control_removed), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn two_drafts_claiming_one_control_both_lose_validity() {
+        // The aggregator cannot know which draft the user meant, and keeping one valid
+        // would authorize an apply nobody confirmed. "At most one valid" is satisfied by
+        // zero, and zero is the only order-independent answer.
+        let mut document = staged();
+        let (first_id, control) = valid_entry_control(&document);
+        let second_id = document
+            .change_sets
+            .iter()
+            .map(|cs| cs.id.clone())
+            .find(|id| id != &first_id)
+            .expect("the fixture publishes more than one change set");
+
+        let template = document
+            .change_sets
+            .iter()
+            .find(|cs| cs.id == first_id)
+            .and_then(|cs| cs.entries.iter().find(|e| e.control == control))
+            .cloned()
+            .expect("located above");
+
+        for change_set in &mut document.change_sets {
+            if change_set.id == second_id {
+                change_set.entries.retain(|e| e.control != control);
+                change_set.entries.push(template.clone());
+            }
+        }
+
+        let admitted = expect_admitted(admit_fresh(document));
+        for id in [&first_id, &second_id] {
+            let change_set = admitted
+                .document
+                .change_sets
+                .iter()
+                .find(|cs| &cs.id == id)
+                .expect("change set survives repair");
+            let entry = change_set
+                .entries
+                .iter()
+                .find(|e| e.control == control)
+                .expect("entry survives repair");
+            match &entry.validity {
+                EntryValidity::Conflicts { with } => assert!(with.contains(&control)),
+                other => panic!("expected Conflicts naming the control, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn a_declared_last_actor_takeover_policy_does_not_change_publication_time_repair() {
+        // `draft_policy.on_conflict` governs *staging* — what happens when a new edit
+        // arrives for a contested control. #324 implements no staging API, so the gate
+        // never reaches that decision. Resolving an already-published C2 violation by
+        // `last_actor_takeover` would require inventing an arrival order the document does
+        // not carry.
+        let mut document = staged();
+        if let Some(policy) = document.draft_policy.as_mut() {
+            policy.on_conflict = unified_hifi_control::adaptive::ConflictPolicy::LastActorTakeover;
+        }
+        let (first_id, control) = valid_entry_control(&document);
+        let second_id = document
+            .change_sets
+            .iter()
+            .map(|cs| cs.id.clone())
+            .find(|id| id != &first_id)
+            .expect("more than one change set");
+        let template = document
+            .change_sets
+            .iter()
+            .find(|cs| cs.id == first_id)
+            .and_then(|cs| cs.entries.iter().find(|e| e.control == control))
+            .cloned()
+            .expect("located above");
+        for change_set in &mut document.change_sets {
+            if change_set.id == second_id {
+                change_set.entries.retain(|e| e.control != control);
+                change_set.entries.push(template.clone());
+            }
+        }
+
+        let admitted = expect_admitted(admit_fresh(document));
+        assert_eq!(
+            admitted.repairs.len(),
+            2,
+            "both claimants demote regardless of the declared conflict policy"
+        );
+    }
+
+    #[test]
+    fn one_draft_holding_one_control_on_two_apply_lanes_is_left_alone() {
+        // Regression cover for the C2 fix in `fdc1ca4`: C2 constrains drafts, not entries.
+        // A producer mirroring one write to the running engine and to persisted
+        // configuration is coherent — one desired lane describes both entries.
+        let mut document = staged();
+        let (change_set_id, control) = valid_entry_control(&document);
+        let mut mirrored = document
+            .change_sets
+            .iter()
+            .find(|cs| cs.id == change_set_id)
+            .and_then(|cs| cs.entries.iter().find(|e| e.control == control))
+            .cloned()
+            .expect("located above");
+        mirrored.lane = ApplyLane::Persistent;
+        for change_set in &mut document.change_sets {
+            if change_set.id == change_set_id {
+                change_set.entries.push(mirrored.clone());
+            }
+        }
+
+        let admitted = expect_admitted(admit_fresh(document));
+        assert!(
+            admitted.repairs.is_empty(),
+            "one draft on two apply lanes is coherent, but was repaired: {:?}",
+            admitted.repairs
+        );
+    }
+
+    #[test]
+    fn repair_changes_validity_and_nothing_else() {
+        // "Never fabricate desired intent", made checkable. Demotion may only lower
+        // validity: it may not add a lane, edit a value, or touch a control.
+        let mut document = staged();
+        let (_, control) = valid_entry_control(&document);
+        for descriptor in &mut document.controls {
+            if descriptor.id == control {
+                descriptor.values.retain(|v| v.lane != ValueLane::Desired);
+            }
+        }
+        let published = document.clone();
+        let admitted = expect_admitted(admit_fresh(document));
+        let repaired = &admitted.document;
+
+        assert_eq!(
+            repaired.controls, published.controls,
+            "controls were touched"
+        );
+        assert_eq!(repaired.lanes, published.lanes, "lane health was touched");
+        assert_eq!(
+            repaired.constraints, published.constraints,
+            "constraints were touched"
+        );
+        assert_eq!(
+            repaired.operations, published.operations,
+            "operations were touched"
+        );
+        assert_eq!(
+            repaired.revisions, published.revisions,
+            "revisions were touched"
+        );
+
+        for (after, before) in repaired
+            .change_sets
+            .iter()
+            .zip(published.change_sets.iter())
+        {
+            assert_eq!(after.id, before.id);
+            assert_eq!(
+                after.generation, before.generation,
+                "generation was touched"
+            );
+            assert_eq!(
+                after.updated_at, before.updated_at,
+                "updated_at was touched"
+            );
+            assert_eq!(after.state, before.state, "change-set state was touched");
+            for (a, b) in after.entries.iter().zip(before.entries.iter()) {
+                assert_eq!(a.control, b.control);
+                assert_eq!(a.lane, b.lane);
+                assert_eq!(a.desired, b.desired, "a staged value was rewritten");
+                assert_eq!(a.base_observed, b.base_observed);
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Aggregator ownership: keying, atomicity, lifecycle
+// =============================================================================
+
+mod aggregator_state {
+    use super::*;
+
+    fn aggregator() -> ProducerAggregator {
+        ProducerAggregator::detached()
+    }
+
+    #[tokio::test]
+    async fn a_published_document_becomes_a_snapshot_keyed_by_producer_and_role() {
+        let aggregator = aggregator();
+        let document = pipeline();
+        let key = ProducerKey::of(&document);
+        aggregator.ingest(document).await;
+
+        let snapshot = aggregator.snapshot(&key).await.expect("snapshot present");
+        assert_eq!(snapshot.key.producer_id, "hqplayer:living-room");
+        assert_eq!(snapshot.key.role, TargetRole::DspEngine);
+        assert_eq!(
+            snapshot.key.zone_id.as_deref(),
+            Some("roon:1601bb42ed14351b99c2926214f6cbb80724")
+        );
+    }
+
+    #[tokio::test]
+    async fn producers_with_the_same_id_but_different_roles_are_separate_entries() {
+        let aggregator = aggregator();
+        let mut instance = pipeline();
+        instance.target.role = TargetRole::Instance;
+        instance.target.zone_id = None;
+
+        aggregator.ingest(pipeline()).await;
+        aggregator.ingest(instance).await;
+        assert_eq!(aggregator.producer_count().await, 2);
+    }
+
+    #[tokio::test]
+    async fn multiple_producers_are_held_independently() {
+        let aggregator = aggregator();
+        for (id, zone) in [
+            ("hqplayer:living-room", "roon:aaa"),
+            ("hqplayer:study", "roon:bbb"),
+            ("hqplayer:kitchen", "lms:ccc"),
+        ] {
+            let mut document = pipeline();
+            document.producer.producer_id = id.to_string();
+            document.target.zone_id = Some(zone.to_string());
+            aggregator.ingest(document).await;
+        }
+        assert_eq!(aggregator.producer_count().await, 3);
+        assert_eq!(aggregator.snapshots().await.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn a_snapshot_is_one_whole_published_document_never_a_mixture() {
+        // The atomicity guarantee. A mode read at revision 4193 and an enumeration read at
+        // 4195 can describe a combination that never existed.
+        let aggregator = aggregator();
+        let key = ProducerKey::of(&pipeline());
+
+        for state in [4193_u64, 4194, 4195, 4196] {
+            let mut document = pipeline();
+            document.revisions = DocumentRevisions::new(12, state);
+            document.producer.instance_label = Some(format!("label-{state}"));
+            aggregator.ingest(document).await;
+
+            let snapshot = aggregator.snapshot(&key).await.expect("snapshot present");
+            assert_eq!(snapshot.document.revisions.state.0, state);
+            assert_eq!(
+                snapshot.document.producer.instance_label.as_deref(),
+                Some(format!("label-{state}").as_str()),
+                "snapshot mixes fields from different revisions"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn a_refused_document_leaves_the_previous_snapshot_intact() {
+        // Why refusal is a safe policy for envelope violations: it fails to advance a
+        // producer rather than blanking one.
+        let aggregator = aggregator();
+        let key = ProducerKey::of(&pipeline());
+        aggregator.ingest(pipeline()).await;
+
+        let mut stale = pipeline();
+        stale.revisions = DocumentRevisions::new(12, 4100);
+        stale.producer.instance_label = Some("should-not-appear".to_string());
+        aggregator.ingest(stale).await;
+
+        let snapshot = aggregator.snapshot(&key).await.expect("snapshot retained");
+        assert_eq!(snapshot.document.revisions.state.0, 4193);
+        assert_eq!(
+            snapshot.document.producer.instance_label.as_deref(),
+            Some("HQP-Main")
+        );
+    }
+
+    #[tokio::test]
+    async fn removal_deletes_every_target_of_that_producer() {
+        let aggregator = aggregator();
+        let mut instance = pipeline();
+        instance.target.role = TargetRole::Instance;
+        instance.target.zone_id = None;
+        aggregator.ingest(pipeline()).await;
+        aggregator.ingest(instance).await;
+        assert_eq!(aggregator.producer_count().await, 2);
+
+        let removed = aggregator.remove("hqplayer:living-room").await;
+        assert_eq!(removed, 2);
+        assert_eq!(aggregator.producer_count().await, 0);
+    }
+
+    #[tokio::test]
+    async fn removing_an_unknown_producer_removes_nothing_and_does_not_error() {
+        let aggregator = aggregator();
+        aggregator.ingest(pipeline()).await;
+        assert_eq!(aggregator.remove("hqplayer:nowhere").await, 0);
+        assert_eq!(aggregator.producer_count().await, 1);
+    }
+}
+
+// =============================================================================
+// Restart, reconnect, and last-known state
+// =============================================================================
+
+mod restart_and_reconnect {
+    use super::*;
+
+    #[tokio::test]
+    async fn a_restart_replaces_state_rather_than_merging_across_the_epoch() {
+        let aggregator = ProducerAggregator::detached();
+        let key = ProducerKey::of(&pipeline());
+        aggregator.ingest(pipeline()).await;
+
+        let mut restarted = pipeline();
+        restarted.producer.epoch = ProducerEpoch(8);
+        restarted.revisions = DocumentRevisions::new(1, 1);
+        restarted.controls.truncate(2);
+        aggregator.ingest(restarted).await;
+
+        let snapshot = aggregator.snapshot(&key).await.expect("snapshot present");
+        assert_eq!(snapshot.document.producer.epoch, ProducerEpoch(8));
+        assert_eq!(
+            snapshot.document.controls.len(),
+            2,
+            "controls from the previous epoch survived a restart"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_disconnected_producer_is_last_known_rather_than_removed() {
+        let aggregator = ProducerAggregator::detached();
+        let mut document = degraded();
+        document.stale = true;
+        let key = ProducerKey::of(&document);
+        aggregator.ingest(document).await;
+
+        let snapshot = aggregator.snapshot(&key).await.expect("still present");
+        assert_eq!(snapshot.presence, ProducerPresence::LastKnown);
+        assert!(
+            !snapshot.document.controls.is_empty(),
+            "last-known controls must still be visible, marked stale"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_lane_that_fails_keeps_its_last_good_timestamp_in_the_witness() {
+        // "Retain last-good per-lane snapshots with explicit stale/error timestamps
+        // instead of blanking the whole producer when one poll fails."
+        let aggregator = ProducerAggregator::detached();
+        let key = ProducerKey::of(&pipeline());
+        aggregator.ingest(pipeline()).await;
+
+        let mut broken = pipeline();
+        broken.revisions = DocumentRevisions::new(12, 4194);
+        for lane in &mut broken.lanes {
+            if lane.lane == TransportLane::Persistent {
+                lane.state = unified_hifi_control::adaptive::LaneState::Disconnected;
+                lane.last_success = None;
+                lane.last_error = Some(Reason::observed(ReasonCode::RequiresConnection));
+            }
+        }
+        aggregator.ingest(broken).await;
+
+        let snapshot = aggregator.snapshot(&key).await.expect("snapshot present");
+        let witness = snapshot
+            .lanes
+            .get(&TransportLane::Persistent)
+            .expect("persistent lane witnessed");
+        assert_eq!(
+            witness.last_success.as_ref().map(Timestamp::as_str),
+            Some("2026-07-30T10:58:02Z"),
+            "the aggregator dropped the last-good timestamp when the lane failed"
+        );
+        assert!(
+            witness.last_error.is_some(),
+            "the error must be visible too"
+        );
+        assert_eq!(
+            witness.state,
+            unified_hifi_control::adaptive::LaneState::Disconnected
+        );
+    }
+
+    #[tokio::test]
+    async fn one_failing_lane_does_not_blank_the_other_lanes() {
+        let aggregator = ProducerAggregator::detached();
+        let key = ProducerKey::of(&pipeline());
+        aggregator.ingest(pipeline()).await;
+
+        let mut broken = pipeline();
+        broken.revisions = DocumentRevisions::new(12, 4194);
+        for lane in &mut broken.lanes {
+            if lane.lane == TransportLane::Persistent {
+                lane.state = unified_hifi_control::adaptive::LaneState::Disconnected;
+            }
+        }
+        aggregator.ingest(broken).await;
+
+        let snapshot = aggregator.snapshot(&key).await.expect("snapshot present");
+        let native = snapshot
+            .lanes
+            .get(&TransportLane::Native)
+            .expect("native lane witnessed");
+        assert_eq!(
+            native.state,
+            unified_hifi_control::adaptive::LaneState::Connected
+        );
+    }
+
+    #[tokio::test]
+    async fn a_lane_witness_records_the_epoch_it_was_observed_in() {
+        // Carrying a last-good timestamp across a restart is honest only if a consumer can
+        // tell that it predates the restart.
+        let aggregator = ProducerAggregator::detached();
+        let key = ProducerKey::of(&pipeline());
+        aggregator.ingest(pipeline()).await;
+
+        let mut restarted = pipeline();
+        restarted.producer.epoch = ProducerEpoch(8);
+        restarted.revisions = DocumentRevisions::new(1, 1);
+        for lane in &mut restarted.lanes {
+            if lane.lane == TransportLane::Persistent {
+                lane.state = unified_hifi_control::adaptive::LaneState::Disconnected;
+                lane.last_success = None;
+            }
+        }
+        aggregator.ingest(restarted).await;
+
+        let snapshot = aggregator.snapshot(&key).await.expect("snapshot present");
+        let witness = snapshot
+            .lanes
+            .get(&TransportLane::Persistent)
+            .expect("persistent lane witnessed");
+        assert_eq!(witness.observed_in_epoch, ProducerEpoch(7));
+    }
+}
+
+// =============================================================================
+// Isolation of staged intent from live commands
+// =============================================================================
+
+mod live_command_isolation {
+    use super::*;
+    use unified_hifi_control::bus::{BusEvent, Command, PrefixedZoneId};
+
+    #[tokio::test]
+    async fn live_command_traffic_cannot_touch_staged_intent() {
+        // "Immediate/live commands cannot read, clear, or flush persistent staged intent."
+        // Structural: the aggregator mutates producer state only on adaptive ingress, so
+        // every other event on the public bus is inert by construction.
+        let bus = unified_hifi_control::bus::create_bus();
+        let adaptive = unified_hifi_control::producers::create_adaptive_bus();
+        let aggregator = ProducerAggregator::new(bus.clone(), adaptive.clone());
+
+        let document = staged();
+        let key = ProducerKey::of(&document);
+        aggregator.ingest(document).await;
+        let before = aggregator.snapshot(&key).await.expect("snapshot present");
+
+        for event in [
+            BusEvent::CommandReceived {
+                zone_id: "roon:1601bb42ed14351b99c2926214f6cbb80724".to_string(),
+                command: Command::Pause,
+                request_id: Some("req-1".to_string()),
+            },
+            BusEvent::VolumeChanged {
+                output_id: "roon:out-1".to_string(),
+                value: 40.0,
+                is_muted: false,
+            },
+            BusEvent::HqpPipelineChanged {
+                host: "living-room".to_string(),
+                filter: Some("poly-sinc-gauss-long".to_string()),
+                shaper: Some("ASDM7EC".to_string()),
+                rate: Some("dsd256".to_string()),
+            },
+            BusEvent::ControlCommand {
+                zone_id: "roon:1601bb42ed14351b99c2926214f6cbb80724".to_string(),
+                action: "pause".to_string(),
+                value: None,
+            },
+            BusEvent::SeekPositionChanged {
+                zone_id: PrefixedZoneId::roon("1601bb42ed14351b99c2926214f6cbb80724"),
+                position: 42,
+            },
+        ] {
+            aggregator.apply_bus_event(event).await;
+        }
+
+        let after = aggregator.snapshot(&key).await.expect("snapshot present");
+        assert_eq!(
+            after.document.change_sets, before.document.change_sets,
+            "live command traffic mutated staged intent"
+        );
+        assert_eq!(after.document, before.document);
+    }
+
+    #[tokio::test]
+    async fn an_adapter_stopping_flushes_only_its_own_producers() {
+        let bus = unified_hifi_control::bus::create_bus();
+        let adaptive = unified_hifi_control::producers::create_adaptive_bus();
+        let aggregator = ProducerAggregator::new(bus, adaptive);
+
+        aggregator.ingest(pipeline()).await;
+        let mut other = pipeline();
+        other.producer.producer_id = "roon:core".to_string();
+        other.producer.producer_type = "roon".to_string();
+        aggregator.ingest(other).await;
+        assert_eq!(aggregator.producer_count().await, 2);
+
+        aggregator
+            .apply_bus_event(BusEvent::AdapterStopping {
+                adapter: "hqplayer".to_string(),
+                reason: Some("test".to_string()),
+            })
+            .await;
+
+        assert_eq!(aggregator.producer_count().await, 1);
+        let survivor = aggregator.snapshots().await;
+        assert_eq!(survivor[0].key.producer_id, "roon:core");
+    }
+}
+
+// =============================================================================
+// Forward compatibility through the publication path
+// =============================================================================
+
+mod forward_compatibility {
+    use super::*;
+
+    #[tokio::test]
+    async fn unknown_additive_fields_survive_publication() {
+        let aggregator = ProducerAggregator::detached();
+        let document = fixture("forward_compatible_additions");
+        let published_paths = document.extension_key_paths();
+        assert!(
+            !published_paths.is_empty(),
+            "the forward-compatibility fixture must actually carry unknown fields"
+        );
+        let key = ProducerKey::of(&document);
+        aggregator.ingest(document).await;
+
+        let snapshot = aggregator.snapshot(&key).await.expect("snapshot present");
+        assert_eq!(
+            snapshot.document.extension_key_paths(),
+            published_paths,
+            "the publication path amputated a newer document"
+        );
+    }
+}
+
+// =============================================================================
+// A poll loop, and what a consumer sees during one
+// =============================================================================
+
+mod poll_loop {
+    use super::*;
+
+    #[tokio::test]
+    async fn a_sequence_of_polls_always_serves_exactly_one_published_document() {
+        let aggregator = ProducerAggregator::detached();
+        let key = ProducerKey::of(&pipeline());
+        let mut published: Vec<ProducerDocument> = Vec::new();
+
+        for step in 0..12_u64 {
+            let mut document = pipeline();
+            document.revisions = DocumentRevisions::new(12, 4193 + step);
+            document.producer.instance_label = Some(format!("poll-{step}"));
+            published.push(document.clone());
+            aggregator.ingest(document).await;
+
+            let snapshot = aggregator.snapshot(&key).await.expect("snapshot present");
+            assert!(
+                published.contains(snapshot.document.as_ref()),
+                "the served snapshot is not any document that was published"
+            );
+        }
+
+        let snapshot = aggregator.snapshot(&key).await.expect("snapshot present");
+        assert_eq!(
+            snapshot.document.as_ref(),
+            published.last().expect("published twelve"),
+            "the last published document is not the one being served"
+        );
+    }
+
+    #[tokio::test]
+    async fn out_of_order_arrivals_never_resurrect_a_removed_control() {
+        let aggregator = ProducerAggregator::detached();
+        let key = ProducerKey::of(&pipeline());
+
+        let mut advanced = pipeline();
+        advanced.revisions = DocumentRevisions::new(13, 4200);
+        let removed: ControlId = advanced
+            .controls
+            .last()
+            .map(|c| c.id.clone())
+            .expect("controls present");
+        advanced.controls.retain(|c| c.id != removed);
+        aggregator.ingest(advanced).await;
+
+        // A delayed delivery from before the control-plane advance.
+        aggregator.ingest(pipeline()).await;
+
+        let snapshot = aggregator.snapshot(&key).await.expect("snapshot present");
+        assert!(
+            snapshot.document.control(&removed).is_none(),
+            "a late delivery resurrected control {removed}"
+        );
+        assert_eq!(snapshot.document.revisions.control_plane.0, 13);
+    }
+}
+
+// =============================================================================
+// Refusals are observable
+// =============================================================================
+
+mod refusal_observability {
+    use super::*;
+
+    #[tokio::test]
+    async fn a_refusal_is_retained_and_queryable_rather_than_only_logged() {
+        // Option E would have returned this synchronously to the publishing adapter. With a
+        // bus it has to be recorded, or a producer author has no way to learn that its
+        // documents are being dropped.
+        let aggregator = ProducerAggregator::detached();
+        let key = ProducerKey::of(&pipeline());
+        aggregator.ingest(pipeline()).await;
+
+        let mut stale = pipeline();
+        stale.revisions = DocumentRevisions::new(12, 4000);
+        aggregator.ingest(stale).await;
+
+        let snapshot = aggregator.snapshot(&key).await.expect("snapshot present");
+        assert!(
+            matches!(
+                snapshot.last_refusal,
+                Some(AdmissionRefusal::RevisionRegressed { .. })
+            ),
+            "the refusal was not retained: {:?}",
+            snapshot.last_refusal
+        );
+        assert_eq!(aggregator.refusals().await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn a_first_document_that_is_refused_is_still_recorded() {
+        // There is no entry to hang the refusal on, and that is exactly the case where a
+        // silent drop would be least diagnosable.
+        let aggregator = ProducerAggregator::detached();
+        let mut document = pipeline();
+        document.target.zone_id = Some("no-prefix".to_string());
+        aggregator.ingest(document).await;
+
+        assert_eq!(aggregator.producer_count().await, 0);
+        let refusals = aggregator.refusals().await;
+        assert_eq!(refusals.len(), 1);
+        assert!(matches!(
+            refusals[0].1,
+            AdmissionRefusal::ZoneIdNotPrefixed { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn a_later_success_does_not_erase_the_record_of_a_refusal() {
+        let aggregator = ProducerAggregator::detached();
+        let key = ProducerKey::of(&pipeline());
+        aggregator.ingest(pipeline()).await;
+
+        let mut stale = pipeline();
+        stale.revisions = DocumentRevisions::new(12, 4000);
+        aggregator.ingest(stale).await;
+
+        let mut good = pipeline();
+        good.revisions = DocumentRevisions::new(12, 4194);
+        aggregator.ingest(good).await;
+
+        let snapshot = aggregator.snapshot(&key).await.expect("snapshot present");
+        assert_eq!(snapshot.document.revisions.state.0, 4194);
+        assert!(
+            snapshot.last_refusal.is_some(),
+            "the refusal record was erased by a later success"
+        );
+    }
+}
+
+// =============================================================================
+// The internal bus actually drives the aggregator
+// =============================================================================
+
+mod internal_bus {
+    use super::*;
+    use unified_hifi_control::producers::AdaptiveEvent;
+
+    #[tokio::test]
+    async fn a_document_published_on_the_internal_bus_reaches_the_aggregator() {
+        let bus = unified_hifi_control::bus::create_bus();
+        let adaptive = unified_hifi_control::producers::create_adaptive_bus();
+        let aggregator =
+            std::sync::Arc::new(ProducerAggregator::new(bus.clone(), adaptive.clone()));
+
+        let runner = aggregator.clone();
+        let handle = tokio::spawn(async move { runner.run().await });
+
+        // Give the subscriber a chance to attach before publishing.
+        tokio::task::yield_now().await;
+        let document = pipeline();
+        let key = ProducerKey::of(&document);
+        adaptive.publish(AdaptiveEvent::ProducerPublished {
+            document: Box::new(document),
+        });
+
+        let mut snapshot = None;
+        for _ in 0..200 {
+            if let Some(found) = aggregator.snapshot(&key).await {
+                snapshot = Some(found);
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        assert!(snapshot.is_some(), "the aggregator never saw the document");
+
+        bus.publish(unified_hifi_control::bus::BusEvent::ShuttingDown { reason: None });
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(5), handle).await;
+    }
+
+    #[tokio::test]
+    async fn a_lagging_aggregator_keeps_running_rather_than_exiting() {
+        // `while let Ok(event) = rx.recv().await` treats RecvError::Lagged as termination,
+        // which would permanently stop producer state after one burst. Documents are full
+        // snapshots, so a dropped update is recoverable — but only if the loop survives.
+        let bus = unified_hifi_control::bus::create_bus();
+        let adaptive = std::sync::Arc::new(unified_hifi_control::producers::AdaptiveBus::new(2));
+        let aggregator =
+            std::sync::Arc::new(ProducerAggregator::new(bus.clone(), adaptive.clone()));
+
+        let runner = aggregator.clone();
+        let handle = tokio::spawn(async move { runner.run().await });
+        tokio::task::yield_now().await;
+
+        for step in 0..64_u64 {
+            let mut document = pipeline();
+            document.revisions = DocumentRevisions::new(12, 4193 + step);
+            adaptive.publish(AdaptiveEvent::ProducerPublished {
+                document: Box::new(document),
+            });
+        }
+
+        let mut final_document = pipeline();
+        final_document.revisions = DocumentRevisions::new(12, 9999);
+        let key = ProducerKey::of(&final_document);
+
+        let mut arrived = false;
+        for _ in 0..200 {
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            adaptive.publish(AdaptiveEvent::ProducerPublished {
+                document: Box::new(final_document.clone()),
+            });
+            if let Some(snapshot) = aggregator.snapshot(&key).await {
+                if snapshot.document.revisions.state.0 == 9999 {
+                    arrived = true;
+                    break;
+                }
+            }
+        }
+        assert!(
+            arrived,
+            "the aggregator stopped consuming after a lag burst; a full-snapshot design \
+             recovers only if the loop survives"
+        );
+
+        bus.publish(unified_hifi_control::bus::BusEvent::ShuttingDown { reason: None });
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(5), handle).await;
+    }
+}
+
+// =============================================================================
+// Determinism of the store
+// =============================================================================
+
+#[tokio::test]
+async fn snapshots_are_returned_in_a_deterministic_order() {
+    let aggregator = ProducerAggregator::detached();
+    for id in ["hqplayer:z", "hqplayer:a", "hqplayer:m"] {
+        let mut document = pipeline();
+        document.producer.producer_id = id.to_string();
+        aggregator.ingest(document).await;
+    }
+    let ids: Vec<String> = aggregator
+        .snapshots()
+        .await
+        .into_iter()
+        .map(|s| s.key.producer_id)
+        .collect();
+    let mut sorted = ids.clone();
+    sorted.sort();
+    assert_eq!(ids, sorted, "snapshot order must not depend on hashing");
+}
+
+#[test]
+fn lane_witnesses_are_keyed_by_lane_without_duplicates() {
+    // A guard on the witness map's shape, independent of any aggregator instance.
+    let document = pipeline();
+    let mut seen: BTreeMap<TransportLane, usize> = BTreeMap::new();
+    for lane in &document.lanes {
+        *seen.entry(lane.lane.clone()).or_default() += 1;
+    }
+    assert!(
+        seen.values().all(|count| *count == 1),
+        "a fixture publishes a lane twice, which the witness map cannot represent"
+    );
+}
+
+#[test]
+fn provenance_helper_is_available_for_constructing_test_lanes() {
+    // Keeps the test module honest about using the contract's own constructors rather than
+    // hand-rolling lane values that could not occur in practice.
+    let value = LaneValue::grounded(
+        ValueLane::Desired,
+        ControlValue::choice("sdm"),
+        Provenance::runtime(),
+    );
+    assert!(value.is_consistent());
+    assert_eq!(value.grounded_value(), Some(&ControlValue::choice("sdm")));
+    let _ = OperationId::new("op-1");
+}

--- a/tests/adaptive_publication.rs
+++ b/tests/adaptive_publication.rs
@@ -92,18 +92,32 @@ fn expect_refused(admission: Admission) -> AdmissionRefusal {
 mod envelope {
     use super::*;
 
+    /// Fixtures the publication gate must admit.
+    ///
+    /// A superset of `adaptive_contract.rs`'s `fixtures::CANONICAL`: it adds
+    /// `forward_compatible_additions`, which is a compatibility probe rather than a canonical
+    /// worked example but must still pass the gate, because §8 forbids refusing a document
+    /// from a newer minor wholesale.
+    const ADMISSIBLE: &[&str] = &[
+        "hqplayer_pipeline_v1",
+        "hqplayer_degraded_lanes",
+        "staged_intent_multi_surface",
+        "command_outcomes",
+        "control_removed_after_advance",
+        "forward_compatible_additions",
+    ];
+
+    /// Fixtures that exist precisely to be refused, so they must not be asserted admissible.
+    ///
+    /// Refusal is asserted where the reason lives - `unsupported_major` is refused before
+    /// parsing, in `adaptive_contract.rs`.
+    const INADMISSIBLE: &[&str] = &["unsupported_major"];
+
     #[test]
     fn every_canonical_fixture_is_admissible_by_the_publication_gate() {
         // If the gate refuses a document #323 calls canonical, one of the two is wrong and
         // #325 would be the one to find out.
-        for name in [
-            "hqplayer_pipeline_v1",
-            "hqplayer_degraded_lanes",
-            "staged_intent_multi_surface",
-            "command_outcomes",
-            "control_removed_after_advance",
-            "forward_compatible_additions",
-        ] {
+        for name in ADMISSIBLE {
             let document = fixture(name);
             let admission = admit_fresh(document);
             assert!(
@@ -111,6 +125,39 @@ mod envelope {
                 "canonical fixture {name} was refused by the publication gate: {admission:?}"
             );
         }
+    }
+
+    #[test]
+    fn every_fixture_on_disk_is_classified_admissible_or_inadmissible() {
+        // The list above is a literal, and a literal drifts: `control_removed_after_advance`
+        // was added to `fixtures::CANONICAL` while this list still omitted it, so the one
+        // document demonstrating the post-repair `control_removed` state was never put
+        // through the gate. Found by CodeRabbit on #363. Enumerating the directory turns
+        // the next omission into a failure here instead of silent non-coverage - adding a
+        // fixture now forces a decision about which side of the gate it belongs on.
+        let mut unclassified = Vec::new();
+        for entry in std::fs::read_dir("tests/fixtures/adaptive")
+            .expect("the adaptive fixture directory must exist")
+        {
+            let path = entry.expect("readable directory entry").path();
+            if path.extension().is_none_or(|ext| ext != "json") {
+                continue;
+            }
+            let name = path
+                .file_stem()
+                .and_then(|stem| stem.to_str())
+                .expect("fixture file name must be UTF-8")
+                .to_string();
+            if !ADMISSIBLE.contains(&name.as_str()) && !INADMISSIBLE.contains(&name.as_str()) {
+                unclassified.push(name);
+            }
+        }
+        unclassified.sort();
+        assert!(
+            unclassified.is_empty(),
+            "fixtures on disk that the publication gate neither admits nor refuses: \
+             {unclassified:?}. Add each to ADMISSIBLE or INADMISSIBLE."
+        );
     }
 
     #[test]
@@ -270,6 +317,155 @@ mod envelope {
 // =============================================================================
 // Invariant: LaneValue consistency (decision 3)
 // =============================================================================
+
+// =============================================================================
+// Document invariants the contract publishes and nothing applied
+//
+// Each of these is a rule #323 states and provides a predicate for, on a path that never
+// called it - the same defect class as `LaneValue::is_consistent`, which decision 3 of
+// `.oh/adaptive-publication.md` calls out by name: *the contract published a rule and no code
+// path applied it*. Envelope class, so the whole document is refused; the previous snapshot
+// stands, and a refused document fails to advance a producer rather than blanking one.
+// =============================================================================
+
+mod document_invariants {
+    use super::*;
+    use unified_hifi_control::adaptive::{Availability, AvailabilityState};
+
+    #[test]
+    fn a_control_publishing_the_same_value_lane_twice_is_refused() {
+        // One lane is one reading. Two `desired` lanes make "the staged value" ambiguous,
+        // and because `effective_view` resolves a single lane, C1 coherence could be
+        // satisfied by one of them and contradicted by the other in the same document.
+        let mut document = pipeline();
+        let control = document
+            .controls
+            .iter_mut()
+            .find(|c| !c.values.is_empty())
+            .expect("a canonical fixture has a control with a lane");
+        let control_id = control.id.clone();
+        let duplicate = control.values[0].clone();
+        let duplicated_lane = duplicate.lane.clone();
+        control.values.push(duplicate);
+
+        match expect_refused(admit_fresh(document)) {
+            AdmissionRefusal::DuplicateValueLane { control, lane } => {
+                assert_eq!(control, control_id, "the refusal named the wrong control");
+                assert_eq!(lane, duplicated_lane, "the refusal named the wrong lane");
+            }
+            other => panic!("expected DuplicateValueLane, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_document_publishing_health_for_the_same_transport_lane_twice_is_refused() {
+        // `LaneWitness` is keyed by lane, so a duplicate is not redundant but
+        // unrepresentable: folding it would silently keep whichever entry came last in a
+        // `Vec`. `lane_witnesses_are_keyed_by_lane_without_duplicates` asserts the fixtures
+        // respect this; this asserts the gate enforces it.
+        let mut document = pipeline();
+        let duplicate = document.lanes[0].clone();
+        let duplicated_lane = duplicate.lane.clone();
+        document.lanes.push(duplicate);
+
+        match expect_refused(admit_fresh(document)) {
+            AdmissionRefusal::DuplicateLaneHealth { lane } => {
+                assert_eq!(lane, duplicated_lane, "the refusal named the wrong lane");
+            }
+            other => panic!("expected DuplicateLaneHealth, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_unavailable_control_that_does_not_say_why_is_refused() {
+        // A consumer that can see "disabled" but not why cannot explain itself, and the user
+        // cannot escape the state that caused it. The contract requires at least one reason
+        // for every non-available state and publishes `is_well_formed` to check it.
+        let mut document = pipeline();
+        let control_id = document.controls[0].id.clone();
+        document.controls[0].availability = Availability {
+            state: AvailabilityState::Unavailable,
+            reasons: Vec::new(),
+        };
+
+        match expect_refused(admit_fresh(document)) {
+            AdmissionRefusal::AvailabilityNotWellFormed { control, state } => {
+                assert_eq!(control, control_id);
+                assert_eq!(state, AvailabilityState::Unavailable);
+            }
+            other => panic!("expected AvailabilityNotWellFormed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_read_only_control_that_does_not_say_why_is_refused_too() {
+        // Every recognized non-available state, not just `unavailable`.
+        let mut document = pipeline();
+        document.controls[0].availability = Availability {
+            state: AvailabilityState::ReadOnly,
+            reasons: Vec::new(),
+        };
+        match expect_refused(admit_fresh(document)) {
+            AdmissionRefusal::AvailabilityNotWellFormed { state, .. } => {
+                assert_eq!(state, AvailabilityState::ReadOnly);
+            }
+            other => panic!("expected AvailabilityNotWellFormed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_unrecognized_availability_state_with_a_reason_is_admitted() {
+        // Forward compatibility means an unknown member stays *representable*: a v1.0 build
+        // meeting a v1.4 availability state must keep the control, keep its observed value,
+        // and pass the state through untouched. That is about the vocabulary, and this
+        // document satisfies the structural rule regardless of whether we recognize the word.
+        let mut document = pipeline();
+        document.controls[0].availability = Availability {
+            state: AvailabilityState::from("quantum_superposition"),
+            reasons: vec![Reason::observed(ReasonCode::from("quantum_decoherence"))],
+        };
+        let admitted = expect_admitted(admit_fresh(document));
+        assert_eq!(
+            admitted.document.controls[0].availability.state,
+            AvailabilityState::from("quantum_superposition"),
+            "an unrecognized state must be passed through, not normalized away"
+        );
+    }
+
+    #[test]
+    fn an_unrecognized_availability_state_without_a_reason_is_refused() {
+        // The structural invariant does not lapse just because the state's name is unknown.
+        // `is_well_formed` is true for `available` and requires at least one reason for
+        // *every* other state, including `Unrecognized` - and the reason it exists is that a
+        // consumer which can see "not usable" but not why cannot explain itself to a user.
+        // An unknown state is exactly the case where that explanation matters most: the
+        // consumer cannot even fall back on knowing what the state means. Exempting unknown
+        // members would make the invariant weakest precisely where it is needed.
+        let mut document = pipeline();
+        let control_id = document.controls[0].id.clone();
+        document.controls[0].availability = Availability {
+            state: AvailabilityState::from("quantum_superposition"),
+            reasons: Vec::new(),
+        };
+
+        match expect_refused(admit_fresh(document)) {
+            AdmissionRefusal::AvailabilityNotWellFormed { control, state } => {
+                assert_eq!(control, control_id);
+                assert_eq!(state, AvailabilityState::from("quantum_superposition"));
+            }
+            other => panic!("expected AvailabilityNotWellFormed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_well_formed_unavailable_control_is_still_admitted() {
+        // The guard must not refuse the legitimate shape it is policing.
+        let mut document = pipeline();
+        document.controls[0].availability =
+            Availability::unavailable(Reason::observed(ReasonCode::NotApplicableInMode));
+        expect_admitted(admit_fresh(document));
+    }
+}
 
 mod lane_value_invariant {
     use super::*;
@@ -606,6 +802,99 @@ mod intent_coherence {
             repair.to,
             EntryValidity::RequiresProducerValidation { .. }
         ));
+    }
+
+    #[test]
+    fn the_c1_demotion_reason_code_is_draft_invalid_and_validity_state_does_not_dictate_it() {
+        // Pins a decision, because the pairing reads like a mistake and was queried on #363:
+        // the C1 demotion sets `EntryValidity::RequiresProducerValidation` while its reason
+        // carries `ReasonCode::DraftInvalid`. Those are two independent axes - the state says
+        // what a consumer may *do* (here: ask the producer, never apply), the code says
+        // *why* - and the contract's own canonical worked example proves it, so this is not
+        // a convention the gate is violating. Asserted from the fixture rather than
+        // described in a comment, so the justification cannot go stale while the test passes.
+        let staged_fixture: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string("tests/fixtures/adaptive/staged_intent_multi_surface.json")
+                .expect("the canonical staged-intent fixture must exist"),
+        )
+        .expect("the canonical fixture must be valid JSON");
+        let crossed = crossed_validity_pairings(&staged_fixture);
+        assert!(
+            !crossed.is_empty(),
+            "the canonical staged-intent fixture no longer pairs an entry validity state \
+             with a differently-named reason code, so the independence this demotion relies \
+             on is no longer demonstrated by the contract"
+        );
+
+        let mut document = staged();
+        let (change_set, control) = valid_entry_control(&document);
+        for descriptor in &mut document.controls {
+            if descriptor.id == control {
+                descriptor.values.retain(|v| v.lane != ValueLane::Desired);
+            }
+        }
+        let admitted = expect_admitted(admit_fresh(document));
+        let repair = admitted
+            .repairs
+            .iter()
+            .find(|r| r.control == control && r.change_set == change_set)
+            .expect("the offending entry must be reported");
+
+        match &repair.to {
+            EntryValidity::RequiresProducerValidation { reason } => {
+                assert_eq!(
+                    reason.code,
+                    ReasonCode::DraftInvalid,
+                    "a C1 demotion reports that the published draft is invalid; the crossed \
+                     pairings the canonical fixture publishes are {crossed:?}"
+                );
+                assert_eq!(
+                    reason.scope,
+                    unified_hifi_control::adaptive::ReasonScope::Draft,
+                    "a C1 violation is a property of the draft, not of the running engine"
+                );
+            }
+            other => panic!("expected RequiresProducerValidation, got {other:?}"),
+        }
+    }
+
+    /// Every `(validity state, reason code)` pair in `value` whose two names differ.
+    ///
+    /// Evidence that the contract treats the two as independent vocabularies rather than one
+    /// state spelled twice.
+    fn crossed_validity_pairings(value: &serde_json::Value) -> Vec<(String, String)> {
+        let mut found = Vec::new();
+        collect_crossed_pairings(value, &mut found);
+        found
+    }
+
+    fn collect_crossed_pairings(value: &serde_json::Value, out: &mut Vec<(String, String)>) {
+        match value {
+            serde_json::Value::Object(map) => {
+                if let Some(validity) = map.get("validity").and_then(serde_json::Value::as_object) {
+                    let state = validity.get("state").and_then(serde_json::Value::as_str);
+                    let code = validity
+                        .get("reason")
+                        .and_then(serde_json::Value::as_object)
+                        .and_then(|reason| reason.get("code"))
+                        .and_then(serde_json::Value::as_str);
+                    if let (Some(state), Some(code)) = (state, code) {
+                        if state != code {
+                            out.push((state.to_string(), code.to_string()));
+                        }
+                    }
+                }
+                for nested in map.values() {
+                    collect_crossed_pairings(nested, out);
+                }
+            }
+            serde_json::Value::Array(items) => {
+                for nested in items {
+                    collect_crossed_pairings(nested, out);
+                }
+            }
+            _ => {}
+        }
     }
 
     #[test]
@@ -991,6 +1280,313 @@ mod aggregator_state {
 // Restart, reconnect, and last-known state
 // =============================================================================
 
+mod witness_monotonicity {
+    use super::*;
+
+    /// Republish `pipeline()` at an advanced revision with the native lane's `last_success`
+    /// set to `instant`, and return the witnessed timestamp afterwards.
+    async fn witness_after_native_success(
+        first: &str,
+        second: &str,
+        second_epoch: ProducerEpoch,
+    ) -> (Option<String>, ProducerEpoch) {
+        let aggregator = ProducerAggregator::detached();
+        let key = ProducerKey::of(&pipeline());
+
+        let mut opening = pipeline();
+        set_native_success(&mut opening, first);
+        aggregator.ingest(opening).await;
+
+        let mut later = pipeline();
+        later.producer.epoch = second_epoch;
+        later.revisions = DocumentRevisions::new(12, 4194);
+        set_native_success(&mut later, second);
+        aggregator.ingest(later).await;
+
+        let snapshot = aggregator.snapshot(&key).await.expect("snapshot present");
+        let witness = snapshot
+            .lanes
+            .get(&TransportLane::Native)
+            .expect("native lane witnessed");
+        (
+            witness
+                .last_success
+                .as_ref()
+                .map(|t| t.as_str().to_string()),
+            witness.observed_in_epoch,
+        )
+    }
+
+    fn set_native_success(document: &mut ProducerDocument, instant: &str) {
+        for lane in &mut document.lanes {
+            if lane.lane == TransportLane::Native {
+                lane.last_success = Some(Timestamp::new(instant));
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn a_newer_document_carrying_an_older_instant_does_not_regress_the_witness() {
+        // `LaneWitness::last_success` is documented as "the newest success ever seen for this
+        // lane. Monotonic: never regresses, so a failing poll cannot erase the evidence that
+        // the lane worked five seconds ago." Taking the producer's latest word unconditionally
+        // breaks that whenever a document reports an *older* instant than one already seen -
+        // which a producer with more than one polling path does routinely.
+        let (witnessed, _) = witness_after_native_success(
+            "2026-07-30T11:18:04Z",
+            "2026-07-30T11:17:00Z",
+            ProducerEpoch(7),
+        )
+        .await;
+        assert_eq!(
+            witnessed.as_deref(),
+            Some("2026-07-30T11:18:04Z"),
+            "the witness regressed to an older instant"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_equivalent_instant_written_with_an_offset_is_not_a_regression() {
+        // `2026-07-30T13:18:04+02:00` *is* `2026-07-30T11:18:04Z`. A comparison that is not
+        // instant-aware cannot see that: a `+00:00` offset does not compare with a `Z` at all
+        // under string ordering. Either spelling is a correct answer here because they denote
+        // one instant; what must not happen is regressing to something genuinely earlier.
+        let (witnessed, _) = witness_after_native_success(
+            "2026-07-30T11:18:04Z",
+            "2026-07-30T13:18:04+02:00",
+            ProducerEpoch(7),
+        )
+        .await;
+        let witnessed = witnessed.expect("a success was witnessed");
+        let parsed = chrono::DateTime::parse_from_rfc3339(&witnessed)
+            .expect("the witnessed timestamp must be RFC 3339");
+        let expected = chrono::DateTime::parse_from_rfc3339("2026-07-30T11:18:04Z").unwrap();
+        assert_eq!(
+            parsed, expected,
+            "an equivalent instant written with an offset moved the witness"
+        );
+    }
+
+    #[tokio::test]
+    async fn fractional_seconds_advance_the_witness_despite_sorting_before_z() {
+        // The trap the previous lexical guard fell into, kept as a test: `…:04.500Z` sorts
+        // *before* `…:04Z` because `.` is 0x2E and `Z` is 0x5A, yet it is 500ms later.
+        let (witnessed, _) = witness_after_native_success(
+            "2026-07-30T11:18:04Z",
+            "2026-07-30T11:18:04.500Z",
+            ProducerEpoch(7),
+        )
+        .await;
+        assert_eq!(
+            witnessed.as_deref(),
+            Some("2026-07-30T11:18:04.500Z"),
+            "a genuinely later instant was rejected because it sorts earlier as a string"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_epoch_advance_carrying_an_older_instant_keeps_the_newer_one_and_its_epoch() {
+        // `observed_in_epoch` exists so a consumer can tell that a carried-over timestamp
+        // predates a restart. It must therefore name the epoch the *retained* instant was
+        // observed in - not the epoch of whichever document happened to arrive last, which
+        // would claim the new process observed something it never did.
+        let (witnessed, epoch) = witness_after_native_success(
+            "2026-07-30T11:18:04Z",
+            "2026-07-30T11:17:00Z",
+            ProducerEpoch(8),
+        )
+        .await;
+        assert_eq!(
+            witnessed.as_deref(),
+            Some("2026-07-30T11:18:04Z"),
+            "a restart regressed the newest-ever success"
+        );
+        assert_eq!(
+            epoch,
+            ProducerEpoch(7),
+            "observed_in_epoch must name the epoch the retained instant was observed in"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_genuinely_newer_instant_after_a_restart_advances_both_fields() {
+        let (witnessed, epoch) = witness_after_native_success(
+            "2026-07-30T11:18:04Z",
+            "2026-07-30T11:19:00Z",
+            ProducerEpoch(8),
+        )
+        .await;
+        assert_eq!(witnessed.as_deref(), Some("2026-07-30T11:19:00Z"));
+        assert_eq!(
+            epoch,
+            ProducerEpoch(8),
+            "a newly observed success belongs to the epoch that observed it"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_malformed_instant_in_a_later_document_leaves_the_old_witness_standing() {
+        // The document is refused outright, so it never reaches the witness at all - and
+        // because a refusal fails to advance a producer rather than blanking one, the
+        // known-good instant and the snapshot it belongs to both stand.
+        let aggregator = ProducerAggregator::detached();
+        let key = ProducerKey::of(&pipeline());
+
+        let mut opening = pipeline();
+        set_native_success(&mut opening, "2026-07-30T11:18:04Z");
+        aggregator.ingest(opening).await;
+
+        let mut malformed = pipeline();
+        malformed.revisions = DocumentRevisions::new(12, 4194);
+        set_native_success(&mut malformed, "not-a-timestamp");
+        let admission = aggregator.ingest(malformed).await;
+        assert!(
+            matches!(admission, Admission::Refused(_)),
+            "a malformed RFC 3339 timestamp was admitted: {admission:?}"
+        );
+
+        let snapshot = aggregator.snapshot(&key).await.expect("snapshot present");
+        assert_eq!(
+            snapshot.document.revisions.state.0, 4193,
+            "the refused document advanced the producer"
+        );
+        let witness = snapshot
+            .lanes
+            .get(&TransportLane::Native)
+            .expect("native lane witnessed");
+        assert_eq!(
+            witness.last_success.as_ref().map(Timestamp::as_str),
+            Some("2026-07-30T11:18:04Z"),
+            "a refused document disturbed the witness"
+        );
+    }
+}
+
+// =============================================================================
+// Timestamps are RFC 3339, and the gate says so
+// =============================================================================
+
+mod timestamp_validity {
+    use super::*;
+
+    fn with_native_success(instant: &str) -> ProducerDocument {
+        let mut document = pipeline();
+        for lane in &mut document.lanes {
+            if lane.lane == TransportLane::Native {
+                lane.last_success = Some(Timestamp::new(instant));
+            }
+        }
+        document
+    }
+
+    #[test]
+    fn a_first_document_carrying_a_malformed_instant_is_refused() {
+        // `Timestamp`'s own documentation is "Wrap an RFC 3339 string", and every consumer
+        // that does anything with a lane's freshness has to parse it. A value that cannot be
+        // parsed is not a degraded reading, it is not a reading - and retaining it would put
+        // a string no consumer can interpret where one it can is expected. There is no
+        // predecessor here, so refusing is the only option that does not publish garbage.
+        match expect_refused(admit_fresh(with_native_success("not-a-timestamp"))) {
+            AdmissionRefusal::LaneTimestampNotRfc3339 { lane, value } => {
+                assert_eq!(lane, TransportLane::Native);
+                assert_eq!(value, "not-a-timestamp");
+            }
+            other => panic!("expected LaneTimestampNotRfc3339, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_advanced_document_carrying_a_malformed_instant_is_refused() {
+        let held = with_native_success("2026-07-30T11:18:04Z");
+        let mut advanced = with_native_success("2026-07-30T11-18-04Z");
+        advanced.revisions = DocumentRevisions::new(12, 4194);
+        match expect_refused(admit(Some(&held), advanced)) {
+            AdmissionRefusal::LaneTimestampNotRfc3339 { value, .. } => {
+                assert_eq!(value, "2026-07-30T11-18-04Z");
+            }
+            other => panic!("expected LaneTimestampNotRfc3339, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn every_malformed_spelling_is_refused() {
+        for malformed in [
+            "",
+            "not-a-timestamp",
+            "2026-07-30",
+            "2026-07-30T11:18:04",
+            "2026-13-30T11:18:04Z",
+            "2026-07-30T25:18:04Z",
+            "2026-07-30T11:18:04+25:00",
+            "1753977484",
+        ] {
+            let admission = admit_fresh(with_native_success(malformed));
+            assert!(
+                matches!(
+                    admission,
+                    Admission::Refused(AdmissionRefusal::LaneTimestampNotRfc3339 { .. })
+                ),
+                "{malformed:?} was not refused as a malformed RFC 3339 instant: {admission:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn every_valid_rfc_3339_spelling_is_admitted() {
+        // The guard must not refuse spellings the format allows. Offsets, fractional seconds,
+        // a lower-case designator and - per the NOTE in RFC 3339 §5.6, which permits replacing
+        // `T` with a space by agreement - a space separator are all accepted by `chrono`, and
+        // `chrono` is the parser both this gate and the witness use. Pinning them here means a
+        // future swap of parser cannot silently narrow what producers may publish.
+        for valid in [
+            "2026-07-30T11:18:04Z",
+            "2026-07-30T11:18:04.5Z",
+            "2026-07-30T11:18:04.123456789Z",
+            "2026-07-30T13:18:04+02:00",
+            "2026-07-30T11:18:04-00:00",
+            "2026-07-30t11:18:04z",
+            "2026-07-30 11:18:04Z",
+        ] {
+            let admission = admit_fresh(with_native_success(valid));
+            assert!(
+                matches!(admission, Admission::Admitted(_)),
+                "{valid:?} is valid RFC 3339 but was refused: {admission:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_lane_with_no_success_timestamp_is_still_admitted() {
+        // Absence is not malformation: a lane that has never succeeded says so by omitting
+        // the field, and that is the shape a failing poll publishes.
+        let mut document = pipeline();
+        for lane in &mut document.lanes {
+            lane.last_success = None;
+        }
+        expect_admitted(admit_fresh(document));
+    }
+
+    #[test]
+    fn the_refusal_names_the_offending_lane_rather_than_the_first_one() {
+        // A refusal that names the wrong lane sends a producer author to the wrong place.
+        let mut document = pipeline();
+        let mut named = None;
+        for lane in &mut document.lanes {
+            if lane.lane == TransportLane::Persistent {
+                lane.last_success = Some(Timestamp::new("nope"));
+                named = Some(lane.lane.clone());
+            }
+        }
+        let expected = named.expect("the fixture publishes a persistent lane");
+        match expect_refused(admit_fresh(document)) {
+            AdmissionRefusal::LaneTimestampNotRfc3339 { lane, .. } => {
+                assert_eq!(lane, expected, "the refusal named the wrong lane");
+            }
+            other => panic!("expected LaneTimestampNotRfc3339, got {other:?}"),
+        }
+    }
+}
+
 mod restart_and_reconnect {
     use super::*;
 
@@ -1137,9 +1733,7 @@ mod live_command_isolation {
         // "Immediate/live commands cannot read, clear, or flush persistent staged intent."
         // Structural: the aggregator mutates producer state only on adaptive ingress, so
         // every other event on the public bus is inert by construction.
-        let bus = unified_hifi_control::bus::create_bus();
-        let adaptive = unified_hifi_control::producers::create_adaptive_bus();
-        let aggregator = ProducerAggregator::new(bus.clone(), adaptive.clone());
+        let aggregator = ProducerAggregator::detached();
 
         let document = staged();
         let key = ProducerKey::of(&document);
@@ -1185,10 +1779,8 @@ mod live_command_isolation {
     }
 
     #[tokio::test]
-    async fn an_adapter_stopping_flushes_only_its_own_producers() {
-        let bus = unified_hifi_control::bus::create_bus();
-        let adaptive = unified_hifi_control::producers::create_adaptive_bus();
-        let aggregator = ProducerAggregator::new(bus, adaptive);
+    async fn an_adapter_stopping_is_informational_and_flushes_no_producer() {
+        let aggregator = ProducerAggregator::detached();
 
         aggregator.ingest(pipeline()).await;
         let mut other = pipeline();
@@ -1204,9 +1796,7 @@ mod live_command_isolation {
             })
             .await;
 
-        assert_eq!(aggregator.producer_count().await, 1);
-        let survivor = aggregator.snapshots().await;
-        assert_eq!(survivor[0].key.producer_id, "roon:core");
+        assert_eq!(aggregator.producer_count().await, 2);
     }
 }
 
@@ -1369,16 +1959,11 @@ mod refusal_observability {
     }
 
     #[tokio::test]
-    async fn stopping_an_adapter_clears_refusals_it_never_became_a_producer_for() {
-        // A first-publication refusal creates a refusal record with no producer entry, so
-        // the flush - which derives its victims from the producer map - never saw it and
-        // left it behind after the adapter stopped. The refusal must not outlive the
-        // adapter that caused it any more than it outlives a producer. Found by CodeRabbit
-        // at `9c53079`.
+    async fn an_unscoped_stop_hint_cannot_clear_a_first_publication_refusal() {
+        // AdapterStopping has no run identity. Clearing by adapter name would let a delayed
+        // stop from run N erase a refusal recorded by run N+1.
         use unified_hifi_control::bus::BusEvent;
-        let bus = unified_hifi_control::bus::create_bus();
-        let adaptive = unified_hifi_control::producers::create_adaptive_bus();
-        let aggregator = ProducerAggregator::new(bus, adaptive);
+        let aggregator = ProducerAggregator::detached();
 
         // Refused on its very first document, so no producer entry is ever created.
         let mut never_admitted = pipeline();
@@ -1394,22 +1979,14 @@ mod refusal_observability {
             })
             .await;
 
-        assert!(
-            aggregator.refusals().await.is_empty(),
-            "a refusal outlived the adapter that produced it: {:?}",
-            aggregator.refusals().await
-        );
+        assert_eq!(aggregator.refusals().await.len(), 1);
     }
 
     #[tokio::test]
-    async fn a_refusal_is_flushed_by_producer_type_even_without_an_id_prefix() {
-        // The id-prefix clause alone is not enough: a producer id need not carry the
-        // adapter prefix, and the flush must still find its refusal. This is what makes
-        // retaining the source adapter load-bearing rather than redundant with the prefix.
+    async fn producer_type_is_not_used_as_a_cleanup_authority() {
+        // Ownership is an exact PublicationOrigin, not a producer-type string.
         use unified_hifi_control::bus::BusEvent;
-        let bus = unified_hifi_control::bus::create_bus();
-        let adaptive = unified_hifi_control::producers::create_adaptive_bus();
-        let aggregator = ProducerAggregator::new(bus, adaptive);
+        let aggregator = ProducerAggregator::detached();
 
         let mut unprefixed = pipeline();
         unprefixed.producer.producer_id = "living-room".to_string();
@@ -1425,12 +2002,7 @@ mod refusal_observability {
             })
             .await;
 
-        assert!(
-            aggregator.refusals().await.is_empty(),
-            "a refusal whose producer id carries no adapter prefix survived its adapter \
-             stopping: {:?}",
-            aggregator.refusals().await
-        );
+        assert_eq!(aggregator.refusals().await.len(), 1);
     }
 
     #[tokio::test]
@@ -1438,9 +2010,7 @@ mod refusal_observability {
         // The other direction: the flush must be as narrow for refusals as it is for
         // producers.
         use unified_hifi_control::bus::BusEvent;
-        let bus = unified_hifi_control::bus::create_bus();
-        let adaptive = unified_hifi_control::producers::create_adaptive_bus();
-        let aggregator = ProducerAggregator::new(bus, adaptive);
+        let aggregator = ProducerAggregator::detached();
 
         let mut other = pipeline();
         other.producer.producer_id = "roon:core".to_string();
@@ -1487,92 +2057,757 @@ mod refusal_observability {
 }
 
 // =============================================================================
-// The internal bus actually drives the aggregator
+// The bounded actor command channel drives the aggregator
 // =============================================================================
 
-mod internal_bus {
+// =============================================================================
+// Retirement is not undone by a straggler
+//
+// The withdrawn design used two independent broadcast channels and therefore had no relative
+// lifecycle/publication order. These tests retain the hostile sequences as regression probes;
+// production ingress now uses one bounded actor command channel and synchronous run leases.
+// =============================================================================
+
+mod retirement {
     use super::*;
-    use unified_hifi_control::producers::AdaptiveEvent;
+    use unified_hifi_control::bus::BusEvent;
+    use unified_hifi_control::producers::AdapterRuns;
 
-    #[tokio::test]
-    async fn a_document_published_on_the_internal_bus_reaches_the_aggregator() {
-        let bus = unified_hifi_control::bus::create_bus();
-        let adaptive = unified_hifi_control::producers::create_adaptive_bus();
-        let aggregator =
-            std::sync::Arc::new(ProducerAggregator::new(bus.clone(), adaptive.clone()));
+    fn at_epoch(mut document: ProducerDocument, epoch: u64) -> ProducerDocument {
+        document.producer.epoch = ProducerEpoch(epoch);
+        document
+    }
 
-        let runner = aggregator.clone();
-        let handle = tokio::spawn(async move { runner.run().await });
-
-        // Give the subscriber a chance to attach before publishing.
-        tokio::task::yield_now().await;
-        let document = pipeline();
-        let key = ProducerKey::of(&document);
-        adaptive.publish(AdaptiveEvent::ProducerPublished {
-            document: Box::new(document),
-        });
-
-        let mut snapshot = None;
-        for _ in 0..200 {
-            if let Some(found) = aggregator.snapshot(&key).await {
-                snapshot = Some(found);
-                break;
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
-        }
-        assert!(snapshot.is_some(), "the aggregator never saw the document");
-
-        bus.publish(unified_hifi_control::bus::BusEvent::ShuttingDown { reason: None });
-        let _ = tokio::time::timeout(std::time::Duration::from_secs(5), handle).await;
+    /// An aggregator plus the run registry it judges publications against.
+    fn rigged() -> (ProducerAggregator, std::sync::Arc<AdapterRuns>) {
+        let aggregator = ProducerAggregator::detached();
+        let runs = aggregator.runs().clone();
+        (aggregator, runs)
     }
 
     #[tokio::test]
-    async fn a_lagging_aggregator_keeps_running_rather_than_exiting() {
-        // `while let Ok(event) = rx.recv().await` treats RecvError::Lagged as termination,
-        // which would permanently stop producer state after one burst. Documents are full
-        // snapshots, so a dropped update is recoverable — but only if the loop survives.
-        let bus = unified_hifi_control::bus::create_bus();
-        let adaptive = std::sync::Arc::new(unified_hifi_control::producers::AdaptiveBus::new(2));
-        let aggregator =
-            std::sync::Arc::new(ProducerAggregator::new(bus.clone(), adaptive.clone()));
+    async fn a_delayed_publish_from_run_n_is_rejected_after_run_n_plus_one_starts() {
+        // The interleaving that defeats every public-bus-ordered scheme: run N publishes, the
+        // document sits unread in the adaptive channel, run N ends, run N+1 begins, and only
+        // then is the document read. Nothing about the *public* bus is involved, so no amount
+        // of care about `AdapterStopping` ordering could have caught it.
+        let (aggregator, runs) = rigged();
+        let document = pipeline();
+        let key = ProducerKey::of(&document);
 
-        let runner = aggregator.clone();
-        let handle = tokio::spawn(async move { runner.run().await });
-        tokio::task::yield_now().await;
+        let first = runs.begin("hqplayer");
+        let queued = first.origin().clone();
+        runs.end(&first);
+        let _second = runs.begin("hqplayer");
 
+        let admission = aggregator.ingest_from(&queued, document).await;
+        assert!(
+            matches!(admission, Admission::Refused(_)),
+            "a document from an ended run was admitted: {admission:?}"
+        );
+        assert!(
+            aggregator.snapshot(&key).await.is_none(),
+            "an ended run's straggler created a producer"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_delayed_publish_from_run_n_is_rejected_even_before_a_successor_starts() {
+        // The run simply ending is enough; a successor is not required.
+        let (aggregator, runs) = rigged();
+        let run = runs.begin("hqplayer");
+        let origin = run.origin().clone();
+        runs.end(&run);
+
+        let admission = aggregator.ingest_from(&origin, pipeline()).await;
+        assert!(
+            matches!(admission, Admission::Refused(_)),
+            "a document from an ended run was admitted: {admission:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_delayed_stop_from_run_n_cannot_flush_run_n_plus_one() {
+        // `AdapterStopping` carries no run, so it cannot be the boundary. It is honoured only
+        // as a hint: producers are flushed when the registry says their run is no longer live.
+        // Here run N+1 *is* live, so its producers survive a stop that belongs to run N.
+        let (aggregator, runs) = rigged();
+        let first = runs.begin("hqplayer");
+        runs.end(&first);
+        let second = runs.begin("hqplayer");
+
+        let document = pipeline();
+        let key = ProducerKey::of(&document);
+        aggregator.ingest_from(second.origin(), document).await;
+        assert_eq!(aggregator.producer_count().await, 1);
+
+        // The stop from run N, arriving late.
+        aggregator
+            .apply_bus_event(BusEvent::AdapterStopping {
+                adapter: "hqplayer".to_string(),
+                reason: None,
+            })
+            .await;
+
+        assert!(
+            aggregator.snapshot(&key).await.is_some(),
+            "a delayed stop from an earlier run flushed the live run's producers"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_ended_run_projects_last_known_without_a_stop_flush() {
+        let (aggregator, runs) = rigged();
+        let run = runs.begin("hqplayer");
+        let document = pipeline();
+        let key = ProducerKey::of(&document);
+        aggregator.ingest_from(run.origin(), document).await;
+        runs.end(&run);
+
+        aggregator
+            .apply_bus_event(BusEvent::AdapterStopping {
+                adapter: "hqplayer".to_string(),
+                reason: None,
+            })
+            .await;
+
+        assert_eq!(
+            aggregator
+                .snapshot(&key)
+                .await
+                .expect("last-known")
+                .presence,
+            ProducerPresence::LastKnown
+        );
+    }
+
+    #[tokio::test]
+    async fn run_n_plus_one_may_republish_the_same_producer_epoch() {
+        // Adapter restart is not producer restart. An engine that never restarted keeps its
+        // epoch, and a reconnecting adapter must be able to republish it - the case an
+        // epoch-based adapter guard stranded permanently.
+        let (aggregator, runs) = rigged();
+        let document = pipeline();
+        let key = ProducerKey::of(&document);
+        let epoch = document.producer.epoch;
+
+        let first = runs.begin("hqplayer");
+        aggregator
+            .ingest_from(first.origin(), document.clone())
+            .await;
+        runs.end(&first);
+        aggregator
+            .apply_bus_event(BusEvent::AdapterStopping {
+                adapter: "hqplayer".to_string(),
+                reason: None,
+            })
+            .await;
+
+        let second = runs.begin("hqplayer");
+        let admission = aggregator.ingest_from(second.origin(), document).await;
+        assert!(
+            matches!(admission, Admission::Admitted(_)),
+            "a reconnected adapter could not republish an unchanged producer: {admission:?}"
+        );
+        let snapshot = aggregator.snapshot(&key).await.expect("republished");
+        assert_eq!(
+            snapshot.document.producer.epoch, epoch,
+            "the same producer epoch must be admissible under a new run"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_new_run_cannot_lower_the_producer_watermark() {
+        // Run identity is connection liveness, not producer history. Reconnecting cannot
+        // make a lower revision authoritative at the same producer epoch.
+        let (aggregator, runs) = rigged();
+        let mut ahead = pipeline();
+        ahead.revisions = DocumentRevisions::new(12, 5000);
+        let key = ProducerKey::of(&ahead);
+
+        let first = runs.begin("hqplayer");
+        aggregator.ingest_from(first.origin(), ahead).await;
+        runs.end(&first);
+
+        let second = runs.begin("hqplayer");
+        let admission = aggregator.ingest_from(second.origin(), pipeline()).await;
+        assert!(
+            matches!(admission, Admission::Refused(_)),
+            "a new run lowered the producer watermark: {admission:?}"
+        );
+        let snapshot = aggregator.snapshot(&key).await.expect("previous snapshot");
+        assert_eq!(snapshot.document.revisions.state.0, 5000);
+    }
+
+    #[tokio::test]
+    async fn an_explicit_producer_removal_still_requires_a_strictly_higher_epoch() {
+        // Producer-epoch retirement is a *different* lifecycle from adapter runs and keeps its
+        // own rule: `ProducerRemoved` says the producer is gone, and only the producer can
+        // contradict that by announcing a restart.
+        let (aggregator, runs) = rigged();
+        let document = pipeline();
+        let key = ProducerKey::of(&document);
+        let epoch = document.producer.epoch.0;
+
+        let run = runs.begin("hqplayer");
+        aggregator.ingest_from(run.origin(), document.clone()).await;
+        aggregator
+            .remove_from(run.origin(), &document.producer.producer_id)
+            .await;
+        assert_eq!(aggregator.producer_count().await, 0);
+
+        // Same epoch, same live run: refused, because the producer was retired by identity.
+        let admission = aggregator.ingest_from(run.origin(), document.clone()).await;
+        assert!(
+            matches!(admission, Admission::Refused(_)),
+            "a removed producer was resurrected at the same epoch: {admission:?}"
+        );
+        assert!(aggregator.snapshot(&key).await.is_none());
+
+        // Strictly higher epoch: admitted, because that is a restart.
+        let restarted = at_epoch(document, epoch + 1);
+        let admission = aggregator.ingest_from(run.origin(), restarted).await;
+        assert!(
+            matches!(admission, Admission::Admitted(_)),
+            "a restarted producer at a higher epoch was refused: {admission:?}"
+        );
+        assert!(aggregator.snapshot(&key).await.is_some());
+    }
+
+    #[tokio::test]
+    async fn a_producer_removal_is_not_undone_by_a_new_adapter_run() {
+        // The unsoundness this replaces: a reconnect used to clear the bar, so a straggler
+        // from before the removal could resurrect the producer. A new run does not speak for
+        // the producer's own lifecycle.
+        let (aggregator, runs) = rigged();
+        let document = pipeline();
+        let key = ProducerKey::of(&document);
+
+        let first = runs.begin("hqplayer");
+        aggregator
+            .ingest_from(first.origin(), document.clone())
+            .await;
+        aggregator
+            .remove_from(first.origin(), &document.producer.producer_id)
+            .await;
+        runs.end(&first);
+
+        let second = runs.begin("hqplayer");
+        let admission = aggregator.ingest_from(second.origin(), document).await;
+        assert!(
+            matches!(admission, Admission::Refused(_)),
+            "a new adapter run undid a producer-epoch retirement: {admission:?}"
+        );
+        assert!(aggregator.snapshot(&key).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn a_delayed_removal_from_an_ended_run_cannot_retire_a_live_producer() {
+        // Removals are stamped too, for the same reason publications are.
+        let (aggregator, runs) = rigged();
+        let document = pipeline();
+        let key = ProducerKey::of(&document);
+
+        let first = runs.begin("hqplayer");
+        let stale = first.origin().clone();
+        runs.end(&first);
+        let second = runs.begin("hqplayer");
+        aggregator
+            .ingest_from(second.origin(), document.clone())
+            .await;
+
+        let removed = aggregator
+            .remove_from(&stale, &document.producer.producer_id)
+            .await;
+        assert_eq!(removed, 0, "a removal from an ended run retired a producer");
+        assert!(
+            aggregator.snapshot(&key).await.is_some(),
+            "a delayed removal from run N retired run N+1's producer"
+        );
+    }
+
+    #[tokio::test]
+    async fn stopping_one_adapter_does_not_flush_another_adapters_producer() {
+        let (aggregator, runs) = rigged();
+        let mut other = pipeline();
+        other.producer.producer_id = "roon:core".to_string();
+        other.producer.producer_type = "roon".to_string();
+        let key = ProducerKey::of(&other);
+
+        let roon = runs.begin("roon");
+        aggregator.ingest_from(roon.origin(), other).await;
+        let hqp = runs.begin("hqplayer");
+        runs.end(&hqp);
+
+        aggregator
+            .apply_bus_event(BusEvent::AdapterStopping {
+                adapter: "hqplayer".to_string(),
+                reason: None,
+            })
+            .await;
+
+        assert!(
+            aggregator.snapshot(&key).await.is_some(),
+            "stopping hqplayer flushed a roon producer"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_stale_run_publication_retains_a_diagnostic_without_creating_a_producer() {
+        let (aggregator, runs) = rigged();
+        let run = runs.begin("hqplayer");
+        let origin = run.origin().clone();
+        runs.end(&run);
+        aggregator.ingest_from(&origin, pipeline()).await;
+
+        assert_eq!(aggregator.producer_count().await, 0);
+        assert!(matches!(
+            aggregator.refusals().await.as_slice(),
+            [(_, AdmissionRefusal::StaleAdapterRun { .. })]
+        ));
+    }
+}
+
+// =============================================================================
+// RED counterexamples for the lifecycle redesign (solution-space revision 2)
+//
+// Each states a consequence of an invariant in `.oh/adaptive-publication.md`. Written against
+// whatever API expresses them, and migrated onto the actor API as it lands.
+// =============================================================================
+
+mod lifecycle_counterexamples {
+    use super::*;
+    use unified_hifi_control::bus::BusEvent;
+    use unified_hifi_control::producers::AdapterRuns;
+
+    fn rigged() -> (ProducerAggregator, std::sync::Arc<AdapterRuns>) {
+        let aggregator = ProducerAggregator::detached();
+        let runs = aggregator.runs().clone();
+        (aggregator, runs)
+    }
+
+    fn at(document: &ProducerDocument, epoch: u64, state: u64) -> ProducerDocument {
+        let mut next = document.clone();
+        next.producer.epoch = ProducerEpoch(epoch);
+        next.revisions = DocumentRevisions::new(12, state);
+        next
+    }
+
+    // I3: no resurrection. A new run must not be able to publish a lower revision at the
+    // same epoch just because it is a new run.
+    #[tokio::test]
+    async fn red_same_epoch_lower_revision_across_runs_is_refused() {
+        let (aggregator, runs) = rigged();
+        let base = pipeline();
+        let key = ProducerKey::of(&base);
+
+        let first = runs.begin("hqplayer");
+        aggregator
+            .ingest_from(first.origin(), at(&base, 7, 5000))
+            .await;
+        runs.end(&first);
+
+        let second = runs.begin("hqplayer");
+        let admission = aggregator
+            .ingest_from(second.origin(), at(&base, 7, 4193))
+            .await;
+        assert!(
+            matches!(admission, Admission::Refused(_)),
+            "a new run published a LOWER revision at the same epoch and it was admitted: \
+             {admission:?}"
+        );
+        let snapshot = aggregator.snapshot(&key).await.expect("snapshot");
+        assert_eq!(
+            snapshot.document.revisions.state.0, 5000,
+            "the served revision regressed across an adapter run boundary"
+        );
+    }
+
+    // I3: the epoch floor is a watermark, not a property of the held document.
+    #[tokio::test]
+    async fn red_lower_epoch_across_runs_is_refused() {
+        let (aggregator, runs) = rigged();
+        let base = pipeline();
+        let key = ProducerKey::of(&base);
+
+        let first = runs.begin("hqplayer");
+        aggregator
+            .ingest_from(first.origin(), at(&base, 8, 4193))
+            .await;
+        runs.end(&first);
+
+        let second = runs.begin("hqplayer");
+        let admission = aggregator
+            .ingest_from(second.origin(), at(&base, 7, 9999))
+            .await;
+        assert!(
+            matches!(admission, Admission::Refused(_)),
+            "a new run published a LOWER epoch and it was admitted: {admission:?}"
+        );
+        let snapshot = aggregator.snapshot(&key).await.expect("snapshot");
+        assert_eq!(
+            snapshot.document.producer.epoch,
+            ProducerEpoch(8),
+            "the served epoch regressed across an adapter run boundary"
+        );
+    }
+
+    // The guard on over-correction: reconnect at the same epoch with real progress works.
+    #[tokio::test]
+    async fn red_same_epoch_higher_revision_across_runs_is_admitted() {
+        let (aggregator, runs) = rigged();
+        let base = pipeline();
+
+        let first = runs.begin("hqplayer");
+        aggregator
+            .ingest_from(first.origin(), at(&base, 7, 4193))
+            .await;
+        runs.end(&first);
+
+        let second = runs.begin("hqplayer");
+        let admission = aggregator
+            .ingest_from(second.origin(), at(&base, 7, 4200))
+            .await;
+        assert!(
+            matches!(admission, Admission::Admitted(_)),
+            "a reconnected adapter making real progress was refused: {admission:?}"
+        );
+    }
+
+    // I2: informational stop events cannot erase either the snapshot or ordering floor.
+    #[tokio::test]
+    async fn red_stop_cannot_erase_the_snapshot_or_watermark() {
+        let (aggregator, runs) = rigged();
+        let base = pipeline();
+
+        let first = runs.begin("hqplayer");
+        aggregator
+            .ingest_from(first.origin(), at(&base, 7, 5000))
+            .await;
+        runs.end(&first);
+        aggregator
+            .apply_bus_event(BusEvent::AdapterStopping {
+                adapter: "hqplayer".to_string(),
+                reason: None,
+            })
+            .await;
+        assert_eq!(
+            aggregator.producer_count().await,
+            1,
+            "an informational stop event erased the last-known snapshot"
+        );
+
+        let second = runs.begin("hqplayer");
+        let admission = aggregator
+            .ingest_from(second.origin(), at(&base, 7, 4193))
+            .await;
+        assert!(
+            matches!(admission, Admission::Refused(_)),
+            "the stop event erased the ordering floor: {admission:?}"
+        );
+    }
+
+    // I6: retirement covers keys the aggregator has never seen.
+    #[tokio::test]
+    async fn red_retiring_an_unseen_producer_blocks_a_later_straggler() {
+        let (handle, actor, view) = unified_hifi_control::producers::AdaptiveRuntime::build(
+            tokio_util::sync::CancellationToken::new(),
+            8,
+        );
+        let worker = tokio::spawn(async move { actor.run().await });
+        let base = pipeline();
+        let key = ProducerKey::of(&base);
+        let run = handle.begin_run("hqplayer");
+
+        // Nothing has ever been published for this key.
+        handle
+            .retire(&run, &base.producer.producer_id, base.producer.epoch)
+            .await
+            .expect("retirement applied");
+
+        let admission = handle.publish(&run, base).await.expect("verdict");
+        assert!(
+            matches!(admission, Admission::Refused(_)),
+            "a straggler for a producer retired before it was ever seen was admitted: \
+             {admission:?}"
+        );
+        assert!(
+            view.snapshot(&key).is_none(),
+            "an unseen retirement failed to block resurrection"
+        );
+        drop(run);
+        drop(handle);
+        worker.await.expect("actor");
+    }
+
+    // I5: cleanup and refusal isolation must be by exact origin, never by adapter identity.
+    #[tokio::test]
+    async fn red_ending_an_old_run_cannot_clear_the_replacement_runs_refusal() {
+        let (aggregator, runs) = rigged();
+
+        let first = runs.begin("hqplayer");
+        runs.end(&first);
+        let second = runs.begin("hqplayer");
+
+        // The live run records a refusal.
+        let mut bad = pipeline();
+        bad.target.zone_id = Some("not-prefixed".to_string());
+        aggregator.ingest_from(second.origin(), bad).await;
+        assert_eq!(
+            aggregator.refusals().await.len(),
+            1,
+            "precondition: the live run has a refusal on record"
+        );
+
+        // The ended run's cleanup arrives late.
+        aggregator
+            .apply_bus_event(BusEvent::AdapterStopping {
+                adapter: "hqplayer".to_string(),
+                reason: None,
+            })
+            .await;
+
+        assert_eq!(
+            aggregator.refusals().await.len(),
+            1,
+            "an ended run's cleanup cleared the live run's refusal: {:?}",
+            aggregator.refusals().await
+        );
+    }
+
+    // I5/I8: no string-inferred cleanup; each ended run remains visible as last-known.
+    #[tokio::test]
+    async fn red_ended_runs_remain_last_known_without_string_inferred_cleanup() {
+        let (aggregator, runs) = rigged();
+
+        let stopping = runs.begin("hqplayer");
+        let mut old = pipeline();
+        old.producer.producer_id = "hqplayer:one".to_string();
+        let old_key = ProducerKey::of(&old);
+        aggregator.ingest_from(stopping.origin(), old).await;
+
+        let live = runs.begin("hqplayer");
+        let mut fresh = pipeline();
+        fresh.producer.producer_id = "hqplayer:two".to_string();
+        let live_key = ProducerKey::of(&fresh);
+        aggregator.ingest_from(live.origin(), fresh).await;
+
+        runs.end(&live);
+
+        // `stopping` is already superseded and `live` ended. The public event is only a hint.
+        aggregator
+            .apply_bus_event(BusEvent::AdapterStopping {
+                adapter: "hqplayer".to_string(),
+                reason: None,
+            })
+            .await;
+
+        assert_eq!(
+            aggregator
+                .snapshot(&old_key)
+                .await
+                .expect("old last-known")
+                .presence,
+            ProducerPresence::LastKnown
+        );
+        assert_eq!(
+            aggregator
+                .snapshot(&live_key)
+                .await
+                .expect("live last-known")
+                .presence,
+            ProducerPresence::LastKnown
+        );
+    }
+}
+
+mod timestamp_fields {
+    use super::*;
+
+    fn expect_timestamp_refusal(document: ProducerDocument, field: &str) {
+        let admission = admit_fresh(document);
+        assert!(
+            matches!(
+                admission,
+                Admission::Refused(AdmissionRefusal::TimestampNotRfc3339 { .. })
+            ),
+            "a malformed {field} was admitted: {admission:?}"
+        );
+    }
+
+    #[test]
+    fn red_lane_freshness_observed_at_must_be_rfc3339() {
+        let mut document = pipeline();
+        document.lanes[0].freshness.observed_at = Some(Timestamp::new("nope"));
+        expect_timestamp_refusal(document, "LaneHealth.freshness.observed_at");
+    }
+
+    #[test]
+    fn red_lane_value_freshness_observed_at_must_be_rfc3339() {
+        let mut document = pipeline();
+        let control = document
+            .controls
+            .iter_mut()
+            .find(|c| !c.values.is_empty())
+            .expect("a control with a lane");
+        control.values[0].freshness.observed_at = Some(Timestamp::new("nope"));
+        expect_timestamp_refusal(document, "LaneValue.freshness.observed_at");
+    }
+
+    #[test]
+    fn red_divergence_detected_at_must_be_rfc3339() {
+        let mut document = pipeline();
+        let control = document
+            .controls
+            .iter_mut()
+            .find(|c| !c.divergences.is_empty())
+            .expect("a control with a divergence");
+        control.divergences[0].detected_at = Some(Timestamp::new("nope"));
+        expect_timestamp_refusal(document, "Divergence.detected_at");
+    }
+
+    #[test]
+    fn red_change_set_created_at_must_be_rfc3339() {
+        let mut document = staged();
+        document.change_sets[0].created_at = Timestamp::new("nope");
+        expect_timestamp_refusal(document, "ChangeSet.created_at");
+    }
+
+    #[test]
+    fn red_change_set_updated_at_must_be_rfc3339() {
+        let mut document = staged();
+        document.change_sets[0].updated_at = Timestamp::new("nope");
+        expect_timestamp_refusal(document, "ChangeSet.updated_at");
+    }
+
+    #[test]
+    fn red_change_set_retention_expires_at_must_be_rfc3339() {
+        let mut document = staged();
+        document.change_sets[0].retention.expires_at = Some(Timestamp::new("nope"));
+        expect_timestamp_refusal(document, "ChangeSet.retention.expires_at");
+    }
+
+    #[test]
+    fn red_draft_policy_retention_expires_at_must_be_rfc3339() {
+        let mut document = pipeline();
+        let policy = document
+            .draft_policy
+            .as_mut()
+            .expect("the fixture publishes a draft policy");
+        policy.retention.expires_at = Some(Timestamp::new("nope"));
+        expect_timestamp_refusal(document, "DraftPolicy.retention.expires_at");
+    }
+
+    #[test]
+    fn red_operation_history_at_must_be_rfc3339() {
+        let mut document = outcomes();
+        let operation = document
+            .operations
+            .iter_mut()
+            .find(|o| !o.history.is_empty())
+            .expect("the fixture publishes an operation with history");
+        operation.history[0].at = Timestamp::new("nope");
+        expect_timestamp_refusal(document, "OutcomeTransition.at");
+    }
+
+    #[test]
+    fn red_every_canonical_fixture_still_admits_with_full_timestamp_validation() {
+        for name in [
+            "hqplayer_pipeline_v1",
+            "hqplayer_degraded_lanes",
+            "staged_intent_multi_surface",
+            "command_outcomes",
+            "control_removed_after_advance",
+            "forward_compatible_additions",
+        ] {
+            let admission = admit_fresh(fixture(name));
+            assert!(
+                matches!(admission, Admission::Admitted(_)),
+                "{name} was refused once every Timestamp field is validated: {admission:?}"
+            );
+        }
+    }
+}
+
+mod internal_bus {
+    use super::*;
+    use unified_hifi_control::producers::AdaptiveRuntime;
+
+    #[tokio::test]
+    async fn a_document_published_after_construction_but_before_run_is_still_admitted() {
+        let (handle, actor, view) =
+            AdaptiveRuntime::build(tokio_util::sync::CancellationToken::new(), 8);
+        let run = handle.begin_run("hqplayer");
+        let document = pipeline();
+        let key = ProducerKey::of(&document);
+        handle
+            .publish_detached(&run, document)
+            .await
+            .expect("queued before actor start");
+        drop(handle);
+        tokio::time::timeout(std::time::Duration::from_secs(5), actor.run())
+            .await
+            .expect("actor drained");
+        assert!(
+            view.snapshot(&key).is_some(),
+            "a document queued between construction and actor start was dropped"
+        );
+        drop(run);
+    }
+
+    #[tokio::test]
+    async fn a_document_published_on_the_internal_bus_reaches_the_aggregator() {
+        let (handle, actor, view) =
+            AdaptiveRuntime::build(tokio_util::sync::CancellationToken::new(), 8);
+        let worker = tokio::spawn(async move { actor.run().await });
+        let run = handle.begin_run("hqplayer");
+
+        let document = pipeline();
+        let key = ProducerKey::of(&document);
+        handle.publish(&run, document).await.expect("verdict");
+        assert!(
+            view.snapshot(&key).is_some(),
+            "the actor never saw the document"
+        );
+        drop(run);
+        drop(handle);
+        worker.await.expect("actor");
+    }
+
+    #[tokio::test]
+    async fn a_capacity_two_actor_applies_every_command_under_backpressure() {
+        let (handle, actor, view) =
+            AdaptiveRuntime::build(tokio_util::sync::CancellationToken::new(), 2);
+        let worker = tokio::spawn(async move { actor.run().await });
+        let run = handle.begin_run("hqplayer");
         for step in 0..64_u64 {
             let mut document = pipeline();
             document.revisions = DocumentRevisions::new(12, 4193 + step);
-            adaptive.publish(AdaptiveEvent::ProducerPublished {
-                document: Box::new(document),
-            });
+            handle
+                .publish_detached(&run, document)
+                .await
+                .expect("lossless enqueue");
         }
 
         let mut final_document = pipeline();
         final_document.revisions = DocumentRevisions::new(12, 9999);
         let key = ProducerKey::of(&final_document);
-
-        let mut arrived = false;
-        for _ in 0..200 {
-            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
-            adaptive.publish(AdaptiveEvent::ProducerPublished {
-                document: Box::new(final_document.clone()),
-            });
-            if let Some(snapshot) = aggregator.snapshot(&key).await {
-                if snapshot.document.revisions.state.0 == 9999 {
-                    arrived = true;
-                    break;
-                }
-            }
-        }
-        assert!(
-            arrived,
-            "the aggregator stopped consuming after a lag burst; a full-snapshot design \
-             recovers only if the loop survives"
+        handle
+            .publish(&run, final_document)
+            .await
+            .expect("final verdict");
+        assert_eq!(
+            view.snapshot(&key)
+                .expect("final snapshot")
+                .document
+                .revisions
+                .state
+                .0,
+            9999
         );
-
-        bus.publish(unified_hifi_control::bus::BusEvent::ShuttingDown { reason: None });
-        let _ = tokio::time::timeout(std::time::Duration::from_secs(5), handle).await;
+        drop(run);
+        drop(handle);
+        worker.await.expect("actor");
     }
 }
 

--- a/tests/adaptive_publication.rs
+++ b/tests/adaptive_publication.rs
@@ -1252,6 +1252,24 @@ mod refusal_observability {
     }
 
     #[tokio::test]
+    async fn a_refusal_does_not_outlive_the_producer_it_names() {
+        // Refusals outlive successes deliberately, so a producer author can see its
+        // documents were dropped. Outliving the producer itself is different: a surface
+        // listing "producers with problems" would show something that no longer exists.
+        let aggregator = ProducerAggregator::detached();
+        let mut document = pipeline();
+        document.target.zone_id = Some("no-prefix".to_string());
+        aggregator.ingest(document).await;
+        assert_eq!(aggregator.refusals().await.len(), 1);
+
+        aggregator.remove("hqplayer:living-room").await;
+        assert!(
+            aggregator.refusals().await.is_empty(),
+            "a refusal survived the removal of the producer it names"
+        );
+    }
+
+    #[tokio::test]
     async fn a_later_success_does_not_erase_the_record_of_a_refusal() {
         let aggregator = ProducerAggregator::detached();
         let key = ProducerKey::of(&pipeline());

--- a/tests/adaptive_publication.rs
+++ b/tests/adaptive_publication.rs
@@ -491,6 +491,33 @@ mod intent_coherence {
         unknown_control.controls.retain(|c| c.id != control);
         broken.push(unknown_control);
 
+        // C2, which the earlier version of this test omitted: it was covered only by
+        // `two_drafts_claiming_one_control_both_lose_validity`, which asserts the demoted
+        // validity but never re-checks the document against the coherence rules. The
+        // invariant has to hold for every way of breaking it, not for three of the four.
+        let mut contested = staged();
+        let (first_id, control) = valid_entry_control(&contested);
+        let second_id = contested
+            .change_sets
+            .iter()
+            .map(|cs| cs.id.clone())
+            .find(|id| id != &first_id)
+            .expect("the fixture publishes more than one change set");
+        let template = contested
+            .change_sets
+            .iter()
+            .find(|cs| cs.id == first_id)
+            .and_then(|cs| cs.entries.iter().find(|e| e.control == control))
+            .cloned()
+            .expect("located above");
+        for change_set in &mut contested.change_sets {
+            if change_set.id == second_id {
+                change_set.entries.retain(|e| e.control != control);
+                change_set.entries.push(template.clone());
+            }
+        }
+        broken.push(contested);
+
         for document in broken {
             let admitted = expect_admitted(admit_fresh(document));
             assert!(

--- a/tests/adaptive_publication.rs
+++ b/tests/adaptive_publication.rs
@@ -101,6 +101,7 @@ mod envelope {
             "hqplayer_degraded_lanes",
             "staged_intent_multi_surface",
             "command_outcomes",
+            "control_removed_after_advance",
             "forward_compatible_additions",
         ] {
             let document = fixture(name);
@@ -273,6 +274,29 @@ mod envelope {
 mod lane_value_invariant {
     use super::*;
 
+    /// Break the first lane of the first control that has one, returning what was broken.
+    ///
+    /// Returns the owning control id as well as the lane, so a refusal can be asserted to
+    /// name both rather than only the lane.
+    fn break_first_lane(
+        document: &mut ProducerDocument,
+        mutate: impl FnOnce(&mut LaneValue),
+    ) -> (ControlId, ValueLane) {
+        let control = document
+            .controls
+            .iter_mut()
+            .find(|c| !c.values.is_empty())
+            .expect("a canonical fixture has at least one control with a lane");
+        let control_id = control.id.clone();
+        let value = control
+            .values
+            .first_mut()
+            .expect("checked non-empty just above");
+        let lane = value.lane.clone();
+        mutate(value);
+        (control_id, lane)
+    }
+
     fn first_control_lane(document: &mut ProducerDocument) -> &mut LaneValue {
         let control = document
             .controls
@@ -288,18 +312,22 @@ mod lane_value_invariant {
     #[test]
     fn a_grounded_lane_with_no_value_is_refused_and_names_control_and_lane() {
         let mut document = pipeline();
-        let (control_id, lane) = {
-            let value = first_control_lane(&mut document);
+        let (control_id, lane) = break_first_lane(&mut document, |value| {
             value.grounding = Grounding::Grounded;
             value.value = None;
-            (None::<ControlId>, value.lane.clone())
-        };
-        let _ = control_id;
+        });
         match expect_refused(admit_fresh(document)) {
             AdmissionRefusal::LaneValueInconsistent {
-                lane: got, detail, ..
+                control,
+                lane: got,
+                detail,
             } => {
-                assert_eq!(got, lane);
+                // Both halves are asserted: a refusal that names the wrong control is as
+                // unactionable as one that names none. An earlier version of this test
+                // carried a `None::<ControlId>` placeholder and matched the control with
+                // `..`, so it proved nothing about it.
+                assert_eq!(control, control_id, "the refusal named the wrong control");
+                assert_eq!(got, lane, "the refusal named the wrong lane");
                 assert_eq!(detail, LaneDefect::GroundedWithoutValue);
             }
             other => panic!("expected LaneValueInconsistent, got {other:?}"),
@@ -448,6 +476,29 @@ mod intent_coherence {
         panic!("staged_intent_multi_surface must publish a valid entry")
     }
 
+    /// Find the `display_text_key` of the first reason in `value` carrying `code`, at any
+    /// depth. Searching rather than indexing a fixed path keeps this test measuring the
+    /// published key itself rather than the fixture's current nesting.
+    fn find_key(value: &serde_json::Value, code: &str) -> Option<String> {
+        match value {
+            serde_json::Value::Object(map) => {
+                if map.get("code").and_then(serde_json::Value::as_str) == Some(code) {
+                    if let Some(key) = map
+                        .get("display_text_key")
+                        .and_then(serde_json::Value::as_str)
+                    {
+                        return Some(key.to_string());
+                    }
+                }
+                map.values().find_map(|nested| find_key(nested, code))
+            }
+            serde_json::Value::Array(items) => {
+                items.iter().find_map(|nested| find_key(nested, code))
+            }
+            _ => None,
+        }
+    }
+
     #[test]
     fn a_coherent_document_is_admitted_with_no_repairs() {
         let admitted = expect_admitted(admit_fresh(staged()));
@@ -583,9 +634,57 @@ mod intent_coherence {
                     ReasonCode::ControlRemoved,
                     "a removed control must be distinguishable from an unvalidated one"
                 );
+                // `detail` is documented as non-localised diagnostic text "for logs rather
+                // than for users". Emitting only `detail` means the sole explanation a user
+                // can be shown is untranslatable English prose - which is precisely the
+                // failure `display_text_key` exists to prevent.
+                assert_eq!(
+                    reason.display_text_key.as_deref(),
+                    Some("reason.control_no_longer_exists"),
+                    "a removed control must carry the catalog key consumers render, not \
+                     only log detail"
+                );
             }
             other => panic!("expected DraftInvalid(control_removed), got {other:?}"),
         }
+    }
+
+    #[test]
+    fn the_removed_control_key_matches_the_one_the_canonical_fixture_publishes() {
+        // Two sources claim to define this key: production and the worked example that
+        // `every_vocabulary_member_has_a_worked_example` forces to exist. If they drift, a
+        // consumer built against the fixture renders a blank string against the real thing.
+        let fixture: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string("tests/fixtures/adaptive/control_removed_after_advance.json")
+                .expect("the canonical control-removed fixture must exist"),
+        )
+        .expect("the canonical fixture must be valid JSON");
+
+        let published = find_key(&fixture, "control_removed")
+            .expect("the fixture must carry a control_removed reason with a display_text_key");
+
+        let mut document = staged();
+        let (_, control) = valid_entry_control(&document);
+        document.controls.retain(|c| c.id != control);
+        document.revisions = DocumentRevisions::new(13, 4194);
+        let admitted = expect_admitted(admit_fresh(document));
+        let produced = admitted
+            .repairs
+            .iter()
+            .find_map(|repair| match &repair.to {
+                EntryValidity::DraftInvalid { reason }
+                    if reason.code == ReasonCode::ControlRemoved =>
+                {
+                    reason.display_text_key.clone()
+                }
+                _ => None,
+            })
+            .expect("production must emit a display_text_key for a removed control");
+
+        assert_eq!(
+            produced, published,
+            "production and the canonical fixture disagree on the control-removed catalog key"
+        );
     }
 
     #[test]
@@ -1266,6 +1365,101 @@ mod refusal_observability {
         assert!(
             aggregator.refusals().await.is_empty(),
             "a refusal survived the removal of the producer it names"
+        );
+    }
+
+    #[tokio::test]
+    async fn stopping_an_adapter_clears_refusals_it_never_became_a_producer_for() {
+        // A first-publication refusal creates a refusal record with no producer entry, so
+        // the flush - which derives its victims from the producer map - never saw it and
+        // left it behind after the adapter stopped. The refusal must not outlive the
+        // adapter that caused it any more than it outlives a producer. Found by CodeRabbit
+        // at `9c53079`.
+        use unified_hifi_control::bus::BusEvent;
+        let bus = unified_hifi_control::bus::create_bus();
+        let adaptive = unified_hifi_control::producers::create_adaptive_bus();
+        let aggregator = ProducerAggregator::new(bus, adaptive);
+
+        // Refused on its very first document, so no producer entry is ever created.
+        let mut never_admitted = pipeline();
+        never_admitted.target.zone_id = Some("no-prefix".to_string());
+        aggregator.ingest(never_admitted).await;
+        assert_eq!(aggregator.producer_count().await, 0);
+        assert_eq!(aggregator.refusals().await.len(), 1);
+
+        aggregator
+            .apply_bus_event(BusEvent::AdapterStopping {
+                adapter: "hqplayer".to_string(),
+                reason: None,
+            })
+            .await;
+
+        assert!(
+            aggregator.refusals().await.is_empty(),
+            "a refusal outlived the adapter that produced it: {:?}",
+            aggregator.refusals().await
+        );
+    }
+
+    #[tokio::test]
+    async fn a_refusal_is_flushed_by_producer_type_even_without_an_id_prefix() {
+        // The id-prefix clause alone is not enough: a producer id need not carry the
+        // adapter prefix, and the flush must still find its refusal. This is what makes
+        // retaining the source adapter load-bearing rather than redundant with the prefix.
+        use unified_hifi_control::bus::BusEvent;
+        let bus = unified_hifi_control::bus::create_bus();
+        let adaptive = unified_hifi_control::producers::create_adaptive_bus();
+        let aggregator = ProducerAggregator::new(bus, adaptive);
+
+        let mut unprefixed = pipeline();
+        unprefixed.producer.producer_id = "living-room".to_string();
+        unprefixed.producer.producer_type = "hqplayer".to_string();
+        unprefixed.target.zone_id = Some("no-prefix".to_string());
+        aggregator.ingest(unprefixed).await;
+        assert_eq!(aggregator.refusals().await.len(), 1);
+
+        aggregator
+            .apply_bus_event(BusEvent::AdapterStopping {
+                adapter: "hqplayer".to_string(),
+                reason: None,
+            })
+            .await;
+
+        assert!(
+            aggregator.refusals().await.is_empty(),
+            "a refusal whose producer id carries no adapter prefix survived its adapter \
+             stopping: {:?}",
+            aggregator.refusals().await
+        );
+    }
+
+    #[tokio::test]
+    async fn stopping_one_adapter_leaves_another_adapters_refusal_alone() {
+        // The other direction: the flush must be as narrow for refusals as it is for
+        // producers.
+        use unified_hifi_control::bus::BusEvent;
+        let bus = unified_hifi_control::bus::create_bus();
+        let adaptive = unified_hifi_control::producers::create_adaptive_bus();
+        let aggregator = ProducerAggregator::new(bus, adaptive);
+
+        let mut other = pipeline();
+        other.producer.producer_id = "roon:core".to_string();
+        other.producer.producer_type = "roon".to_string();
+        other.target.zone_id = Some("not-prefixed".to_string());
+        aggregator.ingest(other).await;
+        assert_eq!(aggregator.refusals().await.len(), 1);
+
+        aggregator
+            .apply_bus_event(BusEvent::AdapterStopping {
+                adapter: "hqplayer".to_string(),
+                reason: None,
+            })
+            .await;
+
+        assert_eq!(
+            aggregator.refusals().await.len(),
+            1,
+            "stopping hqplayer removed a roon refusal"
         );
     }
 

--- a/tests/adaptive_publication_lint.rs
+++ b/tests/adaptive_publication_lint.rs
@@ -196,13 +196,19 @@ fn rust_sources_under(root: &str) -> Vec<(String, String)> {
 /// variants rather than characters to be recognized. `#[allow(unused_imports)] pub use
 /// a::B as C;` is an `ItemUse` exactly as `use a::B;` is.
 fn imports_of(file: &File) -> Vec<String> {
-    let mut found = Vec::new();
-    for item in &file.items {
-        if let Item::Use(item_use) = item {
-            found.extend(flatten_use_tree(&item_use.tree));
+    #[derive(Default)]
+    struct ImportVisitor {
+        found: Vec<String>,
+    }
+    impl<'ast> Visit<'ast> for ImportVisitor {
+        fn visit_item_use(&mut self, item: &'ast syn::ItemUse) {
+            self.found.extend(flatten_use_tree(&item.tree));
+            visit::visit_item_use(self, item);
         }
     }
-    found
+    let mut visitor = ImportVisitor::default();
+    visitor.visit_file(file);
+    visitor.found
 }
 
 fn flatten_use_tree(tree: &UseTree) -> Vec<String> {
@@ -481,23 +487,35 @@ fn disallowed_module_attributes(file: &File) -> Vec<String> {
 ///
 /// Inherent impls (`impl AdaptiveEvent { … }`) are not trait impls and do not appear.
 fn trait_impls_for(file: &File, type_name: &str) -> Vec<String> {
-    file.items
-        .iter()
-        .filter_map(|item| match item {
-            Item::Impl(item_impl) => {
-                let (_, path, _) = item_impl.trait_.as_ref()?;
-                let target = match item_impl.self_ty.as_ref() {
-                    syn::Type::Path(type_path) => type_path.path.segments.last()?.ident.to_string(),
-                    _ => return None,
-                };
-                if target != type_name {
-                    return None;
+    struct ImplVisitor<'a> {
+        type_name: &'a str,
+        found: Vec<String>,
+    }
+    impl<'ast> Visit<'ast> for ImplVisitor<'_> {
+        fn visit_item_impl(&mut self, item: &'ast syn::ItemImpl) {
+            if let Some((_, path, _)) = item.trait_.as_ref() {
+                if let syn::Type::Path(type_path) = item.self_ty.as_ref() {
+                    let target = type_path
+                        .path
+                        .segments
+                        .last()
+                        .map(|segment| segment.ident.to_string());
+                    if target.as_deref() == Some(self.type_name) {
+                        if let Some(last) = path.segments.last() {
+                            self.found.push(last.ident.to_string());
+                        }
+                    }
                 }
-                Some(path.segments.last()?.ident.to_string())
             }
-            _ => None,
-        })
-        .collect()
+            visit::visit_item_impl(self, item);
+        }
+    }
+    let mut visitor = ImplVisitor {
+        type_name,
+        found: Vec::new(),
+    };
+    visitor.visit_file(file);
+    visitor.found
 }
 
 /// Every `#[cfg(...)]` argument applying to module `name`, including from an enclosing
@@ -564,12 +582,25 @@ fn gate_is_server_only(meta: &Meta) -> bool {
 #[derive(Default)]
 struct ModuleReferenceVisitor {
     found: BTreeSet<String>,
+    /// Names that address this crate's root, including aliases bound in this file.
+    roots: BTreeSet<String>,
 }
 
 impl ModuleReferenceVisitor {
     fn note(&mut self, root: &str, module: &str) {
-        if CRATE_ROOTS.contains(&root) && FORBIDDEN_MODULES.contains(&module) {
+        if self.roots.contains(root) && FORBIDDEN_MODULES.contains(&module) {
             self.found.insert(format!("{root}::{module}"));
+        }
+    }
+
+    /// Check every adjacent segment pair, not only the first two.
+    ///
+    /// A root is not always the leading segment: `super::internal::adaptive::X` puts the
+    /// aliased root second. Scanning pairs also covers `self::`, and costs nothing because
+    /// a pair only matches when its left half is a known root.
+    fn note_pairs(&mut self, segments: &[String]) {
+        for window in segments.windows(2) {
+            self.note(&window[0], &window[1]);
         }
     }
 
@@ -610,13 +641,13 @@ impl ModuleReferenceVisitor {
 impl<'ast> Visit<'ast> for ModuleReferenceVisitor {
     fn visit_item_use(&mut self, item: &'ast syn::ItemUse) {
         for leaf in flatten_use_tree(&item.tree) {
-            let mut segments = leaf.split("::");
-            if let (Some(root), Some(module)) = (segments.next(), segments.next()) {
-                // `use crate::adaptive as contract;` renders its leaf as `adaptive as
-                // contract`, so the alias is trimmed before comparison.
-                let module = module.split(" as ").next().unwrap_or(module);
-                self.note(root, module);
-            }
+            // `use crate::adaptive as contract;` renders its leaf as `adaptive as
+            // contract`, so the alias is trimmed before comparison.
+            let segments: Vec<String> = leaf
+                .split("::")
+                .map(|part| part.split(" as ").next().unwrap_or(part).trim().to_string())
+                .collect();
+            self.note_pairs(&segments);
         }
         visit::visit_item_use(self, item);
     }
@@ -627,9 +658,7 @@ impl<'ast> Visit<'ast> for ModuleReferenceVisitor {
             .iter()
             .map(|segment| segment.ident.to_string())
             .collect();
-        if segments.len() >= 2 {
-            self.note(&segments[0], &segments[1]);
-        }
+        self.note_pairs(&segments);
         visit::visit_path(self, path);
     }
 
@@ -639,8 +668,40 @@ impl<'ast> Visit<'ast> for ModuleReferenceVisitor {
     }
 }
 
+/// Names bound to this crate's root in `file`, including `use crate as internal;`.
+///
+/// `use crate as internal;` then `internal::adaptive::X` reached the forbidden module
+/// through a root the visitor had never heard of: the alias statement has a single path
+/// segment so it registered nothing, and the reference began with `internal`. Found by
+/// CodeRabbit at `59523f8`.
+fn crate_root_names(file: &File) -> BTreeSet<String> {
+    #[derive(Default)]
+    struct AliasVisitor {
+        aliases: BTreeSet<String>,
+    }
+    impl<'ast> Visit<'ast> for AliasVisitor {
+        fn visit_use_tree(&mut self, tree: &'ast UseTree) {
+            if let UseTree::Rename(rename) = tree {
+                if CRATE_ROOTS.contains(&rename.ident.to_string().as_str()) {
+                    self.aliases.insert(rename.rename.to_string());
+                }
+            }
+            visit::visit_use_tree(self, tree);
+        }
+    }
+    let mut visitor = AliasVisitor::default();
+    visitor.visit_file(file);
+    let mut roots: BTreeSet<String> = CRATE_ROOTS.iter().map(|r| (*r).to_string()).collect();
+    roots.extend(visitor.aliases);
+    roots
+}
+
+/// Forbidden module references in `file`, resolving crate-root aliases first.
 fn forbidden_module_references(file: &File) -> Vec<String> {
-    let mut visitor = ModuleReferenceVisitor::default();
+    let mut visitor = ModuleReferenceVisitor {
+        found: BTreeSet::new(),
+        roots: crate_root_names(file),
+    };
     visitor.visit_file(file);
     visitor.found.into_iter().collect()
 }
@@ -866,6 +927,39 @@ fn lint_the_internal_event_module_invokes_only_allowed_macros() {
         invocations,
         vec!["tracing::trace".to_string()],
         "the module's macro invocations changed; the allowlist now describes something else"
+    );
+}
+
+#[test]
+fn lint_no_module_anywhere_implements_a_trait_for_adaptive_event() {
+    // The crate-wide half. Rust lets an external trait be implemented for a crate-local
+    // type from *any* module, and `src/producers/aggregator.rs` already imports
+    // `AdaptiveEvent` — so a sibling can make it serializable while every `event.rs`
+    // allowlist stays clean: no new import, derive, attribute, macro or impl in that file.
+    //
+    // The stated invariant is that the internal event cannot become serializable by
+    // accident. That invariant is crate-wide, so the check is too. Found by CodeRabbit at
+    // `59523f8`.
+    let mut violations = Vec::new();
+    let mut swept = 0usize;
+    for (path, text) in rust_sources_under("src") {
+        swept += 1;
+        let file = parse_source(&path, &text);
+        for implemented in trait_impls_for(&file, ADAPTIVE_EVENT) {
+            violations.push(format!("{path}: impl {implemented} for {ADAPTIVE_EVENT}"));
+        }
+    }
+    assert!(
+        swept > 50,
+        "the sweep covered only {swept} files, which means it is not walking src/"
+    );
+    assert!(
+        violations.is_empty(),
+        "{ADAPTIVE_EVENT} has hand-written trait impls somewhere in the crate: \
+         {violations:?}\nAn external trait implemented for a crate-local type is legal from \
+         any module, so this guarantee cannot be enforced in one file. If an impl becomes \
+         necessary, allow it here having checked it is not a serialization trait under \
+         another name."
     );
 }
 
@@ -1347,6 +1441,170 @@ fn the_attribute_allowlist_accepts_what_the_type_actually_carries() {
         macro_invocations(&snippet("pub enum AdaptiveEvent {}\n")).is_empty(),
         "an item macro was invented where there is none"
     );
+}
+
+#[test]
+fn a_nested_module_cannot_hide_an_import_or_a_trait_impl() {
+    // `imports_of` and `trait_impls_for` iterated `File.items` only, so a nested module was
+    // a blind spot for both at once:
+    //
+    //     mod wire {
+    //         impl serde::Serialize for super::AdaptiveEvent { … }
+    //     }
+    //
+    // No new attribute, no derive, no macro invocation - and `AdaptiveEvent` is crate-local
+    // while serde is already a dependency, so the impl is legal. Found by CodeRabbit at
+    // `59523f8`.
+    let exploit = "mod wire {\n    use serde::Serialize;\n    impl serde::Serialize for super::AdaptiveEvent {}\n}\n#[derive(Debug, Clone)]\npub enum AdaptiveEvent {}\n";
+    let file = snippet(exploit);
+
+    assert!(
+        !trait_impls_for(&file, ADAPTIVE_EVENT).is_empty(),
+        "a nested trait impl for AdaptiveEvent was invisible:\n{exploit}"
+    );
+    let imports = imports_of(&file);
+    assert!(
+        imports.iter().any(|i| i == "serde::Serialize"),
+        "an import inside a nested module was invisible: {imports:?}\n{exploit}"
+    );
+    assert!(
+        imports
+            .iter()
+            .any(|i| !EVENT_ALLOWED_IMPORTS.contains(&i.as_str())),
+        "the allowlist admitted a nested import: {imports:?}"
+    );
+
+    // Deeper nesting, and an impl written without the `super::` qualifier.
+    for (label, source) in [
+        (
+            "two modules deep",
+            "mod a {\n    mod b {\n        impl Serialize for crate::producers::event::AdaptiveEvent {}\n    }\n}\n",
+        ),
+        (
+            "nested import only",
+            "mod wire {\n    use crate::wire::EventWire;\n}\n",
+        ),
+        (
+            "nested inside an inline module with items after it",
+            "mod wire {\n    impl Serialize for super::AdaptiveEvent {}\n}\nfn after() {}\n",
+        ),
+    ] {
+        let file = snippet(source);
+        let hit = !trait_impls_for(&file, ADAPTIVE_EVENT).is_empty()
+            || imports_of(&file)
+                .iter()
+                .any(|i| !EVENT_ALLOWED_IMPORTS.contains(&i.as_str()));
+        assert!(hit, "{label}: nesting hid the escape:\n{source}");
+    }
+}
+
+#[test]
+fn a_sibling_module_cannot_implement_a_trait_for_adaptive_event() {
+    // The no-trait-impl guarantee was enforced only inside `event.rs`. Rust allows an
+    // external trait to be implemented for a crate-local type from anywhere in the crate,
+    // and `src/producers/aggregator.rs` already imports `AdaptiveEvent` — so a sibling can
+    // make it serializable while all four `event.rs` allowlists stay clean: no new import,
+    // derive, attribute, macro or impl *in that file*. Found by CodeRabbit at `59523f8`.
+    for (label, source) in [
+        (
+            "sibling importing the type by name",
+            "use super::event::AdaptiveEvent;\nimpl serde::Serialize for AdaptiveEvent {}\n",
+        ),
+        (
+            "sibling using a qualified self type",
+            "impl serde::Serialize for super::event::AdaptiveEvent {}\n",
+        ),
+        (
+            "sibling using the full crate path",
+            "impl serde::Serialize for crate::producers::event::AdaptiveEvent {}\n",
+        ),
+        (
+            "sibling with the impl nested in a module",
+            "mod helper {\n    impl serde::Serialize for crate::producers::event::AdaptiveEvent {}\n}\n",
+        ),
+    ] {
+        assert!(
+            !trait_impls_for(&snippet(source), ADAPTIVE_EVENT).is_empty(),
+            "{label}: a sibling module's impl for AdaptiveEvent was invisible:\n{source}"
+        );
+    }
+
+    // Positive control: an impl for a *different* type in a sibling must not register.
+    for source in [
+        "impl serde::Serialize for super::event::AdaptiveEventLog {}\n",
+        "impl Default for AdaptiveBus {}\n",
+        "impl AdaptiveEvent {}\n",
+    ] {
+        assert!(
+            trait_impls_for(&snippet(source), ADAPTIVE_EVENT).is_empty(),
+            "the scanner invented an impl in:\n{source}"
+        );
+    }
+}
+
+#[test]
+fn a_crate_root_alias_cannot_launder_a_forbidden_module_reference() {
+    // `use crate as internal;` then `internal::adaptive::X`. The alias statement has a
+    // single path segment so it registered nothing, and the reference begins with a root
+    // the visitor had never heard of. Found by CodeRabbit at `59523f8`.
+    for (label, source) in [
+        (
+            "aliased crate root in expression position",
+            "use crate as internal;\nfn handler() { let _ = internal::adaptive::ProducerDocument; }\n",
+        ),
+        (
+            "aliased crate root reaching the publication layer",
+            "use crate as internal;\nfn handler() { let _ = internal::producers::ProducerAggregator; }\n",
+        ),
+        (
+            "aliased crate root in type position",
+            "use crate as internal;\nfn f(x: internal::adaptive::X) {}\n",
+        ),
+        (
+            "aliased crate root inside a macro token stream",
+            "use crate as internal;\nfn f() { println!(\"{:?}\", internal::producers::P); }\n",
+        ),
+        (
+            "aliased external crate root",
+            "use unified_hifi_control as uhc;\nfn f() { let _ = uhc::adaptive::X; }\n",
+        ),
+        (
+            "aliased root used in a nested module",
+            "use crate as internal;\nmod inner {\n    fn f() { let _ = super::internal::adaptive::X; }\n}\n",
+        ),
+    ] {
+        assert!(
+            !forbidden_module_references(&snippet(source)).is_empty(),
+            "{label}: an aliased crate root laundered the reference:\n{source}"
+        );
+    }
+}
+
+#[test]
+fn unrelated_crate_aliases_do_not_false_positive() {
+    // Positive controls for the alias tracking. Aliasing something else, or aliasing the
+    // crate and then not reaching a forbidden module, must stay clean.
+    for (label, source) in [
+        (
+            "alias of another crate",
+            "use std as s;\nfn f() { let _ = s::fmt::Debug; }\n",
+        ),
+        (
+            "crate alias used for something permitted",
+            "use crate as internal;\nfn f() { let _ = internal::bus::SharedBus; }\n",
+        ),
+        ("the alias statement alone", "use crate as internal;\n"),
+        (
+            "a module whose name merely shares a prefix, through an alias",
+            "use crate as internal;\nfn f() { let _ = internal::adaptive_extras::X; }\n",
+        ),
+    ] {
+        assert!(
+            forbidden_module_references(&snippet(source)).is_empty(),
+            "{label}: alias tracking invented a reference: {:?}\n{source}",
+            forbidden_module_references(&snippet(source))
+        );
+    }
 }
 
 #[test]

--- a/tests/adaptive_publication_lint.rs
+++ b/tests/adaptive_publication_lint.rs
@@ -33,15 +33,146 @@ const PRODUCERS_DECLARATION: &str = "pub mod producers;";
 /// The readable spelling, used in failure messages.
 const SERVER_GATE: &str = "#[cfg(feature = \"server\")]";
 
-/// Whether an extracted attribute is the server gate, whitespace notwithstanding.
+/// Whether an extracted attribute gates its item on the `server` feature and nothing looser.
 ///
-/// `#[cfg(feature="server")]` is the same gate as `#[cfg(feature = "server")]`. A substring
-/// match against one spelling silently accepts the other, which is the blind spot
-/// `1577948` fixed in `tests/adaptive_dependency_lint.rs` — and which
-/// `gate_scanner_detects_a_gate_it_must_not_miss` caught in this file before it shipped.
+/// Two ways to get this wrong, both of which accept a gate that is not server-only:
+///
+/// 1. **Whitespace.** `#[cfg(feature="server")]` is the same gate as
+///    `#[cfg(feature = "server")]`; matching one spelling silently accepts the other. That
+///    is the blind spot `1577948` fixed in `tests/adaptive_dependency_lint.rs`, and
+///    `gate_scanner_detects_a_gate_it_must_not_miss` caught it here before it shipped.
+/// 2. **Disjunction.** `#[cfg(any(feature = "server", feature = "web"))]` *contains*
+///    `feature="server"` while compiling the module for `web` **without** `server` — which
+///    is exactly the WASM breakage this lint exists to prevent, admitted by the lint that
+///    was supposed to prevent it. Found by CodeRabbit at `86e5bd2`.
+///
+/// So: the normalized attribute must mention the server feature and must contain neither
+/// `any(` nor `not(`. A stricter conjunctive gate (`all(feature = "server", unix)`) is still
+/// server-only and is accepted; loosening it later has to be deliberate, because the lint
+/// fails until someone edits this function.
 fn is_server_gate(attribute: &str) -> bool {
     let squeezed: String = attribute.chars().filter(|c| !c.is_whitespace()).collect();
     squeezed.contains("feature=\"server\"")
+        && !squeezed.contains("any(")
+        && !squeezed.contains("not(")
+}
+
+/// The module paths a source file reaches, including through grouped `use` trees.
+///
+/// A needle scan for `crate::adaptive` misses `use crate::{adaptive, producers};`, which
+/// names neither literal. That is not hypothetical: `src/main.rs` imports this repository's
+/// modules in exactly that style, so a surface adopting the house style would have slipped
+/// straight past the boundary check. Found by CodeRabbit at `86e5bd2`.
+fn forbidden_module_references(code: &str) -> Vec<String> {
+    const ROOTS: &[&str] = &["crate", "unified_hifi_control"];
+    const FORBIDDEN: &[&str] = &["adaptive", "producers"];
+    let mut found = Vec::new();
+
+    // Fully-spelled paths, anywhere - `use`, a turbofish, a type position.
+    for root in ROOTS {
+        for module in FORBIDDEN {
+            let needle = format!("{root}::{module}");
+            if code.contains(&needle) {
+                found.push(needle);
+            }
+        }
+    }
+
+    // Grouped use trees: `use <root>::{ a, b::c, d as e };`
+    //
+    // Whitespace is collapsed rather than removed. Removing it entirely turns
+    // `adaptive as contract` into `adaptiveascontract`, so the alias can no longer be split
+    // off and the item stops matching - a probe caught exactly that here.
+    let normalized = collapse_whitespace(code);
+    for root in ROOTS {
+        let opener = format!("use {root}::{{");
+        let mut rest = normalized.as_str();
+        while let Some(at) = rest.find(&opener) {
+            let after = &rest[at + opener.len()..];
+            let mut depth = 1usize;
+            let mut end = after.len();
+            for (index, c) in after.char_indices() {
+                match c {
+                    '{' => depth += 1,
+                    '}' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            end = index;
+                            break;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            for item in split_top_level(&after[..end]) {
+                let head = item
+                    .split("::")
+                    .next()
+                    .unwrap_or_default()
+                    .split(" as ")
+                    .next()
+                    .unwrap_or_default();
+                if FORBIDDEN.contains(&head) {
+                    found.push(format!("{root}::{{… {head} …}}"));
+                }
+            }
+            rest = &after[end.min(after.len())..];
+        }
+    }
+
+    found.sort();
+    found.dedup();
+    found
+}
+
+/// Collapse whitespace runs to one space, then close it up around path punctuation.
+///
+/// Leaves ` as ` intact — which is the whole reason this is not a plain whitespace strip.
+fn collapse_whitespace(code: &str) -> String {
+    let mut out = String::with_capacity(code.len());
+    let mut last_was_space = false;
+    for c in code.chars() {
+        if c.is_whitespace() {
+            if !last_was_space {
+                out.push(' ');
+                last_was_space = true;
+            }
+        } else {
+            out.push(c);
+            last_was_space = false;
+        }
+    }
+    for token in ["::", "{", "}", ",", ";"] {
+        out = out.replace(&format!(" {token}"), token);
+        out = out.replace(&format!("{token} "), token);
+    }
+    out
+}
+
+/// Split a brace group on commas that are not inside a nested group.
+fn split_top_level(group: &str) -> Vec<&str> {
+    let mut items = Vec::new();
+    let mut depth = 0usize;
+    let mut start = 0usize;
+    for (index, c) in group.char_indices() {
+        match c {
+            '{' => depth += 1,
+            '}' => depth = depth.saturating_sub(1),
+            ',' if depth == 0 => {
+                items.push(&group[start..index]);
+                start = index + 1;
+            }
+            _ => {}
+        }
+    }
+    if start < group.len() {
+        items.push(&group[start..]);
+    }
+    items
+        .into_iter()
+        .map(str::trim)
+        .filter(|i| !i.is_empty())
+        .collect()
 }
 
 // =============================================================================
@@ -256,16 +387,8 @@ fn lint_only_the_composition_root_names_the_contract_or_the_publication_layer() 
             continue;
         }
         swept += 1;
-        let code = code_only(&text);
-        for needle in [
-            "crate::adaptive",
-            "crate::producers",
-            "unified_hifi_control::adaptive",
-            "unified_hifi_control::producers",
-        ] {
-            if code.contains(needle) {
-                violations.push(format!("{path}: references `{needle}`"));
-            }
+        for reference in forbidden_module_references(&code_only(&text)) {
+            violations.push(format!("{path}: references `{reference}`"));
         }
     }
     assert!(
@@ -352,7 +475,10 @@ fn lint_publication_layer_is_reachable_only_from_the_composition_root() {
         if path.starts_with("src/producers") || path == "src/lib.rs" || path == "src/main.rs" {
             continue;
         }
-        if code_only(&text).contains("crate::producers") {
+        if forbidden_module_references(&code_only(&text))
+            .iter()
+            .any(|reference| reference.contains("producers"))
+        {
             referrers.push(path);
         }
     }
@@ -411,6 +537,13 @@ fn gate_scanner_does_not_invent_a_gate_that_is_not_there() {
         "#[cfg_attr(feature = \"server\", allow(dead_code))]\npub mod producers;\n",
         // A different feature is not the server gate.
         "#[cfg(feature = \"web\")]\npub mod producers;\n",
+        // Disjunctive: contains `feature="server"` but compiles the module for `web`
+        // *without* `server`, which is the WASM breakage this lint exists to prevent.
+        // Passed the pre-fix scanner. Found by CodeRabbit at `86e5bd2`.
+        "#[cfg(any(feature = \"server\", feature = \"web\"))]\npub mod producers;\n",
+        "#[cfg(any(feature=\"server\",feature=\"web\"))]\npub mod producers;\n",
+        // Negation, for the same reason in the opposite direction.
+        "#[cfg(not(feature = \"server\"))]\npub mod producers;\n",
     ] {
         let gates = declaration_gates(source, PRODUCERS_DECLARATION)
             .unwrap_or_else(|| panic!("declaration not found in:\n{source}"));
@@ -432,6 +565,59 @@ fn declaration_scanner_reports_absence_rather_than_guessing() {
         declaration_gates("/// pub mod producers;\n", PRODUCERS_DECLARATION),
         None
     );
+}
+
+#[test]
+fn a_stricter_conjunctive_gate_is_still_server_only() {
+    // `all(feature = "server", unix)` compiles the module in strictly fewer configurations
+    // than the plain gate, so it cannot reintroduce the WASM breakage. Accepted, unlike the
+    // disjunctive form above - the distinction is which direction the gate is loosened.
+    let source = "#[cfg(all(feature = \"server\", unix))]\npub mod producers;\n";
+    let gates = declaration_gates(source, PRODUCERS_DECLARATION).expect("declaration found");
+    assert!(gates.iter().any(|gate| is_server_gate(gate)));
+}
+
+#[test]
+fn grouped_use_trees_do_not_hide_a_forbidden_module() {
+    // A needle scan for `crate::adaptive` misses every one of these. This is the house
+    // style in this repository - `src/main.rs` imports its modules exactly this way - so a
+    // surface writing idiomatic code would have slipped past the boundary check entirely.
+    // Found by CodeRabbit at `86e5bd2`.
+    for source in [
+        "use crate::{adaptive, bus};",
+        "use crate::{bus, producers};",
+        "use unified_hifi_control::{adaptive, producers};",
+        "use unified_hifi_control::{\n    adapters, aggregator, api,\n    producers,\n};",
+        // Nested and aliased forms.
+        "use crate::{producers::ProducerAggregator, bus::SharedBus};",
+        "use crate::{adaptive as contract};",
+        "use crate::{bus::{SharedBus, BusEvent}, adaptive};",
+    ] {
+        let found = forbidden_module_references(source);
+        assert!(
+            !found.is_empty(),
+            "a grouped import hid a forbidden module:\n{source}"
+        );
+    }
+}
+
+#[test]
+fn grouped_use_trees_do_not_produce_false_positives() {
+    // The scanner must not fire on modules that merely share a prefix, on unrelated
+    // groups, or on a group belonging to a different root.
+    for source in [
+        "use crate::{bus, config};",
+        "use crate::{adapters, aggregator};",
+        "use std::{collections::BTreeMap, sync::Arc};",
+        "use serde::{Deserialize, Serialize};",
+        "use other_crate::{adaptive, producers};",
+    ] {
+        let found = forbidden_module_references(source);
+        assert!(
+            found.is_empty(),
+            "the scanner invented a reference in:\n{source}\nfound: {found:?}"
+        );
+    }
 }
 
 #[test]

--- a/tests/adaptive_publication_lint.rs
+++ b/tests/adaptive_publication_lint.rs
@@ -62,7 +62,10 @@
 //! derives and `ItemImpl` entirely clean. An earlier commit recorded that as an accepted
 //! residual; Codex was right to reject it, because it is a live false pass and it closes
 //! the same way everything else here did — by permission. `AdaptiveEvent` may carry only
-//! `derive` and `doc`; and every macro invocation in `src/producers/event.rs` — at any
+//! `derive` and `doc`; every attribute **anywhere in the module** is policed, because a
+//! proc macro emits arbitrary items rather than only code about what it annotates, so
+//! `#[generate_event_wire] fn helper() {}` elsewhere can emit an impl for `AdaptiveEvent`
+//! with every enum-specific check clean; and every macro invocation — at any
 //! depth, not only item position, since a statement-position macro can expand to items —
 //! must be on an allowlist that currently holds only `tracing::trace`.
 //!
@@ -316,6 +319,116 @@ fn macro_invocations(file: &File) -> Vec<String> {
     let mut visitor = MacroInvocationVisitor::default();
     visitor.visit_file(file);
     visitor.found
+}
+
+/// Every attribute in `file`, at any depth, paired with the item that owns it.
+///
+/// Attributes on functions, structs, impl blocks, fields, variants and nested modules all
+/// appear. The enum-specific checks audit only `AdaptiveEvent`'s own attributes, and a
+/// procedural macro emits arbitrary *items* rather than only code about the thing it
+/// annotates — so `#[generate_event_wire] fn helper() {}` elsewhere in the module can emit
+/// `impl Serialize for AdaptiveEvent` with every enum-specific check clean. Found by Codex
+/// at `4a817c9`.
+#[derive(Default)]
+struct AttributeVisitor {
+    owners: Vec<String>,
+    found: Vec<(String, String)>,
+}
+
+fn item_label(item: &Item) -> String {
+    match item {
+        Item::Enum(inner) => format!("enum {}", inner.ident),
+        Item::Struct(inner) => format!("struct {}", inner.ident),
+        Item::Fn(inner) => format!("fn {}", inner.sig.ident),
+        Item::Mod(inner) => format!("mod {}", inner.ident),
+        Item::Impl(inner) => match inner.self_ty.as_ref() {
+            syn::Type::Path(path) => path
+                .path
+                .segments
+                .last()
+                .map(|segment| format!("impl {}", segment.ident))
+                .unwrap_or_else(|| "impl".to_string()),
+            _ => "impl".to_string(),
+        },
+        Item::Type(inner) => format!("type {}", inner.ident),
+        Item::Const(inner) => format!("const {}", inner.ident),
+        Item::Static(inner) => format!("static {}", inner.ident),
+        Item::Trait(inner) => format!("trait {}", inner.ident),
+        Item::Use(_) => "use".to_string(),
+        Item::Macro(inner) => inner
+            .mac
+            .path
+            .segments
+            .last()
+            .map(|segment| format!("{}!", segment.ident))
+            .unwrap_or_else(|| "macro".to_string()),
+        _ => "item".to_string(),
+    }
+}
+
+impl<'ast> Visit<'ast> for AttributeVisitor {
+    fn visit_item(&mut self, item: &'ast Item) {
+        self.owners.push(item_label(item));
+        visit::visit_item(self, item);
+        self.owners.pop();
+    }
+
+    fn visit_attribute(&mut self, attr: &'ast Attribute) {
+        let owner = self
+            .owners
+            .last()
+            .cloned()
+            .unwrap_or_else(|| "<file>".to_string());
+        let path = attr
+            .path()
+            .segments
+            .iter()
+            .map(|segment| segment.ident.to_string())
+            .collect::<Vec<_>>()
+            .join("::");
+        self.found.push((owner, path));
+        visit::visit_attribute(self, attr);
+    }
+}
+
+fn module_attributes(file: &File) -> Vec<(String, String)> {
+    let mut visitor = AttributeVisitor::default();
+    visitor.visit_file(file);
+    visitor.found
+}
+
+/// Attributes anywhere in `file` that the module-wide policy forbids.
+///
+/// The policy, location-aware because a blanket list would have to permit `derive`
+/// everywhere and that is exactly the hole:
+///
+/// * `doc` — anywhere. Doc comments desugar to it and the module is heavily documented.
+/// * `derive` — **only** on `enum AdaptiveEvent`, and only holding
+///   [`ADAPTIVE_EVENT_ALLOWED_DERIVES`]. A custom derive on a helper struct emits arbitrary
+///   items just as an attribute macro does.
+/// * anything else — rejected, wherever it appears.
+///
+/// This is the production gate. The enum-specific checks are kept because they name the
+/// offender more precisely, but they are no longer what carries the guarantee.
+fn disallowed_module_attributes(file: &File) -> Vec<String> {
+    let mut rejected = Vec::new();
+    for (owner, path) in module_attributes(file) {
+        match path.as_str() {
+            "doc" => {}
+            "derive" if owner == format!("enum {ADAPTIVE_EVENT}") => {}
+            _ => rejected.push(format!("#[{path}] on {owner}")),
+        }
+    }
+    // A derive that is in the right place but holds the wrong token is still forbidden, so
+    // the module-wide policy cannot be satisfied by relocating a bad derive onto the enum.
+    if let Some(item) = adaptive_event_enum(file) {
+        for token in derives_in(&item.attrs) {
+            if !ADAPTIVE_EVENT_ALLOWED_DERIVES.contains(&token.as_str()) {
+                rejected.push(format!("derive({token}) on enum {ADAPTIVE_EVENT}"));
+            }
+        }
+    }
+    rejected
 }
 
 /// Every trait implemented for `type_name` in `file`.
@@ -651,6 +764,37 @@ fn lint_adaptive_event_carries_only_allowed_attributes() {
 }
 
 #[test]
+fn lint_the_internal_event_module_carries_only_allowed_attributes_anywhere() {
+    // The production gate for attribute-driven generation. The enum-specific check below
+    // audits only `AdaptiveEvent`'s own attributes, and a procedural macro emits arbitrary
+    // items rather than only code about what it annotates — so an attribute macro on a
+    // helper function, or a custom derive on a helper struct, could emit
+    // `impl Serialize for AdaptiveEvent` with every enum-specific check clean.
+    let file = parse_file_at(EVENT_MODULE);
+    let rejected = disallowed_module_attributes(&file);
+    assert!(
+        rejected.is_empty(),
+        "{EVENT_MODULE} carries attributes the module-wide policy forbids: {rejected:?}\n\
+         Policy: `doc` anywhere; `derive` only on `enum {ADAPTIVE_EVENT}` holding only \
+         {ADAPTIVE_EVENT_ALLOWED_DERIVES:?}; nothing else. A proc macro anywhere in this \
+         module can emit an impl for {ADAPTIVE_EVENT}, so permission is module-wide."
+    );
+
+    // The policy must describe the module, not merely permit it: if the one real derive
+    // vanished, the policy would be silently over-broad.
+    let derive_owners: Vec<String> = module_attributes(&file)
+        .into_iter()
+        .filter(|(_, path)| path == "derive")
+        .map(|(owner, _)| owner)
+        .collect();
+    assert_eq!(
+        derive_owners,
+        vec![format!("enum {ADAPTIVE_EVENT}")],
+        "the module's derives changed; the policy now describes something else"
+    );
+}
+
+#[test]
 fn lint_the_internal_event_module_invokes_only_allowed_macros() {
     // A macro expands to arbitrary code - an `impl`, a `use`, another type - while
     // imports, derives and `ItemImpl` all stay clean. Checked at *every* depth, not only
@@ -951,6 +1095,112 @@ fn code_generating_macros_cannot_target_adaptive_event() {
             "a non-derive attribute was admitted:\n{source}"
         );
     }
+}
+
+#[test]
+fn a_proc_macro_on_any_other_item_cannot_generate_for_adaptive_event() {
+    // The enum-specific checks audit `AdaptiveEvent`'s own attributes. A procedural macro
+    // emits arbitrary *items*, not only code about the thing it annotates — so an
+    // attribute macro on a helper function, or a custom derive on a helper struct, can emit
+    // `impl Serialize for AdaptiveEvent` while the enum's attrs, the imports, the
+    // `ItemImpl` list and the function-like macro allowlist all stay clean.
+    //
+    // Found by Codex at `4a817c9`. Each case asserts both halves: that the enum-only check
+    // passes it (the false pass), and that the module-wide policy rejects it (the fix).
+    for (label, source) in [
+        (
+            "attribute macro on a helper fn",
+            "#[generate_event_wire]\nfn helper() {}\n#[derive(Debug, Clone)]\npub enum AdaptiveEvent {}\n",
+        ),
+        (
+            "custom derive on a helper struct",
+            "#[derive(GenerateAdaptiveWire)]\nstruct Helper;\n#[derive(Debug, Clone)]\npub enum AdaptiveEvent {}\n",
+        ),
+        (
+            "attribute macro on an impl block",
+            "#[generate_event_wire]\nimpl Helper {}\n#[derive(Debug, Clone)]\npub enum AdaptiveEvent {}\n",
+        ),
+        (
+            "attribute macro on a nested item",
+            "mod inner {\n    #[generate_event_wire]\n    fn helper() {}\n}\n#[derive(Debug, Clone)]\npub enum AdaptiveEvent {}\n",
+        ),
+        (
+            "custom derive on a helper enum",
+            "#[derive(GenerateAdaptiveWire)]\nenum Helper { A }\n#[derive(Debug, Clone)]\npub enum AdaptiveEvent {}\n",
+        ),
+        (
+            "attribute macro on a struct field",
+            "struct Helper {\n    #[generate_event_wire]\n    field: u8,\n}\n#[derive(Debug, Clone)]\npub enum AdaptiveEvent {}\n",
+        ),
+    ] {
+        let file = snippet(source);
+
+        // The false pass: every enum-specific check is clean.
+        let item = adaptive_event_enum(&file).expect("enum located");
+        assert!(
+            disallowed_attributes(&item.attrs).is_empty(),
+            "{label}: precondition failed - the enum's own attrs were not clean"
+        );
+        assert!(
+            derives_in(&item.attrs)
+                .iter()
+                .all(|token| ADAPTIVE_EVENT_ALLOWED_DERIVES.contains(&token.as_str())),
+            "{label}: precondition failed - the enum's derives were not clean"
+        );
+        assert!(
+            imports_of(&file).is_empty() && trait_impls_for(&file, ADAPTIVE_EVENT).is_empty(),
+            "{label}: precondition failed - imports or impls were not clean"
+        );
+        assert!(
+            macro_invocations(&file).is_empty(),
+            "{label}: precondition failed - a function-like macro was present"
+        );
+
+        // The fix: the module-wide policy rejects it.
+        let rejected = disallowed_module_attributes(&file);
+        assert!(
+            !rejected.is_empty(),
+            "{label}: a proc macro on another item was admitted:\n{source}"
+        );
+    }
+}
+
+#[test]
+fn the_module_wide_attribute_policy_accepts_the_module_as_it_is() {
+    // Positive control. Doc comments anywhere, and one `derive` on `AdaptiveEvent` holding
+    // only `Debug` and `Clone`, is exactly what `src/producers/event.rs` carries — so the
+    // policy describes the module rather than merely constraining it.
+    for (label, source) in [
+        ("bare enum", "#[derive(Debug, Clone)]\npub enum AdaptiveEvent {}\n"),
+        (
+            "doc comments on helpers and variants",
+            "/// helper docs\nfn helper() {}\n/// enum docs\n#[derive(Debug, Clone)]\npub enum AdaptiveEvent {\n    /// variant docs\n    A,\n}\n",
+        ),
+        (
+            "doc on a struct field",
+            "struct Helper {\n    /// field docs\n    field: u8,\n}\n#[derive(Debug, Clone)]\npub enum AdaptiveEvent {}\n",
+        ),
+        (
+            "an inherent impl with documented methods",
+            "impl Helper {\n    /// method docs\n    fn f(&self) {}\n}\n#[derive(Debug, Clone)]\npub enum AdaptiveEvent {}\n",
+        ),
+    ] {
+        assert!(
+            disallowed_module_attributes(&snippet(source)).is_empty(),
+            "{label}: the policy rejected something the module legitimately has: {:?}\n{source}",
+            disallowed_module_attributes(&snippet(source))
+        );
+    }
+
+    // And a derive on the enum that is *not* allowlisted is still rejected module-wide, so
+    // the two checks agree rather than one masking the other.
+    assert!(
+        !disallowed_module_attributes(&snippet(
+            "#[derive(Debug, Serialize)]\npub enum AdaptiveEvent {}\n"
+        ))
+        .is_empty(),
+        "a forbidden derive on the enum passed the module-wide policy"
+    );
 }
 
 #[test]

--- a/tests/adaptive_publication_lint.rs
+++ b/tests/adaptive_publication_lint.rs
@@ -442,22 +442,143 @@ fn attributes_attached_to(source: &str, declaration: &str) -> Option<Vec<String>
     attached
 }
 
-/// Whether an attribute would make its item serializable.
+/// Every name by which serde's `Serialize`/`Deserialize` can be spelled in `code`.
 ///
-/// Covers `#[derive(Serialize)]` and `#[cfg_attr(…, derive(Serialize))]` alike: the question
-/// is whether the attribute introduces a serialization derive under *any* configuration, not
-/// which spelling it used. A `cfg_attr` gate does not make it safe — it makes it conditional,
-/// and the condition is somebody else's to set.
-fn introduces_serialization(attribute: &str) -> Option<&'static str> {
-    let squeezed: String = attribute.chars().filter(|c| !c.is_whitespace()).collect();
-    if !squeezed.contains("derive(") {
-        return None;
+/// Always includes the canonical two. Adds any **alias**, because
+/// `use serde::Serialize as EventWire;` binds the trait *and* the derive macro under that
+/// name — so `#[derive(EventWire)]` and `impl EventWire for AdaptiveEvent` both compile and
+/// neither contains the substring `Serialize`. Verified by compiling both forms against the
+/// real module before this was written. Found by CodeRabbit at `b35af10`.
+///
+/// Matching is on the **exact final path segment**, never a prefix: `serde::Serializer` and
+/// `serde::de::DeserializeOwned` are ordinary serde imports that must not register as the
+/// serialization traits, and both would match a substring test.
+fn serialization_names(code: &str) -> Vec<String> {
+    let mut names: Vec<String> = vec!["Serialize".to_string(), "Deserialize".to_string()];
+    let normalized = collapse_whitespace(code);
+    let mut rest = normalized.as_str();
+
+    while let Some(at) = rest.find("use serde") {
+        let tail = &rest[at + 4..];
+        let statement = match tail.find(';') {
+            Some(end) => &tail[..end],
+            None => tail,
+        };
+        rest = &tail[statement.len().min(tail.len())..];
+
+        // `use serde::{a, b}` or `use serde::a` (possibly via `ser::` / `de::`).
+        let items: Vec<String> = match (statement.find('{'), statement.rfind('}')) {
+            (Some(open), Some(close)) if open < close => {
+                let base = &statement[..open];
+                split_top_level(&statement[open + 1..close])
+                    .into_iter()
+                    .map(|item| format!("{base}{item}"))
+                    .collect()
+            }
+            _ => vec![statement.to_string()],
+        };
+
+        for item in items {
+            let (path, alias) = match item.split_once(" as ") {
+                Some((path, alias)) => (path.trim(), Some(alias.trim())),
+                None => (item.trim(), None),
+            };
+            let Some(last) = path.rsplit("::").next() else {
+                continue;
+            };
+            if last != "Serialize" && last != "Deserialize" {
+                continue;
+            }
+            if let Some(alias) = alias {
+                if !alias.is_empty() && !names.iter().any(|held| held == alias) {
+                    names.push(alias.to_string());
+                }
+            }
+        }
     }
-    // Matched on the capitalized trait names, which do not overlap: `Deserialize` contains
-    // a lower-case `serialize`, never `Serialize`, so neither can be mistaken for the other.
-    ["Serialize", "Deserialize"]
+    names
+}
+
+/// The trait names an attribute would derive, as final path segments.
+///
+/// Reads every `derive(...)` list in the attribute, including one nested inside
+/// `cfg_attr(...)`, and splits it into tokens so matching is exact rather than substring —
+/// `#[derive(Serializer)]` must not be mistaken for `#[derive(Serialize)]`.
+fn derive_tokens(attribute: &str) -> Vec<String> {
+    let normalized = collapse_whitespace(attribute);
+    let mut tokens = Vec::new();
+    let mut rest = normalized.as_str();
+    while let Some(at) = rest.find("derive(") {
+        let after = &rest[at + "derive(".len()..];
+        let mut depth = 1usize;
+        let mut end = after.len();
+        for (index, c) in after.char_indices() {
+            match c {
+                '(' => depth += 1,
+                ')' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        end = index;
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        for item in after[..end].split(',') {
+            let token = item.trim().rsplit("::").next().unwrap_or_default().trim();
+            if !token.is_empty() {
+                tokens.push(token.to_string());
+            }
+        }
+        rest = &after[end.min(after.len())..];
+    }
+    tokens
+}
+
+/// Whether an attribute would make its item serializable, under any name.
+///
+/// Covers `#[derive(Serialize)]`, `#[cfg_attr(…, derive(Serialize))]` and
+/// `#[derive(EventWire)]` where `EventWire` is an alias for one of the traits. A `cfg_attr`
+/// gate does not make it safe — it makes it conditional, and the condition is somebody
+/// else's to set.
+fn introduces_serialization(attribute: &str, names: &[String]) -> Option<String> {
+    derive_tokens(attribute)
         .into_iter()
-        .find(|forbidden| squeezed.contains(forbidden))
+        .find(|token| names.iter().any(|name| name == token))
+}
+
+/// Whether `code` hand-writes a serialization impl for `type_name`, under any name.
+///
+/// Scans back from each `for <type_name>` to the `impl` that opened it, so
+/// `impl<'de> Deserialize<'de> for AdaptiveEvent` is caught — the previous check looked for
+/// the literal `DeserializeforAdaptiveEvent` and that idiomatic form never produces it.
+fn handwritten_serialization_impl(code: &str, type_name: &str, names: &[String]) -> Option<String> {
+    let normalized = collapse_whitespace(code);
+    let needle = format!("for {type_name}");
+    let mut search_from = 0usize;
+    while let Some(at) = normalized[search_from..].find(&needle) {
+        let absolute = search_from + at;
+        // The character after the match must end the type name, or `AdaptiveEventLog` would
+        // count as `AdaptiveEvent`.
+        let after = normalized[absolute + needle.len()..].chars().next();
+        let terminated = after.is_none_or(|c| !c.is_alphanumeric() && c != '_');
+        if terminated {
+            if let Some(impl_at) = normalized[..absolute].rfind("impl") {
+                let header = &normalized[impl_at..absolute];
+                for name in names {
+                    let mentioned = header
+                        .split(|c: char| !c.is_alphanumeric() && c != '_')
+                        .any(|token| token == name);
+                    if mentioned {
+                        return Some(name.clone());
+                    }
+                }
+            }
+        }
+        search_from = absolute + needle.len();
+    }
+    None
 }
 
 // =============================================================================
@@ -551,7 +672,14 @@ fn lint_adaptive_event_derives_no_serialization() {
     // `#[derive(Serialize)]` above a later `#[derive(Debug, Clone)]` was invisible to the
     // previous `rfind("#[derive(")` scan, as was any `#[cfg_attr(…, derive(Serialize))]`,
     // which the scan never looked for at all. Found by CodeRabbit at `eebde11`.
+    //
+    // Aliases are resolved rather than assumed away: `use serde::Serialize as EventWire;`
+    // binds the derive macro *and* the trait under a name containing no forbidden
+    // substring. Found by CodeRabbit at `b35af10`.
     let event = fs::read_to_string("src/producers/event.rs").expect("src/producers/event.rs");
+    let code = code_only(&event);
+    let names = serialization_names(&code);
+
     let attributes =
         attributes_attached_to(&event, ADAPTIVE_EVENT_DECLARATION).unwrap_or_else(|| {
             panic!("src/producers/event.rs must declare `{ADAPTIVE_EVENT_DECLARATION}`")
@@ -559,7 +687,7 @@ fn lint_adaptive_event_derives_no_serialization() {
     let offenders: Vec<String> = attributes
         .iter()
         .filter_map(|attribute| {
-            introduces_serialization(attribute)
+            introduces_serialization(attribute, &names)
                 .map(|trait_name| format!("{trait_name} via {attribute}"))
         })
         .collect();
@@ -571,17 +699,42 @@ fn lint_adaptive_event_derives_no_serialization() {
     );
 
     // A hand-written impl defeats the same guarantee without any derive at all.
-    let squeezed: String = code_only(&event)
-        .chars()
-        .filter(|c| !c.is_whitespace())
-        .collect();
-    for forbidden in ["Serialize", "Deserialize"] {
-        assert!(
-            !squeezed.contains(&format!("{forbidden}forAdaptiveEvent")),
-            "AdaptiveEvent has a hand-written `{forbidden}` impl, which reaches a wire just \
-             as surely as a derive."
+    if let Some(name) = handwritten_serialization_impl(&code, "AdaptiveEvent", &names) {
+        panic!(
+            "AdaptiveEvent has a hand-written `{name}` impl, which reaches a wire just as \
+             surely as a derive."
         );
     }
+}
+
+#[test]
+fn lint_the_internal_event_module_imports_no_serialization_trait() {
+    // The structural half, and the one that makes aliasing moot rather than merely detected.
+    //
+    // Resolving aliases catches `use serde::Serialize as EventWire;`. Forbidding the import
+    // outright removes the question: this module exists to hold the one producer type that
+    // cannot reach a wire, so it has no legitimate need for a serialization trait under any
+    // name. If that ever changes it should be a deliberate edit that has to delete this
+    // test, not an import nobody noticed.
+    let event = fs::read_to_string("src/producers/event.rs").expect("src/producers/event.rs");
+    let code = code_only(&event);
+
+    let aliases: Vec<String> = serialization_names(&code)
+        .into_iter()
+        .filter(|name| name != "Serialize" && name != "Deserialize")
+        .collect();
+    assert!(
+        aliases.is_empty(),
+        "src/producers/event.rs aliases a serialization trait: {aliases:?}. An alias makes \
+         `#[derive(…)]` and `impl … for AdaptiveEvent` invisible to any literal scan."
+    );
+
+    assert!(
+        !code.contains("serde"),
+        "src/producers/event.rs references serde. This module exists to hold the one \
+         producer type that cannot reach a wire; a serialization import here needs a \
+         deliberate justification, not a silent addition."
+    );
 }
 
 #[test]
@@ -758,12 +911,13 @@ fn a_serializing_adaptive_event_is_rejected_however_it_is_spelled() {
         // 7. Sharing the line with the declaration.
         "#[derive(Debug)] #[derive(Serialize)] pub enum AdaptiveEvent {\n}\n",
     ] {
+        let names = serialization_names(source);
         let attributes = attributes_attached_to(source, ADAPTIVE_EVENT_DECLARATION)
             .unwrap_or_else(|| panic!("declaration not found in:\n{source}"));
         assert!(
             attributes
                 .iter()
-                .any(|attribute| introduces_serialization(attribute).is_some()),
+                .any(|attribute| introduces_serialization(attribute, &names).is_some()),
             "a serializing AdaptiveEvent was admitted:\n{source}\nattributes: {attributes:?}"
         );
     }
@@ -783,13 +937,135 @@ fn a_non_serializing_adaptive_event_is_accepted() {
     ] {
         let attributes = attributes_attached_to(source, ADAPTIVE_EVENT_DECLARATION)
             .unwrap_or_else(|| panic!("declaration not found in:\n{source}"));
+        let names = serialization_names(source);
         let offenders: Vec<_> = attributes
             .iter()
-            .filter(|attribute| introduces_serialization(attribute).is_some())
+            .filter(|attribute| introduces_serialization(attribute, &names).is_some())
             .collect();
         assert!(
             offenders.is_empty(),
             "the scanner invented a serialization derive in:\n{source}\nfound: {offenders:?}"
+        );
+    }
+}
+
+#[test]
+fn an_aliased_serialization_trait_is_rejected() {
+    // `use serde::Serialize as EventWire;` binds the derive macro *and* the trait under a
+    // name containing neither "Serialize" nor "Deserialize", so every literal scan passes
+    // while the type is fully serializable. Both forms were compiled against the real
+    // module to confirm this before the test was written: `cargo build --lib` finished
+    // clean with an aliased derive and an aliased hand-written impl in place, and
+    // `lint_adaptive_event_derives_no_serialization` passed. Found by CodeRabbit at
+    // `b35af10`.
+    for (label, source) in [
+        (
+            "aliased derive",
+            "use serde::Serialize as EventWire;\n#[derive(EventWire)]\npub enum AdaptiveEvent {\n}\n",
+        ),
+        (
+            "aliased derive stacked behind the innocent one",
+            "use serde::Serialize as EventWire;\n#[derive(EventWire)]\n#[derive(Debug, Clone)]\npub enum AdaptiveEvent {\n}\n",
+        ),
+        (
+            "aliased Deserialize",
+            "use serde::Deserialize as EventRead;\n#[derive(Debug)]\n#[derive(EventRead)]\npub enum AdaptiveEvent {\n}\n",
+        ),
+        (
+            "aliased inside a grouped import",
+            "use serde::{Serialize as EventWire, Deserializer};\n#[derive(EventWire)]\npub enum AdaptiveEvent {\n}\n",
+        ),
+        (
+            "aliased via cfg_attr",
+            "use serde::Serialize as EventWire;\n#[cfg_attr(feature = \"x\", derive(EventWire))]\n#[derive(Debug)]\npub enum AdaptiveEvent {\n}\n",
+        ),
+        (
+            "aliased through a submodule path",
+            "use serde::ser::Serialize as EventWire;\n#[derive(EventWire)]\npub enum AdaptiveEvent {\n}\n",
+        ),
+    ] {
+        let names = serialization_names(source);
+        let attributes = attributes_attached_to(source, ADAPTIVE_EVENT_DECLARATION)
+            .unwrap_or_else(|| panic!("declaration not found for {label}:\n{source}"));
+        assert!(
+            attributes
+                .iter()
+                .any(|attribute| introduces_serialization(attribute, &names).is_some()),
+            "{label} was admitted:\n{source}\nresolved names: {names:?}"
+        );
+    }
+}
+
+#[test]
+fn an_aliased_handwritten_impl_is_rejected() {
+    for (label, source) in [
+        (
+            "aliased impl",
+            "use serde::Serialize as EventWire;\nimpl EventWire for AdaptiveEvent {}\n",
+        ),
+        (
+            "aliased Deserialize impl with a lifetime",
+            "use serde::Deserialize as EventRead;\nimpl<'de> EventRead<'de> for AdaptiveEvent {}\n",
+        ),
+        (
+            "canonical impl with a lifetime, which the previous literal scan also missed",
+            "impl<'de> Deserialize<'de> for AdaptiveEvent {}\n",
+        ),
+        ("canonical impl", "impl Serialize for AdaptiveEvent {}\n"),
+    ] {
+        let names = serialization_names(source);
+        assert!(
+            handwritten_serialization_impl(source, "AdaptiveEvent", &names).is_some(),
+            "{label} was admitted:\n{source}\nresolved names: {names:?}"
+        );
+    }
+}
+
+#[test]
+fn unrelated_aliases_and_imports_do_not_false_positive() {
+    // Positive controls. Two of these are the specific traps in exact-name matching:
+    // `Serializer` has `Serialize` as a prefix, and `DeserializeOwned` has `Deserialize`
+    // as one. Both are ordinary serde imports that must not register as the traits.
+    for (label, source) in [
+        (
+            "Serializer is not Serialize",
+            "use serde::Serializer;\n#[derive(Debug, Clone)]\npub enum AdaptiveEvent {\n}\n",
+        ),
+        (
+            "DeserializeOwned is not Deserialize",
+            "use serde::de::DeserializeOwned;\n#[derive(Debug, Clone)]\npub enum AdaptiveEvent {\n}\n",
+        ),
+        (
+            "an alias of something else entirely",
+            "use std::fmt::Display as EventWire;\n#[derive(EventWire)]\npub enum AdaptiveEvent {\n}\n",
+        ),
+        (
+            "a serializing impl for a different type",
+            "use serde::Serialize as EventWire;\nimpl EventWire for SomethingElse {}\n#[derive(Debug)]\npub enum AdaptiveEvent {\n}\n",
+        ),
+        (
+            "a prefix-sharing type name",
+            "impl Serialize for AdaptiveEventLog {}\n#[derive(Debug)]\npub enum AdaptiveEvent {\n}\n",
+        ),
+        (
+            "an unrelated impl for the right type",
+            "impl Clone for AdaptiveEvent {}\n#[derive(Debug)]\npub enum AdaptiveEvent {\n}\n",
+        ),
+    ] {
+        let names = serialization_names(source);
+        let attributes = attributes_attached_to(source, ADAPTIVE_EVENT_DECLARATION)
+            .unwrap_or_else(|| panic!("declaration not found for {label}:\n{source}"));
+        let derived: Vec<_> = attributes
+            .iter()
+            .filter_map(|attribute| introduces_serialization(attribute, &names))
+            .collect();
+        assert!(
+            derived.is_empty(),
+            "{label} produced a false positive on a derive: {derived:?}\n{source}"
+        );
+        assert!(
+            handwritten_serialization_impl(source, "AdaptiveEvent", &names).is_none(),
+            "{label} produced a false positive on an impl\n{source}\nnames: {names:?}"
         );
     }
 }

--- a/tests/adaptive_publication_lint.rs
+++ b/tests/adaptive_publication_lint.rs
@@ -164,11 +164,10 @@ fn is_sweep_exempt(path: &str) -> bool {
 /// `src/lib.rs` and `src/main.rs` are the crate root (0). `src/api/mod.rs` is `api` (1).
 /// `src/adapters/hqplayer.rs` is `adapters::hqplayer` (2).
 fn module_depth(path: &str) -> usize {
-    let trimmed = path
-        .strip_prefix("src/")
-        .unwrap_or(path)
-        .strip_suffix(".rs")
-        .unwrap_or(path);
+    // Two separate steps, because chaining them makes the second `unwrap_or` fall back to
+    // the untrimmed `path` and undo the first: `src/api/mod` would count `src` as a module.
+    let trimmed = path.strip_prefix("src/").unwrap_or(path);
+    let trimmed = trimmed.strip_suffix(".rs").unwrap_or(trimmed);
     if trimmed == "lib" || trimmed == "main" {
         return 0;
     }
@@ -751,16 +750,13 @@ impl<'ast> Visit<'ast> for ModuleReferenceVisitor {
             }
             // An *inline* module puts its contents one module further down, so `super::`
             // inside it needs one more hop to reach the crate root. `depth` was fixed per
-            // file, which got both directions backwards inside a nested module. An external
-            // `mod x;` declares a module whose contents live in another file and are not
-            // traversed here, so it must not change the depth. Raised by Codex against the
-            // first draft of the `super::` fix.
+            // file, which got both directions backwards inside a nested module. Raised by
+            // Codex against the first draft of the `super::` fix.
             //
-            // Incrementing for an external `mod x;` too would be *unobservable* rather than
-            // wrong: there is no inline content to scan under it, and the restore below
-            // makes the pair a no-op. No probe can distinguish the two, so the guard stays
-            // because it is semantically right, not because a test proves it - stated so
-            // nobody mistakes the surviving mutation for coverage.
+            // Gating on `content` is semantic, not load-bearing: an external `mod x;` has
+            // nothing beneath it to scan, so incrementing there too would be paired with the
+            // restore below and observable by nothing. No probe can distinguish the two -
+            // stated so nobody mistakes that surviving mutation for coverage.
             self.depth += 1;
         }
         visit::visit_item_mod(self, item);
@@ -2241,6 +2237,12 @@ fn module_depth_is_derived_from_the_file_path() {
         ("src/producers/event.rs", 2),
         ("src/app/pages/zones.rs", 3),
         ("src/server/routes/mod.rs", 2),
+        // A path with no `.rs` suffix must still lose its `src/` prefix. Chaining the two
+        // `unwrap_or`s made the second fall back to the *original* path, silently undoing
+        // the first trim and counting `src` as a module.
+        ("src/api/mod", 1),
+        ("src/adapters/hqplayer", 2),
+        ("src/lib", 0),
     ] {
         assert_eq!(
             module_depth(path),

--- a/tests/adaptive_publication_lint.rs
+++ b/tests/adaptive_publication_lint.rs
@@ -673,7 +673,7 @@ impl<'ast> Visit<'ast> for ModuleReferenceVisitor {
     fn visit_item_mod(&mut self, item: &'ast syn::ItemMod) {
         self.saved.push(self.roots.clone());
         if let Some((_, items)) = &item.content {
-            let (aliases, shadowed) = scope_delta(items);
+            let (aliases, shadowed) = scope_delta(items, &self.roots);
             self.roots.extend(aliases);
             for name in &shadowed {
                 self.roots.remove(name);
@@ -696,34 +696,85 @@ impl<'ast> Visit<'ast> for ModuleReferenceVisitor {
 /// This is scope tracking, not name resolution: aliases are inherited by descendants and
 /// shadowed by a sibling `mod` of the same name. That covers the reachable cases without
 /// pretending to resolve Rust's full name lookup.
-fn scope_delta(items: &[Item]) -> (BTreeSet<String>, BTreeSet<String>) {
-    let mut aliases = BTreeSet::new();
+fn scope_delta(
+    items: &[Item],
+    known_roots: &BTreeSet<String>,
+) -> (BTreeSet<String>, BTreeSet<String>) {
+    let mut aliases: BTreeSet<String> = BTreeSet::new();
     let mut shadowed = BTreeSet::new();
+
     for item in items {
-        match item {
-            Item::Use(item_use) => collect_crate_aliases(&item_use.tree, &mut aliases),
-            Item::Mod(item_mod) => {
-                shadowed.insert(item_mod.ident.to_string());
-            }
-            _ => {}
+        if let Item::Mod(item_mod) = item {
+            shadowed.insert(item_mod.ident.to_string());
         }
     }
+
+    // Fixed point, because an alias may be bound from another alias:
+    //
+    //     use crate as internal;
+    //     use self::internal as also;
+    //
+    // The second rename's *source* is `internal`, which is not an original root, so a
+    // single pass over the items would bind `internal` and miss `also`. Iterating until
+    // nothing new is bound also handles longer chains and any declaration order. Raised by
+    // Codex against `24ac3de`.
+    loop {
+        let mut roots: BTreeSet<String> = known_roots.clone();
+        roots.extend(aliases.iter().cloned());
+        let before = aliases.len();
+
+        for item in items {
+            match item {
+                Item::Use(item_use) => collect_crate_aliases(&item_use.tree, &roots, &mut aliases),
+                // `extern crate self as internal;` binds the crate root without being a
+                // `use` at all, and `extern crate unified_hifi_control as uhc;` does the
+                // same by name.
+                Item::ExternCrate(item_extern) => {
+                    if let Some((_, rename)) = &item_extern.rename {
+                        let source = item_extern.ident.to_string();
+                        if source == "self" || roots.contains(&source) {
+                            aliases.insert(rename.to_string());
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        if aliases.len() == before {
+            break;
+        }
+    }
+
     (aliases, shadowed)
 }
 
-fn collect_crate_aliases(tree: &UseTree, out: &mut BTreeSet<String>) {
+/// Names bound to a known crate root by a use tree.
+///
+/// The source is matched against the roots known *so far* rather than against the two
+/// original spellings, which is what lets `use self::internal as also;` bind through an
+/// alias. A leading `self::` is transparent, so both `use internal as also;` and
+/// `use self::internal as also;` are recognized.
+fn collect_crate_aliases(tree: &UseTree, roots: &BTreeSet<String>, out: &mut BTreeSet<String>) {
     match tree {
         UseTree::Rename(rename) => {
-            if CRATE_ROOTS.contains(&rename.ident.to_string().as_str()) {
+            if roots.contains(&rename.ident.to_string()) {
                 out.insert(rename.rename.to_string());
             }
         }
         UseTree::Group(group) => {
             for item in &group.items {
-                collect_crate_aliases(item, out);
+                collect_crate_aliases(item, roots, out);
             }
         }
-        UseTree::Path(path) => collect_crate_aliases(&path.tree, out),
+        UseTree::Path(path) => {
+            // `self::x` and `crate::x` are transparent prefixes for this purpose; any
+            // other prefix means the rename below it is not naming a crate root.
+            let head = path.ident.to_string();
+            if head == "self" || roots.contains(&head) {
+                collect_crate_aliases(&path.tree, roots, out);
+            }
+        }
         _ => {}
     }
 }
@@ -731,7 +782,7 @@ fn collect_crate_aliases(tree: &UseTree, out: &mut BTreeSet<String>) {
 /// Forbidden module references in `file`, resolving crate-root aliases within their scope.
 fn forbidden_module_references(file: &File) -> Vec<String> {
     let mut roots: BTreeSet<String> = CRATE_ROOTS.iter().map(|r| (*r).to_string()).collect();
-    let (aliases, shadowed) = scope_delta(&file.items);
+    let (aliases, shadowed) = scope_delta(&file.items, &roots);
     roots.extend(aliases);
     for name in &shadowed {
         roots.remove(name);
@@ -1670,6 +1721,92 @@ fn crate_root_aliases_are_scoped_to_the_module_that_declares_them() {
         assert!(
             !forbidden_module_references(&snippet(source)).is_empty(),
             "{label}: scoping introduced a false negative:\n{source}"
+        );
+    }
+}
+
+#[test]
+fn extern_crate_self_and_transitive_aliases_are_crate_roots_too() {
+    // `scope_delta` recognized only a `UseTree::Rename` whose source ident is literally
+    // `crate` or `unified_hifi_control`. Two further legal forms bind the crate root under
+    // a new name and neither is a direct rename of those idents. Raised by Codex against
+    // `24ac3de`.
+    for (label, source) in [
+        // `extern crate self as X;` is an ItemExternCrate, not an ItemUse at all.
+        (
+            "extern crate self",
+            "extern crate self as internal;\nfn f() { let _ = internal::adaptive::X; }\n",
+        ),
+        (
+            "extern crate self reaching the publication layer",
+            "extern crate self as internal;\nfn f() { let _ = internal::producers::P; }\n",
+        ),
+        (
+            "extern crate by name",
+            "extern crate unified_hifi_control as uhc;\nfn f() { let _ = uhc::adaptive::X; }\n",
+        ),
+        // Transitive: the second rename's source is an alias, not an original root.
+        (
+            "transitive alias",
+            "use crate as internal;\nuse self::internal as also;\nfn f() { let _ = also::producers::P; }\n",
+        ),
+        (
+            "transitive alias two hops",
+            "use crate as internal;\nuse self::internal as also;\nuse self::also as third;\nfn f() { let _ = third::adaptive::X; }\n",
+        ),
+        (
+            "transitive from extern crate self",
+            "extern crate self as internal;\nuse self::internal as also;\nfn f() { let _ = also::adaptive::X; }\n",
+        ),
+        (
+            "transitive without the self:: prefix",
+            "use crate as internal;\nuse internal as also;\nfn f() { let _ = also::adaptive::X; }\n",
+        ),
+    ] {
+        assert!(
+            !forbidden_module_references(&snippet(source)).is_empty(),
+            "{label}: an alias form bypassed the boundary:\n{source}"
+        );
+    }
+}
+
+#[test]
+fn extended_alias_forms_remain_scope_aware_and_shadowable() {
+    // The extra forms must not loosen the boundary into a file-global set again.
+    for (label, source) in [
+        (
+            "extern crate self scoped to a sibling module",
+            "mod a {\n    extern crate self as internal;\n}\nmod b {\n    mod internal { pub mod adaptive {} }\n    fn f() { let _ = internal::adaptive::X; }\n}\n",
+        ),
+        (
+            "extern crate self leaking to a sibling with no shadow",
+            "mod a {\n    extern crate self as internal;\n}\nmod b {\n    fn f() { let _ = internal::adaptive::X; }\n}\n",
+        ),
+        (
+            "transitive alias shadowed by a local module",
+            "use crate as internal;\nuse self::internal as also;\nmod b {\n    mod also { pub mod adaptive {} }\n    fn f() { let _ = also::adaptive::X; }\n}\n",
+        ),
+        (
+            "an extern crate that is not this crate",
+            "extern crate serde as s;\nfn f() { let _ = s::adaptive::X; }\n",
+        ),
+        (
+            "an alias of an alias of something unrelated",
+            "use std as s;\nuse self::s as t;\nfn f() { let _ = t::fmt::Debug; }\n",
+        ),
+        // The prefix guard: `foo::internal` is a real module that merely shares a name with
+        // the alias, so renaming *it* binds nothing. Only `self::` and a known root are
+        // transparent prefixes; treating every prefix as transparent would bind `also` here
+        // and flag clean code.
+        (
+            "a rename under an unrelated path prefix",
+            "use crate as internal;\nmod foo {\n    pub mod internal { pub mod adaptive {} }\n}\nuse foo::internal as also;\nfn f() { let _ = also::adaptive::X; }\n",
+        ),
+    ] {
+        assert!(
+            forbidden_module_references(&snippet(source)).is_empty(),
+            "{label}: the extended forms invented a reference: {:?}\n{source}",
+            forbidden_module_references(&snippet(source))
         );
     }
 }

--- a/tests/adaptive_publication_lint.rs
+++ b/tests/adaptive_publication_lint.rs
@@ -4,498 +4,132 @@
 //! keep that true, and neither is visible from a passing build:
 //!
 //! 1. **The public bus cannot carry adaptive data.** `src/api/mod.rs` serializes every
-//!    [`BusEvent`] verbatim into `GET /events`, which `docs/ARCHITECTURE.md` documents as
+//!    `BusEvent` verbatim into `GET /events`, which `docs/ARCHITECTURE.md` documents as
 //!    consumable by any HTTP client including ESP32 firmware. A variant carrying a producer
 //!    document would be a response-schema change to a public endpoint *and* publication of
 //!    the v1 contract outside this repository.
-//! 2. **No surface reaches the contract or the publication layer.** The one deliberate code
-//!    path that would expose it is a handler serializing a snapshot, and
-//!    `ProducerDocument` derives `Serialize`, so that is a one-line accident away.
+//! 2. **No surface reaches the contract or the publication layer.** `ProducerDocument`
+//!    derives `Serialize`, so one `Json(snapshot)` in a handler re-exports the contract.
 //!
-//! ## Why this file carries probes
+//! ## Why this file parses instead of scanning
 //!
-//! `tests/adaptive_dependency_lint.rs` has been remediated twice for blind spots that made
-//! it *report success on a violation* — `1577948` (three) and `d6da952` (a fourth, where a
-//! stacked `#[allow]` between the gate and the declaration discarded the gate). Every one
-//! failed in the direction that passes. A lint whose non-vacuity was never demonstrated
-//! should be treated as absent, so each scanner here is probed in **both** directions.
+//! It used to scan text. Over eight commits that scanner was escaped **seven** times, every
+//! time in the direction that reports success:
 //!
-//! The polarity matters and is the opposite of `pub mod adaptive;`. That declaration must be
-//! **ungated**, so a scanner that misses a gate fails safe. `pub mod producers;` must be
-//! **gated**, so a scanner that *hallucinates* a gate passes wrongly — which is why the
-//! probes below include "delete the gate, the lint must fail".
+//! | Escape | Found by |
+//! |---|---|
+//! | `#[derive(Serialize)]` stacked above the innocent derive — only the nearest was read | CodeRabbit |
+//! | an attribute wrapped across lines — the continuation line cleared it | CodeRabbit |
+//! | `use serde::Serialize as EventWire;` — no literal `Serialize` anywhere | CodeRabbit |
+//! | a crate-local `pub use` re-export — no literal `serde` anywhere | CodeRabbit |
+//! | `r##"… " … ] …"##` — the lexer left string mode at the embedded quote | CodeRabbit |
+//! | `pub use` — the statement-boundary rule rejected exactly that one form | Codex |
+//! | `'\''` — the char lexer stopped at the escaped apostrophe | Codex |
+//! | `#[allow(unused_imports)] use …;` — an attribute is not a statement boundary | Codex |
+//!
+//! The escape rate was not falling, and each fix was another special case in what had
+//! become an incrementally hand-written Rust lexer living in a test file. The pattern is
+//! the signal: **a text scanner approximates a parser, and every approximation has a
+//! boundary that an adversary finds before its author does.**
+//!
+//! So this file uses `syn::parse_file`. `syn` is already a direct dev-dependency with
+//! `features = ["full", "parsing", "visit"]`, and six sibling lints
+//! (`await_in_lock_lint`, `spawn_cancellation_lint`, `ignored_send_lint`,
+//! `oneshot_leak_lint`, `arbitrary_find_lint`, `unbounded_channel_lint`) already parse this
+//! way — so precedent and dependency both cost nothing.
+//!
+//! Against an AST every escape above stops being *detected* and becomes
+//! *unrepresentable*: attributes are a `Vec<Attribute>` on the item however they were
+//! formatted, `UseTree::Rename` is a variant rather than a spelling, visibility and
+//! attributes are fields of `ItemUse` rather than characters preceding it, and lexing raw
+//! strings and char literals correctly is the parser's job by definition. The whole ad-hoc
+//! lexer — `code_only`, `join_wrapped_attributes`, `attributes_in`, `string_literal_end`,
+//! `char_literal_end`, `imports_in`, `derive_tokens` — is **deleted** rather than kept
+//! alongside, because keeping both would claim a joint sufficiency neither has.
+//!
+//! ## What parsing does not buy
+//!
+//! `syn` resolves no names. `use crate::wire::EventWire;` is an import of *something*; that
+//! it is `serde::Serialize` re-exported lives in another file. That is exactly why the
+//! guarantee is an **allowlist** rather than a detector: parsing makes enumeration exact,
+//! and the allowlist decides without needing to know what a name means. The two compose;
+//! neither is sufficient alone.
+//!
+//! Residual, recorded rather than papered over: items produced by macro *expansion* are
+//! invisible to a parse of pre-expansion source, as they were to the text scanner. Macro
+//! *invocations* are visited and their token streams checked, which is exact because tokens
+//! are post-lexing — but a macro assembling an `impl` from fragments escapes both
+//! architectures.
 
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::Path;
+use syn::punctuated::Punctuated;
+use syn::visit::{self, Visit};
+use syn::{Attribute, Expr, ExprLit, File, Item, ItemEnum, Lit, Meta, Token, UseTree};
 use walkdir::WalkDir;
 
-const PRODUCERS_DECLARATION: &str = "pub mod producers;";
-const ADAPTIVE_EVENT_DECLARATION: &str = "pub enum AdaptiveEvent {";
+const EVENT_MODULE: &str = "src/producers/event.rs";
+const ADAPTIVE_EVENT: &str = "AdaptiveEvent";
+const PRODUCERS_MODULE: &str = "producers";
 
-/// Exactly what `src/producers/event.rs` may import, whitespace-normalized.
+/// Exactly what `src/producers/event.rs` may import, as flattened leaf paths.
 ///
-/// An **allowlist**, not a denylist, and that inversion is the point. Name-based detection
-/// has now been bypassed four times, most recently by a crate-local re-export:
+/// An **allowlist**, not a denylist, and the inversion is the point. Name-based detection
+/// was bypassed by an alias, then by a crate-local re-export that left no trace of serde in
+/// the file at all. Chasing re-export chains would be a partial name resolver wearing a
+/// guarantee's clothes — still blind to multi-hop `pub use`, glob re-exports and macros.
 ///
-/// ```ignore
-/// // src/wire.rs
-/// pub use serde::Serialize as EventWire;
-/// // src/producers/event.rs
-/// use crate::wire::EventWire;
-/// #[derive(EventWire)]
-/// pub enum AdaptiveEvent { … }
-/// ```
-///
-/// That file contains no `serde`, imports nothing from `serde`, and no resolver short of a
-/// real name resolver learns that `EventWire` serializes. Verified by compiling it: the
-/// build finished clean and all 24 lints passed. Found by CodeRabbit at `993d35e`.
-///
-/// Chasing re-export chains would be a partial resolver wearing a guarantee's clothes —
-/// it would still miss `pub use` through several modules, glob re-exports, and macros. An
-/// allowlist does not care what a name means: **any** import not on this list fails, so
-/// every re-export form is closed at once. The cost is that a legitimate new import has to
-/// be added here, deliberately, which for this module is the point rather than the tax.
+/// An allowlist does not care what a name means: any import not on this list fails, so
+/// every re-export form is closed at once. Leaves are flattened, so grouping is irrelevant —
+/// `use a::{b, c}` and two separate statements normalize identically.
 const EVENT_ALLOWED_IMPORTS: &[&str] = &[
-    "use std::sync::Arc;",
-    "use tokio::sync::broadcast;",
-    "use super::admission::{AdmissionRefusal,ProducerKey};",
-    "use crate::adaptive::{DocumentRevisions,ProducerDocument};",
+    "std::sync::Arc",
+    "tokio::sync::broadcast",
+    "super::admission::AdmissionRefusal",
+    "super::admission::ProducerKey",
+    "crate::adaptive::DocumentRevisions",
+    "crate::adaptive::ProducerDocument",
 ];
 
 /// Exactly what `AdaptiveEvent` may derive.
 ///
-/// The companion to [`EVENT_ALLOWED_IMPORTS`], and necessary because a derive needs no
-/// import at all: `#[derive(crate::wire::EventWire)]` names the macro by path. Matching on
-/// permitted names rather than forbidden ones makes the spelling irrelevant.
+/// Needed separately from the import allowlist because a derive requires no import at all:
+/// `#[derive(crate::wire::EventWire)]` names the macro by path.
 const ADAPTIVE_EVENT_ALLOWED_DERIVES: &[&str] = &["Debug", "Clone"];
-/// The readable spelling, used in failure messages.
-const SERVER_GATE: &str = "#[cfg(feature = \"server\")]";
 
-/// Whether an extracted attribute gates its item on the `server` feature and nothing looser.
-///
-/// Two ways to get this wrong, both of which accept a gate that is not server-only:
-///
-/// 1. **Whitespace.** `#[cfg(feature="server")]` is the same gate as
-///    `#[cfg(feature = "server")]`; matching one spelling silently accepts the other. That
-///    is the blind spot `1577948` fixed in `tests/adaptive_dependency_lint.rs`, and
-///    `gate_scanner_detects_a_gate_it_must_not_miss` caught it here before it shipped.
-/// 2. **Disjunction.** `#[cfg(any(feature = "server", feature = "web"))]` *contains*
-///    `feature="server"` while compiling the module for `web` **without** `server` — which
-///    is exactly the WASM breakage this lint exists to prevent, admitted by the lint that
-///    was supposed to prevent it. Found by CodeRabbit at `86e5bd2`.
-///
-/// So: the normalized attribute must mention the server feature and must contain neither
-/// `any(` nor `not(`. A stricter conjunctive gate (`all(feature = "server", unix)`) is still
-/// server-only and is accepted; loosening it later has to be deliberate, because the lint
-/// fails until someone edits this function.
-fn is_server_gate(attribute: &str) -> bool {
-    let squeezed: String = attribute.chars().filter(|c| !c.is_whitespace()).collect();
-    squeezed.contains("feature=\"server\"")
-        && !squeezed.contains("any(")
-        && !squeezed.contains("not(")
-}
-
-/// The module paths a source file reaches, including through grouped `use` trees.
-///
-/// A needle scan for `crate::adaptive` misses `use crate::{adaptive, producers};`, which
-/// names neither literal. That is not hypothetical: `src/main.rs` imports this repository's
-/// modules in exactly that style, so a surface adopting the house style would have slipped
-/// straight past the boundary check. Found by CodeRabbit at `86e5bd2`.
-fn forbidden_module_references(code: &str) -> Vec<String> {
-    const ROOTS: &[&str] = &["crate", "unified_hifi_control"];
-    const FORBIDDEN: &[&str] = &["adaptive", "producers"];
-    let mut found = Vec::new();
-
-    // Fully-spelled paths, anywhere - `use`, a turbofish, a type position.
-    for root in ROOTS {
-        for module in FORBIDDEN {
-            let needle = format!("{root}::{module}");
-            if code.contains(&needle) {
-                found.push(needle);
-            }
-        }
-    }
-
-    // Grouped use trees: `use <root>::{ a, b::c, d as e };`
-    //
-    // Whitespace is collapsed rather than removed. Removing it entirely turns
-    // `adaptive as contract` into `adaptiveascontract`, so the alias can no longer be split
-    // off and the item stops matching - a probe caught exactly that here.
-    let normalized = collapse_whitespace(code);
-    for root in ROOTS {
-        let opener = format!("use {root}::{{");
-        let mut rest = normalized.as_str();
-        while let Some(at) = rest.find(&opener) {
-            let after = &rest[at + opener.len()..];
-            let mut depth = 1usize;
-            let mut end = after.len();
-            for (index, c) in after.char_indices() {
-                match c {
-                    '{' => depth += 1,
-                    '}' => {
-                        depth -= 1;
-                        if depth == 0 {
-                            end = index;
-                            break;
-                        }
-                    }
-                    _ => {}
-                }
-            }
-            for item in split_top_level(&after[..end]) {
-                let head = item
-                    .split("::")
-                    .next()
-                    .unwrap_or_default()
-                    .split(" as ")
-                    .next()
-                    .unwrap_or_default();
-                if FORBIDDEN.contains(&head) {
-                    found.push(format!("{root}::{{… {head} …}}"));
-                }
-            }
-            rest = &after[end.min(after.len())..];
-        }
-    }
-
-    found.sort();
-    found.dedup();
-    found
-}
-
-/// If a string literal begins at `chars[index]`, the index just past its end.
-///
-/// Recognizes ordinary `"…"`, byte `b"…"`, and **raw** `r"…"` / `r#"…"#` / `r##"…"##` /
-/// `br#"…"#`. Raw strings were the gap: a scanner that leaves string mode at the first `"`
-/// reads the rest of `r##"quote: " then ] remains data"##` as code, takes the `]` for an
-/// attribute close, and silently stops joining whatever follows. Found by CodeRabbit at
-/// `993d35e`, with the exploit supplied.
-///
-/// The terminator of a raw string is `"` followed by **the same number of hashes** it
-/// opened with, so an inner `"#` inside a `r##"…"##` literal is data.
-///
-/// `None` means no literal starts here. Callers must also check that the preceding
-/// character is not part of an identifier, or the `r` in `counter` looks like a prefix.
-fn string_literal_end(chars: &[char], index: usize) -> Option<usize> {
-    let mut cursor = index;
-    if chars.get(cursor) == Some(&'b') {
-        cursor += 1;
-    }
-    let raw = chars.get(cursor) == Some(&'r');
-    if raw {
-        cursor += 1;
-    }
-    let mut hashes = 0usize;
-    if raw {
-        while chars.get(cursor) == Some(&'#') {
-            hashes += 1;
-            cursor += 1;
-        }
-    }
-    if chars.get(cursor) != Some(&'"') {
-        return None;
-    }
-
-    let mut scan = cursor + 1;
-    if raw {
-        while scan < chars.len() {
-            if chars[scan] == '"' && (1..=hashes).all(|k| chars.get(scan + k) == Some(&'#')) {
-                return Some(scan + hashes + 1);
-            }
-            scan += 1;
-        }
-        return Some(chars.len());
-    }
-    while scan < chars.len() {
-        match chars[scan] {
-            '\\' => scan += 2,
-            '"' => return Some(scan + 1),
-            _ => scan += 1,
-        }
-    }
-    Some(chars.len())
-}
-
-/// If a character literal begins at `chars[index]`, the index just past its end.
-///
-/// Distinguished from a lifetime, which is the whole difficulty: `']'` is a literal whose
-/// bracket is data, while `'de` in `impl<'de> Deserialize<'de>` is not a literal at all and
-/// must not swallow the rest of the line.
-fn char_literal_end(chars: &[char], index: usize) -> Option<usize> {
-    if chars.get(index) != Some(&'\'') {
-        return None;
-    }
-    if chars.get(index + 1) == Some(&'\\') {
-        // The escaped character comes first, then the closing quote. Scanning forward for
-        // "the next `'`" stops at the *escaped* apostrophe in `'\''` and leaves a dangling
-        // quote behind that reads as the start of another literal. Found by Codex at
-        // `20926e1`.
-        let mut scan = index + 2;
-        if chars.get(scan) == Some(&'u') && chars.get(scan + 1) == Some(&'{') {
-            scan += 2;
-            while scan < chars.len() && chars[scan] != '}' {
-                scan += 1;
-            }
-            scan += 1;
-        } else {
-            scan += 1;
-        }
-        return if chars.get(scan) == Some(&'\'') {
-            Some(scan + 1)
-        } else {
-            None
-        };
-    }
-    if chars.get(index + 2) == Some(&'\'') {
-        return Some(index + 3);
-    }
-    None
-}
-
-/// Whether a literal prefix at `index` is a real prefix rather than the tail of a name.
-fn starts_a_literal(chars: &[char], index: usize) -> bool {
-    index == 0 || !(chars[index - 1].is_alphanumeric() || chars[index - 1] == '_')
-}
-
-/// The index just past a literal beginning at `index`, if one does.
-fn literal_end(chars: &[char], index: usize) -> Option<usize> {
-    match chars.get(index) {
-        Some('"') => string_literal_end(chars, index),
-        Some('r') if starts_a_literal(chars, index) => string_literal_end(chars, index),
-        // `b'x'` is a byte-char literal; `b"…"` and `br#"…"#` are byte strings.
-        Some('b') if starts_a_literal(chars, index) => {
-            if chars.get(index + 1) == Some(&'\'') {
-                char_literal_end(chars, index + 1)
-            } else {
-                string_literal_end(chars, index)
-            }
-        }
-        Some('\'') => char_literal_end(chars, index),
-        _ => None,
-    }
-}
-
-/// Every `use` statement in `code`, whitespace-normalized, one per statement.
-///
-/// Run over comment-stripped code and anchored at a statement boundary: a doc comment
-/// containing the word "use" produced a spurious 700-character "import" when this was
-/// first written against raw source.
-fn imports_in(code: &str) -> Vec<String> {
-    let normalized = collapse_whitespace(code);
-    let chars: Vec<char> = normalized.chars().collect();
-    let mut found = Vec::new();
-    let mut index = 0usize;
-
-    while index < chars.len() {
-        let is_use = chars[index..].starts_with(&['u', 's', 'e', ' ']);
-        if is_use && starts_a_use_statement(&chars, index) {
-            let mut scan = index;
-            while scan < chars.len() && chars[scan] != ';' {
-                scan += 1;
-            }
-            let statement: String = chars[index..scan.min(chars.len())].iter().collect();
-            found.push(format!("{statement};"));
-            index = scan + 1;
-            continue;
-        }
-        index += 1;
-    }
-    found
-}
-
-/// Whether the `use` at `index` opens a statement rather than ending an identifier.
-///
-/// The previous rule rejected "alphanumeric then space" before `use`, to stop `misuse` and
-/// prose from registering. It also rejected `pub use` — and *only* `pub use`, since
-/// `pub(crate) use` ends in `)` — so the plainest re-export form in Rust was invisible to
-/// the allowlist while its parenthesised siblings were caught. Wrong in the direction that
-/// passes. Found by Codex at `20926e1`.
-///
-/// Now: the `use` must not be the tail of an identifier, and whatever immediately precedes
-/// it must be a statement boundary or a visibility qualifier — `pub`, `pub(crate)`,
-/// `pub(super)`, `pub(in some::path)`.
-fn starts_a_use_statement(chars: &[char], index: usize) -> bool {
-    if index == 0 {
-        return true;
-    }
-    // `misuse ` must not count: `use` has to begin a word.
-    let previous = chars[index - 1];
-    if previous.is_alphanumeric() || previous == '_' {
-        return false;
-    }
-    if matches!(previous, ';' | '{' | '}' | '\n') {
-        return true;
-    }
-    if previous != ' ' {
-        return false;
-    }
-    // A space precedes it. Accept only a statement start or a visibility qualifier.
-    let before: String = chars[..index - 1].iter().collect();
-    let head = before.trim_end();
-    if head.is_empty() {
-        return true;
-    }
-    if head.ends_with(';') || head.ends_with('{') || head.ends_with('}') {
-        return true;
-    }
-    let last_word = head
-        .rsplit(|c: char| c == ';' || c == '{' || c == '}' || c == '\n')
-        .next()
-        .unwrap_or_default()
-        .trim();
-    last_word == "pub" || (last_word.starts_with("pub(") && last_word.ends_with(')'))
-}
-
-/// Every trait implemented for `type_name` in `code`, as written.
-///
-/// The companion to the derive allowlist: a hand-written `impl` needs no derive and no
-/// import. Terminator-checked so `AdaptiveEventLog` is not read as `AdaptiveEvent`.
-fn trait_impls_for(code: &str, type_name: &str) -> Vec<String> {
-    let normalized = collapse_whitespace(code);
-    let needle = format!("for {type_name}");
-    let mut found = Vec::new();
-    let mut search_from = 0usize;
-
-    while let Some(at) = normalized[search_from..].find(&needle) {
-        let absolute = search_from + at;
-        let after = normalized[absolute + needle.len()..].chars().next();
-        let terminated = after.is_none_or(|c| !c.is_alphanumeric() && c != '_');
-        if terminated {
-            if let Some(impl_at) = normalized[..absolute].rfind("impl") {
-                let header = normalized[impl_at + "impl".len()..absolute].trim();
-                // Strip any generic parameter list introduced by `impl<…>`.
-                let trait_part = header.strip_prefix('<').map_or(header, |rest| {
-                    rest.split_once('>').map_or(rest, |(_, tail)| tail).trim()
-                });
-                if !trait_part.is_empty() {
-                    found.push(trait_part.to_string());
-                }
-            }
-        }
-        search_from = absolute + needle.len();
-    }
-    found
-}
-
-/// Collapse whitespace runs to one space, then close it up around path punctuation.
-///
-/// Leaves ` as ` intact — which is the whole reason this is not a plain whitespace strip.
-fn collapse_whitespace(code: &str) -> String {
-    let mut out = String::with_capacity(code.len());
-    let mut last_was_space = false;
-    for c in code.chars() {
-        if c.is_whitespace() {
-            if !last_was_space {
-                out.push(' ');
-                last_was_space = true;
-            }
-        } else {
-            out.push(c);
-            last_was_space = false;
-        }
-    }
-    for token in ["::", "{", "}", ",", ";"] {
-        out = out.replace(&format!(" {token}"), token);
-        out = out.replace(&format!("{token} "), token);
-    }
-    out
-}
-
-/// Split a brace group on commas that are not inside a nested group.
-fn split_top_level(group: &str) -> Vec<&str> {
-    let mut items = Vec::new();
-    let mut depth = 0usize;
-    let mut start = 0usize;
-    for (index, c) in group.char_indices() {
-        match c {
-            '{' => depth += 1,
-            '}' => depth = depth.saturating_sub(1),
-            ',' if depth == 0 => {
-                items.push(&group[start..index]);
-                start = index + 1;
-            }
-            _ => {}
-        }
-    }
-    if start < group.len() {
-        items.push(&group[start..]);
-    }
-    items
-        .into_iter()
-        .map(str::trim)
-        .filter(|i| !i.is_empty())
-        .collect()
-}
+/// Modules a surface may not reach.
+const FORBIDDEN_MODULES: &[&str] = &["adaptive", "producers"];
+/// Crate roots those modules can be addressed through.
+const CRATE_ROOTS: &[&str] = &["crate", "unified_hifi_control"];
 
 // =============================================================================
-// Source scanning
+// Parsing
 // =============================================================================
 
-/// Strip comments while keeping string literals.
+/// Parse a source file, failing loudly.
 ///
-/// Prose must not be linted: this file, `src/producers/mod.rs` and `src/bus/events.rs` all
-/// discuss the boundary in doc comments, and punishing that would push the explanation out
-/// of the code. String literals are kept so a forbidden path written as a string is still
-/// caught.
-fn code_only(text: &str) -> String {
-    let chars: Vec<char> = text.chars().collect();
-    let mut out = String::with_capacity(text.len());
-    let mut index = 0usize;
-    let mut block_depth = 0usize;
-
-    while index < chars.len() {
-        let c = chars[index];
-
-        if block_depth > 0 {
-            if c == '*' && chars.get(index + 1) == Some(&'/') {
-                block_depth -= 1;
-                index += 2;
-                continue;
-            }
-            if c == '/' && chars.get(index + 1) == Some(&'*') {
-                block_depth += 1;
-                index += 2;
-                continue;
-            }
-            if c == '\n' {
-                out.push('\n');
-            }
-            index += 1;
-            continue;
-        }
-
-        // A literal is data. `//` and `/*` inside one are not comment markers, and a `"`
-        // inside a raw string does not end it.
-        if let Some(end) = literal_end(&chars, index) {
-            out.extend(&chars[index..end.min(chars.len())]);
-            index = end;
-            continue;
-        }
-
-        if c == '/' && chars.get(index + 1) == Some(&'/') {
-            while index < chars.len() && chars[index] != '\n' {
-                index += 1;
-            }
-            continue;
-        }
-        if c == '/' && chars.get(index + 1) == Some(&'*') {
-            block_depth += 1;
-            index += 2;
-            continue;
-        }
-        out.push(c);
-        index += 1;
+/// A lint that silently treats an unparsable file as empty passes vacuously, which is the
+/// defect class this file exists to stop reproducing.
+fn parse_source(path: &str, source: &str) -> File {
+    match syn::parse_file(source) {
+        Ok(file) => file,
+        Err(error) => panic!("failed to parse {path}: {error}"),
     }
-    out
 }
 
-fn sources_under(root: &str) -> Vec<(String, String)> {
-    let path = Path::new(root);
-    if !path.exists() {
+fn parse_file_at(path: &str) -> File {
+    let source = fs::read_to_string(path).unwrap_or_else(|error| panic!("read {path}: {error}"));
+    parse_source(path, &source)
+}
+
+fn rust_sources_under(root: &str) -> Vec<(String, String)> {
+    let base = Path::new(root);
+    if !base.exists() {
         return Vec::new();
     }
     let mut sources = Vec::new();
-    for entry in WalkDir::new(path).into_iter().filter_map(Result::ok) {
+    for entry in WalkDir::new(base).into_iter().filter_map(Result::ok) {
         let file = entry.path();
         if file.extension().is_some_and(|ext| ext == "rs") {
             let text = fs::read_to_string(file)
@@ -506,400 +140,225 @@ fn sources_under(root: &str) -> Vec<(String, String)> {
     sources
 }
 
-/// Join attributes that wrap across lines onto a single line.
-///
-/// [`attributes_attached_to`] and [`declaration_gates`] walk lines, and a line that is not
-/// itself an attribute clears the pending set — that is the rule which stops one item's
-/// attributes leaking onto the next. A wrapped attribute defeats it:
-///
-/// ```ignore
-/// #[derive(          // seen as an unterminated attribute, held as pending
-///     Debug,         // not an attribute -> pending cleared, the derive is lost
-///     Serialize,
-/// )]
-/// pub enum AdaptiveEvent { … }
-/// ```
-///
-/// The declaration then reports only `#[derive(Debug, Clone)]` and the scanner passes.
-/// Verified against the real module before this existed: a wrapped
-/// `#[cfg_attr(…, derive(serde::Serialize))]` compiled and
-/// `lint_adaptive_event_derives_no_serialization` passed. Found by CodeRabbit at
-/// `b35af10`.
-///
-/// Newlines are replaced by spaces only while inside an attribute's brackets, so the line
-/// structure everywhere else — and therefore the pending-clearing rule — is untouched.
-fn join_wrapped_attributes(code: &str) -> String {
-    let chars: Vec<char> = code.chars().collect();
-    let mut out = String::with_capacity(code.len());
-    let mut index = 0usize;
-    let mut depth = 0usize;
+// =============================================================================
+// Structural inspection
+// =============================================================================
 
-    while index < chars.len() {
-        // A literal is copied through whole, whatever it contains. This is the raw-string
-        // fix: `r##"quote: " then ] remains data"##` no longer ends at its embedded quote,
-        // so its `]` is data rather than an attribute close.
-        if let Some(end) = literal_end(&chars, index) {
-            let slice: String = chars[index..end.min(chars.len())].iter().collect();
-            if depth > 0 {
-                out.push_str(&slice.replace('\n', " "));
-            } else {
-                out.push_str(&slice);
-            }
-            index = end;
-            continue;
-        }
-
-        let c = chars[index];
-        if c == '#' {
-            let bracket = if chars.get(index + 1) == Some(&'!') {
-                index + 2
-            } else {
-                index + 1
-            };
-            if chars.get(bracket) == Some(&'[') {
-                out.extend(&chars[index..=bracket]);
-                depth += 1;
-                index = bracket + 1;
-                continue;
-            }
-        }
-        match c {
-            '[' if depth > 0 => {
-                depth += 1;
-                out.push(c);
-            }
-            ']' if depth > 0 => {
-                depth -= 1;
-                out.push(c);
-            }
-            '\n' if depth > 0 => out.push(' '),
-            _ => out.push(c),
-        }
-        index += 1;
-    }
-    out
-}
-
-/// Every `#[...]` attribute written in `text`, whole.
+/// Every import in `file`, flattened to leaf paths.
 ///
-/// Bracket-depth aware and string-literal aware, so `#[cfg_attr(feature = "server",
-/// derive(Serialize))]` and `#[doc = "contains a ] bracket"]` are each captured entire
-/// rather than truncated at the first `]`.
-fn attributes_in(text: &str) -> Vec<String> {
+/// Structural, so attributes, visibility, grouping, renaming and formatting are fields and
+/// variants rather than characters to be recognized. `#[allow(unused_imports)] pub use
+/// a::B as C;` is an `ItemUse` exactly as `use a::B;` is.
+fn imports_of(file: &File) -> Vec<String> {
     let mut found = Vec::new();
-    let chars: Vec<char> = text.chars().collect();
-    let mut index = 0usize;
-
-    while index + 1 < chars.len() {
-        if chars[index] != '#' || (chars[index + 1] != '[' && chars[index + 1] != '!') {
-            index += 1;
-            continue;
-        }
-        let open = if chars[index + 1] == '!' {
-            index + 2
-        } else {
-            index + 1
-        };
-        if chars.get(open) != Some(&'[') {
-            index += 1;
-            continue;
-        }
-        let inner = chars[index + 1] == '!';
-        let mut depth = 0usize;
-        let mut cursor = open;
-        let mut end = None;
-        while cursor < chars.len() {
-            if let Some(past) = literal_end(&chars, cursor) {
-                cursor = past;
-                continue;
-            }
-            match chars[cursor] {
-                '[' => depth += 1,
-                ']' => {
-                    depth -= 1;
-                    if depth == 0 {
-                        end = Some(cursor);
-                        break;
-                    }
-                }
-                _ => {}
-            }
-            cursor += 1;
-        }
-        match end {
-            Some(close) => {
-                if !inner {
-                    found.push(chars[index..=close].iter().collect());
-                }
-                index = close + 1;
-            }
-            None => {
-                found.push(chars[index..].iter().collect());
-                break;
-            }
+    for item in &file.items {
+        if let Item::Use(item_use) = item {
+            found.extend(flatten_use_tree(&item_use.tree));
         }
     }
     found
 }
 
-/// Every `#[cfg(...)]` attribute written in `text`.
+fn flatten_use_tree(tree: &UseTree) -> Vec<String> {
+    match tree {
+        UseTree::Path(path) => flatten_use_tree(&path.tree)
+            .into_iter()
+            .map(|leaf| format!("{}::{leaf}", path.ident))
+            .collect(),
+        UseTree::Name(name) => vec![name.ident.to_string()],
+        UseTree::Rename(rename) => vec![format!("{} as {}", rename.ident, rename.rename)],
+        UseTree::Glob(_) => vec!["*".to_string()],
+        UseTree::Group(group) => group.items.iter().flat_map(flatten_use_tree).collect(),
+    }
+}
+
+/// The `AdaptiveEvent` enum, located by identity rather than by matching a declaration
+/// string.
+fn adaptive_event_enum(file: &File) -> Option<&ItemEnum> {
+    file.items.iter().find_map(|item| match item {
+        Item::Enum(item_enum) if item_enum.ident == ADAPTIVE_EVENT => Some(item_enum),
+        _ => None,
+    })
+}
+
+/// Every trait derived by `attrs`, as final path segments.
 ///
-/// Extracted rather than matched whole-line, because a gate may share a line with the item
-/// it gates. `#[cfg_attr(...)]` must not match: it cannot exclude a module.
-fn cfg_attributes_in(text: &str) -> Vec<String> {
+/// Recurses through `cfg_attr`, because a conditional derive is not a safe derive — it is
+/// one whose condition is somebody else's build flag.
+fn derives_in(attrs: &[Attribute]) -> Vec<String> {
     let mut found = Vec::new();
-    let mut rest = text;
-    while let Some(start) = rest.find("#[cfg(") {
-        let tail = &rest[start..];
-        match tail.find(")]") {
-            Some(end) => {
-                found.push(tail[..end + 2].to_string());
-                rest = &tail[end + 2..];
-            }
-            None => {
-                found.push(tail.trim().to_string());
-                break;
-            }
-        }
+    for attr in attrs {
+        collect_derives(&attr.meta, &mut found);
     }
     found
 }
 
-/// Every `#[cfg(...)]` that applies to `declaration` in `source`.
-///
-/// `None` means the declaration is absent; an empty vector means it is present and ungated.
-///
-/// Pending attributes **accumulate** across consecutive attribute lines, because Rust allows
-/// any number in any order — `#[cfg(...)]` / `#[allow(...)]` / `pub mod x;` is gated. The
-/// accumulation stops at whatever consumes it (the declaration, a block opener, or the next
-/// item), or every ungated `pub mod` below a gated one would be reported as gated.
-fn declaration_gates(source: &str, declaration: &str) -> Option<Vec<String>> {
-    let mut enclosing: Vec<Vec<String>> = Vec::new();
-    let mut pending: Vec<String> = Vec::new();
-    let mut gates: Option<Vec<String>> = None;
-
-    // Wrapped attributes are joined first: a line-oriented walk would see only `#[cfg(` and
-    // then clear it on the continuation line. See `join_wrapped_attributes`.
-    let joined = join_wrapped_attributes(&code_only(source));
-    for line in joined.lines() {
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        if let Some(prefix) = trimmed.strip_suffix(declaration) {
-            let mut found = cfg_attributes_in(prefix);
-            found.append(&mut pending);
-            found.extend(enclosing.iter().flatten().cloned());
-            gates = Some(found);
-            continue;
-        }
-        if trimmed.ends_with('{') {
-            let mut frame = cfg_attributes_in(trimmed);
-            frame.append(&mut pending);
-            enclosing.push(frame);
-            continue;
-        }
-        if trimmed == "}" {
-            enclosing.pop();
-            continue;
-        }
-        if trimmed.starts_with('#') {
-            pending.extend(cfg_attributes_in(trimmed));
-            continue;
-        }
-        pending.clear();
-    }
-    gates
-}
-
-/// Every attribute attached to `declaration` in `source`, including those on an enclosing
-/// block.
-///
-/// `None` means the declaration is absent; an empty vector means it carries no attributes.
-///
-/// Same accumulation rule as [`declaration_gates`] — Rust allows any number of attributes in
-/// any order, so they gather across consecutive attribute lines and are consumed by whatever
-/// comes next. Inspecting only the *nearest* attribute is the blind spot this replaced: an
-/// earlier `#[derive(Serialize)]` sitting above a later `#[derive(Debug, Clone)]` was
-/// invisible.
-fn attributes_attached_to(source: &str, declaration: &str) -> Option<Vec<String>> {
-    let mut enclosing: Vec<Vec<String>> = Vec::new();
-    let mut pending: Vec<String> = Vec::new();
-    let mut attached: Option<Vec<String>> = None;
-
-    // Wrapped attributes are joined first. Without this a `#[derive(` spanning lines is
-    // held as pending, then discarded by its own continuation line, and the declaration
-    // reports only the attributes that happened to fit on one line. See
-    // `join_wrapped_attributes`.
-    let joined = join_wrapped_attributes(&code_only(source));
-    for line in joined.lines() {
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        if let Some(prefix) = trimmed.strip_suffix(declaration) {
-            let mut found = attributes_in(prefix);
-            found.append(&mut pending);
-            found.extend(enclosing.iter().flatten().cloned());
-            attached = Some(found);
-            continue;
-        }
-        if trimmed.ends_with('{') {
-            let mut frame = attributes_in(trimmed);
-            frame.append(&mut pending);
-            enclosing.push(frame);
-            continue;
-        }
-        if trimmed == "}" {
-            enclosing.pop();
-            continue;
-        }
-        if trimmed.starts_with('#') {
-            pending.extend(attributes_in(trimmed));
-            continue;
-        }
-        pending.clear();
-    }
-    attached
-}
-
-/// Every name by which serde's `Serialize`/`Deserialize` can be spelled in `code`.
-///
-/// Always includes the canonical two. Adds any **alias**, because
-/// `use serde::Serialize as EventWire;` binds the trait *and* the derive macro under that
-/// name — so `#[derive(EventWire)]` and `impl EventWire for AdaptiveEvent` both compile and
-/// neither contains the substring `Serialize`. Verified by compiling both forms against the
-/// real module before this was written. Found by CodeRabbit at `b35af10`.
-///
-/// Matching is on the **exact final path segment**, never a prefix: `serde::Serializer` and
-/// `serde::de::DeserializeOwned` are ordinary serde imports that must not register as the
-/// serialization traits, and both would match a substring test.
-fn serialization_names(code: &str) -> Vec<String> {
-    let mut names: Vec<String> = vec!["Serialize".to_string(), "Deserialize".to_string()];
-    let normalized = collapse_whitespace(code);
-    let mut rest = normalized.as_str();
-
-    while let Some(at) = rest.find("use serde") {
-        let tail = &rest[at + 4..];
-        let statement = match tail.find(';') {
-            Some(end) => &tail[..end],
-            None => tail,
-        };
-        rest = &tail[statement.len().min(tail.len())..];
-
-        // `use serde::{a, b}` or `use serde::a` (possibly via `ser::` / `de::`).
-        let items: Vec<String> = match (statement.find('{'), statement.rfind('}')) {
-            (Some(open), Some(close)) if open < close => {
-                let base = &statement[..open];
-                split_top_level(&statement[open + 1..close])
-                    .into_iter()
-                    .map(|item| format!("{base}{item}"))
-                    .collect()
+fn collect_derives(meta: &Meta, out: &mut Vec<String>) {
+    let Meta::List(list) = meta else {
+        return;
+    };
+    if list.path.is_ident("derive") {
+        if let Ok(paths) =
+            list.parse_args_with(Punctuated::<syn::Path, Token![,]>::parse_terminated)
+        {
+            for path in paths {
+                if let Some(last) = path.segments.last() {
+                    out.push(last.ident.to_string());
+                }
             }
-            _ => vec![statement.to_string()],
-        };
+        }
+        return;
+    }
+    if list.path.is_ident("cfg_attr") {
+        if let Ok(metas) = list.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated) {
+            // The first element is the predicate; everything after it is what gets applied.
+            for nested in metas.iter().skip(1) {
+                collect_derives(nested, out);
+            }
+        }
+    }
+}
 
+/// Every trait implemented for `type_name` in `file`.
+///
+/// Inherent impls (`impl AdaptiveEvent { … }`) are not trait impls and do not appear.
+fn trait_impls_for(file: &File, type_name: &str) -> Vec<String> {
+    file.items
+        .iter()
+        .filter_map(|item| match item {
+            Item::Impl(item_impl) => {
+                let (_, path, _) = item_impl.trait_.as_ref()?;
+                let target = match item_impl.self_ty.as_ref() {
+                    syn::Type::Path(type_path) => type_path.path.segments.last()?.ident.to_string(),
+                    _ => return None,
+                };
+                if target != type_name {
+                    return None;
+                }
+                Some(path.segments.last()?.ident.to_string())
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+/// Every `#[cfg(...)]` argument applying to module `name`, including from an enclosing
+/// module. `None` means the module is not declared here.
+fn module_cfg_gates(file: &File, name: &str) -> Option<Vec<Meta>> {
+    fn search(items: &[Item], name: &str, inherited: &[Meta]) -> Option<Vec<Meta>> {
         for item in items {
-            let (path, alias) = match item.split_once(" as ") {
-                Some((path, alias)) => (path.trim(), Some(alias.trim())),
-                None => (item.trim(), None),
-            };
-            let Some(last) = path.rsplit("::").next() else {
+            let Item::Mod(item_mod) = item else {
                 continue;
             };
-            if last != "Serialize" && last != "Deserialize" {
-                continue;
+            let mut gates = inherited.to_vec();
+            gates.extend(cfg_arguments(&item_mod.attrs));
+            if item_mod.ident == name {
+                return Some(gates);
             }
-            if let Some(alias) = alias {
-                if !alias.is_empty() && !names.iter().any(|held| held == alias) {
-                    names.push(alias.to_string());
+            if let Some((_, nested)) = &item_mod.content {
+                if let Some(found) = search(nested, name, &gates) {
+                    return Some(found);
                 }
             }
         }
+        None
     }
-    names
+    search(&file.items, name, &[])
 }
 
-/// The trait names an attribute would derive, as final path segments.
+fn cfg_arguments(attrs: &[Attribute]) -> Vec<Meta> {
+    attrs
+        .iter()
+        .filter_map(|attr| match &attr.meta {
+            Meta::List(list) if list.path.is_ident("cfg") => list.parse_args::<Meta>().ok(),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Whether a `cfg` argument compiles its item **only** when the `server` feature is on.
 ///
-/// Reads every `derive(...)` list in the attribute, including one nested inside
-/// `cfg_attr(...)`, and splits it into tokens so matching is exact rather than substring —
-/// `#[derive(Serializer)]` must not be mistaken for `#[derive(Serialize)]`.
-fn derive_tokens(attribute: &str) -> Vec<String> {
-    let normalized = collapse_whitespace(attribute);
-    let mut tokens = Vec::new();
-    let mut rest = normalized.as_str();
-    while let Some(at) = rest.find("derive(") {
-        let after = &rest[at + "derive(".len()..];
-        let mut depth = 1usize;
-        let mut end = after.len();
-        for (index, c) in after.char_indices() {
-            match c {
-                '(' => depth += 1,
-                ')' => {
-                    depth -= 1;
-                    if depth == 0 {
-                        end = index;
-                        break;
-                    }
+/// `all(feature = "server", …)` narrows and is accepted. `any(…)` widens — it would compile
+/// the module for `web` without `server`, the WASM breakage the gate exists to prevent —
+/// and `not(…)` inverts. Neither has an accepting arm.
+fn gate_is_server_only(meta: &Meta) -> bool {
+    match meta {
+        Meta::NameValue(name_value) => {
+            name_value.path.is_ident("feature")
+                && matches!(
+                    &name_value.value,
+                    Expr::Lit(ExprLit { lit: Lit::Str(text), .. }) if text.value() == "server"
+                )
+        }
+        Meta::List(list) if list.path.is_ident("all") => list
+            .parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
+            .map(|items| items.iter().any(gate_is_server_only))
+            .unwrap_or(false),
+        _ => false,
+    }
+}
+
+/// Forbidden module paths referenced anywhere in a file.
+///
+/// Visits use trees, every path in type and expression position, and macro token streams.
+/// Macro tokens are checked as *tokens* rather than text, so a forbidden path inside
+/// `rsx! { … }` is found while a raw string or comment inside one cannot fabricate a match.
+#[derive(Default)]
+struct ModuleReferenceVisitor {
+    found: BTreeSet<String>,
+}
+
+impl ModuleReferenceVisitor {
+    fn note(&mut self, root: &str, module: &str) {
+        if CRATE_ROOTS.contains(&root) && FORBIDDEN_MODULES.contains(&module) {
+            self.found.insert(format!("{root}::{module}"));
+        }
+    }
+}
+
+impl<'ast> Visit<'ast> for ModuleReferenceVisitor {
+    fn visit_item_use(&mut self, item: &'ast syn::ItemUse) {
+        for leaf in flatten_use_tree(&item.tree) {
+            let mut segments = leaf.split("::");
+            if let (Some(root), Some(module)) = (segments.next(), segments.next()) {
+                // `use crate::adaptive as contract;` renders its leaf as `adaptive as
+                // contract`, so the alias is trimmed before comparison.
+                let module = module.split(" as ").next().unwrap_or(module);
+                self.note(root, module);
+            }
+        }
+        visit::visit_item_use(self, item);
+    }
+
+    fn visit_path(&mut self, path: &'ast syn::Path) {
+        let segments: Vec<String> = path
+            .segments
+            .iter()
+            .map(|segment| segment.ident.to_string())
+            .collect();
+        if segments.len() >= 2 {
+            self.note(&segments[0], &segments[1]);
+        }
+        visit::visit_path(self, path);
+    }
+
+    fn visit_macro(&mut self, mac: &'ast syn::Macro) {
+        let rendered = mac.tokens.to_string().replace(' ', "");
+        for root in CRATE_ROOTS {
+            for module in FORBIDDEN_MODULES {
+                if rendered.contains(&format!("{root}::{module}")) {
+                    self.found.insert(format!("{root}::{module}"));
                 }
-                _ => {}
             }
         }
-        for item in after[..end].split(',') {
-            let token = item.trim().rsplit("::").next().unwrap_or_default().trim();
-            if !token.is_empty() {
-                tokens.push(token.to_string());
-            }
-        }
-        rest = &after[end.min(after.len())..];
+        visit::visit_macro(self, mac);
     }
-    tokens
 }
 
-/// Whether an attribute would make its item serializable, under any name.
-///
-/// Covers `#[derive(Serialize)]`, `#[cfg_attr(…, derive(Serialize))]` and
-/// `#[derive(EventWire)]` where `EventWire` is an alias for one of the traits. A `cfg_attr`
-/// gate does not make it safe — it makes it conditional, and the condition is somebody
-/// else's to set.
-fn introduces_serialization(attribute: &str, names: &[String]) -> Option<String> {
-    derive_tokens(attribute)
-        .into_iter()
-        .find(|token| names.iter().any(|name| name == token))
-}
-
-/// Whether `code` hand-writes a serialization impl for `type_name`, under any name.
-///
-/// Scans back from each `for <type_name>` to the `impl` that opened it, so
-/// `impl<'de> Deserialize<'de> for AdaptiveEvent` is caught — the previous check looked for
-/// the literal `DeserializeforAdaptiveEvent` and that idiomatic form never produces it.
-fn handwritten_serialization_impl(code: &str, type_name: &str, names: &[String]) -> Option<String> {
-    let normalized = collapse_whitespace(code);
-    let needle = format!("for {type_name}");
-    let mut search_from = 0usize;
-    while let Some(at) = normalized[search_from..].find(&needle) {
-        let absolute = search_from + at;
-        // The character after the match must end the type name, or `AdaptiveEventLog` would
-        // count as `AdaptiveEvent`.
-        let after = normalized[absolute + needle.len()..].chars().next();
-        let terminated = after.is_none_or(|c| !c.is_alphanumeric() && c != '_');
-        if terminated {
-            if let Some(impl_at) = normalized[..absolute].rfind("impl") {
-                let header = &normalized[impl_at..absolute];
-                for name in names {
-                    let mentioned = header
-                        .split(|c: char| !c.is_alphanumeric() && c != '_')
-                        .any(|token| token == name);
-                    if mentioned {
-                        return Some(name.clone());
-                    }
-                }
-            }
-        }
-        search_from = absolute + needle.len();
-    }
-    None
+fn forbidden_module_references(file: &File) -> Vec<String> {
+    let mut visitor = ModuleReferenceVisitor::default();
+    visitor.visit_file(file);
+    visitor.found.into_iter().collect()
 }
 
 // =============================================================================
@@ -911,36 +370,33 @@ fn lint_public_bus_cannot_carry_adaptive_types() {
     // `BusEvent` is a wire payload, not merely an internal enum: `src/api/mod.rs`
     // serializes it verbatim into `GET /events`. A variant naming an adaptive type would
     // change that endpoint's response schema and publish the v1 contract outside this
-    // repository, both of which #324 is scoped not to do.
+    // repository.
     let mut violations = Vec::new();
-    for (path, text) in sources_under("src/bus") {
-        let code = code_only(&text);
-        for needle in ["adaptive", "producers", "ProducerDocument", "AdaptiveEvent"] {
-            if code.contains(needle) {
-                violations.push(format!("{path}: references `{needle}`"));
-            }
+    for (path, text) in rust_sources_under("src/bus") {
+        let file = parse_source(&path, &text);
+        for reference in forbidden_module_references(&file) {
+            violations.push(format!("{path}: references `{reference}`"));
         }
     }
     assert!(
         violations.is_empty(),
         "the public bus must not carry adaptive data - `GET /events` serializes every \
-         BusEvent verbatim, so a variant here is a public response-schema change:\n{}",
+         BusEvent variant verbatim, so a variant here is a public response-schema \
+         change:\n{}",
         violations.join("\n")
     );
 }
 
 #[test]
 fn lint_the_sse_projection_does_not_mention_the_publication_layer() {
-    let api = fs::read_to_string("src/api/mod.rs").expect("src/api/mod.rs readable");
-    let code = code_only(&api);
-    for needle in ["crate::producers", "crate::adaptive"] {
-        assert!(
-            !code.contains(needle),
-            "src/api/mod.rs references `{needle}`. Any HTTP or SSE exposure of the producer \
-             document needs explicit API approval and an `api-change-approved` label that \
-             must never be self-applied."
-        );
-    }
+    let file = parse_file_at("src/api/mod.rs");
+    let references = forbidden_module_references(&file);
+    assert!(
+        references.is_empty(),
+        "src/api/mod.rs references {references:?}. Any HTTP or SSE exposure of the producer \
+         document needs explicit API approval and an `api-change-approved` label that must \
+         never be self-applied."
+    );
 }
 
 // =============================================================================
@@ -949,185 +405,31 @@ fn lint_the_sse_projection_does_not_mention_the_publication_layer() {
 
 #[test]
 fn lint_only_the_composition_root_names_the_contract_or_the_publication_layer() {
-    // Swept over *all* of `src/` rather than an enumerated list of surfaces. An enumerated
-    // list is the same shape of blind spot that has now been remediated twice in
-    // `tests/adaptive_dependency_lint.rs`: it silently stops covering whatever is added
-    // next. The first draft of this lint listed six directories and omitted `src/mqtt`,
-    // which publishes to Home Assistant — an out-of-repository consumer, and therefore the
-    // single worst omission available.
-    //
-    // Exempt, with reasons:
-    //   src/adaptive, src/producers — the layers themselves
-    //   src/lib.rs, src/main.rs     — the composition root, which must name both to wire them
+    // Swept over all of `src/` rather than an enumerated list of surfaces. An enumerated
+    // list stops covering whatever is added next; the first draft listed six directories
+    // and omitted `src/mqtt`, which publishes to Home Assistant.
     const EXEMPT: &[&str] = &["src/adaptive", "src/producers", "src/lib.rs", "src/main.rs"];
     let mut violations = Vec::new();
     let mut swept = 0usize;
-    for (path, text) in sources_under("src") {
+    for (path, text) in rust_sources_under("src") {
         if EXEMPT.iter().any(|exempt| path.starts_with(exempt)) {
             continue;
         }
         swept += 1;
-        for reference in forbidden_module_references(&code_only(&text)) {
+        let file = parse_source(&path, &text);
+        for reference in forbidden_module_references(&file) {
             violations.push(format!("{path}: references `{reference}`"));
         }
     }
     assert!(
         swept > 50,
-        "the sweep covered only {swept} files, which means it is not actually walking src/"
+        "the sweep covered only {swept} files, which means it is not walking src/"
     );
     assert!(
         violations.is_empty(),
         "#324 publishes to in-repository consumers only, and `ProducerDocument` derives \
-         `Serialize` — one `Json(snapshot)` re-exports the whole contract. A surface reading \
-         the producer document is #326's decision and needs its own API approval:\n{}",
+         `Serialize` - one `Json(snapshot)` re-exports the whole contract:\n{}",
         violations.join("\n")
-    );
-}
-
-#[test]
-fn lint_adaptive_event_derives_no_serialization() {
-    // Belt to the braces above: even if a variant were added to the wrong enum, the
-    // internal event type itself cannot be written to a wire.
-    //
-    // Inspects *every* attached attribute, not the nearest one. An earlier
-    // `#[derive(Serialize)]` above a later `#[derive(Debug, Clone)]` was invisible to the
-    // previous `rfind("#[derive(")` scan, as was any `#[cfg_attr(…, derive(Serialize))]`,
-    // which the scan never looked for at all. Found by CodeRabbit at `eebde11`.
-    //
-    // Aliases are resolved rather than assumed away: `use serde::Serialize as EventWire;`
-    // binds the derive macro *and* the trait under a name containing no forbidden
-    // substring. Found by CodeRabbit at `b35af10`.
-    let event = fs::read_to_string("src/producers/event.rs").expect("src/producers/event.rs");
-    let code = code_only(&event);
-    let names = serialization_names(&code);
-
-    let attributes =
-        attributes_attached_to(&event, ADAPTIVE_EVENT_DECLARATION).unwrap_or_else(|| {
-            panic!("src/producers/event.rs must declare `{ADAPTIVE_EVENT_DECLARATION}`")
-        });
-    let offenders: Vec<String> = attributes
-        .iter()
-        .filter_map(|attribute| {
-            introduces_serialization(attribute, &names)
-                .map(|trait_name| format!("{trait_name} via {attribute}"))
-        })
-        .collect();
-    assert!(
-        offenders.is_empty(),
-        "AdaptiveEvent would be serializable. The internal bus exists precisely so producer \
-         lifecycle cannot reach a wire, and a derive is the only structural part of that \
-         guarantee. Found: {offenders:?}"
-    );
-
-    // A hand-written impl defeats the same guarantee without any derive at all.
-    if let Some(name) = handwritten_serialization_impl(&code, "AdaptiveEvent", &names) {
-        panic!(
-            "AdaptiveEvent has a hand-written `{name}` impl, which reaches a wire just as \
-             surely as a derive."
-        );
-    }
-}
-
-#[test]
-fn lint_the_internal_event_module_imports_only_what_it_is_allowed_to() {
-    // The durable half. Every name-based guard in this file has now been bypassed —
-    // aliases, wrapped attributes, raw strings, and finally a crate-local re-export that
-    // leaves no trace of serde in the file at all. Detection loses that race by
-    // construction; permission does not.
-    //
-    // Anything not on `EVENT_ALLOWED_IMPORTS` fails, whatever it is named and wherever it
-    // was re-exported from.
-    let event = fs::read_to_string("src/producers/event.rs").expect("src/producers/event.rs");
-    let imports = imports_in(&code_only(&event));
-
-    let unexpected: Vec<&String> = imports
-        .iter()
-        .filter(|import| !EVENT_ALLOWED_IMPORTS.contains(&import.as_str()))
-        .collect();
-    assert!(
-        unexpected.is_empty(),
-        "src/producers/event.rs imports something not on the allowlist: {unexpected:?}\n\
-         This module holds the one producer type that must not reach a wire. A new import \
-         may be entirely fine — add it to EVENT_ALLOWED_IMPORTS deliberately, having \
-         checked it is not a serialization trait re-exported under another name."
-    );
-    assert!(
-        !imports.is_empty(),
-        "no imports were found at all, which means the scanner is not reading the file"
-    );
-}
-
-#[test]
-fn lint_adaptive_event_derives_only_what_it_is_allowed_to() {
-    // A derive needs no import: `#[derive(crate::wire::EventWire)]` names the macro by
-    // path, so the import allowlist alone does not close it. Permitting `Debug` and `Clone`
-    // and nothing else closes every spelling at once.
-    let event = fs::read_to_string("src/producers/event.rs").expect("src/producers/event.rs");
-    let attributes =
-        attributes_attached_to(&event, ADAPTIVE_EVENT_DECLARATION).unwrap_or_else(|| {
-            panic!("src/producers/event.rs must declare `{ADAPTIVE_EVENT_DECLARATION}`")
-        });
-
-    let derived: Vec<String> = attributes.iter().flat_map(|a| derive_tokens(a)).collect();
-    let unexpected: Vec<&String> = derived
-        .iter()
-        .filter(|token| !ADAPTIVE_EVENT_ALLOWED_DERIVES.contains(&token.as_str()))
-        .collect();
-    assert!(
-        unexpected.is_empty(),
-        "AdaptiveEvent derives something not on the allowlist: {unexpected:?}\n\
-         Permitted: {ADAPTIVE_EVENT_ALLOWED_DERIVES:?}. A derive under an alias or a \
-         re-exported path is indistinguishable from any other name, so the list is what \
-         decides."
-    );
-    assert!(
-        !derived.is_empty(),
-        "no derives were found at all, which means the scanner is not reading the type"
-    );
-}
-
-#[test]
-fn lint_adaptive_event_implements_no_traits() {
-    // The third surface a name-based guard has to cover, and the one a re-export hides
-    // best: `impl EventWire for AdaptiveEvent` needs neither serde in the file nor a
-    // derive. AdaptiveEvent implements nothing by hand today, so the allowlist is empty.
-    let event = fs::read_to_string("src/producers/event.rs").expect("src/producers/event.rs");
-    let impls = trait_impls_for(&code_only(&event), "AdaptiveEvent");
-    assert!(
-        impls.is_empty(),
-        "AdaptiveEvent has hand-written trait impls: {impls:?}\n\
-         None are expected. If one becomes necessary, allow it here having checked it is \
-         not a serialization trait under another name."
-    );
-}
-
-#[test]
-fn lint_the_internal_event_module_imports_no_serialization_trait() {
-    // The structural half, and the one that makes aliasing moot rather than merely detected.
-    //
-    // Resolving aliases catches `use serde::Serialize as EventWire;`. Forbidding the import
-    // outright removes the question: this module exists to hold the one producer type that
-    // cannot reach a wire, so it has no legitimate need for a serialization trait under any
-    // name. If that ever changes it should be a deliberate edit that has to delete this
-    // test, not an import nobody noticed.
-    let event = fs::read_to_string("src/producers/event.rs").expect("src/producers/event.rs");
-    let code = code_only(&event);
-
-    let aliases: Vec<String> = serialization_names(&code)
-        .into_iter()
-        .filter(|name| name != "Serialize" && name != "Deserialize")
-        .collect();
-    assert!(
-        aliases.is_empty(),
-        "src/producers/event.rs aliases a serialization trait: {aliases:?}. An alias makes \
-         `#[derive(…)]` and `impl … for AdaptiveEvent` invisible to any literal scan."
-    );
-
-    assert!(
-        !code.contains("serde"),
-        "src/producers/event.rs references serde. This module exists to hold the one \
-         producer type that cannot reach a wire; a serialization import here needs a \
-         deliberate justification, not a silent addition."
     );
 }
 
@@ -1153,6 +455,69 @@ fn lint_publication_layer_adds_no_routes() {
 }
 
 // =============================================================================
+// The internal event module: three allowlists
+// =============================================================================
+
+#[test]
+fn lint_the_internal_event_module_imports_only_what_it_is_allowed_to() {
+    let file = parse_file_at(EVENT_MODULE);
+    let imports = imports_of(&file);
+
+    let unexpected: Vec<&String> = imports
+        .iter()
+        .filter(|import| !EVENT_ALLOWED_IMPORTS.contains(&import.as_str()))
+        .collect();
+    assert!(
+        unexpected.is_empty(),
+        "{EVENT_MODULE} imports something not on the allowlist: {unexpected:?}\n\
+         This module holds the one producer type that must not reach a wire. A new import \
+         may be entirely fine - add it to EVENT_ALLOWED_IMPORTS deliberately, having \
+         checked it is not a serialization trait re-exported under another name."
+    );
+    assert!(
+        !imports.is_empty(),
+        "no imports were found at all, which means the parse is not reaching the file"
+    );
+}
+
+#[test]
+fn lint_adaptive_event_derives_only_what_it_is_allowed_to() {
+    let file = parse_file_at(EVENT_MODULE);
+    let item = adaptive_event_enum(&file)
+        .unwrap_or_else(|| panic!("{EVENT_MODULE} must declare `enum {ADAPTIVE_EVENT}`"));
+
+    let derived = derives_in(&item.attrs);
+    let unexpected: Vec<&String> = derived
+        .iter()
+        .filter(|token| !ADAPTIVE_EVENT_ALLOWED_DERIVES.contains(&token.as_str()))
+        .collect();
+    assert!(
+        unexpected.is_empty(),
+        "{ADAPTIVE_EVENT} derives something not on the allowlist: {unexpected:?}\n\
+         Permitted: {ADAPTIVE_EVENT_ALLOWED_DERIVES:?}. A derive under an alias or a \
+         re-exported path is indistinguishable from any other name, so the list decides."
+    );
+    assert!(
+        !derived.is_empty(),
+        "no derives were found at all, which means the parse is not reaching the type"
+    );
+}
+
+#[test]
+fn lint_adaptive_event_implements_no_traits() {
+    // The third surface, and the one a re-export hides best: `impl EventWire for
+    // AdaptiveEvent` needs neither serde in the file nor a derive.
+    let file = parse_file_at(EVENT_MODULE);
+    let impls = trait_impls_for(&file, ADAPTIVE_EVENT);
+    assert!(
+        impls.is_empty(),
+        "{ADAPTIVE_EVENT} has hand-written trait impls: {impls:?}\n\
+         None are expected. If one becomes necessary, allow it here having checked it is \
+         not a serialization trait under another name."
+    );
+}
+
+// =============================================================================
 // The publication layer is server-only
 // =============================================================================
 
@@ -1162,28 +527,28 @@ fn lint_producers_module_is_server_gated() {
     // can use the contract types. `src/producers/` depends on `crate::bus` and `tokio`, so
     // an ungated declaration breaks `dx build --platform web` in CI rather than anything a
     // host `cargo test` would notice.
-    let lib = fs::read_to_string("src/lib.rs").expect("src/lib.rs readable");
-    let gates = declaration_gates(&lib, PRODUCERS_DECLARATION)
-        .unwrap_or_else(|| panic!("src/lib.rs must declare `{PRODUCERS_DECLARATION}`"));
+    let file = parse_file_at("src/lib.rs");
+    let gates = module_cfg_gates(&file, PRODUCERS_MODULE)
+        .unwrap_or_else(|| panic!("src/lib.rs must declare `mod {PRODUCERS_MODULE}`"));
     assert!(
-        gates.iter().any(|gate| is_server_gate(gate)),
-        "`{PRODUCERS_DECLARATION}` must be `{SERVER_GATE}`; it depends on crate::bus and \
-         tokio, neither of which exists in the WASM build. Found gates: {gates:?}"
+        gates.iter().any(gate_is_server_only),
+        "`mod {PRODUCERS_MODULE}` must be gated on `feature = \"server\"` and nothing \
+         looser; it depends on crate::bus and tokio, neither of which exists in the WASM \
+         build."
     );
 }
 
 #[test]
 fn lint_publication_layer_is_reachable_only_from_the_composition_root() {
-    // If nothing outside `src/producers/` names it except `src/lib.rs` and `src/main.rs`,
-    // then the exposure surface is exactly one file and reviewing it is tractable.
     let mut referrers = Vec::new();
-    for (path, text) in sources_under("src") {
+    for (path, text) in rust_sources_under("src") {
         if path.starts_with("src/producers") || path == "src/lib.rs" || path == "src/main.rs" {
             continue;
         }
-        if forbidden_module_references(&code_only(&text))
+        let file = parse_source(&path, &text);
+        if forbidden_module_references(&file)
             .iter()
-            .any(|reference| reference.contains("producers"))
+            .any(|reference| reference.ends_with("::producers"))
         {
             referrers.push(path);
         }
@@ -1195,788 +560,328 @@ fn lint_publication_layer_is_reachable_only_from_the_composition_root() {
 }
 
 // =============================================================================
-// Non-vacuity probes
+// The exploit corpus
+//
+// Every escape found against the previous text scanner, kept as source and run through the
+// production helpers. This is the regression cover for the architecture change: if a future
+// edit reintroduces text scanning, these are what fail.
+// =============================================================================
+
+/// Parse a snippet exactly as the lints parse a file.
+fn snippet(source: &str) -> File {
+    parse_source("<probe>", source)
+}
+
+#[test]
+fn every_known_serialization_escape_is_rejected() {
+    let exploits = [
+        // CodeRabbit: only the nearest derive was inspected.
+        (
+            "stacked derive",
+            "#[derive(Serialize)]\n#[derive(Debug, Clone)]\npub enum AdaptiveEvent {}\n",
+        ),
+        // CodeRabbit: a conditional derive was never looked for.
+        (
+            "cfg_attr derive",
+            "#[cfg_attr(feature = \"x\", derive(Serialize))]\n#[derive(Debug)]\npub enum AdaptiveEvent {}\n",
+        ),
+        // CodeRabbit: an attribute wrapped across lines was discarded by the line walk.
+        (
+            "wrapped derive",
+            "#[derive(\n    Debug,\n    Serialize,\n)]\npub enum AdaptiveEvent {}\n",
+        ),
+        (
+            "wrapped cfg_attr",
+            "#[cfg_attr(\n    feature = \"x\",\n    derive(serde::Serialize)\n)]\n#[derive(Debug)]\npub enum AdaptiveEvent {}\n",
+        ),
+        // CodeRabbit: an alias contains no forbidden substring.
+        (
+            "aliased derive",
+            "use serde::Serialize as EventWire;\n#[derive(EventWire)]\npub enum AdaptiveEvent {}\n",
+        ),
+        // CodeRabbit: a raw string ended the attribute early and hid what followed.
+        (
+            "raw string then wrapped derive",
+            "#[doc = r##\"quote: \" then ] remains data\"##]\n#[cfg_attr(\n    feature = \"x\",\n    derive(serde::Serialize)\n)]\npub enum AdaptiveEvent {}\n",
+        ),
+        // Codex: an escaped apostrophe under-consumed and mis-lexed everything after it.
+        (
+            "escaped-quote char literal then derive",
+            "#[doc = \"sep is '\\''\"]\n#[derive(Serialize)]\npub enum AdaptiveEvent {}\n",
+        ),
+        // A derive by fully-qualified path, needing no import at all.
+        (
+            "fully-qualified re-exported derive",
+            "#[derive(crate::wire::EventWire)]\npub enum AdaptiveEvent {}\n",
+        ),
+        // Nested conditionals.
+        (
+            "nested cfg_attr",
+            "#[cfg_attr(unix, cfg_attr(feature = \"x\", derive(Serialize)))]\npub enum AdaptiveEvent {}\n",
+        ),
+    ];
+
+    for (label, source) in exploits {
+        let file = snippet(source);
+        let item = adaptive_event_enum(&file)
+            .unwrap_or_else(|| panic!("{label}: enum not located:\n{source}"));
+        let derived = derives_in(&item.attrs);
+        assert!(
+            derived
+                .iter()
+                .any(|token| !ADAPTIVE_EVENT_ALLOWED_DERIVES.contains(&token.as_str())),
+            "{label}: a forbidden derive was admitted. Derives seen: {derived:?}\n{source}"
+        );
+    }
+}
+
+#[test]
+fn every_known_import_escape_is_rejected() {
+    let exploits = [
+        ("plain alias", "use serde::Serialize as W;"),
+        ("crate-local re-export", "use crate::wire::EventWire;"),
+        // Codex: `pub use` was the one visibility form the boundary rule rejected.
+        ("pub use", "pub use serde::Serialize as W;"),
+        ("pub(crate) use", "pub(crate) use serde::Serialize as W;"),
+        ("pub(super) use", "pub(super) use serde::Deserialize as R;"),
+        (
+            "pub(in path) use",
+            "pub(in crate::producers) use serde::Serialize as W;",
+        ),
+        // Codex: an attribute is not a statement boundary, so every decorated import was
+        // invisible - including a perfectly ordinary `#[allow(unused_imports)]`.
+        (
+            "cfg-decorated",
+            "#[cfg(any())]\nuse crate::wire::EventWire;",
+        ),
+        (
+            "allow-decorated",
+            "#[allow(unused_imports)]\nuse crate::wire::EventWire;",
+        ),
+        (
+            "cfg_attr-decorated",
+            "#[cfg_attr(test, allow(unused))]\nuse crate::wire::EventWire;",
+        ),
+        (
+            "attribute and visibility together",
+            "#[cfg(any())]\npub use crate::wire::EventWire;",
+        ),
+        ("grouped", "use serde::{Serialize as W, Deserializer};"),
+        ("glob", "use crate::wire::*;"),
+        (
+            "wrapped across lines",
+            "use crate::wire::{\n    EventWire,\n};",
+        ),
+    ];
+
+    for (label, source) in exploits {
+        let file = snippet(source);
+        let imports = imports_of(&file);
+        assert!(
+            !imports.is_empty(),
+            "{label}: no import was seen at all:\n{source}"
+        );
+        assert!(
+            imports
+                .iter()
+                .any(|import| !EVENT_ALLOWED_IMPORTS.contains(&import.as_str())),
+            "{label}: the allowlist admitted {imports:?}\n{source}"
+        );
+    }
+}
+
+#[test]
+fn every_known_impl_escape_is_rejected() {
+    for (label, source) in [
+        ("canonical", "impl Serialize for AdaptiveEvent {}"),
+        (
+            "with a lifetime",
+            "impl<'de> Deserialize<'de> for AdaptiveEvent {}",
+        ),
+        (
+            "aliased",
+            "use serde::Serialize as EventWire;\nimpl EventWire for AdaptiveEvent {}",
+        ),
+        (
+            "fully-qualified re-export",
+            "impl crate::wire::EventWire for AdaptiveEvent {}",
+        ),
+        (
+            "escaped-quote char literal nearby",
+            "const SEP: char = '\\'';\nimpl Serialize for AdaptiveEvent {}",
+        ),
+        (
+            "raw string nearby",
+            "const D: &str = r##\"] \" ]\"##;\nimpl Serialize for AdaptiveEvent {}",
+        ),
+    ] {
+        let file = snippet(source);
+        assert!(
+            !trait_impls_for(&file, ADAPTIVE_EVENT).is_empty(),
+            "{label}: a hand-written impl was admitted:\n{source}"
+        );
+    }
+}
+
+// =============================================================================
+// Positive controls
 // =============================================================================
 
 #[test]
-fn gate_scanner_detects_a_gate_it_must_not_miss() {
-    // Each case was verified against the shapes that defeated earlier versions of the
-    // sibling lint in `tests/adaptive_dependency_lint.rs`.
-    for source in [
-        // Directly above.
-        "#[cfg(feature = \"server\")]\npub mod producers;\n",
-        // Stacked behind another attribute - the `d6da952` blind spot.
-        "#[cfg(feature = \"server\")]\n#[allow(dead_code)]\npub mod producers;\n",
-        // Other order.
-        "#[allow(dead_code)]\n#[cfg(feature = \"server\")]\npub mod producers;\n",
-        // Unspaced.
-        "#[cfg(feature=\"server\")]\npub mod producers;\n",
-        // Sharing the line.
-        "#[cfg(feature = \"server\")] pub mod producers;\n",
-        // Behind a doc comment that names the declaration, so a `find`-based scan would
-        // inspect the wrong line.
-        "/// see `pub mod producers;`\n#[cfg(feature = \"server\")]\npub mod producers;\n",
-        // Gated by an enclosing block.
-        "#[cfg(feature = \"server\")]\nmod inner {\npub mod producers;\n}\n",
-    ] {
-        let gates = declaration_gates(source, PRODUCERS_DECLARATION)
-            .unwrap_or_else(|| panic!("declaration not found in:\n{source}"));
-        assert!(
-            gates.iter().any(|gate| is_server_gate(gate)),
-            "a server gate was missed in:\n{source}\nfound: {gates:?}"
-        );
-    }
-}
-
-#[test]
-fn gate_scanner_does_not_invent_a_gate_that_is_not_there() {
-    // The direction that matters for this module's polarity. A scanner that hallucinates a
-    // gate would let an ungated `pub mod producers;` pass and break the WASM build in CI.
-    for source in [
-        // No gate at all.
-        "pub mod producers;\n",
-        // A gate that belongs to the item above it, not to this declaration.
-        "#[cfg(feature = \"server\")]\npub mod bus;\npub mod producers;\n",
-        // A gate consumed by a block that has already closed.
-        "#[cfg(feature = \"server\")]\nmod inner {\npub mod other;\n}\npub mod producers;\n",
-        // `cfg_attr` cannot exclude a module.
-        "#[cfg_attr(feature = \"server\", allow(dead_code))]\npub mod producers;\n",
-        // A different feature is not the server gate.
-        "#[cfg(feature = \"web\")]\npub mod producers;\n",
-        // Disjunctive: contains `feature="server"` but compiles the module for `web`
-        // *without* `server`, which is the WASM breakage this lint exists to prevent.
-        // Passed the pre-fix scanner. Found by CodeRabbit at `86e5bd2`.
-        "#[cfg(any(feature = \"server\", feature = \"web\"))]\npub mod producers;\n",
-        "#[cfg(any(feature=\"server\",feature=\"web\"))]\npub mod producers;\n",
-        // Negation, for the same reason in the opposite direction.
-        "#[cfg(not(feature = \"server\"))]\npub mod producers;\n",
-    ] {
-        let gates = declaration_gates(source, PRODUCERS_DECLARATION)
-            .unwrap_or_else(|| panic!("declaration not found in:\n{source}"));
-        assert!(
-            !gates.iter().any(|gate| is_server_gate(gate)),
-            "a server gate was invented for:\n{source}\nfound: {gates:?}"
-        );
-    }
-}
-
-#[test]
-fn declaration_scanner_reports_absence_rather_than_guessing() {
-    assert_eq!(
-        declaration_gates("pub mod adaptive;\n", PRODUCERS_DECLARATION),
-        None
-    );
-    // A doc comment mentioning it is not a declaration.
-    assert_eq!(
-        declaration_gates("/// pub mod producers;\n", PRODUCERS_DECLARATION),
-        None
-    );
-}
-
-#[test]
-fn a_stricter_conjunctive_gate_is_still_server_only() {
-    // `all(feature = "server", unix)` compiles the module in strictly fewer configurations
-    // than the plain gate, so it cannot reintroduce the WASM breakage. Accepted, unlike the
-    // disjunctive form above - the distinction is which direction the gate is loosened.
-    let source = "#[cfg(all(feature = \"server\", unix))]\npub mod producers;\n";
-    let gates = declaration_gates(source, PRODUCERS_DECLARATION).expect("declaration found");
-    assert!(gates.iter().any(|gate| is_server_gate(gate)));
-}
-
-#[test]
-fn a_serializing_adaptive_event_is_rejected_however_it_is_spelled() {
-    // Non-vacuity for `lint_adaptive_event_derives_no_serialization`. Cases 2 and 4 through
-    // 7 all passed the previous scanner, which read only the *nearest* `#[derive(` and never
-    // looked for `cfg_attr` at all. Found by CodeRabbit at `eebde11`.
-    for source in [
-        // 1. The obvious form.
-        "#[derive(Serialize)]\npub enum AdaptiveEvent {\n}\n",
-        // 2. Stacked behind the innocent derive - the reported blind spot.
-        "#[derive(Serialize, Deserialize)]\n#[derive(Debug, Clone)]\npub enum AdaptiveEvent {\n}\n",
-        // 3. The other order.
-        "#[derive(Debug, Clone)]\n#[derive(Deserialize)]\npub enum AdaptiveEvent {\n}\n",
-        // 4. Behind an unrelated attribute.
-        "#[derive(Serialize)]\n#[non_exhaustive]\n#[derive(Debug)]\npub enum AdaptiveEvent {\n}\n",
-        // 5. Conditional. A cfg_attr gate does not make it safe, it makes it somebody
-        //    else's build flag.
-        "#[cfg_attr(feature = \"server\", derive(Serialize))]\n#[derive(Debug, Clone)]\npub enum AdaptiveEvent {\n}\n",
-        // 6. Conditional, unspaced, and behind the innocent derive.
-        "#[derive(Debug,Clone)]\n#[cfg_attr(test,derive(Deserialize))]\npub enum AdaptiveEvent {\n}\n",
-        // 7. Sharing the line with the declaration.
-        "#[derive(Debug)] #[derive(Serialize)] pub enum AdaptiveEvent {\n}\n",
-    ] {
-        let names = serialization_names(source);
-        let attributes = attributes_attached_to(source, ADAPTIVE_EVENT_DECLARATION)
-            .unwrap_or_else(|| panic!("declaration not found in:\n{source}"));
-        assert!(
-            attributes
-                .iter()
-                .any(|attribute| introduces_serialization(attribute, &names).is_some()),
-            "a serializing AdaptiveEvent was admitted:\n{source}\nattributes: {attributes:?}"
-        );
-    }
-}
-
-#[test]
-fn a_non_serializing_adaptive_event_is_accepted() {
-    // The other direction. A scanner that rejects everything is as useless as one that
-    // rejects nothing, and case 3 is the false positive the previous implementation
-    // avoided by accident and this one must avoid on purpose: a *different* type's
-    // serializing derive higher up the file.
-    for source in [
-        "#[derive(Debug, Clone)]\npub enum AdaptiveEvent {\n}\n",
-        "#[derive(Debug, Clone)]\n#[non_exhaustive]\npub enum AdaptiveEvent {\n}\n",
-        "#[derive(Serialize, Deserialize)]\npub struct Unrelated {\n}\n#[derive(Debug, Clone)]\npub enum AdaptiveEvent {\n}\n",
-        "#[cfg_attr(test, derive(Default))]\n#[derive(Debug, Clone)]\npub enum AdaptiveEvent {\n}\n",
-    ] {
-        let attributes = attributes_attached_to(source, ADAPTIVE_EVENT_DECLARATION)
-            .unwrap_or_else(|| panic!("declaration not found in:\n{source}"));
-        let names = serialization_names(source);
-        let offenders: Vec<_> = attributes
-            .iter()
-            .filter(|attribute| introduces_serialization(attribute, &names).is_some())
-            .collect();
-        assert!(
-            offenders.is_empty(),
-            "the scanner invented a serialization derive in:\n{source}\nfound: {offenders:?}"
-        );
-    }
-}
-
-#[test]
-fn a_crate_local_re_export_is_rejected_by_the_allowlists() {
-    // The exploit CodeRabbit supplied at `993d35e`, verbatim in shape. `src/wire.rs` does
-    // `pub use serde::Serialize as EventWire;` and `event.rs` imports `crate::wire::EventWire`
-    // — no `serde` anywhere in the file, and nothing short of a real name resolver learns
-    // what `EventWire` is. Verified by compiling it: the build was clean and all 24 lints
-    // passed.
-    //
-    // The allowlists do not try to learn. They refuse the import and refuse the derive.
-    let re_export_derive = "use crate::wire::EventWire;\nuse std::sync::Arc;\n#[derive(EventWire)]\npub enum AdaptiveEvent {\n}\n";
-    let imports = imports_in(&code_only(re_export_derive));
-    assert!(
-        imports
-            .iter()
-            .any(|import| !EVENT_ALLOWED_IMPORTS.contains(&import.as_str())),
-        "the re-exported import was admitted: {imports:?}"
-    );
-    let attributes = attributes_attached_to(re_export_derive, ADAPTIVE_EVENT_DECLARATION)
-        .expect("declaration found");
-    let derived: Vec<String> = attributes.iter().flat_map(|a| derive_tokens(a)).collect();
-    assert!(
-        derived
-            .iter()
-            .any(|token| !ADAPTIVE_EVENT_ALLOWED_DERIVES.contains(&token.as_str())),
-        "the re-exported derive was admitted: {derived:?}"
-    );
-
-    // A derive by fully-qualified path needs no import at all, so the import allowlist
-    // alone would not have closed it.
-    let qualified = "#[derive(crate::wire::EventWire)]\npub enum AdaptiveEvent {\n}\n";
-    let attributes =
-        attributes_attached_to(qualified, ADAPTIVE_EVENT_DECLARATION).expect("declaration");
-    let derived: Vec<String> = attributes.iter().flat_map(|a| derive_tokens(a)).collect();
-    assert!(
-        derived
-            .iter()
-            .any(|token| !ADAPTIVE_EVENT_ALLOWED_DERIVES.contains(&token.as_str())),
-        "a fully-qualified re-exported derive was admitted: {derived:?}"
-    );
-
-    // The hand-written form, which has the same gap and no derive to catch.
-    for source in [
-        "use crate::wire::EventWire;\nimpl EventWire for AdaptiveEvent {}\n",
-        "impl crate::wire::EventWire for AdaptiveEvent {}\n",
-        "impl<'de> crate::wire::EventRead<'de> for AdaptiveEvent {}\n",
-    ] {
-        let impls = trait_impls_for(&code_only(source), "AdaptiveEvent");
-        assert!(
-            !impls.is_empty(),
-            "a re-exported hand-written impl was admitted:\n{source}"
-        );
-    }
-}
-
-#[test]
 fn the_allowlists_accept_the_module_as_it_actually_is() {
-    // Positive control, and the one that keeps the allowlists honest rather than merely
-    // strict: the real module must pass without exception. A list that only ever fails is
-    // as useless as one that only ever passes.
-    let event = fs::read_to_string("src/producers/event.rs").expect("src/producers/event.rs");
-    let code = code_only(&event);
-
-    for import in imports_in(&code) {
+    // A list that only ever fails is as useless as one that only ever passes.
+    let file = parse_file_at(EVENT_MODULE);
+    for import in imports_of(&file) {
         assert!(
             EVENT_ALLOWED_IMPORTS.contains(&import.as_str()),
             "the allowlist rejects an import the module legitimately has: {import:?}"
         );
     }
-    assert!(
-        trait_impls_for(&code, "AdaptiveEvent").is_empty(),
-        "the impl scanner invented an impl in the real module"
-    );
+    for derive in derives_in(
+        &adaptive_event_enum(&file)
+            .expect("AdaptiveEvent declared")
+            .attrs,
+    ) {
+        assert!(
+            ADAPTIVE_EVENT_ALLOWED_DERIVES.contains(&derive.as_str()),
+            "the allowlist rejects a derive the type legitimately has: {derive:?}"
+        );
+    }
+    assert!(trait_impls_for(&file, ADAPTIVE_EVENT).is_empty());
+}
 
-    // And an unrelated impl for a *different* type in the same file must not register.
-    let other = "impl Default for AdaptiveBus {}\nimpl AdaptiveEvent {}\n";
+#[test]
+fn the_inspectors_do_not_invent_findings() {
+    // Prose, identifiers and string content must not register as imports; an inherent impl
+    // and another type's impl must not register as trait impls; an innocent derive must not
+    // register as forbidden. Under a parser these are not near-misses to be excluded - they
+    // are different syntax - but they are pinned so a regression to scanning is visible.
+    let benign = "//! doc: callers use crate::adaptive::X for this\n\
+                  use std::sync::Arc;\n\
+                  const S: &str = \"please use crate::adaptive::Z\";\n\
+                  fn f(thing: T) { let misuse = 1; let reuse_count = 2; thing.use_default(); \
+                  let _ = (misuse, reuse_count); }\n\
+                  impl Default for AdaptiveBus {}\n\
+                  impl AdaptiveEvent {}\n\
+                  #[derive(Debug, Clone)]\n\
+                  pub enum AdaptiveEvent {}\n";
+    let file = snippet(benign);
+
+    assert_eq!(
+        imports_of(&file),
+        vec!["std::sync::Arc".to_string()],
+        "prose or a string literal registered as an import"
+    );
     assert!(
-        trait_impls_for(other, "AdaptiveEvent").is_empty(),
+        trait_impls_for(&file, ADAPTIVE_EVENT).is_empty(),
         "an inherent impl or another type's impl was counted: {:?}",
-        trait_impls_for(other, "AdaptiveEvent")
+        trait_impls_for(&file, ADAPTIVE_EVENT)
+    );
+    let derived = derives_in(&adaptive_event_enum(&file).expect("declared").attrs);
+    assert_eq!(derived, vec!["Debug".to_string(), "Clone".to_string()]);
+
+    // A doc comment and a string mentioning a forbidden module are not references.
+    let prose_only = "//! crate::adaptive is discussed here\n\
+                      const S: &str = \"crate::producers\";\n\
+                      fn f() {}\n";
+    assert!(
+        forbidden_module_references(&snippet(prose_only)).is_empty(),
+        "prose or a string literal registered as a module reference"
+    );
+
+    // A module whose name merely shares a prefix is not forbidden.
+    let near_miss = "use crate::adaptive_extras::X;\nuse crate::production::Y;\n";
+    assert!(
+        forbidden_module_references(&snippet(near_miss)).is_empty(),
+        "a prefix-sharing module name registered: {:?}",
+        forbidden_module_references(&snippet(near_miss))
     );
 }
 
 #[test]
-fn raw_strings_do_not_break_the_shared_lexer() {
-    // A raw string ends at `"` followed by its own hash count, not at the first `"`. A
-    // scanner that leaves string mode at an embedded quote then reads the following `]` as
-    // the attribute close, so the attribute ends early, the next wrapped attribute is never
-    // joined, and the line walk discards it. Found by CodeRabbit at `993d35e`, which also
-    // supplied the working exploit.
-    let raw_then_wrapped = "#[doc = r##\"quote: \" then ] remains data\"##]\n\
-                            #[cfg_attr(\n    feature = \"x\",\n    derive(serde::Serialize)\n)]\n\
-                            pub enum AdaptiveEvent {\n}\n";
-
-    // Asserted on the property rather than on exact spacing: the wrapped attribute and its
-    // derive must end up on one line. Indentation inside the attribute is preserved, so a
-    // literal comparison would pin formatting rather than behaviour.
-    let joined = join_wrapped_attributes(raw_then_wrapped);
-    let cfg_line = joined
-        .lines()
-        .find(|line| line.contains("#[cfg_attr("))
-        .unwrap_or_default();
-    assert!(
-        cfg_line.contains("derive(serde::Serialize)") && cfg_line.trim_end().ends_with(")]"),
-        "a raw string ended the attribute early, so the wrapped derive was never joined:\n{joined}"
-    );
-
-    let names = serialization_names(raw_then_wrapped);
-    let attributes = attributes_attached_to(raw_then_wrapped, ADAPTIVE_EVENT_DECLARATION)
-        .expect("declaration found");
-    assert!(
-        attributes
-            .iter()
-            .any(|attribute| introduces_serialization(attribute, &names).is_some()),
-        "a raw doc attribute hid a serializing derive:\n{attributes:?}"
-    );
-
-    // The same limitation in `code_only`: a `//` or `/*` inside a raw string is data, not a
-    // comment, and treating it as one silently deletes the rest of the line.
-    let raw_with_comment_markers = "#[doc = r\"a // b /* c\"]\nuse crate::adaptive::X;\n";
-    assert!(
-        code_only(raw_with_comment_markers).contains("use crate::adaptive::X;"),
-        "a raw string containing comment markers swallowed the code after it: {:?}",
-        code_only(raw_with_comment_markers)
-    );
-
-    // Hash-count matching: an inner `"#` must not terminate a `r##"…"##` literal.
-    let nested_hashes = "#[doc = r##\"ends with \"# not here\"##]\n#[derive(Serialize)]\npub enum AdaptiveEvent {\n}\n";
-    let attributes =
-        attributes_attached_to(nested_hashes, ADAPTIVE_EVENT_DECLARATION).expect("declaration");
-    assert!(
-        attributes.iter().any(|attribute| introduces_serialization(
-            attribute,
-            &["Serialize".to_string()]
-        )
-        .is_some()),
-        "hash-count matching failed, hiding the derive:\n{attributes:?}"
-    );
-}
-
-#[test]
-fn char_literals_are_data_not_brackets_or_quotes() {
-    // An earlier version of this file claimed to test char literals in a case whose source
-    // contained none — `#[doc = "x"]` is an ordinary string. Codex caught the mislabel and
-    // the real defect underneath it. These are actual char literals.
+fn module_references_are_found_in_every_position() {
     for (label, source) in [
-        // A bracket inside a char literal must not close the attribute.
+        ("use", "use crate::adaptive::X;"),
+        ("grouped use", "use crate::{adaptive, bus};"),
+        ("renamed use", "use crate::adaptive as contract;"),
         (
-            "bracket",
-            "#[x = ']']\n#[derive(Serialize)]\npub enum AdaptiveEvent {\n}\n",
+            "external crate root",
+            "use unified_hifi_control::producers::P;",
         ),
-        // An escaped apostrophe. `char_literal_end` returned at the *escaped* quote rather
-        // than the closing one, leaving a dangling `'` that reads as another literal.
+        ("type position", "fn f(x: crate::adaptive::X) {}"),
         (
-            "escaped quote",
-            "#[x = '\\'']\n#[derive(Serialize)]\npub enum AdaptiveEvent {\n}\n",
-        ),
-        (
-            "escaped backslash",
-            "#[x = '\\\\']\n#[derive(Serialize)]\npub enum AdaptiveEvent {\n}\n",
+            "expression position",
+            "fn f() { let _ = crate::producers::g(); }",
         ),
         (
-            "byte char",
-            "#[x = b']']\n#[derive(Serialize)]\npub enum AdaptiveEvent {\n}\n",
+            "inside a macro",
+            "fn f() { println!(\"{:?}\", crate::adaptive::X); }",
         ),
         (
-            "unicode escape that is a closing bracket",
-            "#[x = '\\u{5D}']\n#[derive(Serialize)]\npub enum AdaptiveEvent {\n}\n",
+            "attribute-decorated use",
+            "#[allow(unused_imports)]\nuse crate::producers::P;",
         ),
     ] {
-        let attributes = attributes_attached_to(source, ADAPTIVE_EVENT_DECLARATION)
-            .unwrap_or_else(|| panic!("declaration not found for {label}:\n{source}"));
         assert!(
-            attributes.iter().any(|attribute| introduces_serialization(
-                attribute,
-                &["Serialize".to_string()]
-            )
-            .is_some()),
-            "{label}: a char literal ate the derive:\n{attributes:?}"
-        );
-    }
-
-    // The lexer directly, so a failure names the cause rather than a symptom.
-    for (literal, expected) in [
-        ("']'", Some(3)),
-        ("'\\''", Some(4)),
-        ("'\\\\'", Some(4)),
-        ("'\\n'", Some(4)),
-        ("'\\u{5D}'", Some(8)),
-        ("'a'", Some(3)),
-    ] {
-        let chars: Vec<char> = literal.chars().collect();
-        assert_eq!(
-            char_literal_end(&chars, 0),
-            expected,
-            "char literal {literal:?} was mis-measured"
-        );
-    }
-
-    // Lifetimes are not char literals and must consume nothing.
-    for lifetime in ["'de", "'a", "'static"] {
-        let chars: Vec<char> = lifetime.chars().collect();
-        assert_eq!(
-            char_literal_end(&chars, 0),
-            None,
-            "lifetime {lifetime:?} was read as a char literal"
-        );
-    }
-    assert!(
-        handwritten_serialization_impl(
-            "impl<'de> Deserialize<'de> for AdaptiveEvent {}\n",
-            "AdaptiveEvent",
-            &["Deserialize".to_string()]
-        )
-        .is_some(),
-        "a lifetime swallowed a hand-written impl"
-    );
-}
-
-#[test]
-fn visibility_qualified_use_statements_are_still_imports() {
-    // `pub use serde::Serialize as EventWire;` written directly in the module is the same
-    // re-export exploit as the previous round, one file closer. `imports_in` explicitly
-    // rejected "alphanumeric then space" before `use`, so `pub use` — and only `pub use` —
-    // was invisible, while `pub(crate) use` was caught because `)` is not alphanumeric.
-    // Inconsistent, and wrong in the direction that passes. Found by Codex at `20926e1`.
-    for (label, source) in [
-        ("plain", "use serde::Serialize as W;"),
-        ("pub", "pub use serde::Serialize as W;"),
-        ("pub(crate)", "pub(crate) use serde::Serialize as W;"),
-        ("pub(super)", "pub(super) use serde::Deserialize as R;"),
-        (
-            "pub(in path)",
-            "pub(in crate::producers) use serde::Serialize as W;",
-        ),
-        ("indented pub", "    pub use serde::Serialize as W;"),
-    ] {
-        let found = imports_in(&code_only(source));
-        assert_eq!(
-            found.len(),
-            1,
-            "{label}: a visibility-qualified use was missed: {found:?}\n{source}"
-        );
-        assert!(
-            !EVENT_ALLOWED_IMPORTS.contains(&found[0].as_str()),
-            "{label}: the allowlist admitted a re-export: {found:?}"
+            !forbidden_module_references(&snippet(source)).is_empty(),
+            "{label}: a module reference was missed:\n{source}"
         );
     }
 }
 
 #[test]
-fn the_import_scanner_does_not_invent_imports() {
-    // The other direction. `use` appears inside identifiers and prose, and a scanner that
-    // fires on those makes the allowlist unmaintainable — which is how it ends up deleted.
-    for (label, source) in [
-        (
-            "identifier containing use",
-            "let misuse = 1;\nlet reuse_count = 2;\n",
-        ),
-        ("word in a string literal", "let s = \"please use this\";\n"),
-        ("method named use_default", "thing.use_default();\n"),
-    ] {
-        let found = imports_in(&code_only(source));
-        assert!(
-            found.is_empty(),
-            "{label}: the scanner invented an import: {found:?}\n{source}"
-        );
-    }
-
-    // Prose is stripped before the scan, so a doc comment mentioning `use` is not one.
-    let prose = "/// callers use crate::adaptive::X for this\nuse std::sync::Arc;\n";
-    assert_eq!(
-        imports_in(&code_only(prose)),
-        vec!["use std::sync::Arc;".to_string()],
-        "a doc comment was read as an import"
-    );
-}
-
-#[test]
-fn raw_string_lexing_does_not_over_consume() {
-    // Positive controls for the lexer. Over-consuming is as bad as under-consuming: it would
-    // swallow real code into a phantom string and hide whatever came next.
-    let ordinary = "#[doc = \"plain\"]\n#[derive(Debug)]\npub enum AdaptiveEvent {\n}\n";
-    let attributes =
-        attributes_attached_to(ordinary, ADAPTIVE_EVENT_DECLARATION).expect("declaration");
-    assert_eq!(
-        attributes.len(),
-        2,
-        "ordinary strings mis-lexed: {attributes:?}"
-    );
-
-    // `r` as the tail of an identifier is not a raw-string prefix.
-    let identifier_r = "let counter = 1; let other = \"x\";\nuse crate::adaptive::Y;\n";
-    assert!(
-        code_only(identifier_r).contains("use crate::adaptive::Y;"),
-        "an identifier ending in `r` was read as a raw string: {:?}",
-        code_only(identifier_r)
-    );
-
-    // A lifetime is not a char literal.
-    let lifetime = "impl<'de> Deserialize<'de> for AdaptiveEvent {}\n";
-    assert!(
-        handwritten_serialization_impl(lifetime, "AdaptiveEvent", &["Deserialize".to_string()])
-            .is_some(),
-        "a lifetime was mistaken for a char literal and lost the impl"
-    );
-
-    // Comments still get stripped when they are actually comments.
-    assert!(!code_only("// crate::adaptive\nlet x = 1;\n").contains("crate::adaptive"));
-}
-
-#[test]
-fn a_wrapped_attribute_is_not_lost_by_the_line_walk() {
-    // The scanners walk lines, and a line that is not an attribute clears the pending set —
-    // that rule is what stops one item's attributes leaking onto the next. A wrapped
-    // attribute was destroyed by it: `#[derive(` was held as pending and then discarded by
-    // its own continuation line, so the declaration reported only the attributes that
-    // happened to fit on one line.
-    //
-    // Verified against the real module before the fix: a wrapped
-    // `#[cfg_attr(…, derive(serde::Serialize))]` compiled, and
-    // `lint_adaptive_event_derives_no_serialization` passed while
-    // `attributes_attached_to` reported only `["#[derive(Debug, Clone)]"]`. Found by
-    // CodeRabbit at `b35af10`.
-    for (label, source) in [
-        (
-            "wrapped derive with a serializing member",
-            "#[derive(\n    Debug,\n    Serialize,\n)]\npub enum AdaptiveEvent {\n}\n",
-        ),
-        (
-            "wrapped derive above the innocent one",
-            "#[derive(\n    Serialize,\n)]\n#[derive(Debug, Clone)]\npub enum AdaptiveEvent {\n}\n",
-        ),
-        (
-            "wrapped cfg_attr - the form proved against the real module",
-            "#[cfg_attr(\n    feature = \"x\",\n    derive(serde::Serialize)\n)]\n#[derive(Debug, Clone)]\npub enum AdaptiveEvent {\n}\n",
-        ),
-        (
-            "wrapped derive of an alias",
-            "use serde::Serialize as EventWire;\n#[derive(\n    Debug,\n    EventWire,\n)]\npub enum AdaptiveEvent {\n}\n",
-        ),
-        (
-            "deeply wrapped, one member per line",
-            "#[cfg_attr(\n    all(\n        feature = \"x\",\n        unix,\n    ),\n    derive(\n        Deserialize,\n    )\n)]\npub enum AdaptiveEvent {\n}\n",
-        ),
-    ] {
-        let names = serialization_names(source);
-        let attributes = attributes_attached_to(source, ADAPTIVE_EVENT_DECLARATION)
-            .unwrap_or_else(|| panic!("declaration not found for {label}:\n{source}"));
-        assert!(
-            attributes
-                .iter()
-                .any(|attribute| introduces_serialization(attribute, &names).is_some()),
-            "{label} was admitted:\n{source}\nattributes seen: {attributes:?}"
-        );
-    }
-}
-
-#[test]
-fn joining_wrapped_attributes_does_not_attach_them_to_the_wrong_item() {
-    // Positive controls for the joiner. Collapsing newlines inside brackets must not
-    // collapse the line structure that separates one item from the next, or every wrapped
-    // attribute in a file would leak onto whatever declaration came after it.
-    for (label, source) in [
-        (
-            "a wrapped serializing derive on a different item",
-            "#[derive(\n    Serialize,\n)]\npub struct Unrelated {\n}\n#[derive(Debug, Clone)]\npub enum AdaptiveEvent {\n}\n",
-        ),
-        (
-            "a wrapped innocent derive on the right item",
-            "#[derive(\n    Debug,\n    Clone,\n)]\npub enum AdaptiveEvent {\n}\n",
-        ),
-        (
-            "a wrapped cfg_attr deriving something harmless",
-            "#[cfg_attr(\n    test,\n    derive(Default)\n)]\n#[derive(Debug)]\npub enum AdaptiveEvent {\n}\n",
-        ),
-        (
-            "a wrapped doc comment containing a bracket and the word Serialize",
-            "#[doc = \"see Serialize ]\"]\n#[derive(\n    Debug,\n)]\npub enum AdaptiveEvent {\n}\n",
-        ),
-    ] {
-        let names = serialization_names(source);
-        let attributes = attributes_attached_to(source, ADAPTIVE_EVENT_DECLARATION)
-            .unwrap_or_else(|| panic!("declaration not found for {label}:\n{source}"));
-        let offenders: Vec<_> = attributes
-            .iter()
-            .filter_map(|attribute| introduces_serialization(attribute, &names))
-            .collect();
-        assert!(
-            offenders.is_empty(),
-            "{label} produced a false positive: {offenders:?}\n{source}\nattributes: {attributes:?}"
-        );
-    }
-
-    // The joiner itself: newlines inside brackets become spaces, newlines outside do not.
-    let joined = join_wrapped_attributes("#[derive(\n  Debug,\n)]\npub enum X {\n}\n");
-    assert!(
-        joined.starts_with("#[derive(   Debug, )]\n"),
-        "attribute was not joined onto one line: {joined:?}"
-    );
-    assert!(
-        joined.contains("]\npub enum X"),
-        "the joiner collapsed the line structure between the attribute and its item: {joined:?}"
-    );
-}
-
-#[test]
-fn a_wrapped_server_gate_is_still_detected() {
-    // `declaration_gates` had the identical defect, so it takes the identical fix. A gate
-    // that wraps is still a gate.
-    let source = "#[cfg(\n    feature = \"server\"\n)]\npub mod producers;\n";
-    let gates = declaration_gates(source, PRODUCERS_DECLARATION)
-        .unwrap_or_else(|| panic!("declaration not found in:\n{source}"));
-    assert!(
-        gates.iter().any(|gate| is_server_gate(gate)),
-        "a wrapped server gate was missed: {gates:?}"
-    );
-
-    // And the false-positive direction: a wrapped gate belonging to the item above must
-    // not carry onto this declaration.
-    let neighbour = "#[cfg(\n    feature = \"server\"\n)]\npub mod bus;\npub mod producers;\n";
-    let carried = declaration_gates(neighbour, PRODUCERS_DECLARATION)
-        .unwrap_or_else(|| panic!("declaration not found in:\n{neighbour}"));
-    assert!(
-        !carried.iter().any(|gate| is_server_gate(gate)),
-        "a wrapped gate leaked from the item above: {carried:?}"
-    );
-}
-
-#[test]
-fn an_aliased_serialization_trait_is_rejected() {
-    // `use serde::Serialize as EventWire;` binds the derive macro *and* the trait under a
-    // name containing neither "Serialize" nor "Deserialize", so every literal scan passes
-    // while the type is fully serializable. Both forms were compiled against the real
-    // module to confirm this before the test was written: `cargo build --lib` finished
-    // clean with an aliased derive and an aliased hand-written impl in place, and
-    // `lint_adaptive_event_derives_no_serialization` passed. Found by CodeRabbit at
-    // `b35af10`.
-    for (label, source) in [
-        (
-            "aliased derive",
-            "use serde::Serialize as EventWire;\n#[derive(EventWire)]\npub enum AdaptiveEvent {\n}\n",
-        ),
-        (
-            "aliased derive stacked behind the innocent one",
-            "use serde::Serialize as EventWire;\n#[derive(EventWire)]\n#[derive(Debug, Clone)]\npub enum AdaptiveEvent {\n}\n",
-        ),
-        (
-            "aliased Deserialize",
-            "use serde::Deserialize as EventRead;\n#[derive(Debug)]\n#[derive(EventRead)]\npub enum AdaptiveEvent {\n}\n",
-        ),
-        (
-            "aliased inside a grouped import",
-            "use serde::{Serialize as EventWire, Deserializer};\n#[derive(EventWire)]\npub enum AdaptiveEvent {\n}\n",
-        ),
-        (
-            "aliased via cfg_attr",
-            "use serde::Serialize as EventWire;\n#[cfg_attr(feature = \"x\", derive(EventWire))]\n#[derive(Debug)]\npub enum AdaptiveEvent {\n}\n",
-        ),
-        (
-            "aliased through a submodule path",
-            "use serde::ser::Serialize as EventWire;\n#[derive(EventWire)]\npub enum AdaptiveEvent {\n}\n",
-        ),
-    ] {
-        let names = serialization_names(source);
-        let attributes = attributes_attached_to(source, ADAPTIVE_EVENT_DECLARATION)
-            .unwrap_or_else(|| panic!("declaration not found for {label}:\n{source}"));
-        assert!(
-            attributes
-                .iter()
-                .any(|attribute| introduces_serialization(attribute, &names).is_some()),
-            "{label} was admitted:\n{source}\nresolved names: {names:?}"
-        );
-    }
-}
-
-#[test]
-fn an_aliased_handwritten_impl_is_rejected() {
-    for (label, source) in [
-        (
-            "aliased impl",
-            "use serde::Serialize as EventWire;\nimpl EventWire for AdaptiveEvent {}\n",
-        ),
-        (
-            "aliased Deserialize impl with a lifetime",
-            "use serde::Deserialize as EventRead;\nimpl<'de> EventRead<'de> for AdaptiveEvent {}\n",
-        ),
-        (
-            "canonical impl with a lifetime, which the previous literal scan also missed",
-            "impl<'de> Deserialize<'de> for AdaptiveEvent {}\n",
-        ),
-        ("canonical impl", "impl Serialize for AdaptiveEvent {}\n"),
-    ] {
-        let names = serialization_names(source);
-        assert!(
-            handwritten_serialization_impl(source, "AdaptiveEvent", &names).is_some(),
-            "{label} was admitted:\n{source}\nresolved names: {names:?}"
-        );
-    }
-}
-
-#[test]
-fn unrelated_aliases_and_imports_do_not_false_positive() {
-    // Positive controls. Two of these are the specific traps in exact-name matching:
-    // `Serializer` has `Serialize` as a prefix, and `DeserializeOwned` has `Deserialize`
-    // as one. Both are ordinary serde imports that must not register as the traits.
-    for (label, source) in [
-        (
-            "Serializer is not Serialize",
-            "use serde::Serializer;\n#[derive(Debug, Clone)]\npub enum AdaptiveEvent {\n}\n",
-        ),
-        (
-            "DeserializeOwned is not Deserialize",
-            "use serde::de::DeserializeOwned;\n#[derive(Debug, Clone)]\npub enum AdaptiveEvent {\n}\n",
-        ),
-        (
-            "an alias of something else entirely",
-            "use std::fmt::Display as EventWire;\n#[derive(EventWire)]\npub enum AdaptiveEvent {\n}\n",
-        ),
-        (
-            "a serializing impl for a different type",
-            "use serde::Serialize as EventWire;\nimpl EventWire for SomethingElse {}\n#[derive(Debug)]\npub enum AdaptiveEvent {\n}\n",
-        ),
-        (
-            "a prefix-sharing type name",
-            "impl Serialize for AdaptiveEventLog {}\n#[derive(Debug)]\npub enum AdaptiveEvent {\n}\n",
-        ),
-        (
-            "an unrelated impl for the right type",
-            "impl Clone for AdaptiveEvent {}\n#[derive(Debug)]\npub enum AdaptiveEvent {\n}\n",
-        ),
-    ] {
-        let names = serialization_names(source);
-        let attributes = attributes_attached_to(source, ADAPTIVE_EVENT_DECLARATION)
-            .unwrap_or_else(|| panic!("declaration not found for {label}:\n{source}"));
-        let derived: Vec<_> = attributes
-            .iter()
-            .filter_map(|attribute| introduces_serialization(attribute, &names))
-            .collect();
-        assert!(
-            derived.is_empty(),
-            "{label} produced a false positive on a derive: {derived:?}\n{source}"
-        );
-        assert!(
-            handwritten_serialization_impl(source, "AdaptiveEvent", &names).is_none(),
-            "{label} produced a false positive on an impl\n{source}\nnames: {names:?}"
-        );
-    }
-}
-
-#[test]
-fn attribute_extraction_survives_nesting_and_string_literals() {
-    // `attributes_in` has to close on the matching bracket, not the first one. A
-    // `cfg_attr` carrying a derive and a doc comment carrying a `]` are the two shapes
-    // that break a naive scan, and both are reachable in ordinary code.
-    let nested = attributes_in("#[cfg_attr(feature = \"server\", derive(Serialize))]");
-    assert_eq!(nested.len(), 1);
-    assert!(
-        nested[0].ends_with("))]"),
-        "attribute was truncated: {nested:?}"
-    );
-
-    let bracketed = attributes_in("#[doc = \"a ] bracket\"]\n#[derive(Debug)]");
-    assert_eq!(
-        bracketed.len(),
-        2,
-        "a string literal split an attribute: {bracketed:?}"
-    );
-    assert_eq!(bracketed[1], "#[derive(Debug)]");
-
-    // Inner attributes belong to the enclosing module, not to the next item.
-    let inner = attributes_in("#![deny(unsafe_code)]\n#[derive(Debug)]");
-    assert_eq!(inner, vec!["#[derive(Debug)]".to_string()]);
-}
-
-#[test]
-fn grouped_use_trees_do_not_hide_a_forbidden_module() {
-    // A needle scan for `crate::adaptive` misses every one of these. This is the house
-    // style in this repository - `src/main.rs` imports its modules exactly this way - so a
-    // surface writing idiomatic code would have slipped past the boundary check entirely.
-    // Found by CodeRabbit at `86e5bd2`.
+fn server_gate_detection_is_structural() {
+    // Accepted: the plain gate, and a conjunction that only narrows it.
     for source in [
-        "use crate::{adaptive, bus};",
-        "use crate::{bus, producers};",
-        "use unified_hifi_control::{adaptive, producers};",
-        "use unified_hifi_control::{\n    adapters, aggregator, api,\n    producers,\n};",
-        // Nested and aliased forms.
-        "use crate::{producers::ProducerAggregator, bus::SharedBus};",
-        "use crate::{adaptive as contract};",
-        "use crate::{bus::{SharedBus, BusEvent}, adaptive};",
+        "#[cfg(feature = \"server\")]\npub mod producers;",
+        "#[cfg(feature=\"server\")]\npub mod producers;",
+        "#[cfg(feature = \"server\")]\n#[allow(dead_code)]\npub mod producers;",
+        "#[allow(dead_code)]\n#[cfg(feature = \"server\")]\npub mod producers;",
+        "#[cfg(all(feature = \"server\", unix))]\npub mod producers;",
+        "#[cfg(\n    feature = \"server\"\n)]\npub mod producers;",
+        "#[cfg(feature = \"server\")]\nmod inner {\n    pub mod producers;\n}",
     ] {
-        let found = forbidden_module_references(source);
+        let gates = module_cfg_gates(&snippet(source), PRODUCERS_MODULE)
+            .unwrap_or_else(|| panic!("module not located:\n{source}"));
         assert!(
-            !found.is_empty(),
-            "a grouped import hid a forbidden module:\n{source}"
+            gates.iter().any(gate_is_server_only),
+            "a server gate was missed:\n{source}"
         );
     }
-}
 
-#[test]
-fn grouped_use_trees_do_not_produce_false_positives() {
-    // The scanner must not fire on modules that merely share a prefix, on unrelated
-    // groups, or on a group belonging to a different root.
+    // Rejected: absent, a different feature, a disjunction that widens it, a negation, a
+    // gate belonging to a neighbouring item, and `cfg_attr`, which cannot exclude a module.
     for source in [
-        "use crate::{bus, config};",
-        "use crate::{adapters, aggregator};",
-        "use std::{collections::BTreeMap, sync::Arc};",
-        "use serde::{Deserialize, Serialize};",
-        "use other_crate::{adaptive, producers};",
+        "pub mod producers;",
+        "#[cfg(feature = \"web\")]\npub mod producers;",
+        "#[cfg(any(feature = \"server\", feature = \"web\"))]\npub mod producers;",
+        "#[cfg(any(feature=\"server\",feature=\"web\"))]\npub mod producers;",
+        "#[cfg(not(feature = \"server\"))]\npub mod producers;",
+        "#[cfg(feature = \"server\")]\npub mod bus;\npub mod producers;",
+        "#[cfg_attr(feature = \"server\", allow(dead_code))]\npub mod producers;",
     ] {
-        let found = forbidden_module_references(source);
+        let gates = module_cfg_gates(&snippet(source), PRODUCERS_MODULE)
+            .unwrap_or_else(|| panic!("module not located:\n{source}"));
         assert!(
-            found.is_empty(),
-            "the scanner invented a reference in:\n{source}\nfound: {found:?}"
+            !gates.iter().any(gate_is_server_only),
+            "a server gate was invented:\n{source}"
         );
     }
+
+    assert_eq!(
+        module_cfg_gates(&snippet("pub mod adaptive;"), PRODUCERS_MODULE).is_none(),
+        true,
+        "an absent module was reported as present"
+    );
 }
 
 #[test]
-fn comment_stripper_keeps_strings_and_drops_prose() {
-    // Prose discussing the boundary must not trip the dependency checks...
-    let prose = "// this must not reference crate::adaptive\nlet x = 1;\n";
-    assert!(!code_only(prose).contains("crate::adaptive"));
-
-    let trailing = "let x = 1; // not crate::producers\n";
-    assert!(!code_only(trailing).contains("crate::producers"));
-
-    let block = "/* crate::adaptive /* nested */ still comment */\nlet x = 1;\n";
-    assert!(!code_only(block).contains("crate::adaptive"));
-
-    // ...but a forbidden path written as a string literal is still a reference.
-    let literal = "let path = \"crate::producers\";\n";
-    assert!(code_only(literal).contains("crate::producers"));
-
-    // A `//` inside a string must not truncate the line.
-    let url = "let u = \"https://example.com\"; let y = crate::producers::X;\n";
-    assert!(code_only(url).contains("crate::producers"));
+fn an_unparsable_file_fails_loudly_rather_than_vacuously() {
+    // A lint that treats an unparsable file as empty passes for the wrong reason. That is
+    // the failure mode this file exists to stop reproducing, so it is pinned.
+    let broken = std::panic::catch_unwind(|| parse_source("<probe>", "fn broken( {"));
+    assert!(
+        broken.is_err(),
+        "an unparsable file was accepted, which would make every lint over it vacuous"
+    );
 }

--- a/tests/adaptive_publication_lint.rs
+++ b/tests/adaptive_publication_lint.rs
@@ -725,7 +725,9 @@ fn scope_delta(
 
         for item in items {
             match item {
-                Item::Use(item_use) => collect_crate_aliases(&item_use.tree, &roots, &mut aliases),
+                Item::Use(item_use) => {
+                    collect_crate_aliases(&item_use.tree, &roots, false, &mut aliases)
+                }
                 // `extern crate self as internal;` binds the crate root without being a
                 // `use` at all, and `extern crate unified_hifi_control as uhc;` does the
                 // same by name.
@@ -751,28 +753,52 @@ fn scope_delta(
 
 /// Names bound to a known crate root by a use tree.
 ///
-/// The source is matched against the roots known *so far* rather than against the two
-/// original spellings, which is what lets `use self::internal as also;` bind through an
-/// alias. A leading `self::` is transparent, so both `use internal as also;` and
-/// `use self::internal as also;` are recognized.
-fn collect_crate_aliases(tree: &UseTree, roots: &BTreeSet<String>, out: &mut BTreeSet<String>) {
+/// `at_root` records whether the subtree being walked is rooted at a known crate root, which
+/// is what makes grouped `self` work: in `use crate::{self as internal};` the rename's source
+/// ident is `self`, not a root name, so matching only against `roots` binds nothing. Inside a
+/// group under `crate`, `self` *is* the crate root. Raised by an independent audit at
+/// `6980b7b`; both that form and `use internal::{self as also};` compile clean.
+///
+/// The source is matched against the roots known *so far* rather than the two original
+/// spellings, which is what lets an alias be bound from another alias.
+///
+/// Prefixes stay strict: a leading `self::` is transparent for lookup but is not itself the
+/// crate root, and any other prefix stops the descent - `use foo::{self as also};` renames
+/// `foo`, so recognizing grouped `self` must not make every group transparent.
+fn collect_crate_aliases(
+    tree: &UseTree,
+    roots: &BTreeSet<String>,
+    at_root: bool,
+    out: &mut BTreeSet<String>,
+) {
     match tree {
         UseTree::Rename(rename) => {
-            if roots.contains(&rename.ident.to_string()) {
+            let source = rename.ident.to_string();
+            if roots.contains(&source) || (at_root && source == "self") {
                 out.insert(rename.rename.to_string());
             }
         }
         UseTree::Group(group) => {
             for item in &group.items {
-                collect_crate_aliases(item, roots, out);
+                collect_crate_aliases(item, roots, at_root, out);
             }
         }
         UseTree::Path(path) => {
-            // `self::x` and `crate::x` are transparent prefixes for this purpose; any
-            // other prefix means the rename below it is not naming a crate root.
             let head = path.ident.to_string();
-            if head == "self" || roots.contains(&head) {
-                collect_crate_aliases(&path.tree, roots, out);
+            if roots.contains(&head) {
+                // Descending through a crate root: a `self` below it names that root.
+                collect_crate_aliases(&path.tree, roots, true, out);
+            } else if head == "self" {
+                // `self::x` looks up in the current module; transparent for finding a
+                // rename of a known alias, but `self` here is not the crate root.
+                //
+                // Passing `false` rather than `true` is semantically right and currently
+                // unobservable: the only shape that would distinguish them is
+                // `use self::{self as x};`, which rustc rejects with
+                // `error[E0432]: unresolved import self`. Flipping it fails no probe.
+                // Stated rather than implied, so nobody mistakes the surviving mutation
+                // for dead code.
+                collect_crate_aliases(&path.tree, roots, false, out);
             }
         }
         _ => {}
@@ -1762,6 +1788,30 @@ fn extern_crate_self_and_transitive_aliases_are_crate_roots_too() {
             "transitive without the self:: prefix",
             "use crate as internal;\nuse internal as also;\nfn f() { let _ = also::adaptive::X; }\n",
         ),
+        // `use crate::{self as internal};` binds the crate root through a *group*, where the
+        // rename's source ident is `self` rather than a root name. Both of these compile
+        // clean under `rustc --crate-type lib`. Raised by an independent audit at
+        // `6980b7b`.
+        (
+            "grouped self",
+            "use crate::{self as internal};\nfn f() { let _ = internal::adaptive::X; }\n",
+        ),
+        (
+            "grouped self reaching the publication layer",
+            "use crate::{self as internal};\nfn f() { let _ = internal::producers::P; }\n",
+        ),
+        (
+            "transitive grouped self",
+            "use crate::{self as internal};\nuse internal::{self as also};\nfn f() { let _ = also::producers::P; }\n",
+        ),
+        (
+            "grouped self alongside a sibling leaf",
+            "use crate::{self as internal, bus};\nfn f() { let _ = internal::adaptive::X; }\n",
+        ),
+        (
+            "grouped self from the external crate name",
+            "use unified_hifi_control::{self as uhc};\nfn f() { let _ = uhc::adaptive::X; }\n",
+        ),
     ] {
         assert!(
             !forbidden_module_references(&snippet(source)).is_empty(),
@@ -1801,6 +1851,20 @@ fn extended_alias_forms_remain_scope_aware_and_shadowable() {
         (
             "a rename under an unrelated path prefix",
             "use crate as internal;\nmod foo {\n    pub mod internal { pub mod adaptive {} }\n}\nuse foo::internal as also;\nfn f() { let _ = also::adaptive::X; }\n",
+        ),
+        // The same guard for the grouped form: `foo::{self as also}` renames `foo`, not the
+        // crate root, so recognizing grouped `self` must not make every group transparent.
+        (
+            "grouped self under an unrelated prefix",
+            "mod foo {\n    pub mod adaptive {}\n}\nuse foo::{self as also};\nfn f() { let _ = also::adaptive::X; }\n",
+        ),
+        (
+            "grouped self under an unrelated alias chain",
+            "use std::{self as s};\nuse s::{self as t};\nfn f() { let _ = t::fmt::Debug; }\n",
+        ),
+        (
+            "grouped self scoped to a sibling module",
+            "mod a {\n    use crate::{self as internal};\n}\nmod b {\n    fn f() { let _ = internal::adaptive::X; }\n}\n",
         ),
     ] {
         assert!(

--- a/tests/adaptive_publication_lint.rs
+++ b/tests/adaptive_publication_lint.rs
@@ -582,8 +582,9 @@ fn gate_is_server_only(meta: &Meta) -> bool {
 #[derive(Default)]
 struct ModuleReferenceVisitor {
     found: BTreeSet<String>,
-    /// Names that address this crate's root, including aliases bound in this file.
+    /// Names that address this crate's root in the module currently being visited.
     roots: BTreeSet<String>,
+    saved: Vec<BTreeSet<String>>,
 }
 
 impl ModuleReferenceVisitor {
@@ -666,41 +667,79 @@ impl<'ast> Visit<'ast> for ModuleReferenceVisitor {
         self.scan_tokens(&mac.tokens);
         visit::visit_macro(self, mac);
     }
-}
 
-/// Names bound to this crate's root in `file`, including `use crate as internal;`.
-///
-/// `use crate as internal;` then `internal::adaptive::X` reached the forbidden module
-/// through a root the visitor had never heard of: the alias statement has a single path
-/// segment so it registered nothing, and the reference began with `internal`. Found by
-/// CodeRabbit at `59523f8`.
-fn crate_root_names(file: &File) -> BTreeSet<String> {
-    #[derive(Default)]
-    struct AliasVisitor {
-        aliases: BTreeSet<String>,
-    }
-    impl<'ast> Visit<'ast> for AliasVisitor {
-        fn visit_use_tree(&mut self, tree: &'ast UseTree) {
-            if let UseTree::Rename(rename) = tree {
-                if CRATE_ROOTS.contains(&rename.ident.to_string().as_str()) {
-                    self.aliases.insert(rename.rename.to_string());
-                }
+    /// Enter a module with its own crate-root scope: aliases it declares become roots for
+    /// its subtree, and a `mod` it declares shadows an inherited alias of the same name.
+    fn visit_item_mod(&mut self, item: &'ast syn::ItemMod) {
+        self.saved.push(self.roots.clone());
+        if let Some((_, items)) = &item.content {
+            let (aliases, shadowed) = scope_delta(items);
+            self.roots.extend(aliases);
+            for name in &shadowed {
+                self.roots.remove(name);
             }
-            visit::visit_use_tree(self, tree);
+        }
+        visit::visit_item_mod(self, item);
+        if let Some(previous) = self.saved.pop() {
+            self.roots = previous;
         }
     }
-    let mut visitor = AliasVisitor::default();
-    visitor.visit_file(file);
-    let mut roots: BTreeSet<String> = CRATE_ROOTS.iter().map(|r| (*r).to_string()).collect();
-    roots.extend(visitor.aliases);
-    roots
 }
 
-/// Forbidden module references in `file`, resolving crate-root aliases first.
+/// Crate-root names declared directly among `items`, and local module names that shadow.
+///
+/// A file-global alias set is wrong in both directions. `mod a { use crate as internal; }`
+/// must not make `internal` a crate root inside `mod b`, and a genuine
+/// `use crate as internal;` must stop being one inside a module that declares its own
+/// `mod internal`. Found by Codex reviewing the first alias fix.
+///
+/// This is scope tracking, not name resolution: aliases are inherited by descendants and
+/// shadowed by a sibling `mod` of the same name. That covers the reachable cases without
+/// pretending to resolve Rust's full name lookup.
+fn scope_delta(items: &[Item]) -> (BTreeSet<String>, BTreeSet<String>) {
+    let mut aliases = BTreeSet::new();
+    let mut shadowed = BTreeSet::new();
+    for item in items {
+        match item {
+            Item::Use(item_use) => collect_crate_aliases(&item_use.tree, &mut aliases),
+            Item::Mod(item_mod) => {
+                shadowed.insert(item_mod.ident.to_string());
+            }
+            _ => {}
+        }
+    }
+    (aliases, shadowed)
+}
+
+fn collect_crate_aliases(tree: &UseTree, out: &mut BTreeSet<String>) {
+    match tree {
+        UseTree::Rename(rename) => {
+            if CRATE_ROOTS.contains(&rename.ident.to_string().as_str()) {
+                out.insert(rename.rename.to_string());
+            }
+        }
+        UseTree::Group(group) => {
+            for item in &group.items {
+                collect_crate_aliases(item, out);
+            }
+        }
+        UseTree::Path(path) => collect_crate_aliases(&path.tree, out),
+        _ => {}
+    }
+}
+
+/// Forbidden module references in `file`, resolving crate-root aliases within their scope.
 fn forbidden_module_references(file: &File) -> Vec<String> {
+    let mut roots: BTreeSet<String> = CRATE_ROOTS.iter().map(|r| (*r).to_string()).collect();
+    let (aliases, shadowed) = scope_delta(&file.items);
+    roots.extend(aliases);
+    for name in &shadowed {
+        roots.remove(name);
+    }
     let mut visitor = ModuleReferenceVisitor {
         found: BTreeSet::new(),
-        roots: crate_root_names(file),
+        roots,
+        saved: Vec::new(),
     };
     visitor.visit_file(file);
     visitor.found.into_iter().collect()
@@ -1576,6 +1615,61 @@ fn a_crate_root_alias_cannot_launder_a_forbidden_module_reference() {
         assert!(
             !forbidden_module_references(&snippet(source)).is_empty(),
             "{label}: an aliased crate root laundered the reference:\n{source}"
+        );
+    }
+}
+
+#[test]
+fn crate_root_aliases_are_scoped_to_the_module_that_declares_them() {
+    // A file-global alias set is wrong in both directions. Found by Codex reviewing the
+    // alias fix at `1c48c2e`.
+    //
+    // Forward: an alias declared inside one module must not make an unrelated *local*
+    // module of the same name look like the crate root somewhere else.
+    let sibling_scope = "mod a {\n    use crate as internal;\n}\nmod b {\n    mod internal {\n        pub mod adaptive {}\n    }\n    fn f() { let _ = internal::adaptive::X; }\n}\n";
+    assert!(
+        forbidden_module_references(&snippet(sibling_scope)).is_empty(),
+        "an alias declared in a sibling module leaked: {:?}\n{sibling_scope}",
+        forbidden_module_references(&snippet(sibling_scope))
+    );
+
+    // The same leak without any shadowing to mask it: `b` declares no `mod internal`, so
+    // only restoring the outer scope on the way out of `a` keeps this clean.
+    let sibling_no_shadow = "mod a {\n    use crate as internal;\n}\nmod b {\n    fn f() { let _ = internal::adaptive::X; }\n}\n";
+    assert!(
+        forbidden_module_references(&snippet(sibling_no_shadow)).is_empty(),
+        "an alias leaked out of the module that declared it: {:?}\n{sibling_no_shadow}",
+        forbidden_module_references(&snippet(sibling_no_shadow))
+    );
+
+    // Reverse: a real crate alias shadowed by a local module of the same name is no longer
+    // the crate root inside that module.
+    let shadowed = "use crate as internal;\nmod b {\n    mod internal {\n        pub mod adaptive {}\n    }\n    fn f() { let _ = internal::adaptive::X; }\n}\n";
+    assert!(
+        forbidden_module_references(&snippet(shadowed)).is_empty(),
+        "a shadowed alias still counted as the crate root: {:?}\n{shadowed}",
+        forbidden_module_references(&snippet(shadowed))
+    );
+
+    // The three genuine exploits must stay caught, so the scoping does not buy its
+    // precision with a false negative.
+    for (label, source) in [
+        (
+            "file-level alias",
+            "use crate as internal;\nfn f() { let _ = internal::adaptive::X; }\n",
+        ),
+        (
+            "alias inherited by a nested module",
+            "use crate as internal;\nmod inner {\n    fn f() { let _ = internal::producers::P; }\n}\n",
+        ),
+        (
+            "alias declared and used in the same module",
+            "mod a {\n    use crate as internal;\n    fn f() { let _ = internal::adaptive::X; }\n}\n",
+        ),
+    ] {
+        assert!(
+            !forbidden_module_references(&snippet(source)).is_empty(),
+            "{label}: scoping introduced a false negative:\n{source}"
         );
     }
 }

--- a/tests/adaptive_publication_lint.rs
+++ b/tests/adaptive_publication_lint.rs
@@ -30,6 +30,7 @@ use std::path::Path;
 use walkdir::WalkDir;
 
 const PRODUCERS_DECLARATION: &str = "pub mod producers;";
+const ADAPTIVE_EVENT_DECLARATION: &str = "pub enum AdaptiveEvent {";
 /// The readable spelling, used in failure messages.
 const SERVER_GATE: &str = "#[cfg(feature = \"server\")]";
 
@@ -255,6 +256,79 @@ fn sources_under(root: &str) -> Vec<(String, String)> {
     sources
 }
 
+/// Every `#[...]` attribute written in `text`, whole.
+///
+/// Bracket-depth aware and string-literal aware, so `#[cfg_attr(feature = "server",
+/// derive(Serialize))]` and `#[doc = "contains a ] bracket"]` are each captured entire
+/// rather than truncated at the first `]`.
+fn attributes_in(text: &str) -> Vec<String> {
+    let mut found = Vec::new();
+    let bytes: Vec<char> = text.chars().collect();
+    let mut index = 0usize;
+    while index + 1 < bytes.len() {
+        if bytes[index] != '#' || (bytes[index + 1] != '[' && bytes[index + 1] != '!') {
+            index += 1;
+            continue;
+        }
+        // `#![...]` is an inner attribute; it applies to the enclosing module, not to the
+        // next item, so it is skipped rather than attributed to a declaration below it.
+        let open = if bytes[index + 1] == '!' {
+            index + 2
+        } else {
+            index + 1
+        };
+        if open >= bytes.len() || bytes[open] != '[' {
+            index += 1;
+            continue;
+        }
+        let inner = bytes[index + 1] == '!';
+        let mut depth = 0usize;
+        let mut in_string = false;
+        let mut cursor = open;
+        let mut end = None;
+        while cursor < bytes.len() {
+            let c = bytes[cursor];
+            if in_string {
+                if c == '\\' {
+                    cursor += 2;
+                    continue;
+                }
+                if c == '"' {
+                    in_string = false;
+                }
+            } else {
+                match c {
+                    '"' => in_string = true,
+                    '[' => depth += 1,
+                    ']' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            end = Some(cursor);
+                            break;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            cursor += 1;
+        }
+        match end {
+            Some(close) => {
+                if !inner {
+                    found.push(bytes[index..=close].iter().collect());
+                }
+                index = close + 1;
+            }
+            // Unterminated. Record what is there rather than dropping an attribute.
+            None => {
+                found.push(bytes[index..].iter().collect());
+                break;
+            }
+        }
+    }
+    found
+}
+
 /// Every `#[cfg(...)]` attribute written in `text`.
 ///
 /// Extracted rather than matched whole-line, because a gate may share a line with the item
@@ -320,6 +394,70 @@ fn declaration_gates(source: &str, declaration: &str) -> Option<Vec<String>> {
         pending.clear();
     }
     gates
+}
+
+/// Every attribute attached to `declaration` in `source`, including those on an enclosing
+/// block.
+///
+/// `None` means the declaration is absent; an empty vector means it carries no attributes.
+///
+/// Same accumulation rule as [`declaration_gates`] — Rust allows any number of attributes in
+/// any order, so they gather across consecutive attribute lines and are consumed by whatever
+/// comes next. Inspecting only the *nearest* attribute is the blind spot this replaced: an
+/// earlier `#[derive(Serialize)]` sitting above a later `#[derive(Debug, Clone)]` was
+/// invisible.
+fn attributes_attached_to(source: &str, declaration: &str) -> Option<Vec<String>> {
+    let mut enclosing: Vec<Vec<String>> = Vec::new();
+    let mut pending: Vec<String> = Vec::new();
+    let mut attached: Option<Vec<String>> = None;
+
+    for line in code_only(source).lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if let Some(prefix) = trimmed.strip_suffix(declaration) {
+            let mut found = attributes_in(prefix);
+            found.append(&mut pending);
+            found.extend(enclosing.iter().flatten().cloned());
+            attached = Some(found);
+            continue;
+        }
+        if trimmed.ends_with('{') {
+            let mut frame = attributes_in(trimmed);
+            frame.append(&mut pending);
+            enclosing.push(frame);
+            continue;
+        }
+        if trimmed == "}" {
+            enclosing.pop();
+            continue;
+        }
+        if trimmed.starts_with('#') {
+            pending.extend(attributes_in(trimmed));
+            continue;
+        }
+        pending.clear();
+    }
+    attached
+}
+
+/// Whether an attribute would make its item serializable.
+///
+/// Covers `#[derive(Serialize)]` and `#[cfg_attr(…, derive(Serialize))]` alike: the question
+/// is whether the attribute introduces a serialization derive under *any* configuration, not
+/// which spelling it used. A `cfg_attr` gate does not make it safe — it makes it conditional,
+/// and the condition is somebody else's to set.
+fn introduces_serialization(attribute: &str) -> Option<&'static str> {
+    let squeezed: String = attribute.chars().filter(|c| !c.is_whitespace()).collect();
+    if !squeezed.contains("derive(") {
+        return None;
+    }
+    // Matched on the capitalized trait names, which do not overlap: `Deserialize` contains
+    // a lower-case `serialize`, never `Serialize`, so neither can be mistaken for the other.
+    ["Serialize", "Deserialize"]
+        .into_iter()
+        .find(|forbidden| squeezed.contains(forbidden))
 }
 
 // =============================================================================
@@ -408,19 +546,40 @@ fn lint_only_the_composition_root_names_the_contract_or_the_publication_layer() 
 fn lint_adaptive_event_derives_no_serialization() {
     // Belt to the braces above: even if a variant were added to the wrong enum, the
     // internal event type itself cannot be written to a wire.
+    //
+    // Inspects *every* attached attribute, not the nearest one. An earlier
+    // `#[derive(Serialize)]` above a later `#[derive(Debug, Clone)]` was invisible to the
+    // previous `rfind("#[derive(")` scan, as was any `#[cfg_attr(…, derive(Serialize))]`,
+    // which the scan never looked for at all. Found by CodeRabbit at `eebde11`.
     let event = fs::read_to_string("src/producers/event.rs").expect("src/producers/event.rs");
-    let code = code_only(&event);
-    let derive = code
-        .split("pub enum AdaptiveEvent")
-        .next()
-        .and_then(|before| before.rfind("#[derive(").map(|at| before[at..].to_string()))
-        .expect("AdaptiveEvent must carry a derive attribute");
+    let attributes =
+        attributes_attached_to(&event, ADAPTIVE_EVENT_DECLARATION).unwrap_or_else(|| {
+            panic!("src/producers/event.rs must declare `{ADAPTIVE_EVENT_DECLARATION}`")
+        });
+    let offenders: Vec<String> = attributes
+        .iter()
+        .filter_map(|attribute| {
+            introduces_serialization(attribute)
+                .map(|trait_name| format!("{trait_name} via {attribute}"))
+        })
+        .collect();
+    assert!(
+        offenders.is_empty(),
+        "AdaptiveEvent would be serializable. The internal bus exists precisely so producer \
+         lifecycle cannot reach a wire, and a derive is the only structural part of that \
+         guarantee. Found: {offenders:?}"
+    );
+
+    // A hand-written impl defeats the same guarantee without any derive at all.
+    let squeezed: String = code_only(&event)
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect();
     for forbidden in ["Serialize", "Deserialize"] {
         assert!(
-            !derive.contains(forbidden),
-            "AdaptiveEvent derives `{forbidden}`. The internal bus exists precisely so that \
-             producer lifecycle cannot reach a wire; deriving serialization removes the \
-             only structural part of that guarantee. Found: {derive}"
+            !squeezed.contains(&format!("{forbidden}forAdaptiveEvent")),
+            "AdaptiveEvent has a hand-written `{forbidden}` impl, which reaches a wire just \
+             as surely as a derive."
         );
     }
 }
@@ -575,6 +734,89 @@ fn a_stricter_conjunctive_gate_is_still_server_only() {
     let source = "#[cfg(all(feature = \"server\", unix))]\npub mod producers;\n";
     let gates = declaration_gates(source, PRODUCERS_DECLARATION).expect("declaration found");
     assert!(gates.iter().any(|gate| is_server_gate(gate)));
+}
+
+#[test]
+fn a_serializing_adaptive_event_is_rejected_however_it_is_spelled() {
+    // Non-vacuity for `lint_adaptive_event_derives_no_serialization`. Cases 2 and 4 through
+    // 7 all passed the previous scanner, which read only the *nearest* `#[derive(` and never
+    // looked for `cfg_attr` at all. Found by CodeRabbit at `eebde11`.
+    for source in [
+        // 1. The obvious form.
+        "#[derive(Serialize)]\npub enum AdaptiveEvent {\n}\n",
+        // 2. Stacked behind the innocent derive - the reported blind spot.
+        "#[derive(Serialize, Deserialize)]\n#[derive(Debug, Clone)]\npub enum AdaptiveEvent {\n}\n",
+        // 3. The other order.
+        "#[derive(Debug, Clone)]\n#[derive(Deserialize)]\npub enum AdaptiveEvent {\n}\n",
+        // 4. Behind an unrelated attribute.
+        "#[derive(Serialize)]\n#[non_exhaustive]\n#[derive(Debug)]\npub enum AdaptiveEvent {\n}\n",
+        // 5. Conditional. A cfg_attr gate does not make it safe, it makes it somebody
+        //    else's build flag.
+        "#[cfg_attr(feature = \"server\", derive(Serialize))]\n#[derive(Debug, Clone)]\npub enum AdaptiveEvent {\n}\n",
+        // 6. Conditional, unspaced, and behind the innocent derive.
+        "#[derive(Debug,Clone)]\n#[cfg_attr(test,derive(Deserialize))]\npub enum AdaptiveEvent {\n}\n",
+        // 7. Sharing the line with the declaration.
+        "#[derive(Debug)] #[derive(Serialize)] pub enum AdaptiveEvent {\n}\n",
+    ] {
+        let attributes = attributes_attached_to(source, ADAPTIVE_EVENT_DECLARATION)
+            .unwrap_or_else(|| panic!("declaration not found in:\n{source}"));
+        assert!(
+            attributes
+                .iter()
+                .any(|attribute| introduces_serialization(attribute).is_some()),
+            "a serializing AdaptiveEvent was admitted:\n{source}\nattributes: {attributes:?}"
+        );
+    }
+}
+
+#[test]
+fn a_non_serializing_adaptive_event_is_accepted() {
+    // The other direction. A scanner that rejects everything is as useless as one that
+    // rejects nothing, and case 3 is the false positive the previous implementation
+    // avoided by accident and this one must avoid on purpose: a *different* type's
+    // serializing derive higher up the file.
+    for source in [
+        "#[derive(Debug, Clone)]\npub enum AdaptiveEvent {\n}\n",
+        "#[derive(Debug, Clone)]\n#[non_exhaustive]\npub enum AdaptiveEvent {\n}\n",
+        "#[derive(Serialize, Deserialize)]\npub struct Unrelated {\n}\n#[derive(Debug, Clone)]\npub enum AdaptiveEvent {\n}\n",
+        "#[cfg_attr(test, derive(Default))]\n#[derive(Debug, Clone)]\npub enum AdaptiveEvent {\n}\n",
+    ] {
+        let attributes = attributes_attached_to(source, ADAPTIVE_EVENT_DECLARATION)
+            .unwrap_or_else(|| panic!("declaration not found in:\n{source}"));
+        let offenders: Vec<_> = attributes
+            .iter()
+            .filter(|attribute| introduces_serialization(attribute).is_some())
+            .collect();
+        assert!(
+            offenders.is_empty(),
+            "the scanner invented a serialization derive in:\n{source}\nfound: {offenders:?}"
+        );
+    }
+}
+
+#[test]
+fn attribute_extraction_survives_nesting_and_string_literals() {
+    // `attributes_in` has to close on the matching bracket, not the first one. A
+    // `cfg_attr` carrying a derive and a doc comment carrying a `]` are the two shapes
+    // that break a naive scan, and both are reachable in ordinary code.
+    let nested = attributes_in("#[cfg_attr(feature = \"server\", derive(Serialize))]");
+    assert_eq!(nested.len(), 1);
+    assert!(
+        nested[0].ends_with("))]"),
+        "attribute was truncated: {nested:?}"
+    );
+
+    let bracketed = attributes_in("#[doc = \"a ] bracket\"]\n#[derive(Debug)]");
+    assert_eq!(
+        bracketed.len(),
+        2,
+        "a string literal split an attribute: {bracketed:?}"
+    );
+    assert_eq!(bracketed[1], "#[derive(Debug)]");
+
+    // Inner attributes belong to the enclosing module, not to the next item.
+    let inner = attributes_in("#![deny(unsafe_code)]\n#[derive(Debug)]");
+    assert_eq!(inner, vec!["#[derive(Debug)]".to_string()]);
 }
 
 #[test]

--- a/tests/adaptive_publication_lint.rs
+++ b/tests/adaptive_publication_lint.rs
@@ -256,6 +256,85 @@ fn sources_under(root: &str) -> Vec<(String, String)> {
     sources
 }
 
+/// Join attributes that wrap across lines onto a single line.
+///
+/// [`attributes_attached_to`] and [`declaration_gates`] walk lines, and a line that is not
+/// itself an attribute clears the pending set — that is the rule which stops one item's
+/// attributes leaking onto the next. A wrapped attribute defeats it:
+///
+/// ```ignore
+/// #[derive(          // seen as an unterminated attribute, held as pending
+///     Debug,         // not an attribute -> pending cleared, the derive is lost
+///     Serialize,
+/// )]
+/// pub enum AdaptiveEvent { … }
+/// ```
+///
+/// The declaration then reports only `#[derive(Debug, Clone)]` and the scanner passes.
+/// Verified against the real module before this existed: a wrapped
+/// `#[cfg_attr(…, derive(serde::Serialize))]` compiled and
+/// `lint_adaptive_event_derives_no_serialization` passed. Found by CodeRabbit at
+/// `b35af10`.
+///
+/// Newlines are replaced by spaces only while inside an attribute's brackets, so the line
+/// structure everywhere else — and therefore the pending-clearing rule — is untouched.
+fn join_wrapped_attributes(code: &str) -> String {
+    let chars: Vec<char> = code.chars().collect();
+    let mut out = String::with_capacity(code.len());
+    let mut index = 0usize;
+    let mut depth = 0usize;
+    let mut in_string = false;
+
+    while index < chars.len() {
+        let c = chars[index];
+        if in_string {
+            out.push(c);
+            if c == '\\' && index + 1 < chars.len() {
+                out.push(chars[index + 1]);
+                index += 2;
+                continue;
+            }
+            if c == '"' {
+                in_string = false;
+            }
+            index += 1;
+            continue;
+        }
+        // `#[` and `#![` both open an attribute.
+        if c == '#' {
+            let bracket = if chars.get(index + 1) == Some(&'!') {
+                index + 2
+            } else {
+                index + 1
+            };
+            if chars.get(bracket) == Some(&'[') {
+                out.extend(&chars[index..=bracket]);
+                depth += 1;
+                index = bracket + 1;
+                continue;
+            }
+        }
+        match c {
+            '"' => {
+                in_string = true;
+                out.push(c);
+            }
+            '[' if depth > 0 => {
+                depth += 1;
+                out.push(c);
+            }
+            ']' if depth > 0 => {
+                depth -= 1;
+                out.push(c);
+            }
+            '\n' if depth > 0 => out.push(' '),
+            _ => out.push(c),
+        }
+        index += 1;
+    }
+    out
+}
+
 /// Every `#[...]` attribute written in `text`, whole.
 ///
 /// Bracket-depth aware and string-literal aware, so `#[cfg_attr(feature = "server",
@@ -365,7 +444,10 @@ fn declaration_gates(source: &str, declaration: &str) -> Option<Vec<String>> {
     let mut pending: Vec<String> = Vec::new();
     let mut gates: Option<Vec<String>> = None;
 
-    for line in code_only(source).lines() {
+    // Wrapped attributes are joined first: a line-oriented walk would see only `#[cfg(` and
+    // then clear it on the continuation line. See `join_wrapped_attributes`.
+    let joined = join_wrapped_attributes(&code_only(source));
+    for line in joined.lines() {
         let trimmed = line.trim();
         if trimmed.is_empty() {
             continue;
@@ -411,7 +493,12 @@ fn attributes_attached_to(source: &str, declaration: &str) -> Option<Vec<String>
     let mut pending: Vec<String> = Vec::new();
     let mut attached: Option<Vec<String>> = None;
 
-    for line in code_only(source).lines() {
+    // Wrapped attributes are joined first. Without this a `#[derive(` spanning lines is
+    // held as pending, then discarded by its own continuation line, and the declaration
+    // reports only the attributes that happened to fit on one line. See
+    // `join_wrapped_attributes`.
+    let joined = join_wrapped_attributes(&code_only(source));
+    for line in joined.lines() {
         let trimmed = line.trim();
         if trimmed.is_empty() {
             continue;
@@ -947,6 +1034,124 @@ fn a_non_serializing_adaptive_event_is_accepted() {
             "the scanner invented a serialization derive in:\n{source}\nfound: {offenders:?}"
         );
     }
+}
+
+#[test]
+fn a_wrapped_attribute_is_not_lost_by_the_line_walk() {
+    // The scanners walk lines, and a line that is not an attribute clears the pending set —
+    // that rule is what stops one item's attributes leaking onto the next. A wrapped
+    // attribute was destroyed by it: `#[derive(` was held as pending and then discarded by
+    // its own continuation line, so the declaration reported only the attributes that
+    // happened to fit on one line.
+    //
+    // Verified against the real module before the fix: a wrapped
+    // `#[cfg_attr(…, derive(serde::Serialize))]` compiled, and
+    // `lint_adaptive_event_derives_no_serialization` passed while
+    // `attributes_attached_to` reported only `["#[derive(Debug, Clone)]"]`. Found by
+    // CodeRabbit at `b35af10`.
+    for (label, source) in [
+        (
+            "wrapped derive with a serializing member",
+            "#[derive(\n    Debug,\n    Serialize,\n)]\npub enum AdaptiveEvent {\n}\n",
+        ),
+        (
+            "wrapped derive above the innocent one",
+            "#[derive(\n    Serialize,\n)]\n#[derive(Debug, Clone)]\npub enum AdaptiveEvent {\n}\n",
+        ),
+        (
+            "wrapped cfg_attr - the form proved against the real module",
+            "#[cfg_attr(\n    feature = \"x\",\n    derive(serde::Serialize)\n)]\n#[derive(Debug, Clone)]\npub enum AdaptiveEvent {\n}\n",
+        ),
+        (
+            "wrapped derive of an alias",
+            "use serde::Serialize as EventWire;\n#[derive(\n    Debug,\n    EventWire,\n)]\npub enum AdaptiveEvent {\n}\n",
+        ),
+        (
+            "deeply wrapped, one member per line",
+            "#[cfg_attr(\n    all(\n        feature = \"x\",\n        unix,\n    ),\n    derive(\n        Deserialize,\n    )\n)]\npub enum AdaptiveEvent {\n}\n",
+        ),
+    ] {
+        let names = serialization_names(source);
+        let attributes = attributes_attached_to(source, ADAPTIVE_EVENT_DECLARATION)
+            .unwrap_or_else(|| panic!("declaration not found for {label}:\n{source}"));
+        assert!(
+            attributes
+                .iter()
+                .any(|attribute| introduces_serialization(attribute, &names).is_some()),
+            "{label} was admitted:\n{source}\nattributes seen: {attributes:?}"
+        );
+    }
+}
+
+#[test]
+fn joining_wrapped_attributes_does_not_attach_them_to_the_wrong_item() {
+    // Positive controls for the joiner. Collapsing newlines inside brackets must not
+    // collapse the line structure that separates one item from the next, or every wrapped
+    // attribute in a file would leak onto whatever declaration came after it.
+    for (label, source) in [
+        (
+            "a wrapped serializing derive on a different item",
+            "#[derive(\n    Serialize,\n)]\npub struct Unrelated {\n}\n#[derive(Debug, Clone)]\npub enum AdaptiveEvent {\n}\n",
+        ),
+        (
+            "a wrapped innocent derive on the right item",
+            "#[derive(\n    Debug,\n    Clone,\n)]\npub enum AdaptiveEvent {\n}\n",
+        ),
+        (
+            "a wrapped cfg_attr deriving something harmless",
+            "#[cfg_attr(\n    test,\n    derive(Default)\n)]\n#[derive(Debug)]\npub enum AdaptiveEvent {\n}\n",
+        ),
+        (
+            "a wrapped doc comment containing a bracket and the word Serialize",
+            "#[doc = \"see Serialize ]\"]\n#[derive(\n    Debug,\n)]\npub enum AdaptiveEvent {\n}\n",
+        ),
+    ] {
+        let names = serialization_names(source);
+        let attributes = attributes_attached_to(source, ADAPTIVE_EVENT_DECLARATION)
+            .unwrap_or_else(|| panic!("declaration not found for {label}:\n{source}"));
+        let offenders: Vec<_> = attributes
+            .iter()
+            .filter_map(|attribute| introduces_serialization(attribute, &names))
+            .collect();
+        assert!(
+            offenders.is_empty(),
+            "{label} produced a false positive: {offenders:?}\n{source}\nattributes: {attributes:?}"
+        );
+    }
+
+    // The joiner itself: newlines inside brackets become spaces, newlines outside do not.
+    let joined = join_wrapped_attributes("#[derive(\n  Debug,\n)]\npub enum X {\n}\n");
+    assert!(
+        joined.starts_with("#[derive(   Debug, )]\n"),
+        "attribute was not joined onto one line: {joined:?}"
+    );
+    assert!(
+        joined.contains("]\npub enum X"),
+        "the joiner collapsed the line structure between the attribute and its item: {joined:?}"
+    );
+}
+
+#[test]
+fn a_wrapped_server_gate_is_still_detected() {
+    // `declaration_gates` had the identical defect, so it takes the identical fix. A gate
+    // that wraps is still a gate.
+    let source = "#[cfg(\n    feature = \"server\"\n)]\npub mod producers;\n";
+    let gates = declaration_gates(source, PRODUCERS_DECLARATION)
+        .unwrap_or_else(|| panic!("declaration not found in:\n{source}"));
+    assert!(
+        gates.iter().any(|gate| is_server_gate(gate)),
+        "a wrapped server gate was missed: {gates:?}"
+    );
+
+    // And the false-positive direction: a wrapped gate belonging to the item above must
+    // not carry onto this declaration.
+    let neighbour = "#[cfg(\n    feature = \"server\"\n)]\npub mod bus;\npub mod producers;\n";
+    let carried = declaration_gates(neighbour, PRODUCERS_DECLARATION)
+        .unwrap_or_else(|| panic!("declaration not found in:\n{neighbour}"));
+    assert!(
+        !carried.iter().any(|gate| is_server_gate(gate)),
+        "a wrapped gate leaked from the item above: {carried:?}"
+    );
 }
 
 #[test]

--- a/tests/adaptive_publication_lint.rs
+++ b/tests/adaptive_publication_lint.rs
@@ -1,0 +1,448 @@
+//! Boundary lints for adaptive producer publication (issue #324).
+//!
+//! #324 publishes producer documents to **in-repository consumers only**. Two boundaries
+//! keep that true, and neither is visible from a passing build:
+//!
+//! 1. **The public bus cannot carry adaptive data.** `src/api/mod.rs` serializes every
+//!    [`BusEvent`] verbatim into `GET /events`, which `docs/ARCHITECTURE.md` documents as
+//!    consumable by any HTTP client including ESP32 firmware. A variant carrying a producer
+//!    document would be a response-schema change to a public endpoint *and* publication of
+//!    the v1 contract outside this repository.
+//! 2. **No surface reaches the contract or the publication layer.** The one deliberate code
+//!    path that would expose it is a handler serializing a snapshot, and
+//!    `ProducerDocument` derives `Serialize`, so that is a one-line accident away.
+//!
+//! ## Why this file carries probes
+//!
+//! `tests/adaptive_dependency_lint.rs` has been remediated twice for blind spots that made
+//! it *report success on a violation* — `1577948` (three) and `d6da952` (a fourth, where a
+//! stacked `#[allow]` between the gate and the declaration discarded the gate). Every one
+//! failed in the direction that passes. A lint whose non-vacuity was never demonstrated
+//! should be treated as absent, so each scanner here is probed in **both** directions.
+//!
+//! The polarity matters and is the opposite of `pub mod adaptive;`. That declaration must be
+//! **ungated**, so a scanner that misses a gate fails safe. `pub mod producers;` must be
+//! **gated**, so a scanner that *hallucinates* a gate passes wrongly — which is why the
+//! probes below include "delete the gate, the lint must fail".
+
+use std::fs;
+use std::path::Path;
+use walkdir::WalkDir;
+
+const PRODUCERS_DECLARATION: &str = "pub mod producers;";
+/// The readable spelling, used in failure messages.
+const SERVER_GATE: &str = "#[cfg(feature = \"server\")]";
+
+/// Whether an extracted attribute is the server gate, whitespace notwithstanding.
+///
+/// `#[cfg(feature="server")]` is the same gate as `#[cfg(feature = "server")]`. A substring
+/// match against one spelling silently accepts the other, which is the blind spot
+/// `1577948` fixed in `tests/adaptive_dependency_lint.rs` — and which
+/// `gate_scanner_detects_a_gate_it_must_not_miss` caught in this file before it shipped.
+fn is_server_gate(attribute: &str) -> bool {
+    let squeezed: String = attribute.chars().filter(|c| !c.is_whitespace()).collect();
+    squeezed.contains("feature=\"server\"")
+}
+
+// =============================================================================
+// Source scanning
+// =============================================================================
+
+/// Strip comments while keeping string literals.
+///
+/// Prose must not be linted: this file, `src/producers/mod.rs` and `src/bus/events.rs` all
+/// discuss the boundary in doc comments, and punishing that would push the explanation out
+/// of the code. String literals are kept so a forbidden path written as a string is still
+/// caught.
+fn code_only(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut chars = text.chars().peekable();
+    let mut in_string = false;
+    let mut block_depth = 0usize;
+
+    while let Some(c) = chars.next() {
+        if block_depth > 0 {
+            if c == '*' && chars.peek() == Some(&'/') {
+                chars.next();
+                block_depth -= 1;
+            } else if c == '/' && chars.peek() == Some(&'*') {
+                chars.next();
+                block_depth += 1;
+            } else if c == '\n' {
+                out.push('\n');
+            }
+            continue;
+        }
+        if in_string {
+            out.push(c);
+            if c == '\\' {
+                if let Some(escaped) = chars.next() {
+                    out.push(escaped);
+                }
+            } else if c == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match c {
+            '"' => {
+                in_string = true;
+                out.push(c);
+            }
+            '/' if chars.peek() == Some(&'/') => {
+                for skipped in chars.by_ref() {
+                    if skipped == '\n' {
+                        out.push('\n');
+                        break;
+                    }
+                }
+            }
+            '/' if chars.peek() == Some(&'*') => {
+                chars.next();
+                block_depth += 1;
+            }
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+fn sources_under(root: &str) -> Vec<(String, String)> {
+    let path = Path::new(root);
+    if !path.exists() {
+        return Vec::new();
+    }
+    let mut sources = Vec::new();
+    for entry in WalkDir::new(path).into_iter().filter_map(Result::ok) {
+        let file = entry.path();
+        if file.extension().is_some_and(|ext| ext == "rs") {
+            let text = fs::read_to_string(file)
+                .unwrap_or_else(|error| panic!("failed to read {}: {error}", file.display()));
+            sources.push((file.display().to_string(), text));
+        }
+    }
+    sources
+}
+
+/// Every `#[cfg(...)]` attribute written in `text`.
+///
+/// Extracted rather than matched whole-line, because a gate may share a line with the item
+/// it gates. `#[cfg_attr(...)]` must not match: it cannot exclude a module.
+fn cfg_attributes_in(text: &str) -> Vec<String> {
+    let mut found = Vec::new();
+    let mut rest = text;
+    while let Some(start) = rest.find("#[cfg(") {
+        let tail = &rest[start..];
+        match tail.find(")]") {
+            Some(end) => {
+                found.push(tail[..end + 2].to_string());
+                rest = &tail[end + 2..];
+            }
+            None => {
+                found.push(tail.trim().to_string());
+                break;
+            }
+        }
+    }
+    found
+}
+
+/// Every `#[cfg(...)]` that applies to `declaration` in `source`.
+///
+/// `None` means the declaration is absent; an empty vector means it is present and ungated.
+///
+/// Pending attributes **accumulate** across consecutive attribute lines, because Rust allows
+/// any number in any order — `#[cfg(...)]` / `#[allow(...)]` / `pub mod x;` is gated. The
+/// accumulation stops at whatever consumes it (the declaration, a block opener, or the next
+/// item), or every ungated `pub mod` below a gated one would be reported as gated.
+fn declaration_gates(source: &str, declaration: &str) -> Option<Vec<String>> {
+    let mut enclosing: Vec<Vec<String>> = Vec::new();
+    let mut pending: Vec<String> = Vec::new();
+    let mut gates: Option<Vec<String>> = None;
+
+    for line in code_only(source).lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if let Some(prefix) = trimmed.strip_suffix(declaration) {
+            let mut found = cfg_attributes_in(prefix);
+            found.append(&mut pending);
+            found.extend(enclosing.iter().flatten().cloned());
+            gates = Some(found);
+            continue;
+        }
+        if trimmed.ends_with('{') {
+            let mut frame = cfg_attributes_in(trimmed);
+            frame.append(&mut pending);
+            enclosing.push(frame);
+            continue;
+        }
+        if trimmed == "}" {
+            enclosing.pop();
+            continue;
+        }
+        if trimmed.starts_with('#') {
+            pending.extend(cfg_attributes_in(trimmed));
+            continue;
+        }
+        pending.clear();
+    }
+    gates
+}
+
+// =============================================================================
+// Boundary 1: the public bus cannot carry adaptive data
+// =============================================================================
+
+#[test]
+fn lint_public_bus_cannot_carry_adaptive_types() {
+    // `BusEvent` is a wire payload, not merely an internal enum: `src/api/mod.rs`
+    // serializes it verbatim into `GET /events`. A variant naming an adaptive type would
+    // change that endpoint's response schema and publish the v1 contract outside this
+    // repository, both of which #324 is scoped not to do.
+    let mut violations = Vec::new();
+    for (path, text) in sources_under("src/bus") {
+        let code = code_only(&text);
+        for needle in ["adaptive", "producers", "ProducerDocument", "AdaptiveEvent"] {
+            if code.contains(needle) {
+                violations.push(format!("{path}: references `{needle}`"));
+            }
+        }
+    }
+    assert!(
+        violations.is_empty(),
+        "the public bus must not carry adaptive data - `GET /events` serializes every \
+         BusEvent verbatim, so a variant here is a public response-schema change:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn lint_the_sse_projection_does_not_mention_the_publication_layer() {
+    let api = fs::read_to_string("src/api/mod.rs").expect("src/api/mod.rs readable");
+    let code = code_only(&api);
+    for needle in ["crate::producers", "crate::adaptive"] {
+        assert!(
+            !code.contains(needle),
+            "src/api/mod.rs references `{needle}`. Any HTTP or SSE exposure of the producer \
+             document needs explicit API approval and an `api-change-approved` label that \
+             must never be self-applied."
+        );
+    }
+}
+
+// =============================================================================
+// Boundary 2: no surface reaches the contract or the publication layer
+// =============================================================================
+
+#[test]
+fn lint_surfaces_do_not_import_the_contract_or_the_publication_layer() {
+    // `ProducerDocument` derives `Serialize`, so a single `Json(snapshot)` in a handler
+    // re-exports the whole contract. `src/main.rs` is deliberately not listed: it is the
+    // composition root and must name both to wire them together.
+    const SURFACES: &[&str] = &[
+        "src/api",
+        "src/mcp",
+        "src/app",
+        "src/knobs",
+        "src/devices",
+        "src/components",
+    ];
+    let mut violations = Vec::new();
+    for surface in SURFACES {
+        for (path, text) in sources_under(surface) {
+            let code = code_only(&text);
+            for needle in [
+                "crate::adaptive",
+                "crate::producers",
+                "unified_hifi_control::adaptive",
+                "unified_hifi_control::producers",
+            ] {
+                if code.contains(needle) {
+                    violations.push(format!("{path}: references `{needle}`"));
+                }
+            }
+        }
+    }
+    assert!(
+        violations.is_empty(),
+        "#324 publishes to in-repository consumers only. A surface reading the producer \
+         document is #326's decision and needs its own API approval:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn lint_adaptive_event_derives_no_serialization() {
+    // Belt to the braces above: even if a variant were added to the wrong enum, the
+    // internal event type itself cannot be written to a wire.
+    let event = fs::read_to_string("src/producers/event.rs").expect("src/producers/event.rs");
+    let code = code_only(&event);
+    let derive = code
+        .split("pub enum AdaptiveEvent")
+        .next()
+        .and_then(|before| before.rfind("#[derive(").map(|at| before[at..].to_string()))
+        .expect("AdaptiveEvent must carry a derive attribute");
+    for forbidden in ["Serialize", "Deserialize"] {
+        assert!(
+            !derive.contains(forbidden),
+            "AdaptiveEvent derives `{forbidden}`. The internal bus exists precisely so that \
+             producer lifecycle cannot reach a wire; deriving serialization removes the \
+             only structural part of that guarantee. Found: {derive}"
+        );
+    }
+}
+
+#[test]
+fn lint_publication_layer_adds_no_routes() {
+    let routes = fs::read_to_string("tests/fixtures/api_routes.txt")
+        .expect("tests/fixtures/api_routes.txt readable");
+    for forbidden in [
+        "/adaptive",
+        "/producer",
+        "/producers",
+        "/change_set",
+        "/changeset",
+        "/snapshot",
+    ] {
+        assert!(
+            !routes.contains(forbidden),
+            "tests/fixtures/api_routes.txt contains `{forbidden}`: #324 adds no routes. \
+             Any HTTP/SSE exposure needs explicit approval, and `api-change-approved` must \
+             never be self-applied."
+        );
+    }
+}
+
+// =============================================================================
+// The publication layer is server-only
+// =============================================================================
+
+#[test]
+fn lint_producers_module_is_server_gated() {
+    // Opposite polarity to `pub mod adaptive;`, which must be *ungated* so the WASM build
+    // can use the contract types. `src/producers/` depends on `crate::bus` and `tokio`, so
+    // an ungated declaration breaks `dx build --platform web` in CI rather than anything a
+    // host `cargo test` would notice.
+    let lib = fs::read_to_string("src/lib.rs").expect("src/lib.rs readable");
+    let gates = declaration_gates(&lib, PRODUCERS_DECLARATION)
+        .unwrap_or_else(|| panic!("src/lib.rs must declare `{PRODUCERS_DECLARATION}`"));
+    assert!(
+        gates.iter().any(|gate| is_server_gate(gate)),
+        "`{PRODUCERS_DECLARATION}` must be `{SERVER_GATE}`; it depends on crate::bus and \
+         tokio, neither of which exists in the WASM build. Found gates: {gates:?}"
+    );
+}
+
+#[test]
+fn lint_publication_layer_is_reachable_only_from_the_composition_root() {
+    // If nothing outside `src/producers/` names it except `src/lib.rs` and `src/main.rs`,
+    // then the exposure surface is exactly one file and reviewing it is tractable.
+    let mut referrers = Vec::new();
+    for (path, text) in sources_under("src") {
+        if path.starts_with("src/producers") || path == "src/lib.rs" || path == "src/main.rs" {
+            continue;
+        }
+        if code_only(&text).contains("crate::producers") {
+            referrers.push(path);
+        }
+    }
+    assert!(
+        referrers.is_empty(),
+        "only the composition root may reference the publication layer, found: {referrers:?}"
+    );
+}
+
+// =============================================================================
+// Non-vacuity probes
+// =============================================================================
+
+#[test]
+fn gate_scanner_detects_a_gate_it_must_not_miss() {
+    // Each case was verified against the shapes that defeated earlier versions of the
+    // sibling lint in `tests/adaptive_dependency_lint.rs`.
+    for source in [
+        // Directly above.
+        "#[cfg(feature = \"server\")]\npub mod producers;\n",
+        // Stacked behind another attribute - the `d6da952` blind spot.
+        "#[cfg(feature = \"server\")]\n#[allow(dead_code)]\npub mod producers;\n",
+        // Other order.
+        "#[allow(dead_code)]\n#[cfg(feature = \"server\")]\npub mod producers;\n",
+        // Unspaced.
+        "#[cfg(feature=\"server\")]\npub mod producers;\n",
+        // Sharing the line.
+        "#[cfg(feature = \"server\")] pub mod producers;\n",
+        // Behind a doc comment that names the declaration, so a `find`-based scan would
+        // inspect the wrong line.
+        "/// see `pub mod producers;`\n#[cfg(feature = \"server\")]\npub mod producers;\n",
+        // Gated by an enclosing block.
+        "#[cfg(feature = \"server\")]\nmod inner {\npub mod producers;\n}\n",
+    ] {
+        let gates = declaration_gates(source, PRODUCERS_DECLARATION)
+            .unwrap_or_else(|| panic!("declaration not found in:\n{source}"));
+        assert!(
+            gates.iter().any(|gate| is_server_gate(gate)),
+            "a server gate was missed in:\n{source}\nfound: {gates:?}"
+        );
+    }
+}
+
+#[test]
+fn gate_scanner_does_not_invent_a_gate_that_is_not_there() {
+    // The direction that matters for this module's polarity. A scanner that hallucinates a
+    // gate would let an ungated `pub mod producers;` pass and break the WASM build in CI.
+    for source in [
+        // No gate at all.
+        "pub mod producers;\n",
+        // A gate that belongs to the item above it, not to this declaration.
+        "#[cfg(feature = \"server\")]\npub mod bus;\npub mod producers;\n",
+        // A gate consumed by a block that has already closed.
+        "#[cfg(feature = \"server\")]\nmod inner {\npub mod other;\n}\npub mod producers;\n",
+        // `cfg_attr` cannot exclude a module.
+        "#[cfg_attr(feature = \"server\", allow(dead_code))]\npub mod producers;\n",
+        // A different feature is not the server gate.
+        "#[cfg(feature = \"web\")]\npub mod producers;\n",
+    ] {
+        let gates = declaration_gates(source, PRODUCERS_DECLARATION)
+            .unwrap_or_else(|| panic!("declaration not found in:\n{source}"));
+        assert!(
+            !gates.iter().any(|gate| is_server_gate(gate)),
+            "a server gate was invented for:\n{source}\nfound: {gates:?}"
+        );
+    }
+}
+
+#[test]
+fn declaration_scanner_reports_absence_rather_than_guessing() {
+    assert_eq!(
+        declaration_gates("pub mod adaptive;\n", PRODUCERS_DECLARATION),
+        None
+    );
+    // A doc comment mentioning it is not a declaration.
+    assert_eq!(
+        declaration_gates("/// pub mod producers;\n", PRODUCERS_DECLARATION),
+        None
+    );
+}
+
+#[test]
+fn comment_stripper_keeps_strings_and_drops_prose() {
+    // Prose discussing the boundary must not trip the dependency checks...
+    let prose = "// this must not reference crate::adaptive\nlet x = 1;\n";
+    assert!(!code_only(prose).contains("crate::adaptive"));
+
+    let trailing = "let x = 1; // not crate::producers\n";
+    assert!(!code_only(trailing).contains("crate::producers"));
+
+    let block = "/* crate::adaptive /* nested */ still comment */\nlet x = 1;\n";
+    assert!(!code_only(block).contains("crate::adaptive"));
+
+    // ...but a forbidden path written as a string literal is still a reference.
+    let literal = "let path = \"crate::producers\";\n";
+    assert!(code_only(literal).contains("crate::producers"));
+
+    // A `//` inside a string must not truncate the line.
+    let url = "let u = \"https://example.com\"; let y = crate::producers::X;\n";
+    assert!(code_only(url).contains("crate::producers"));
+}

--- a/tests/adaptive_publication_lint.rs
+++ b/tests/adaptive_publication_lint.rs
@@ -55,12 +55,22 @@
 //! and the allowlist decides without needing to know what a name means. The two compose;
 //! neither is sufficient alone.
 //!
-//! Residual, recorded rather than papered over: items produced by macro *expansion* are
-//! invisible to a parse of pre-expansion source, as they were to the text scanner. Macro
-//! *invocations* are visited and their token streams checked, which is exact because tokens
-//! are post-lexing — but a macro assembling an `impl` from fragments escapes both
-//! architectures.
+//! ## Macros, which parsing alone does not close either
+//!
+//! An attribute macro (`#[event_wire] pub enum AdaptiveEvent {}`) and an item-position
+//! macro (`make_event_wire!(AdaptiveEvent);`) each generate code while leaving imports,
+//! derives and `ItemImpl` entirely clean. An earlier commit recorded that as an accepted
+//! residual; Codex was right to reject it, because it is a live false pass and it closes
+//! the same way everything else here did — by permission. `AdaptiveEvent` may carry only
+//! `derive` and `doc`; and every macro invocation in `src/producers/event.rs` — at any
+//! depth, not only item position, since a statement-position macro can expand to items —
+//! must be on an allowlist that currently holds only `tracing::trace`.
+//!
+//! What genuinely remains: a macro *already allowlisted* could expand to anything, and
+//! expansion is not in this source. That is why both lists are empty or minimal — the
+//! guarantee is that nothing generative is permitted, not that generation is understood.
 
+use proc_macro2::TokenTree;
 use std::collections::BTreeSet;
 use std::fs;
 use std::path::Path;
@@ -97,6 +107,39 @@ const EVENT_ALLOWED_IMPORTS: &[&str] = &[
 /// Needed separately from the import allowlist because a derive requires no import at all:
 /// `#[derive(crate::wire::EventWire)]` names the macro by path.
 const ADAPTIVE_EVENT_ALLOWED_DERIVES: &[&str] = &["Debug", "Clone"];
+
+/// Exactly what attributes `AdaptiveEvent` may carry.
+///
+/// The third allowlist, and the one that closes what an earlier commit merely *documented*
+/// as residual. An **attribute macro** generates code without being a derive:
+///
+/// ```ignore
+/// #[event_wire]
+/// pub enum AdaptiveEvent { … }
+/// ```
+///
+/// leaves imports, derives and `ItemImpl` entirely clean while expanding to whatever it
+/// likes, including a `Serialize` impl. Inspecting derives alone cannot see it, and no
+/// amount of inspecting *can*, because the expansion is not in this file.
+///
+/// So the decision is again permission rather than detection: `derive` and `doc` are what
+/// the type actually carries, and anything else fails until somebody adds it deliberately.
+/// `cfg_attr` is deliberately **absent** — a conditional attribute is a conditional
+/// expansion, and the condition is somebody else's build flag.
+const ADAPTIVE_EVENT_ALLOWED_ATTRIBUTES: &[&str] = &["derive", "doc"];
+
+/// Macro invocations permitted **anywhere** in `src/producers/event.rs`.
+///
+/// `make_event_wire!(AdaptiveEvent);` generates an `impl` while leaving imports, derives
+/// and `ItemImpl` clean. Restricting the check to item position is not enough: Rust lets a
+/// macro in statement position expand to item definitions, and a trait impl is valid
+/// wherever it is written — so the escape simply moves one level down, into a function
+/// body. The collector therefore visits every `syn::Macro` at any depth.
+///
+/// `tracing::trace` is the module's one real invocation, and listing it is the price of the
+/// broader net: an allowlist that excluded it would be deleted the first time somebody
+/// added a log line.
+const EVENT_ALLOWED_MACROS: &[&str] = &["tracing::trace"];
 
 /// Modules a surface may not reach.
 const FORBIDDEN_MODULES: &[&str] = &["adaptive", "producers"];
@@ -219,6 +262,62 @@ fn collect_derives(meta: &Meta, out: &mut Vec<String>) {
     }
 }
 
+/// The path of every attribute in `attrs`, as a dotted name.
+///
+/// `#[derive(Debug)]` is `derive`, `#[doc = "…"]` is `doc`, `#[event_wire]` is
+/// `event_wire`, and `#[serde::skip]` is `serde::skip`.
+fn attribute_paths(attrs: &[Attribute]) -> Vec<String> {
+    attrs
+        .iter()
+        .map(|attr| {
+            attr.path()
+                .segments
+                .iter()
+                .map(|segment| segment.ident.to_string())
+                .collect::<Vec<_>>()
+                .join("::")
+        })
+        .collect()
+}
+
+/// Attributes not on [`ADAPTIVE_EVENT_ALLOWED_ATTRIBUTES`].
+fn disallowed_attributes(attrs: &[Attribute]) -> Vec<String> {
+    attribute_paths(attrs)
+        .into_iter()
+        .filter(|path| !ADAPTIVE_EVENT_ALLOWED_ATTRIBUTES.contains(&path.as_str()))
+        .collect()
+}
+
+/// Every macro invocation in `file`, at any depth, as a dotted path.
+///
+/// Item position, statement position, expression position, inside an `impl` method, inside
+/// a closure — all of them. A `syn::visit::Visit` walk reaches each one, so there is no
+/// position for a code-generating macro to hide in.
+#[derive(Default)]
+struct MacroInvocationVisitor {
+    found: Vec<String>,
+}
+
+impl<'ast> Visit<'ast> for MacroInvocationVisitor {
+    fn visit_macro(&mut self, mac: &'ast syn::Macro) {
+        self.found.push(
+            mac.path
+                .segments
+                .iter()
+                .map(|segment| segment.ident.to_string())
+                .collect::<Vec<_>>()
+                .join("::"),
+        );
+        visit::visit_macro(self, mac);
+    }
+}
+
+fn macro_invocations(file: &File) -> Vec<String> {
+    let mut visitor = MacroInvocationVisitor::default();
+    visitor.visit_file(file);
+    visitor.found
+}
+
 /// Every trait implemented for `type_name` in `file`.
 ///
 /// Inherent impls (`impl AdaptiveEvent { … }`) are not trait impls and do not appear.
@@ -314,6 +413,39 @@ impl ModuleReferenceVisitor {
             self.found.insert(format!("{root}::{module}"));
         }
     }
+
+    /// Look for an `Ident :: Ident` token sequence, recursing into groups.
+    ///
+    /// The previous implementation stringified the whole token stream and substring-matched
+    /// it, so `println!("crate::adaptive")` registered as a reference — while the comment
+    /// above it claimed a literal could not fabricate a match. It could, and did. Found by
+    /// Codex at `4129b87`.
+    ///
+    /// Walking `TokenTree` fixes it by construction rather than by exclusion: a `Literal`
+    /// is a different variant from an `Ident`, so its contents are never sequence material.
+    /// A real path inside a macro is still four tokens and is still found.
+    fn scan_tokens(&mut self, stream: &proc_macro2::TokenStream) {
+        let trees: Vec<TokenTree> = stream.clone().into_iter().collect();
+        for window in trees.windows(4) {
+            let (
+                TokenTree::Ident(root),
+                TokenTree::Punct(first),
+                TokenTree::Punct(second),
+                TokenTree::Ident(module),
+            ) = (&window[0], &window[1], &window[2], &window[3])
+            else {
+                continue;
+            };
+            if first.as_char() == ':' && second.as_char() == ':' {
+                self.note(&root.to_string(), &module.to_string());
+            }
+        }
+        for tree in trees {
+            if let TokenTree::Group(group) = tree {
+                self.scan_tokens(&group.stream());
+            }
+        }
+    }
 }
 
 impl<'ast> Visit<'ast> for ModuleReferenceVisitor {
@@ -343,14 +475,7 @@ impl<'ast> Visit<'ast> for ModuleReferenceVisitor {
     }
 
     fn visit_macro(&mut self, mac: &'ast syn::Macro) {
-        let rendered = mac.tokens.to_string().replace(' ', "");
-        for root in CRATE_ROOTS {
-            for module in FORBIDDEN_MODULES {
-                if rendered.contains(&format!("{root}::{module}")) {
-                    self.found.insert(format!("{root}::{module}"));
-                }
-            }
-        }
+        self.scan_tokens(&mac.tokens);
         visit::visit_macro(self, mac);
     }
 }
@@ -500,6 +625,57 @@ fn lint_adaptive_event_derives_only_what_it_is_allowed_to() {
     assert!(
         !derived.is_empty(),
         "no derives were found at all, which means the parse is not reaching the type"
+    );
+}
+
+#[test]
+fn lint_adaptive_event_carries_only_allowed_attributes() {
+    // Closes what the previous commit recorded as residual. An attribute macro generates
+    // code without being a derive, so inspecting derives alone cannot see it — and nothing
+    // can, because the expansion is not in this file. Permission rather than detection.
+    let file = parse_file_at(EVENT_MODULE);
+    let item = adaptive_event_enum(&file)
+        .unwrap_or_else(|| panic!("{EVENT_MODULE} must declare `enum {ADAPTIVE_EVENT}`"));
+
+    let unexpected = disallowed_attributes(&item.attrs);
+    assert!(
+        unexpected.is_empty(),
+        "{ADAPTIVE_EVENT} carries an attribute not on the allowlist: {unexpected:?}\n\
+         Permitted: {ADAPTIVE_EVENT_ALLOWED_ATTRIBUTES:?}. An attribute macro expands to \
+         code this file does not contain, so the list is the only thing that can decide."
+    );
+    assert!(
+        !item.attrs.is_empty(),
+        "no attributes were found at all, which means the parse is not reaching the type"
+    );
+}
+
+#[test]
+fn lint_the_internal_event_module_invokes_only_allowed_macros() {
+    // A macro expands to arbitrary code - an `impl`, a `use`, another type - while
+    // imports, derives and `ItemImpl` all stay clean. Checked at *every* depth, not only
+    // item position: Rust lets a statement-position macro expand to item definitions, and
+    // a trait impl is valid wherever it is written.
+    let file = parse_file_at(EVENT_MODULE);
+    let invocations = macro_invocations(&file);
+    let unexpected: Vec<&String> = invocations
+        .iter()
+        .filter(|name| !EVENT_ALLOWED_MACROS.contains(&name.as_str()))
+        .collect();
+    assert!(
+        unexpected.is_empty(),
+        "{EVENT_MODULE} invokes macros not on the allowlist: {unexpected:?}\n\
+         A macro can generate an impl for {ADAPTIVE_EVENT} without appearing in any \
+         import, derive or impl. Permitted: {EVENT_ALLOWED_MACROS:?}. If another becomes \
+         necessary, add it here having checked what it expands to."
+    );
+
+    // The allowlist must describe the module rather than merely permit it: if the one real
+    // invocation disappeared, the list would be silently over-broad.
+    assert_eq!(
+        invocations,
+        vec!["tracing::trace".to_string()],
+        "the module's macro invocations changed; the allowlist now describes something else"
     );
 }
 
@@ -691,6 +867,116 @@ fn every_known_import_escape_is_rejected() {
 }
 
 #[test]
+fn code_generating_macros_cannot_target_adaptive_event() {
+    // The residual the previous commit *documented* rather than closed. Codex was right
+    // that it is a live false pass, not a theoretical one: both of these leave imports,
+    // derives and `ItemImpl` entirely clean while generating whatever they like.
+    //
+    // An attribute macro on the item:
+    let attribute_macro = "#[event_wire]\npub enum AdaptiveEvent {}\n";
+    let file = snippet(attribute_macro);
+    let item = adaptive_event_enum(&file).expect("enum located");
+    let unexpected = disallowed_attributes(&item.attrs);
+    assert!(
+        !unexpected.is_empty(),
+        "an attribute macro was admitted: {:?}\n{attribute_macro}",
+        attribute_paths(&item.attrs)
+    );
+
+    // A function-like macro in item position:
+    let item_macro = "make_event_wire!(AdaptiveEvent);\npub enum AdaptiveEvent {}\n";
+    let invocations = macro_invocations(&snippet(item_macro));
+    assert!(
+        !invocations.is_empty(),
+        "an item-position macro invocation was invisible:\n{item_macro}"
+    );
+
+    // Nested inside a module, so the walk cannot be top-level only.
+    let nested = "mod inner {\n    make_event_wire!(AdaptiveEvent);\n}\n";
+    assert!(
+        !macro_invocations(&snippet(nested)).is_empty(),
+        "a nested item macro was invisible:\n{nested}"
+    );
+
+    // Inside a function body. Rust permits a macro in statement position to expand to item
+    // definitions, and a trait impl is valid wherever it is written — so restricting the
+    // walk to item position leaves the escape open one level down. Raised by the reviewer
+    // against the first version of this closure, which did exactly that.
+    for (label, source) in [
+        (
+            "statement position",
+            "fn f() {\n    make_event_wire!(AdaptiveEvent);\n}\n",
+        ),
+        (
+            "nested block",
+            "fn f() {\n    if x {\n        make_event_wire!(AdaptiveEvent);\n    }\n}\n",
+        ),
+        (
+            "expression position",
+            "fn f() {\n    let _ = make_event_wire!(AdaptiveEvent);\n}\n",
+        ),
+        (
+            "inside an impl method",
+            "impl Bus {\n    fn f(&self) {\n        make_event_wire!(AdaptiveEvent);\n    }\n}\n",
+        ),
+        (
+            "inside a nested closure",
+            "fn f() {\n    let g = || { make_event_wire!(AdaptiveEvent); };\n}\n",
+        ),
+    ] {
+        let found = macro_invocations(&snippet(source));
+        assert!(
+            found.iter().any(|name| name == "make_event_wire"),
+            "{label}: a macro invocation below item position was invisible: {found:?}\n{source}"
+        );
+        assert!(
+            found
+                .iter()
+                .any(|name| !EVENT_ALLOWED_MACROS.contains(&name.as_str())),
+            "{label}: the allowlist admitted {found:?}\n{source}"
+        );
+    }
+
+    // Derive-adjacent attributes that are inert on their own must still be rejected,
+    // because inertness is a property of the *expansion*, which is not in this file.
+    for source in [
+        "#[serde(rename_all = \"snake_case\")]\npub enum AdaptiveEvent {}\n",
+        "#[event_wire(with = \"json\")]\npub enum AdaptiveEvent {}\n",
+        "#[cfg_attr(feature = \"x\", event_wire)]\npub enum AdaptiveEvent {}\n",
+    ] {
+        let file = snippet(source);
+        let item = adaptive_event_enum(&file).expect("enum located");
+        assert!(
+            !disallowed_attributes(&item.attrs).is_empty(),
+            "a non-derive attribute was admitted:\n{source}"
+        );
+    }
+}
+
+#[test]
+fn the_attribute_allowlist_accepts_what_the_type_actually_carries() {
+    // Positive control. `#[derive(...)]` and doc comments are what the real enum has;
+    // rejecting either would make the list unmaintainable.
+    for source in [
+        "#[derive(Debug, Clone)]\npub enum AdaptiveEvent {}\n",
+        "/// docs\n#[derive(Debug, Clone)]\npub enum AdaptiveEvent {}\n",
+        "#[doc = \"explicit\"]\n#[derive(Debug)]\npub enum AdaptiveEvent {}\n",
+    ] {
+        let file = snippet(source);
+        let item = adaptive_event_enum(&file).expect("enum located");
+        assert!(
+            disallowed_attributes(&item.attrs).is_empty(),
+            "an allowed attribute was rejected: {:?}\n{source}",
+            disallowed_attributes(&item.attrs)
+        );
+    }
+    assert!(
+        macro_invocations(&snippet("pub enum AdaptiveEvent {}\n")).is_empty(),
+        "an item macro was invented where there is none"
+    );
+}
+
+#[test]
 fn every_known_impl_escape_is_rejected() {
     for (label, source) in [
         ("canonical", "impl Serialize for AdaptiveEvent {}"),
@@ -789,6 +1075,32 @@ fn the_inspectors_do_not_invent_findings() {
         "prose or a string literal registered as a module reference"
     );
 
+    // A string literal *inside a macro* is the same thing, and the previous
+    // implementation got it wrong: it stringified the whole token stream and
+    // substring-matched, so `println!("crate::adaptive")` registered as a reference while
+    // the doc comment above the function claimed literals could not fabricate a match.
+    // Found by Codex at `4129b87`.
+    for (label, source) in [
+        (
+            "string literal in a macro",
+            "fn f() { println!(\"crate::adaptive\"); }",
+        ),
+        (
+            "raw string literal in a macro",
+            "fn f() { println!(r#\"crate::producers\"#); }",
+        ),
+        (
+            "literal nested in a macro group",
+            "fn f() { assert_eq!(x, vec![\"crate::adaptive\"]); }",
+        ),
+    ] {
+        assert!(
+            forbidden_module_references(&snippet(source)).is_empty(),
+            "{label}: a literal inside a macro fabricated a module reference: {:?}\n{source}",
+            forbidden_module_references(&snippet(source))
+        );
+    }
+
     // A module whose name merely shares a prefix is not forbidden.
     let near_miss = "use crate::adaptive_extras::X;\nuse crate::production::Y;\n";
     assert!(
@@ -816,6 +1128,17 @@ fn module_references_are_found_in_every_position() {
         (
             "inside a macro",
             "fn f() { println!(\"{:?}\", crate::adaptive::X); }",
+        ),
+        // `syn` strips a macro's outer delimiter, so the case above puts the path at the
+        // top level of the token stream and never exercises group recursion. A mutation
+        // that deleted the recursion still passed until this case existed.
+        (
+            "nested in a group inside a macro",
+            "fn f() { assert_eq!(a, wrap(crate::adaptive::X)); }",
+        ),
+        (
+            "nested two groups deep",
+            "fn f() { assert_eq!(a, wrap(vec![crate::producers::P])); }",
         ),
         (
             "attribute-decorated use",
@@ -868,9 +1191,8 @@ fn server_gate_detection_is_structural() {
         );
     }
 
-    assert_eq!(
+    assert!(
         module_cfg_gates(&snippet("pub mod adaptive;"), PRODUCERS_MODULE).is_none(),
-        true,
         "an absent module was reported as present"
     );
 }

--- a/tests/adaptive_publication_lint.rs
+++ b/tests/adaptive_publication_lint.rs
@@ -144,6 +144,41 @@ const ADAPTIVE_EVENT_ALLOWED_ATTRIBUTES: &[&str] = &["derive", "doc"];
 /// added a log line.
 const EVENT_ALLOWED_MACROS: &[&str] = &["tracing::trace"];
 
+/// Directories exempt from the source sweep. Trailing separator, so a sibling directory
+/// sharing a prefix - `src/adaptive_extras/` - is not accidentally exempted too.
+const EXEMPT_DIRS: &[&str] = &["src/adaptive/", "src/producers/"];
+/// Files exempt from the source sweep, matched by exact equality rather than prefix.
+const EXEMPT_FILES: &[&str] = &["src/lib.rs", "src/main.rs"];
+
+/// Whether a source path is outside the surface sweep.
+///
+/// Raw prefix matching would exempt `src/adaptive_extras/` along with `src/adaptive/`, and
+/// anything beginning with `src/lib.rs`. A too-broad exemption is silent - the sweep just
+/// stops covering a directory - which is the same failure class as a lint that passes.
+fn is_sweep_exempt(path: &str) -> bool {
+    EXEMPT_FILES.contains(&path) || EXEMPT_DIRS.iter().any(|dir| path.starts_with(dir))
+}
+
+/// How many modules deep a source file sits, so `super::` can be resolved.
+///
+/// `src/lib.rs` and `src/main.rs` are the crate root (0). `src/api/mod.rs` is `api` (1).
+/// `src/adapters/hqplayer.rs` is `adapters::hqplayer` (2).
+fn module_depth(path: &str) -> usize {
+    let trimmed = path
+        .strip_prefix("src/")
+        .unwrap_or(path)
+        .strip_suffix(".rs")
+        .unwrap_or(path);
+    if trimmed == "lib" || trimmed == "main" {
+        return 0;
+    }
+    let mut parts: Vec<&str> = trimmed.split('/').collect();
+    if parts.last() == Some(&"mod") {
+        parts.pop();
+    }
+    parts.len()
+}
+
 /// Modules a surface may not reach.
 const FORBIDDEN_MODULES: &[&str] = &["adaptive", "producers"];
 /// Crate roots those modules can be addressed through.
@@ -585,6 +620,8 @@ struct ModuleReferenceVisitor {
     /// Names that address this crate's root in the module currently being visited.
     roots: BTreeSet<String>,
     saved: Vec<BTreeSet<String>>,
+    /// How many modules deep the file being scanned sits, so `super::` can be resolved.
+    depth: usize,
 }
 
 impl ModuleReferenceVisitor {
@@ -600,36 +637,69 @@ impl ModuleReferenceVisitor {
     /// aliased root second. Scanning pairs also covers `self::`, and costs nothing because
     /// a pair only matches when its left half is a known root.
     fn note_pairs(&mut self, segments: &[String]) {
+        // A leading run of `super` is resolved against the file's own module depth: from
+        // `src/api/mod.rs`, one module deep, `super::adaptive::X` *is* `crate::adaptive::X`.
+        // Exactly `depth` supers reach the crate root; fewer land in an intermediate module
+        // and more are not expressible. Found by CodeRabbit at `9c53079`.
+        let supers = segments.iter().take_while(|s| *s == "super").count();
+        if supers > 0 && supers == self.depth {
+            if let Some(module) = segments.get(supers) {
+                if FORBIDDEN_MODULES.contains(&module.as_str()) {
+                    self.found.insert(format!("super x{supers}::{module}"));
+                }
+            }
+        }
         for window in segments.windows(2) {
             self.note(&window[0], &window[1]);
         }
     }
 
-    /// Look for an `Ident :: Ident` token sequence, recursing into groups.
+    /// Collect maximal `Ident (:: Ident)*` runs and resolve each like an ordinary path,
+    /// recursing into groups.
     ///
     /// The previous implementation stringified the whole token stream and substring-matched
     /// it, so `println!("crate::adaptive")` registered as a reference — while the comment
     /// above it claimed a literal could not fabricate a match. It could, and did. Found by
     /// Codex at `4129b87`.
     ///
-    /// Walking `TokenTree` fixes it by construction rather than by exclusion: a `Literal`
+    /// Walking `TokenTree` fixes that by construction rather than by exclusion: a `Literal`
     /// is a different variant from an `Ident`, so its contents are never sequence material.
-    /// A real path inside a macro is still four tokens and is still found.
+    ///
+    /// Collecting whole runs rather than adjacent four-token windows is what makes macro
+    /// arguments obey the same rules as everything else. A window can only ever see one
+    /// pair, and a leading `super` run is by definition wider than a pair — so
+    /// `super::adaptive::X` was caught by [`Visit::visit_path`] and missed here, in the one
+    /// place a path can be written without syn parsing it as a path. Feeding the full run
+    /// through [`Self::note_pairs`] gives macro tokens the same depth resolution.
     fn scan_tokens(&mut self, stream: &proc_macro2::TokenStream) {
         let trees: Vec<TokenTree> = stream.clone().into_iter().collect();
-        for window in trees.windows(4) {
-            let (
-                TokenTree::Ident(root),
-                TokenTree::Punct(first),
-                TokenTree::Punct(second),
-                TokenTree::Ident(module),
-            ) = (&window[0], &window[1], &window[2], &window[3])
-            else {
+        let mut index = 0;
+        while index < trees.len() {
+            let TokenTree::Ident(first) = &trees[index] else {
+                index += 1;
                 continue;
             };
-            if first.as_char() == ':' && second.as_char() == ':' {
-                self.note(&root.to_string(), &module.to_string());
+            // Extend through every following `:: Ident`, so the run is the whole path.
+            let mut segments = vec![first.to_string()];
+            let mut end = index + 1;
+            while let (
+                Some(TokenTree::Punct(left)),
+                Some(TokenTree::Punct(right)),
+                Some(TokenTree::Ident(next)),
+            ) = (trees.get(end), trees.get(end + 1), trees.get(end + 2))
+            {
+                if left.as_char() != ':' || right.as_char() != ':' {
+                    break;
+                }
+                segments.push(next.to_string());
+                end += 3;
             }
+            if segments.len() > 1 {
+                self.note_pairs(&segments);
+            }
+            // Resume past the run: its interior idents were already considered as segments,
+            // and restarting inside it would only rediscover suffixes of the same path.
+            index = end.max(index + 1);
         }
         for tree in trees {
             if let TokenTree::Group(group) = tree {
@@ -672,14 +742,29 @@ impl<'ast> Visit<'ast> for ModuleReferenceVisitor {
     /// its subtree, and a `mod` it declares shadows an inherited alias of the same name.
     fn visit_item_mod(&mut self, item: &'ast syn::ItemMod) {
         self.saved.push(self.roots.clone());
+        let outer_depth = self.depth;
         if let Some((_, items)) = &item.content {
             let (aliases, shadowed) = scope_delta(items, &self.roots);
             self.roots.extend(aliases);
             for name in &shadowed {
                 self.roots.remove(name);
             }
+            // An *inline* module puts its contents one module further down, so `super::`
+            // inside it needs one more hop to reach the crate root. `depth` was fixed per
+            // file, which got both directions backwards inside a nested module. An external
+            // `mod x;` declares a module whose contents live in another file and are not
+            // traversed here, so it must not change the depth. Raised by Codex against the
+            // first draft of the `super::` fix.
+            //
+            // Incrementing for an external `mod x;` too would be *unobservable* rather than
+            // wrong: there is no inline content to scan under it, and the restore below
+            // makes the pair a no-op. No probe can distinguish the two, so the guard stays
+            // because it is semantically right, not because a test proves it - stated so
+            // nobody mistakes the surviving mutation for coverage.
+            self.depth += 1;
         }
         visit::visit_item_mod(self, item);
+        self.depth = outer_depth;
         if let Some(previous) = self.saved.pop() {
             self.roots = previous;
         }
@@ -806,7 +891,7 @@ fn collect_crate_aliases(
 }
 
 /// Forbidden module references in `file`, resolving crate-root aliases within their scope.
-fn forbidden_module_references(file: &File) -> Vec<String> {
+fn forbidden_module_references(file: &File, depth: usize) -> Vec<String> {
     let mut roots: BTreeSet<String> = CRATE_ROOTS.iter().map(|r| (*r).to_string()).collect();
     let (aliases, shadowed) = scope_delta(&file.items, &roots);
     roots.extend(aliases);
@@ -817,6 +902,7 @@ fn forbidden_module_references(file: &File) -> Vec<String> {
         found: BTreeSet::new(),
         roots,
         saved: Vec::new(),
+        depth,
     };
     visitor.visit_file(file);
     visitor.found.into_iter().collect()
@@ -832,10 +918,32 @@ fn lint_public_bus_cannot_carry_adaptive_types() {
     // serializes it verbatim into `GET /events`. A variant naming an adaptive type would
     // change that endpoint's response schema and publish the v1 contract outside this
     // repository.
+    // Both layouts supported, and the collection asserted non-empty before it is iterated:
+    // `rust_sources_under` returns an empty vector for a path that does not exist, so
+    // renaming `src/bus/` to `src/bus.rs` would have made this pass by scanning nothing.
+    // Found by CodeRabbit at `9c53079`.
+    let mut sources = rust_sources_under("src/bus");
+    if let Ok(text) = fs::read_to_string("src/bus.rs") {
+        sources.push(("src/bus.rs".to_string(), text));
+    }
+    assert!(
+        !sources.is_empty(),
+        "no bus sources found under src/bus/ or at src/bus.rs; this lint would pass by \
+         scanning nothing"
+    );
+    // The vacuity this guards against is real, not hypothetical: a path that does not exist
+    // yields an empty collection rather than an error, so the loop below would simply not
+    // run. Asserted directly, because a mutation that disables the guard cannot fail while
+    // `src/bus/` still exists.
+    assert!(
+        rust_sources_under("src/bus_does_not_exist").is_empty(),
+        "the source walker is expected to return empty for a missing path"
+    );
+
     let mut violations = Vec::new();
-    for (path, text) in rust_sources_under("src/bus") {
+    for (path, text) in sources {
         let file = parse_source(&path, &text);
-        for reference in forbidden_module_references(&file) {
+        for reference in forbidden_module_references(&file, module_depth(&path)) {
             violations.push(format!("{path}: references `{reference}`"));
         }
     }
@@ -851,7 +959,7 @@ fn lint_public_bus_cannot_carry_adaptive_types() {
 #[test]
 fn lint_the_sse_projection_does_not_mention_the_publication_layer() {
     let file = parse_file_at("src/api/mod.rs");
-    let references = forbidden_module_references(&file);
+    let references = forbidden_module_references(&file, module_depth("src/api/mod.rs"));
     assert!(
         references.is_empty(),
         "src/api/mod.rs references {references:?}. Any HTTP or SSE exposure of the producer \
@@ -869,16 +977,15 @@ fn lint_only_the_composition_root_names_the_contract_or_the_publication_layer() 
     // Swept over all of `src/` rather than an enumerated list of surfaces. An enumerated
     // list stops covering whatever is added next; the first draft listed six directories
     // and omitted `src/mqtt`, which publishes to Home Assistant.
-    const EXEMPT: &[&str] = &["src/adaptive", "src/producers", "src/lib.rs", "src/main.rs"];
     let mut violations = Vec::new();
     let mut swept = 0usize;
     for (path, text) in rust_sources_under("src") {
-        if EXEMPT.iter().any(|exempt| path.starts_with(exempt)) {
+        if is_sweep_exempt(&path) {
             continue;
         }
         swept += 1;
         let file = parse_source(&path, &text);
-        for reference in forbidden_module_references(&file) {
+        for reference in forbidden_module_references(&file, module_depth(&path)) {
             violations.push(format!("{path}: references `{reference}`"));
         }
     }
@@ -1118,11 +1225,11 @@ fn lint_producers_module_is_server_gated() {
 fn lint_publication_layer_is_reachable_only_from_the_composition_root() {
     let mut referrers = Vec::new();
     for (path, text) in rust_sources_under("src") {
-        if path.starts_with("src/producers") || path == "src/lib.rs" || path == "src/main.rs" {
+        if path.starts_with("src/producers/") || path == "src/lib.rs" || path == "src/main.rs" {
             continue;
         }
         let file = parse_source(&path, &text);
-        if forbidden_module_references(&file)
+        if forbidden_module_references(&file, module_depth(&path))
             .iter()
             .any(|reference| reference.ends_with("::producers"))
         {
@@ -1690,7 +1797,7 @@ fn a_crate_root_alias_cannot_launder_a_forbidden_module_reference() {
         ),
     ] {
         assert!(
-            !forbidden_module_references(&snippet(source)).is_empty(),
+            !forbidden_module_references(&snippet(source), 0).is_empty(),
             "{label}: an aliased crate root laundered the reference:\n{source}"
         );
     }
@@ -1705,27 +1812,27 @@ fn crate_root_aliases_are_scoped_to_the_module_that_declares_them() {
     // module of the same name look like the crate root somewhere else.
     let sibling_scope = "mod a {\n    use crate as internal;\n}\nmod b {\n    mod internal {\n        pub mod adaptive {}\n    }\n    fn f() { let _ = internal::adaptive::X; }\n}\n";
     assert!(
-        forbidden_module_references(&snippet(sibling_scope)).is_empty(),
+        forbidden_module_references(&snippet(sibling_scope), 0).is_empty(),
         "an alias declared in a sibling module leaked: {:?}\n{sibling_scope}",
-        forbidden_module_references(&snippet(sibling_scope))
+        forbidden_module_references(&snippet(sibling_scope), 0)
     );
 
     // The same leak without any shadowing to mask it: `b` declares no `mod internal`, so
     // only restoring the outer scope on the way out of `a` keeps this clean.
     let sibling_no_shadow = "mod a {\n    use crate as internal;\n}\nmod b {\n    fn f() { let _ = internal::adaptive::X; }\n}\n";
     assert!(
-        forbidden_module_references(&snippet(sibling_no_shadow)).is_empty(),
+        forbidden_module_references(&snippet(sibling_no_shadow), 0).is_empty(),
         "an alias leaked out of the module that declared it: {:?}\n{sibling_no_shadow}",
-        forbidden_module_references(&snippet(sibling_no_shadow))
+        forbidden_module_references(&snippet(sibling_no_shadow), 0)
     );
 
     // Reverse: a real crate alias shadowed by a local module of the same name is no longer
     // the crate root inside that module.
     let shadowed = "use crate as internal;\nmod b {\n    mod internal {\n        pub mod adaptive {}\n    }\n    fn f() { let _ = internal::adaptive::X; }\n}\n";
     assert!(
-        forbidden_module_references(&snippet(shadowed)).is_empty(),
+        forbidden_module_references(&snippet(shadowed), 0).is_empty(),
         "a shadowed alias still counted as the crate root: {:?}\n{shadowed}",
-        forbidden_module_references(&snippet(shadowed))
+        forbidden_module_references(&snippet(shadowed), 0)
     );
 
     // The three genuine exploits must stay caught, so the scoping does not buy its
@@ -1745,7 +1852,7 @@ fn crate_root_aliases_are_scoped_to_the_module_that_declares_them() {
         ),
     ] {
         assert!(
-            !forbidden_module_references(&snippet(source)).is_empty(),
+            !forbidden_module_references(&snippet(source), 0).is_empty(),
             "{label}: scoping introduced a false negative:\n{source}"
         );
     }
@@ -1814,7 +1921,7 @@ fn extern_crate_self_and_transitive_aliases_are_crate_roots_too() {
         ),
     ] {
         assert!(
-            !forbidden_module_references(&snippet(source)).is_empty(),
+            !forbidden_module_references(&snippet(source), 0).is_empty(),
             "{label}: an alias form bypassed the boundary:\n{source}"
         );
     }
@@ -1868,9 +1975,308 @@ fn extended_alias_forms_remain_scope_aware_and_shadowable() {
         ),
     ] {
         assert!(
-            forbidden_module_references(&snippet(source)).is_empty(),
+            forbidden_module_references(&snippet(source), 0).is_empty(),
             "{label}: the extended forms invented a reference: {:?}\n{source}",
-            forbidden_module_references(&snippet(source))
+            forbidden_module_references(&snippet(source), 0)
+        );
+    }
+}
+
+#[test]
+fn super_resolves_to_the_crate_root_at_the_right_depth() {
+    // `super::adaptive::X` written in `src/api/mod.rs` *is* `crate::adaptive::X`, because
+    // that file is one module deep. The visitor only knew `crate` and `unified_hifi_control`
+    // as roots, so every `super::` route was invisible. Found by CodeRabbit at `9c53079`.
+    for (label, depth, source) in [
+        (
+            "one super at depth 1",
+            1,
+            "fn f() { let _ = super::adaptive::X; }",
+        ),
+        (
+            "one super at depth 1, publication layer",
+            1,
+            "fn f() { let _ = super::producers::P; }",
+        ),
+        (
+            "two supers at depth 2",
+            2,
+            "fn f() { let _ = super::super::adaptive::X; }",
+        ),
+        (
+            "three supers at depth 3",
+            3,
+            "fn f() { let _ = super::super::super::producers::P; }",
+        ),
+        (
+            "super in a use tree at depth 1",
+            1,
+            "use super::adaptive::X;",
+        ),
+        (
+            "super in type position at depth 1",
+            1,
+            "fn f(x: super::adaptive::X) {}",
+        ),
+    ] {
+        assert!(
+            !forbidden_module_references(&snippet(source), depth).is_empty(),
+            "{label}: a super:: route to the crate root was missed:\n{source}"
+        );
+    }
+}
+
+#[test]
+fn super_does_not_reach_the_crate_root_from_the_wrong_depth() {
+    // Near misses. Too few supers lands in an intermediate module, too many is not
+    // expressible, and a file at the crate root has no `super` at all.
+    for (label, depth, source) in [
+        (
+            "one super at depth 2 lands one module short",
+            2,
+            "fn f() { let _ = super::adaptive::X; }",
+        ),
+        (
+            "two supers at depth 3 lands one module short",
+            3,
+            "fn f() { let _ = super::super::adaptive::X; }",
+        ),
+        (
+            "two supers at depth 1 over-shoots",
+            1,
+            "fn f() { let _ = super::super::adaptive::X; }",
+        ),
+        (
+            "no super at depth 1 is a sibling module",
+            1,
+            "fn f() { let _ = adaptive::X; }",
+        ),
+        (
+            "super at depth 0 has no parent",
+            0,
+            "fn f() { let _ = super::adaptive::X; }",
+        ),
+        (
+            "a prefix-sharing module through super",
+            1,
+            "fn f() { let _ = super::adaptive_extras::X; }",
+        ),
+    ] {
+        assert!(
+            forbidden_module_references(&snippet(source), depth).is_empty(),
+            "{label}: super:: resolution over-reached: {:?}\n{source}",
+            forbidden_module_references(&snippet(source), depth)
+        );
+    }
+}
+
+#[test]
+fn inline_modules_shift_the_effective_super_depth() {
+    // `depth` is the file's depth, but an inline `mod nested { … }` puts its contents one
+    // module further down. At file depth 1, inside one inline module the effective depth is
+    // 2: `super::super::adaptive` reaches the crate root and `super::adaptive` only reaches
+    // the file's own module. A fixed per-file depth gets both backwards. Raised by Codex
+    // against the first draft of the `super::` fix.
+    for (label, depth, source) in [
+        (
+            "two supers inside one inline module at file depth 1",
+            1,
+            "mod nested {\n    fn f() { let _ = super::super::adaptive::X; }\n}\n",
+        ),
+        (
+            "three supers inside two inline modules at file depth 1",
+            1,
+            "mod a {\n    mod b {\n        fn f() { let _ = super::super::super::producers::P; }\n    }\n}\n",
+        ),
+        (
+            "one super inside an inline module at file depth 0",
+            0,
+            "mod nested {\n    fn f() { let _ = super::adaptive::X; }\n}\n",
+        ),
+    ] {
+        assert!(
+            !forbidden_module_references(&snippet(source), depth).is_empty(),
+            "{label}: an inline module's effective depth was not applied:\n{source}"
+        );
+    }
+
+    for (label, depth, source) in [
+        (
+            "one super inside an inline module at file depth 1 stops at the file's module",
+            1,
+            "mod nested {\n    fn f() { let _ = super::adaptive::X; }\n}\n",
+        ),
+        (
+            "two supers inside two inline modules at file depth 1 falls short",
+            1,
+            "mod a {\n    mod b {\n        fn f() { let _ = super::super::adaptive::X; }\n    }\n}\n",
+        ),
+        (
+            "depth must be restored after leaving an inline module",
+            1,
+            "mod nested {\n    fn inner() {}\n}\nfn after() { let _ = super::super::adaptive::X; }\n",
+        ),
+        (
+            "an external module declaration does not add depth",
+            1,
+            "mod external;\nfn f() { let _ = super::super::adaptive::X; }\n",
+        ),
+    ] {
+        assert!(
+            forbidden_module_references(&snippet(source), depth).is_empty(),
+            "{label}: super:: over-reached: {:?}\n{source}",
+            forbidden_module_references(&snippet(source), depth)
+        );
+    }
+
+    // And the file-level case still holds inside a file that also has inline modules.
+    let mixed = "fn top() { let _ = super::adaptive::X; }\nmod nested { fn f() {} }\n";
+    assert!(
+        !forbidden_module_references(&snippet(mixed), 1).is_empty(),
+        "a file-level super:: stopped being caught once the file gained an inline module"
+    );
+}
+
+#[test]
+fn macro_token_paths_resolve_super_against_the_same_depth_as_ordinary_paths() {
+    // A path written inside a macro invocation is compiled exactly like one written outside
+    // it, so the sweep must resolve it identically. The token scanner checked only adjacent
+    // `Ident :: Ident` windows, which cannot see a leading `super` run at all - so
+    // `super::adaptive::X` was caught as a plain path and missed as a macro argument. That
+    // asymmetry is the whole bypass. Raised before commit against the `super::` fix.
+    for (label, depth, source) in [
+        (
+            "one super at file depth 1",
+            1,
+            "fn f() { do_thing!(super::adaptive::X); }\n",
+        ),
+        (
+            "two supers at file depth 2",
+            2,
+            "fn f() { do_thing!(super::super::adaptive::X); }\n",
+        ),
+        (
+            "two supers inside one inline module at file depth 1",
+            1,
+            "mod nested {\n    fn f() { do_thing!(super::super::adaptive::X); }\n}\n",
+        ),
+        (
+            "three supers inside two inline modules at file depth 1",
+            1,
+            "mod a {\n    mod b {\n        fn f() { do_thing!(super::super::super::producers::P); }\n    }\n}\n",
+        ),
+        (
+            "nested inside a delimiter group",
+            1,
+            "fn f() { do_thing!(vec![(super::adaptive::X)]); }\n",
+        ),
+        (
+            "an aliased root reached through super still resolves",
+            1,
+            "use crate as internal;\nfn f() { do_thing!(super::internal::adaptive::X); }\n",
+        ),
+    ] {
+        assert!(
+            !forbidden_module_references(&snippet(source), depth).is_empty(),
+            "{label}: a forbidden path inside a macro escaped depth resolution:\n{source}"
+        );
+    }
+
+    for (label, depth, source) in [
+        (
+            "one super at file depth 2 falls short",
+            2,
+            "fn f() { do_thing!(super::adaptive::X); }\n",
+        ),
+        (
+            "two supers at file depth 1 over-reach",
+            1,
+            "fn f() { do_thing!(super::super::adaptive::X); }\n",
+        ),
+        (
+            "one super inside an inline module at file depth 1 stops at the file's module",
+            1,
+            "mod nested {\n    fn f() { do_thing!(super::adaptive::X); }\n}\n",
+        ),
+    ] {
+        assert!(
+            forbidden_module_references(&snippet(source), depth).is_empty(),
+            "{label}: super:: over-reached inside a macro: {:?}\n{source}",
+            forbidden_module_references(&snippet(source), depth)
+        );
+    }
+
+    // The literal controls must survive the change: a string is a different TokenTree
+    // variant from an Ident, so its contents can never become path segments. This is the
+    // regression Codex found at `4129b87` and it stays covered.
+    for (label, source) in [
+        (
+            "a plain string literal",
+            r#"fn f() { println!("crate::adaptive"); }"#,
+        ),
+        (
+            "a raw string literal",
+            "fn f() { println!(r#\"super::super::adaptive::X\"#); }",
+        ),
+        (
+            "a literal inside a nested group",
+            r#"fn f() { do_thing!(vec![("super::adaptive::X")]); }"#,
+        ),
+    ] {
+        assert!(
+            forbidden_module_references(&snippet(source), 1).is_empty(),
+            "{label}: a string literal fabricated a module reference:\n{source}"
+        );
+    }
+}
+
+#[test]
+fn module_depth_is_derived_from_the_file_path() {
+    for (path, expected) in [
+        ("src/lib.rs", 0),
+        ("src/main.rs", 0),
+        ("src/aggregator.rs", 1),
+        ("src/api/mod.rs", 1),
+        ("src/adapters/hqplayer.rs", 2),
+        ("src/producers/event.rs", 2),
+        ("src/app/pages/zones.rs", 3),
+        ("src/server/routes/mod.rs", 2),
+    ] {
+        assert_eq!(
+            module_depth(path),
+            expected,
+            "wrong module depth for {path}"
+        );
+    }
+}
+
+#[test]
+fn sweep_exemptions_do_not_match_sibling_paths() {
+    // The exemptions were raw prefixes, so `src/adaptive` would also exempt a future
+    // `src/adaptive_extras/`, and a file exemption would match anything beginning with it.
+    // A too-broad exemption is silent: the sweep simply stops covering a directory.
+    // Found by CodeRabbit at `9c53079`.
+    for exempt in [
+        "src/adaptive/mod.rs",
+        "src/adaptive/value.rs",
+        "src/producers/event.rs",
+        "src/lib.rs",
+        "src/main.rs",
+    ] {
+        assert!(is_sweep_exempt(exempt), "{exempt} should be exempt");
+    }
+    for covered in [
+        "src/adaptive_extras/mod.rs",
+        "src/producers_extra/thing.rs",
+        "src/lib.rs.bak.rs",
+        "src/main.rs.orig.rs",
+        "src/lib/helper.rs",
+        "src/api/mod.rs",
+        "src/mqtt/mod.rs",
+    ] {
+        assert!(
+            !is_sweep_exempt(covered),
+            "{covered} must stay inside the sweep"
         );
     }
 }
@@ -1895,9 +2301,9 @@ fn unrelated_crate_aliases_do_not_false_positive() {
         ),
     ] {
         assert!(
-            forbidden_module_references(&snippet(source)).is_empty(),
+            forbidden_module_references(&snippet(source), 0).is_empty(),
             "{label}: alias tracking invented a reference: {:?}\n{source}",
-            forbidden_module_references(&snippet(source))
+            forbidden_module_references(&snippet(source), 0)
         );
     }
 }
@@ -1997,7 +2403,7 @@ fn the_inspectors_do_not_invent_findings() {
                       const S: &str = \"crate::producers\";\n\
                       fn f() {}\n";
     assert!(
-        forbidden_module_references(&snippet(prose_only)).is_empty(),
+        forbidden_module_references(&snippet(prose_only), 0).is_empty(),
         "prose or a string literal registered as a module reference"
     );
 
@@ -2021,18 +2427,18 @@ fn the_inspectors_do_not_invent_findings() {
         ),
     ] {
         assert!(
-            forbidden_module_references(&snippet(source)).is_empty(),
+            forbidden_module_references(&snippet(source), 0).is_empty(),
             "{label}: a literal inside a macro fabricated a module reference: {:?}\n{source}",
-            forbidden_module_references(&snippet(source))
+            forbidden_module_references(&snippet(source), 0)
         );
     }
 
     // A module whose name merely shares a prefix is not forbidden.
     let near_miss = "use crate::adaptive_extras::X;\nuse crate::production::Y;\n";
     assert!(
-        forbidden_module_references(&snippet(near_miss)).is_empty(),
+        forbidden_module_references(&snippet(near_miss), 0).is_empty(),
         "a prefix-sharing module name registered: {:?}",
-        forbidden_module_references(&snippet(near_miss))
+        forbidden_module_references(&snippet(near_miss), 0)
     );
 }
 
@@ -2072,7 +2478,7 @@ fn module_references_are_found_in_every_position() {
         ),
     ] {
         assert!(
-            !forbidden_module_references(&snippet(source)).is_empty(),
+            !forbidden_module_references(&snippet(source), 0).is_empty(),
             "{label}: a module reference was missed:\n{source}"
         );
     }

--- a/tests/adaptive_publication_lint.rs
+++ b/tests/adaptive_publication_lint.rs
@@ -31,6 +31,43 @@ use walkdir::WalkDir;
 
 const PRODUCERS_DECLARATION: &str = "pub mod producers;";
 const ADAPTIVE_EVENT_DECLARATION: &str = "pub enum AdaptiveEvent {";
+
+/// Exactly what `src/producers/event.rs` may import, whitespace-normalized.
+///
+/// An **allowlist**, not a denylist, and that inversion is the point. Name-based detection
+/// has now been bypassed four times, most recently by a crate-local re-export:
+///
+/// ```ignore
+/// // src/wire.rs
+/// pub use serde::Serialize as EventWire;
+/// // src/producers/event.rs
+/// use crate::wire::EventWire;
+/// #[derive(EventWire)]
+/// pub enum AdaptiveEvent { … }
+/// ```
+///
+/// That file contains no `serde`, imports nothing from `serde`, and no resolver short of a
+/// real name resolver learns that `EventWire` serializes. Verified by compiling it: the
+/// build finished clean and all 24 lints passed. Found by CodeRabbit at `993d35e`.
+///
+/// Chasing re-export chains would be a partial resolver wearing a guarantee's clothes —
+/// it would still miss `pub use` through several modules, glob re-exports, and macros. An
+/// allowlist does not care what a name means: **any** import not on this list fails, so
+/// every re-export form is closed at once. The cost is that a legitimate new import has to
+/// be added here, deliberately, which for this module is the point rather than the tax.
+const EVENT_ALLOWED_IMPORTS: &[&str] = &[
+    "use std::sync::Arc;",
+    "use tokio::sync::broadcast;",
+    "use super::admission::{AdmissionRefusal,ProducerKey};",
+    "use crate::adaptive::{DocumentRevisions,ProducerDocument};",
+];
+
+/// Exactly what `AdaptiveEvent` may derive.
+///
+/// The companion to [`EVENT_ALLOWED_IMPORTS`], and necessary because a derive needs no
+/// import at all: `#[derive(crate::wire::EventWire)]` names the macro by path. Matching on
+/// permitted names rather than forbidden ones makes the spelling irrelevant.
+const ADAPTIVE_EVENT_ALLOWED_DERIVES: &[&str] = &["Debug", "Clone"];
 /// The readable spelling, used in failure messages.
 const SERVER_GATE: &str = "#[cfg(feature = \"server\")]";
 
@@ -126,6 +163,162 @@ fn forbidden_module_references(code: &str) -> Vec<String> {
     found
 }
 
+/// If a string literal begins at `chars[index]`, the index just past its end.
+///
+/// Recognizes ordinary `"…"`, byte `b"…"`, and **raw** `r"…"` / `r#"…"#` / `r##"…"##` /
+/// `br#"…"#`. Raw strings were the gap: a scanner that leaves string mode at the first `"`
+/// reads the rest of `r##"quote: " then ] remains data"##` as code, takes the `]` for an
+/// attribute close, and silently stops joining whatever follows. Found by CodeRabbit at
+/// `993d35e`, with the exploit supplied.
+///
+/// The terminator of a raw string is `"` followed by **the same number of hashes** it
+/// opened with, so an inner `"#` inside a `r##"…"##` literal is data.
+///
+/// `None` means no literal starts here. Callers must also check that the preceding
+/// character is not part of an identifier, or the `r` in `counter` looks like a prefix.
+fn string_literal_end(chars: &[char], index: usize) -> Option<usize> {
+    let mut cursor = index;
+    if chars.get(cursor) == Some(&'b') {
+        cursor += 1;
+    }
+    let raw = chars.get(cursor) == Some(&'r');
+    if raw {
+        cursor += 1;
+    }
+    let mut hashes = 0usize;
+    if raw {
+        while chars.get(cursor) == Some(&'#') {
+            hashes += 1;
+            cursor += 1;
+        }
+    }
+    if chars.get(cursor) != Some(&'"') {
+        return None;
+    }
+
+    let mut scan = cursor + 1;
+    if raw {
+        while scan < chars.len() {
+            if chars[scan] == '"' && (1..=hashes).all(|k| chars.get(scan + k) == Some(&'#')) {
+                return Some(scan + hashes + 1);
+            }
+            scan += 1;
+        }
+        return Some(chars.len());
+    }
+    while scan < chars.len() {
+        match chars[scan] {
+            '\\' => scan += 2,
+            '"' => return Some(scan + 1),
+            _ => scan += 1,
+        }
+    }
+    Some(chars.len())
+}
+
+/// If a character literal begins at `chars[index]`, the index just past its end.
+///
+/// Distinguished from a lifetime, which is the whole difficulty: `']'` is a literal whose
+/// bracket is data, while `'de` in `impl<'de> Deserialize<'de>` is not a literal at all and
+/// must not swallow the rest of the line.
+fn char_literal_end(chars: &[char], index: usize) -> Option<usize> {
+    if chars.get(index) != Some(&'\'') {
+        return None;
+    }
+    if chars.get(index + 1) == Some(&'\\') {
+        let mut scan = index + 2;
+        while scan < chars.len() {
+            if chars[scan] == '\'' {
+                return Some(scan + 1);
+            }
+            scan += 1;
+        }
+        return None;
+    }
+    if chars.get(index + 2) == Some(&'\'') {
+        return Some(index + 3);
+    }
+    None
+}
+
+/// Whether a literal prefix at `index` is a real prefix rather than the tail of a name.
+fn starts_a_literal(chars: &[char], index: usize) -> bool {
+    index == 0 || !(chars[index - 1].is_alphanumeric() || chars[index - 1] == '_')
+}
+
+/// The index just past a literal beginning at `index`, if one does.
+fn literal_end(chars: &[char], index: usize) -> Option<usize> {
+    match chars.get(index) {
+        Some('"') => string_literal_end(chars, index),
+        Some('r') | Some('b') if starts_a_literal(chars, index) => string_literal_end(chars, index),
+        Some('\'') => char_literal_end(chars, index),
+        _ => None,
+    }
+}
+
+/// Every `use` statement in `code`, whitespace-normalized, one per statement.
+///
+/// Run over comment-stripped code and anchored at a statement boundary: a doc comment
+/// containing the word "use" produced a spurious 700-character "import" when this was
+/// first written against raw source.
+fn imports_in(code: &str) -> Vec<String> {
+    let normalized = collapse_whitespace(code);
+    let chars: Vec<char> = normalized.chars().collect();
+    let mut found = Vec::new();
+    let mut index = 0usize;
+
+    while index < chars.len() {
+        let at_boundary = index == 0
+            || matches!(chars[index - 1], ' ' | ';' | '{' | '}' | '\n')
+                && !(index >= 2 && chars[index - 2].is_alphanumeric() && chars[index - 1] == ' ');
+        let is_use = chars[index..].starts_with(&['u', 's', 'e', ' ']);
+        // `pub use …` counts too; the boundary check sits before `pub`.
+        if is_use && at_boundary {
+            let mut scan = index;
+            while scan < chars.len() && chars[scan] != ';' {
+                scan += 1;
+            }
+            let statement: String = chars[index..scan.min(chars.len())].iter().collect();
+            found.push(format!("{statement};"));
+            index = scan + 1;
+            continue;
+        }
+        index += 1;
+    }
+    found
+}
+
+/// Every trait implemented for `type_name` in `code`, as written.
+///
+/// The companion to the derive allowlist: a hand-written `impl` needs no derive and no
+/// import. Terminator-checked so `AdaptiveEventLog` is not read as `AdaptiveEvent`.
+fn trait_impls_for(code: &str, type_name: &str) -> Vec<String> {
+    let normalized = collapse_whitespace(code);
+    let needle = format!("for {type_name}");
+    let mut found = Vec::new();
+    let mut search_from = 0usize;
+
+    while let Some(at) = normalized[search_from..].find(&needle) {
+        let absolute = search_from + at;
+        let after = normalized[absolute + needle.len()..].chars().next();
+        let terminated = after.is_none_or(|c| !c.is_alphanumeric() && c != '_');
+        if terminated {
+            if let Some(impl_at) = normalized[..absolute].rfind("impl") {
+                let header = normalized[impl_at + "impl".len()..absolute].trim();
+                // Strip any generic parameter list introduced by `impl<…>`.
+                let trait_part = header.strip_prefix('<').map_or(header, |rest| {
+                    rest.split_once('>').map_or(rest, |(_, tail)| tail).trim()
+                });
+                if !trait_part.is_empty() {
+                    found.push(trait_part.to_string());
+                }
+            }
+        }
+        search_from = absolute + needle.len();
+    }
+    found
+}
+
 /// Collapse whitespace runs to one space, then close it up around path punctuation.
 ///
 /// Leaves ` as ` intact — which is the whole reason this is not a plain whitespace strip.
@@ -187,54 +380,53 @@ fn split_top_level(group: &str) -> Vec<&str> {
 /// of the code. String literals are kept so a forbidden path written as a string is still
 /// caught.
 fn code_only(text: &str) -> String {
+    let chars: Vec<char> = text.chars().collect();
     let mut out = String::with_capacity(text.len());
-    let mut chars = text.chars().peekable();
-    let mut in_string = false;
+    let mut index = 0usize;
     let mut block_depth = 0usize;
 
-    while let Some(c) = chars.next() {
+    while index < chars.len() {
+        let c = chars[index];
+
         if block_depth > 0 {
-            if c == '*' && chars.peek() == Some(&'/') {
-                chars.next();
+            if c == '*' && chars.get(index + 1) == Some(&'/') {
                 block_depth -= 1;
-            } else if c == '/' && chars.peek() == Some(&'*') {
-                chars.next();
+                index += 2;
+                continue;
+            }
+            if c == '/' && chars.get(index + 1) == Some(&'*') {
                 block_depth += 1;
-            } else if c == '\n' {
+                index += 2;
+                continue;
+            }
+            if c == '\n' {
                 out.push('\n');
             }
+            index += 1;
             continue;
         }
-        if in_string {
-            out.push(c);
-            if c == '\\' {
-                if let Some(escaped) = chars.next() {
-                    out.push(escaped);
-                }
-            } else if c == '"' {
-                in_string = false;
+
+        // A literal is data. `//` and `/*` inside one are not comment markers, and a `"`
+        // inside a raw string does not end it.
+        if let Some(end) = literal_end(&chars, index) {
+            out.extend(&chars[index..end.min(chars.len())]);
+            index = end;
+            continue;
+        }
+
+        if c == '/' && chars.get(index + 1) == Some(&'/') {
+            while index < chars.len() && chars[index] != '\n' {
+                index += 1;
             }
             continue;
         }
-        match c {
-            '"' => {
-                in_string = true;
-                out.push(c);
-            }
-            '/' if chars.peek() == Some(&'/') => {
-                for skipped in chars.by_ref() {
-                    if skipped == '\n' {
-                        out.push('\n');
-                        break;
-                    }
-                }
-            }
-            '/' if chars.peek() == Some(&'*') => {
-                chars.next();
-                block_depth += 1;
-            }
-            _ => out.push(c),
+        if c == '/' && chars.get(index + 1) == Some(&'*') {
+            block_depth += 1;
+            index += 2;
+            continue;
         }
+        out.push(c);
+        index += 1;
     }
     out
 }
@@ -283,24 +475,23 @@ fn join_wrapped_attributes(code: &str) -> String {
     let mut out = String::with_capacity(code.len());
     let mut index = 0usize;
     let mut depth = 0usize;
-    let mut in_string = false;
 
     while index < chars.len() {
-        let c = chars[index];
-        if in_string {
-            out.push(c);
-            if c == '\\' && index + 1 < chars.len() {
-                out.push(chars[index + 1]);
-                index += 2;
-                continue;
+        // A literal is copied through whole, whatever it contains. This is the raw-string
+        // fix: `r##"quote: " then ] remains data"##` no longer ends at its embedded quote,
+        // so its `]` is data rather than an attribute close.
+        if let Some(end) = literal_end(&chars, index) {
+            let slice: String = chars[index..end.min(chars.len())].iter().collect();
+            if depth > 0 {
+                out.push_str(&slice.replace('\n', " "));
+            } else {
+                out.push_str(&slice);
             }
-            if c == '"' {
-                in_string = false;
-            }
-            index += 1;
+            index = end;
             continue;
         }
-        // `#[` and `#![` both open an attribute.
+
+        let c = chars[index];
         if c == '#' {
             let bracket = if chars.get(index + 1) == Some(&'!') {
                 index + 2
@@ -315,10 +506,6 @@ fn join_wrapped_attributes(code: &str) -> String {
             }
         }
         match c {
-            '"' => {
-                in_string = true;
-                out.push(c);
-            }
             '[' if depth > 0 => {
                 depth += 1;
                 out.push(c);
@@ -342,65 +529,54 @@ fn join_wrapped_attributes(code: &str) -> String {
 /// rather than truncated at the first `]`.
 fn attributes_in(text: &str) -> Vec<String> {
     let mut found = Vec::new();
-    let bytes: Vec<char> = text.chars().collect();
+    let chars: Vec<char> = text.chars().collect();
     let mut index = 0usize;
-    while index + 1 < bytes.len() {
-        if bytes[index] != '#' || (bytes[index + 1] != '[' && bytes[index + 1] != '!') {
+
+    while index + 1 < chars.len() {
+        if chars[index] != '#' || (chars[index + 1] != '[' && chars[index + 1] != '!') {
             index += 1;
             continue;
         }
-        // `#![...]` is an inner attribute; it applies to the enclosing module, not to the
-        // next item, so it is skipped rather than attributed to a declaration below it.
-        let open = if bytes[index + 1] == '!' {
+        let open = if chars[index + 1] == '!' {
             index + 2
         } else {
             index + 1
         };
-        if open >= bytes.len() || bytes[open] != '[' {
+        if chars.get(open) != Some(&'[') {
             index += 1;
             continue;
         }
-        let inner = bytes[index + 1] == '!';
+        let inner = chars[index + 1] == '!';
         let mut depth = 0usize;
-        let mut in_string = false;
         let mut cursor = open;
         let mut end = None;
-        while cursor < bytes.len() {
-            let c = bytes[cursor];
-            if in_string {
-                if c == '\\' {
-                    cursor += 2;
-                    continue;
-                }
-                if c == '"' {
-                    in_string = false;
-                }
-            } else {
-                match c {
-                    '"' => in_string = true,
-                    '[' => depth += 1,
-                    ']' => {
-                        depth -= 1;
-                        if depth == 0 {
-                            end = Some(cursor);
-                            break;
-                        }
+        while cursor < chars.len() {
+            if let Some(past) = literal_end(&chars, cursor) {
+                cursor = past;
+                continue;
+            }
+            match chars[cursor] {
+                '[' => depth += 1,
+                ']' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        end = Some(cursor);
+                        break;
                     }
-                    _ => {}
                 }
+                _ => {}
             }
             cursor += 1;
         }
         match end {
             Some(close) => {
                 if !inner {
-                    found.push(bytes[index..=close].iter().collect());
+                    found.push(chars[index..=close].iter().collect());
                 }
                 index = close + 1;
             }
-            // Unterminated. Record what is there rather than dropping an attribute.
             None => {
-                found.push(bytes[index..].iter().collect());
+                found.push(chars[index..].iter().collect());
                 break;
             }
         }
@@ -795,6 +971,79 @@ fn lint_adaptive_event_derives_no_serialization() {
 }
 
 #[test]
+fn lint_the_internal_event_module_imports_only_what_it_is_allowed_to() {
+    // The durable half. Every name-based guard in this file has now been bypassed —
+    // aliases, wrapped attributes, raw strings, and finally a crate-local re-export that
+    // leaves no trace of serde in the file at all. Detection loses that race by
+    // construction; permission does not.
+    //
+    // Anything not on `EVENT_ALLOWED_IMPORTS` fails, whatever it is named and wherever it
+    // was re-exported from.
+    let event = fs::read_to_string("src/producers/event.rs").expect("src/producers/event.rs");
+    let imports = imports_in(&code_only(&event));
+
+    let unexpected: Vec<&String> = imports
+        .iter()
+        .filter(|import| !EVENT_ALLOWED_IMPORTS.contains(&import.as_str()))
+        .collect();
+    assert!(
+        unexpected.is_empty(),
+        "src/producers/event.rs imports something not on the allowlist: {unexpected:?}\n\
+         This module holds the one producer type that must not reach a wire. A new import \
+         may be entirely fine — add it to EVENT_ALLOWED_IMPORTS deliberately, having \
+         checked it is not a serialization trait re-exported under another name."
+    );
+    assert!(
+        !imports.is_empty(),
+        "no imports were found at all, which means the scanner is not reading the file"
+    );
+}
+
+#[test]
+fn lint_adaptive_event_derives_only_what_it_is_allowed_to() {
+    // A derive needs no import: `#[derive(crate::wire::EventWire)]` names the macro by
+    // path, so the import allowlist alone does not close it. Permitting `Debug` and `Clone`
+    // and nothing else closes every spelling at once.
+    let event = fs::read_to_string("src/producers/event.rs").expect("src/producers/event.rs");
+    let attributes =
+        attributes_attached_to(&event, ADAPTIVE_EVENT_DECLARATION).unwrap_or_else(|| {
+            panic!("src/producers/event.rs must declare `{ADAPTIVE_EVENT_DECLARATION}`")
+        });
+
+    let derived: Vec<String> = attributes.iter().flat_map(|a| derive_tokens(a)).collect();
+    let unexpected: Vec<&String> = derived
+        .iter()
+        .filter(|token| !ADAPTIVE_EVENT_ALLOWED_DERIVES.contains(&token.as_str()))
+        .collect();
+    assert!(
+        unexpected.is_empty(),
+        "AdaptiveEvent derives something not on the allowlist: {unexpected:?}\n\
+         Permitted: {ADAPTIVE_EVENT_ALLOWED_DERIVES:?}. A derive under an alias or a \
+         re-exported path is indistinguishable from any other name, so the list is what \
+         decides."
+    );
+    assert!(
+        !derived.is_empty(),
+        "no derives were found at all, which means the scanner is not reading the type"
+    );
+}
+
+#[test]
+fn lint_adaptive_event_implements_no_traits() {
+    // The third surface a name-based guard has to cover, and the one a re-export hides
+    // best: `impl EventWire for AdaptiveEvent` needs neither serde in the file nor a
+    // derive. AdaptiveEvent implements nothing by hand today, so the allowlist is empty.
+    let event = fs::read_to_string("src/producers/event.rs").expect("src/producers/event.rs");
+    let impls = trait_impls_for(&code_only(&event), "AdaptiveEvent");
+    assert!(
+        impls.is_empty(),
+        "AdaptiveEvent has hand-written trait impls: {impls:?}\n\
+         None are expected. If one becomes necessary, allow it here having checked it is \
+         not a serialization trait under another name."
+    );
+}
+
+#[test]
 fn lint_the_internal_event_module_imports_no_serialization_trait() {
     // The structural half, and the one that makes aliasing moot rather than merely detected.
     //
@@ -1034,6 +1283,192 @@ fn a_non_serializing_adaptive_event_is_accepted() {
             "the scanner invented a serialization derive in:\n{source}\nfound: {offenders:?}"
         );
     }
+}
+
+#[test]
+fn a_crate_local_re_export_is_rejected_by_the_allowlists() {
+    // The exploit CodeRabbit supplied at `993d35e`, verbatim in shape. `src/wire.rs` does
+    // `pub use serde::Serialize as EventWire;` and `event.rs` imports `crate::wire::EventWire`
+    // — no `serde` anywhere in the file, and nothing short of a real name resolver learns
+    // what `EventWire` is. Verified by compiling it: the build was clean and all 24 lints
+    // passed.
+    //
+    // The allowlists do not try to learn. They refuse the import and refuse the derive.
+    let re_export_derive = "use crate::wire::EventWire;\nuse std::sync::Arc;\n#[derive(EventWire)]\npub enum AdaptiveEvent {\n}\n";
+    let imports = imports_in(&code_only(re_export_derive));
+    assert!(
+        imports
+            .iter()
+            .any(|import| !EVENT_ALLOWED_IMPORTS.contains(&import.as_str())),
+        "the re-exported import was admitted: {imports:?}"
+    );
+    let attributes = attributes_attached_to(re_export_derive, ADAPTIVE_EVENT_DECLARATION)
+        .expect("declaration found");
+    let derived: Vec<String> = attributes.iter().flat_map(|a| derive_tokens(a)).collect();
+    assert!(
+        derived
+            .iter()
+            .any(|token| !ADAPTIVE_EVENT_ALLOWED_DERIVES.contains(&token.as_str())),
+        "the re-exported derive was admitted: {derived:?}"
+    );
+
+    // A derive by fully-qualified path needs no import at all, so the import allowlist
+    // alone would not have closed it.
+    let qualified = "#[derive(crate::wire::EventWire)]\npub enum AdaptiveEvent {\n}\n";
+    let attributes =
+        attributes_attached_to(qualified, ADAPTIVE_EVENT_DECLARATION).expect("declaration");
+    let derived: Vec<String> = attributes.iter().flat_map(|a| derive_tokens(a)).collect();
+    assert!(
+        derived
+            .iter()
+            .any(|token| !ADAPTIVE_EVENT_ALLOWED_DERIVES.contains(&token.as_str())),
+        "a fully-qualified re-exported derive was admitted: {derived:?}"
+    );
+
+    // The hand-written form, which has the same gap and no derive to catch.
+    for source in [
+        "use crate::wire::EventWire;\nimpl EventWire for AdaptiveEvent {}\n",
+        "impl crate::wire::EventWire for AdaptiveEvent {}\n",
+        "impl<'de> crate::wire::EventRead<'de> for AdaptiveEvent {}\n",
+    ] {
+        let impls = trait_impls_for(&code_only(source), "AdaptiveEvent");
+        assert!(
+            !impls.is_empty(),
+            "a re-exported hand-written impl was admitted:\n{source}"
+        );
+    }
+}
+
+#[test]
+fn the_allowlists_accept_the_module_as_it_actually_is() {
+    // Positive control, and the one that keeps the allowlists honest rather than merely
+    // strict: the real module must pass without exception. A list that only ever fails is
+    // as useless as one that only ever passes.
+    let event = fs::read_to_string("src/producers/event.rs").expect("src/producers/event.rs");
+    let code = code_only(&event);
+
+    for import in imports_in(&code) {
+        assert!(
+            EVENT_ALLOWED_IMPORTS.contains(&import.as_str()),
+            "the allowlist rejects an import the module legitimately has: {import:?}"
+        );
+    }
+    assert!(
+        trait_impls_for(&code, "AdaptiveEvent").is_empty(),
+        "the impl scanner invented an impl in the real module"
+    );
+
+    // And an unrelated impl for a *different* type in the same file must not register.
+    let other = "impl Default for AdaptiveBus {}\nimpl AdaptiveEvent {}\n";
+    assert!(
+        trait_impls_for(other, "AdaptiveEvent").is_empty(),
+        "an inherent impl or another type's impl was counted: {:?}",
+        trait_impls_for(other, "AdaptiveEvent")
+    );
+}
+
+#[test]
+fn raw_strings_do_not_break_the_shared_lexer() {
+    // A raw string ends at `"` followed by its own hash count, not at the first `"`. A
+    // scanner that leaves string mode at an embedded quote then reads the following `]` as
+    // the attribute close, so the attribute ends early, the next wrapped attribute is never
+    // joined, and the line walk discards it. Found by CodeRabbit at `993d35e`, which also
+    // supplied the working exploit.
+    let raw_then_wrapped = "#[doc = r##\"quote: \" then ] remains data\"##]\n\
+                            #[cfg_attr(\n    feature = \"x\",\n    derive(serde::Serialize)\n)]\n\
+                            pub enum AdaptiveEvent {\n}\n";
+
+    // Asserted on the property rather than on exact spacing: the wrapped attribute and its
+    // derive must end up on one line. Indentation inside the attribute is preserved, so a
+    // literal comparison would pin formatting rather than behaviour.
+    let joined = join_wrapped_attributes(raw_then_wrapped);
+    let cfg_line = joined
+        .lines()
+        .find(|line| line.contains("#[cfg_attr("))
+        .unwrap_or_default();
+    assert!(
+        cfg_line.contains("derive(serde::Serialize)") && cfg_line.trim_end().ends_with(")]"),
+        "a raw string ended the attribute early, so the wrapped derive was never joined:\n{joined}"
+    );
+
+    let names = serialization_names(raw_then_wrapped);
+    let attributes = attributes_attached_to(raw_then_wrapped, ADAPTIVE_EVENT_DECLARATION)
+        .expect("declaration found");
+    assert!(
+        attributes
+            .iter()
+            .any(|attribute| introduces_serialization(attribute, &names).is_some()),
+        "a raw doc attribute hid a serializing derive:\n{attributes:?}"
+    );
+
+    // The same limitation in `code_only`: a `//` or `/*` inside a raw string is data, not a
+    // comment, and treating it as one silently deletes the rest of the line.
+    let raw_with_comment_markers = "#[doc = r\"a // b /* c\"]\nuse crate::adaptive::X;\n";
+    assert!(
+        code_only(raw_with_comment_markers).contains("use crate::adaptive::X;"),
+        "a raw string containing comment markers swallowed the code after it: {:?}",
+        code_only(raw_with_comment_markers)
+    );
+
+    // Hash-count matching: an inner `"#` must not terminate a `r##"…"##` literal.
+    let nested_hashes = "#[doc = r##\"ends with \"# not here\"##]\n#[derive(Serialize)]\npub enum AdaptiveEvent {\n}\n";
+    let attributes =
+        attributes_attached_to(nested_hashes, ADAPTIVE_EVENT_DECLARATION).expect("declaration");
+    assert!(
+        attributes.iter().any(|attribute| introduces_serialization(
+            attribute,
+            &["Serialize".to_string()]
+        )
+        .is_some()),
+        "hash-count matching failed, hiding the derive:\n{attributes:?}"
+    );
+
+    // Char literals are the same class: `']'` is data, not a bracket.
+    let char_bracket =
+        "#[doc = \"x\"]\n#[cfg_attr(all(unix), derive(Serialize))]\npub enum AdaptiveEvent {\n}\n";
+    let attributes =
+        attributes_attached_to(char_bracket, ADAPTIVE_EVENT_DECLARATION).expect("declaration");
+    assert!(
+        attributes.iter().any(|attribute| introduces_serialization(
+            attribute,
+            &["Serialize".to_string()]
+        )
+        .is_some()),
+        "attribute scan lost the derive:\n{attributes:?}"
+    );
+}
+
+#[test]
+fn raw_string_lexing_does_not_over_consume() {
+    // Positive controls for the lexer. Over-consuming is as bad as under-consuming: it would
+    // swallow real code into a phantom string and hide whatever came next.
+    let ordinary = "#[doc = \"plain\"]\n#[derive(Debug)]\npub enum AdaptiveEvent {\n}\n";
+    let attributes =
+        attributes_attached_to(ordinary, ADAPTIVE_EVENT_DECLARATION).expect("declaration");
+    assert_eq!(
+        attributes.len(),
+        2,
+        "ordinary strings mis-lexed: {attributes:?}"
+    );
+
+    // `r` as the tail of an identifier is not a raw-string prefix.
+    let identifier_r = "let counter = 1; let other = \"x\";\nuse crate::adaptive::Y;\n";
+    assert!(
+        code_only(identifier_r).contains("use crate::adaptive::Y;"),
+        "an identifier ending in `r` was read as a raw string: {:?}",
+        code_only(identifier_r)
+    );
+
+    // A lifetime is not a char literal.
+    let lifetime = "impl<'de> Deserialize<'de> for AdaptiveEvent {}\n";
+    assert!(
+        handwritten_serialization_impl(lifetime, "AdaptiveEvent", &["Deserialize".to_string()])
+            .is_some(),
+        "a lifetime was mistaken for a char literal and lost the impl"
+    );
+
+    // Comments still get stripped when they are actually comments.
+    assert!(!code_only("// crate::adaptive\nlet x = 1;\n").contains("crate::adaptive"));
 }
 
 #[test]

--- a/tests/adaptive_publication_lint.rs
+++ b/tests/adaptive_publication_lint.rs
@@ -237,38 +237,46 @@ fn lint_the_sse_projection_does_not_mention_the_publication_layer() {
 // =============================================================================
 
 #[test]
-fn lint_surfaces_do_not_import_the_contract_or_the_publication_layer() {
-    // `ProducerDocument` derives `Serialize`, so a single `Json(snapshot)` in a handler
-    // re-exports the whole contract. `src/main.rs` is deliberately not listed: it is the
-    // composition root and must name both to wire them together.
-    const SURFACES: &[&str] = &[
-        "src/api",
-        "src/mcp",
-        "src/app",
-        "src/knobs",
-        "src/devices",
-        "src/components",
-    ];
+fn lint_only_the_composition_root_names_the_contract_or_the_publication_layer() {
+    // Swept over *all* of `src/` rather than an enumerated list of surfaces. An enumerated
+    // list is the same shape of blind spot that has now been remediated twice in
+    // `tests/adaptive_dependency_lint.rs`: it silently stops covering whatever is added
+    // next. The first draft of this lint listed six directories and omitted `src/mqtt`,
+    // which publishes to Home Assistant — an out-of-repository consumer, and therefore the
+    // single worst omission available.
+    //
+    // Exempt, with reasons:
+    //   src/adaptive, src/producers — the layers themselves
+    //   src/lib.rs, src/main.rs     — the composition root, which must name both to wire them
+    const EXEMPT: &[&str] = &["src/adaptive", "src/producers", "src/lib.rs", "src/main.rs"];
     let mut violations = Vec::new();
-    for surface in SURFACES {
-        for (path, text) in sources_under(surface) {
-            let code = code_only(&text);
-            for needle in [
-                "crate::adaptive",
-                "crate::producers",
-                "unified_hifi_control::adaptive",
-                "unified_hifi_control::producers",
-            ] {
-                if code.contains(needle) {
-                    violations.push(format!("{path}: references `{needle}`"));
-                }
+    let mut swept = 0usize;
+    for (path, text) in sources_under("src") {
+        if EXEMPT.iter().any(|exempt| path.starts_with(exempt)) {
+            continue;
+        }
+        swept += 1;
+        let code = code_only(&text);
+        for needle in [
+            "crate::adaptive",
+            "crate::producers",
+            "unified_hifi_control::adaptive",
+            "unified_hifi_control::producers",
+        ] {
+            if code.contains(needle) {
+                violations.push(format!("{path}: references `{needle}`"));
             }
         }
     }
     assert!(
+        swept > 50,
+        "the sweep covered only {swept} files, which means it is not actually walking src/"
+    );
+    assert!(
         violations.is_empty(),
-        "#324 publishes to in-repository consumers only. A surface reading the producer \
-         document is #326's decision and needs its own API approval:\n{}",
+        "#324 publishes to in-repository consumers only, and `ProducerDocument` derives \
+         `Serialize` — one `Json(snapshot)` re-exports the whole contract. A surface reading \
+         the producer document is #326's decision and needs its own API approval:\n{}",
         violations.join("\n")
     );
 }

--- a/tests/adaptive_publication_lint.rs
+++ b/tests/adaptive_publication_lint.rs
@@ -226,14 +226,25 @@ fn char_literal_end(chars: &[char], index: usize) -> Option<usize> {
         return None;
     }
     if chars.get(index + 1) == Some(&'\\') {
+        // The escaped character comes first, then the closing quote. Scanning forward for
+        // "the next `'`" stops at the *escaped* apostrophe in `'\''` and leaves a dangling
+        // quote behind that reads as the start of another literal. Found by Codex at
+        // `20926e1`.
         let mut scan = index + 2;
-        while scan < chars.len() {
-            if chars[scan] == '\'' {
-                return Some(scan + 1);
+        if chars.get(scan) == Some(&'u') && chars.get(scan + 1) == Some(&'{') {
+            scan += 2;
+            while scan < chars.len() && chars[scan] != '}' {
+                scan += 1;
             }
             scan += 1;
+        } else {
+            scan += 1;
         }
-        return None;
+        return if chars.get(scan) == Some(&'\'') {
+            Some(scan + 1)
+        } else {
+            None
+        };
     }
     if chars.get(index + 2) == Some(&'\'') {
         return Some(index + 3);
@@ -250,7 +261,15 @@ fn starts_a_literal(chars: &[char], index: usize) -> bool {
 fn literal_end(chars: &[char], index: usize) -> Option<usize> {
     match chars.get(index) {
         Some('"') => string_literal_end(chars, index),
-        Some('r') | Some('b') if starts_a_literal(chars, index) => string_literal_end(chars, index),
+        Some('r') if starts_a_literal(chars, index) => string_literal_end(chars, index),
+        // `b'x'` is a byte-char literal; `b"…"` and `br#"…"#` are byte strings.
+        Some('b') if starts_a_literal(chars, index) => {
+            if chars.get(index + 1) == Some(&'\'') {
+                char_literal_end(chars, index + 1)
+            } else {
+                string_literal_end(chars, index)
+            }
+        }
         Some('\'') => char_literal_end(chars, index),
         _ => None,
     }
@@ -268,12 +287,8 @@ fn imports_in(code: &str) -> Vec<String> {
     let mut index = 0usize;
 
     while index < chars.len() {
-        let at_boundary = index == 0
-            || matches!(chars[index - 1], ' ' | ';' | '{' | '}' | '\n')
-                && !(index >= 2 && chars[index - 2].is_alphanumeric() && chars[index - 1] == ' ');
         let is_use = chars[index..].starts_with(&['u', 's', 'e', ' ']);
-        // `pub use …` counts too; the boundary check sits before `pub`.
-        if is_use && at_boundary {
+        if is_use && starts_a_use_statement(&chars, index) {
             let mut scan = index;
             while scan < chars.len() && chars[scan] != ';' {
                 scan += 1;
@@ -286,6 +301,49 @@ fn imports_in(code: &str) -> Vec<String> {
         index += 1;
     }
     found
+}
+
+/// Whether the `use` at `index` opens a statement rather than ending an identifier.
+///
+/// The previous rule rejected "alphanumeric then space" before `use`, to stop `misuse` and
+/// prose from registering. It also rejected `pub use` — and *only* `pub use`, since
+/// `pub(crate) use` ends in `)` — so the plainest re-export form in Rust was invisible to
+/// the allowlist while its parenthesised siblings were caught. Wrong in the direction that
+/// passes. Found by Codex at `20926e1`.
+///
+/// Now: the `use` must not be the tail of an identifier, and whatever immediately precedes
+/// it must be a statement boundary or a visibility qualifier — `pub`, `pub(crate)`,
+/// `pub(super)`, `pub(in some::path)`.
+fn starts_a_use_statement(chars: &[char], index: usize) -> bool {
+    if index == 0 {
+        return true;
+    }
+    // `misuse ` must not count: `use` has to begin a word.
+    let previous = chars[index - 1];
+    if previous.is_alphanumeric() || previous == '_' {
+        return false;
+    }
+    if matches!(previous, ';' | '{' | '}' | '\n') {
+        return true;
+    }
+    if previous != ' ' {
+        return false;
+    }
+    // A space precedes it. Accept only a statement start or a visibility qualifier.
+    let before: String = chars[..index - 1].iter().collect();
+    let head = before.trim_end();
+    if head.is_empty() {
+        return true;
+    }
+    if head.ends_with(';') || head.ends_with('{') || head.ends_with('}') {
+        return true;
+    }
+    let last_word = head
+        .rsplit(|c: char| c == ';' || c == '{' || c == '}' || c == '\n')
+        .next()
+        .unwrap_or_default()
+        .trim();
+    last_word == "pub" || (last_word.starts_with("pub(") && last_word.ends_with(')'))
 }
 
 /// Every trait implemented for `type_name` in `code`, as written.
@@ -1422,19 +1480,143 @@ fn raw_strings_do_not_break_the_shared_lexer() {
         .is_some()),
         "hash-count matching failed, hiding the derive:\n{attributes:?}"
     );
+}
 
-    // Char literals are the same class: `']'` is data, not a bracket.
-    let char_bracket =
-        "#[doc = \"x\"]\n#[cfg_attr(all(unix), derive(Serialize))]\npub enum AdaptiveEvent {\n}\n";
-    let attributes =
-        attributes_attached_to(char_bracket, ADAPTIVE_EVENT_DECLARATION).expect("declaration");
+#[test]
+fn char_literals_are_data_not_brackets_or_quotes() {
+    // An earlier version of this file claimed to test char literals in a case whose source
+    // contained none — `#[doc = "x"]` is an ordinary string. Codex caught the mislabel and
+    // the real defect underneath it. These are actual char literals.
+    for (label, source) in [
+        // A bracket inside a char literal must not close the attribute.
+        (
+            "bracket",
+            "#[x = ']']\n#[derive(Serialize)]\npub enum AdaptiveEvent {\n}\n",
+        ),
+        // An escaped apostrophe. `char_literal_end` returned at the *escaped* quote rather
+        // than the closing one, leaving a dangling `'` that reads as another literal.
+        (
+            "escaped quote",
+            "#[x = '\\'']\n#[derive(Serialize)]\npub enum AdaptiveEvent {\n}\n",
+        ),
+        (
+            "escaped backslash",
+            "#[x = '\\\\']\n#[derive(Serialize)]\npub enum AdaptiveEvent {\n}\n",
+        ),
+        (
+            "byte char",
+            "#[x = b']']\n#[derive(Serialize)]\npub enum AdaptiveEvent {\n}\n",
+        ),
+        (
+            "unicode escape that is a closing bracket",
+            "#[x = '\\u{5D}']\n#[derive(Serialize)]\npub enum AdaptiveEvent {\n}\n",
+        ),
+    ] {
+        let attributes = attributes_attached_to(source, ADAPTIVE_EVENT_DECLARATION)
+            .unwrap_or_else(|| panic!("declaration not found for {label}:\n{source}"));
+        assert!(
+            attributes.iter().any(|attribute| introduces_serialization(
+                attribute,
+                &["Serialize".to_string()]
+            )
+            .is_some()),
+            "{label}: a char literal ate the derive:\n{attributes:?}"
+        );
+    }
+
+    // The lexer directly, so a failure names the cause rather than a symptom.
+    for (literal, expected) in [
+        ("']'", Some(3)),
+        ("'\\''", Some(4)),
+        ("'\\\\'", Some(4)),
+        ("'\\n'", Some(4)),
+        ("'\\u{5D}'", Some(8)),
+        ("'a'", Some(3)),
+    ] {
+        let chars: Vec<char> = literal.chars().collect();
+        assert_eq!(
+            char_literal_end(&chars, 0),
+            expected,
+            "char literal {literal:?} was mis-measured"
+        );
+    }
+
+    // Lifetimes are not char literals and must consume nothing.
+    for lifetime in ["'de", "'a", "'static"] {
+        let chars: Vec<char> = lifetime.chars().collect();
+        assert_eq!(
+            char_literal_end(&chars, 0),
+            None,
+            "lifetime {lifetime:?} was read as a char literal"
+        );
+    }
     assert!(
-        attributes.iter().any(|attribute| introduces_serialization(
-            attribute,
-            &["Serialize".to_string()]
+        handwritten_serialization_impl(
+            "impl<'de> Deserialize<'de> for AdaptiveEvent {}\n",
+            "AdaptiveEvent",
+            &["Deserialize".to_string()]
         )
-        .is_some()),
-        "attribute scan lost the derive:\n{attributes:?}"
+        .is_some(),
+        "a lifetime swallowed a hand-written impl"
+    );
+}
+
+#[test]
+fn visibility_qualified_use_statements_are_still_imports() {
+    // `pub use serde::Serialize as EventWire;` written directly in the module is the same
+    // re-export exploit as the previous round, one file closer. `imports_in` explicitly
+    // rejected "alphanumeric then space" before `use`, so `pub use` — and only `pub use` —
+    // was invisible, while `pub(crate) use` was caught because `)` is not alphanumeric.
+    // Inconsistent, and wrong in the direction that passes. Found by Codex at `20926e1`.
+    for (label, source) in [
+        ("plain", "use serde::Serialize as W;"),
+        ("pub", "pub use serde::Serialize as W;"),
+        ("pub(crate)", "pub(crate) use serde::Serialize as W;"),
+        ("pub(super)", "pub(super) use serde::Deserialize as R;"),
+        (
+            "pub(in path)",
+            "pub(in crate::producers) use serde::Serialize as W;",
+        ),
+        ("indented pub", "    pub use serde::Serialize as W;"),
+    ] {
+        let found = imports_in(&code_only(source));
+        assert_eq!(
+            found.len(),
+            1,
+            "{label}: a visibility-qualified use was missed: {found:?}\n{source}"
+        );
+        assert!(
+            !EVENT_ALLOWED_IMPORTS.contains(&found[0].as_str()),
+            "{label}: the allowlist admitted a re-export: {found:?}"
+        );
+    }
+}
+
+#[test]
+fn the_import_scanner_does_not_invent_imports() {
+    // The other direction. `use` appears inside identifiers and prose, and a scanner that
+    // fires on those makes the allowlist unmaintainable — which is how it ends up deleted.
+    for (label, source) in [
+        (
+            "identifier containing use",
+            "let misuse = 1;\nlet reuse_count = 2;\n",
+        ),
+        ("word in a string literal", "let s = \"please use this\";\n"),
+        ("method named use_default", "thing.use_default();\n"),
+    ] {
+        let found = imports_in(&code_only(source));
+        assert!(
+            found.is_empty(),
+            "{label}: the scanner invented an import: {found:?}\n{source}"
+        );
+    }
+
+    // Prose is stripped before the scan, so a doc comment mentioning `use` is not one.
+    let prose = "/// callers use crate::adaptive::X for this\nuse std::sync::Arc;\n";
+    assert_eq!(
+        imports_in(&code_only(prose)),
+        vec!["use std::sync::Arc;".to_string()],
+        "a doc comment was read as an import"
     );
 }
 

--- a/tests/adaptive_publication_lint.rs
+++ b/tests/adaptive_publication_lint.rs
@@ -79,7 +79,9 @@ use std::fs;
 use std::path::Path;
 use syn::punctuated::Punctuated;
 use syn::visit::{self, Visit};
-use syn::{Attribute, Expr, ExprLit, File, Item, ItemEnum, Lit, Meta, Token, UseTree};
+use syn::{
+    Attribute, Expr, ExprLit, File, Item, ItemEnum, Lit, Meta, Token, Type, UseTree, Visibility,
+};
 use walkdir::WalkDir;
 
 const EVENT_MODULE: &str = "src/producers/event.rs";
@@ -102,7 +104,7 @@ const EVENT_ALLOWED_IMPORTS: &[&str] = &[
     "super::admission::AdmissionRefusal",
     "super::admission::ProducerKey",
     "crate::adaptive::DocumentRevisions",
-    "crate::adaptive::ProducerDocument",
+    "crate::adaptive::ProducerEpoch",
 ];
 
 /// Exactly what `AdaptiveEvent` may derive.
@@ -550,6 +552,486 @@ fn trait_impls_for(file: &File, type_name: &str) -> Vec<String> {
     };
     visitor.visit_file(file);
     visitor.found
+}
+
+/// Every alias in `file` that gives the internal event a second name.
+///
+/// [`trait_impls_for`] matches an impl's self type by its last path segment against the literal
+/// `AdaptiveEvent`. So this implements a serialization trait for the internal event while every
+/// allowlist in `event.rs` stays clean and the crate-wide impl sweep sees an impl for a type it
+/// has never heard of:
+///
+/// ```ignore
+/// type Ev = AdaptiveEvent;
+/// impl serde::Serialize for Ev { /* ... */ }
+/// ```
+///
+/// **Prohibited rather than resolved.** Following aliases needs name resolution, which this
+/// file deliberately does not attempt — a half-built resolver would fail silently, which is the
+/// one outcome a lint must never have. The alias is banned instead: if the internal event can
+/// only ever be spelled `AdaptiveEvent`, matching that single spelling is sufficient. The cost
+/// is a rule to be told about; the benefit is that the guarantee does not depend on this test
+/// file being cleverer than the next escape.
+fn adaptive_event_aliases(file: &File) -> Vec<String> {
+    #[derive(Default)]
+    struct AliasVisitor {
+        found: Vec<String>,
+    }
+    impl<'ast> Visit<'ast> for AliasVisitor {
+        fn visit_item_type(&mut self, item: &'ast syn::ItemType) {
+            if type_tail_is(&item.ty, ADAPTIVE_EVENT) {
+                self.found
+                    .push(format!("type {} = {ADAPTIVE_EVENT}", item.ident));
+            }
+            visit::visit_item_type(self, item);
+        }
+        fn visit_item_use(&mut self, item: &'ast syn::ItemUse) {
+            for leaf in flatten_use_tree(&item.tree) {
+                let Some((original, rename)) = leaf.split_once(" as ") else {
+                    continue;
+                };
+                if original.rsplit("::").next() == Some(ADAPTIVE_EVENT) {
+                    self.found.push(format!("use {ADAPTIVE_EVENT} as {rename}"));
+                }
+            }
+            visit::visit_item_use(self, item);
+        }
+    }
+    let mut visitor = AliasVisitor::default();
+    visitor.visit_file(file);
+    visitor.found
+}
+
+/// Whether `ty` is a path type whose final segment is `name`.
+fn type_tail_is(ty: &Type, name: &str) -> bool {
+    struct TailVisitor<'a> {
+        name: &'a str,
+        found: bool,
+    }
+    impl<'ast> Visit<'ast> for TailVisitor<'_> {
+        fn visit_type_path(&mut self, path: &'ast syn::TypePath) {
+            if path
+                .path
+                .segments
+                .last()
+                .is_some_and(|segment| segment.ident == self.name)
+            {
+                self.found = true;
+            }
+            visit::visit_type_path(self, path);
+        }
+    }
+    let mut visitor = TailVisitor { name, found: false };
+    visitor.visit_type(ty);
+    visitor.found
+}
+
+/// Whether a `::`-joined path names a forbidden module as a whole segment.
+///
+/// Split on separators and compared for equality, so `adaptive_extras` is not `adaptive` — the
+/// same boundary-anchoring [`is_sweep_exempt`] applies to directory names.
+fn path_names_forbidden_module(path: &str) -> bool {
+    path.split(" as ")
+        .next()
+        .unwrap_or(path)
+        .split("::")
+        .any(|segment| FORBIDDEN_MODULES.contains(&segment.trim()))
+}
+
+/// Exported re-exports and aliases that launder a forbidden module's types through a root.
+///
+/// `src/lib.rs` and `src/main.rs` are exempt from both reference sweeps, because the
+/// composition root must name `producers` to construct the aggregator. That exemption is a hole
+/// if the root may also *re-export*: this in `lib.rs`
+///
+/// ```ignore
+/// pub use crate::adaptive::ProducerDocument as Doc;
+/// ```
+///
+/// lets `src/api/mod.rs` write `use crate::Doc;` and `Json(doc)`, which names neither forbidden
+/// module and so passes [`forbidden_module_references`] untouched — publishing the v1 contract
+/// from a public endpoint with every lint green.
+///
+/// Exported uses, aliases, functions, constants and statics are covered. Visibility is what
+/// makes a root item reachable from another module; private helpers remain composition details.
+/// Type syntax is traversed recursively, so wrapping a forbidden type does not launder it.
+fn root_launderings(file: &File) -> Vec<String> {
+    #[derive(Default)]
+    struct AliasCollector<'ast> {
+        aliases: Vec<(String, &'ast Type)>,
+        imports: Vec<(String, String)>,
+        macros: std::collections::BTreeSet<String>,
+    }
+    impl<'ast> Visit<'ast> for AliasCollector<'ast> {
+        fn visit_item_type(&mut self, item: &'ast syn::ItemType) {
+            self.aliases.push((item.ident.to_string(), &item.ty));
+            visit::visit_item_type(self, item);
+        }
+        fn visit_item_use(&mut self, item: &'ast syn::ItemUse) {
+            for leaf in flatten_use_tree(&item.tree) {
+                let (source, introduced) = leaf.split_once(" as ").map_or_else(
+                    || (leaf.as_str(), leaf.rsplit("::").next().unwrap_or(&leaf)),
+                    |(source, rename)| (source, rename),
+                );
+                self.imports
+                    .push((introduced.to_string(), source.to_string()));
+            }
+            visit::visit_item_use(self, item);
+        }
+        fn visit_item_macro(&mut self, item: &'ast syn::ItemMacro) {
+            if let Some(name) = &item.ident {
+                self.macros.insert(name.to_string());
+            }
+            visit::visit_item_macro(self, item);
+        }
+    }
+    let mut collector = AliasCollector::default();
+    collector.visit_file(file);
+    let mut tainted_aliases = std::collections::BTreeSet::new();
+    loop {
+        let before = tainted_aliases.len();
+        for (name, ty) in &collector.aliases {
+            if type_names_forbidden_module_or_alias(ty, &tainted_aliases) {
+                tainted_aliases.insert(name.clone());
+            }
+        }
+        for (introduced, source) in &collector.imports {
+            if path_names_forbidden_module(source)
+                || source
+                    .split("::")
+                    .any(|segment| tainted_aliases.contains(segment))
+            {
+                tainted_aliases.insert(introduced.clone());
+            }
+        }
+        if tainted_aliases.len() == before {
+            break;
+        }
+    }
+
+    struct RootVisitor<'a> {
+        found: Vec<String>,
+        tainted_aliases: &'a std::collections::BTreeSet<String>,
+        macro_names: &'a std::collections::BTreeSet<String>,
+    }
+    impl RootVisitor<'_> {
+        fn type_is_forbidden(&self, ty: &Type) -> bool {
+            type_names_forbidden_module_or_alias(ty, self.tainted_aliases)
+        }
+
+        fn signature_is_forbidden(&self, signature: &syn::Signature) -> bool {
+            signature_names_forbidden_module_or_alias(signature, self.tainted_aliases)
+        }
+    }
+    impl<'ast> Visit<'ast> for RootVisitor<'_> {
+        fn visit_item_use(&mut self, item: &'ast syn::ItemUse) {
+            for leaf in flatten_use_tree(&item.tree) {
+                if !is_exported(&item.vis)
+                    && leaf.rsplit("::").next() == Some("*")
+                    && (path_names_forbidden_module(&leaf)
+                        || leaf
+                            .split("::")
+                            .any(|segment| self.tainted_aliases.contains(segment)))
+                {
+                    self.found
+                        .push(format!("private glob from forbidden module {leaf}"));
+                }
+                if is_exported(&item.vis) {
+                    if path_names_forbidden_module(&leaf)
+                        || leaf
+                            .split("::")
+                            .any(|segment| self.tainted_aliases.contains(segment))
+                    {
+                        self.found.push(format!("exported use {leaf}"));
+                    }
+                    let source = leaf
+                        .split_once(" as ")
+                        .map_or(leaf.as_str(), |(source, _)| source);
+                    if source
+                        .rsplit("::")
+                        .next()
+                        .is_some_and(|name| self.macro_names.contains(name))
+                    {
+                        self.found.push(format!("exported macro use {leaf}"));
+                    }
+                }
+            }
+            visit::visit_item_use(self, item);
+        }
+        fn visit_item_type(&mut self, item: &'ast syn::ItemType) {
+            if is_exported(&item.vis)
+                && (self.type_is_forbidden(&item.ty)
+                    || generics_names_forbidden_module_or_alias(
+                        &item.generics,
+                        self.tainted_aliases,
+                    ))
+            {
+                self.found.push(format!("exported type {}", item.ident));
+            }
+            visit::visit_item_type(self, item);
+        }
+        fn visit_item_fn(&mut self, item: &'ast syn::ItemFn) {
+            if is_exported(&item.vis) && self.signature_is_forbidden(&item.sig) {
+                self.found.push(format!("exported fn {}", item.sig.ident));
+            }
+            visit::visit_item_fn(self, item);
+        }
+        fn visit_item_struct(&mut self, item: &'ast syn::ItemStruct) {
+            if is_exported(&item.vis)
+                && (generics_names_forbidden_module_or_alias(&item.generics, self.tainted_aliases)
+                    || item
+                        .fields
+                        .iter()
+                        .any(|field| is_exported(&field.vis) && self.type_is_forbidden(&field.ty)))
+            {
+                self.found.push(format!("exported struct {}", item.ident));
+            }
+            visit::visit_item_struct(self, item);
+        }
+        fn visit_item_enum(&mut self, item: &'ast syn::ItemEnum) {
+            if is_exported(&item.vis)
+                && (generics_names_forbidden_module_or_alias(&item.generics, self.tainted_aliases)
+                    || item
+                        .variants
+                        .iter()
+                        .flat_map(|variant| variant.fields.iter())
+                        .any(|field| self.type_is_forbidden(&field.ty)))
+            {
+                self.found.push(format!("exported enum {}", item.ident));
+            }
+            visit::visit_item_enum(self, item);
+        }
+        fn visit_item_union(&mut self, item: &'ast syn::ItemUnion) {
+            if is_exported(&item.vis)
+                && (generics_names_forbidden_module_or_alias(&item.generics, self.tainted_aliases)
+                    || item
+                        .fields
+                        .named
+                        .iter()
+                        .any(|field| is_exported(&field.vis) && self.type_is_forbidden(&field.ty)))
+            {
+                self.found.push(format!("exported union {}", item.ident));
+            }
+            visit::visit_item_union(self, item);
+        }
+        fn visit_item_trait(&mut self, item: &'ast syn::ItemTrait) {
+            if is_exported(&item.vis)
+                && (generics_names_forbidden_module_or_alias(&item.generics, self.tainted_aliases)
+                    || bounds_name_forbidden_module_or_alias(
+                        &item.supertraits,
+                        self.tainted_aliases,
+                    )
+                    || item.items.iter().any(|trait_item| match trait_item {
+                        syn::TraitItem::Fn(method) => self.signature_is_forbidden(&method.sig),
+                        syn::TraitItem::Const(item) => self.type_is_forbidden(&item.ty),
+                        syn::TraitItem::Type(item) => {
+                            trait_item_type_names_forbidden_module_or_alias(
+                                item,
+                                self.tainted_aliases,
+                            )
+                        }
+                        _ => false,
+                    }))
+            {
+                self.found.push(format!("exported trait {}", item.ident));
+            }
+            visit::visit_item_trait(self, item);
+        }
+        fn visit_item_impl(&mut self, item: &'ast syn::ItemImpl) {
+            if generics_names_forbidden_module_or_alias(&item.generics, self.tainted_aliases)
+                || self.type_is_forbidden(&item.self_ty)
+                || item.trait_.as_ref().is_some_and(|(_, path, _)| {
+                    syn_path_names_forbidden_module_or_alias(path, self.tainted_aliases)
+                })
+            {
+                self.found.push("impl on forbidden type".to_string());
+            }
+            let trait_impl = item.trait_.is_some();
+            for impl_item in &item.items {
+                match impl_item {
+                    syn::ImplItem::Fn(method)
+                        if (trait_impl || is_exported(&method.vis))
+                            && self.signature_is_forbidden(&method.sig) =>
+                    {
+                        self.found
+                            .push(format!("exported method {}", method.sig.ident));
+                    }
+                    syn::ImplItem::Const(item)
+                        if (trait_impl || is_exported(&item.vis))
+                            && self.type_is_forbidden(&item.ty) =>
+                    {
+                        self.found
+                            .push(format!("exported associated const {}", item.ident));
+                    }
+                    syn::ImplItem::Type(item) if self.type_is_forbidden(&item.ty) => {
+                        self.found
+                            .push(format!("exported associated type {}", item.ident));
+                    }
+                    _ => {}
+                }
+            }
+            visit::visit_item_impl(self, item);
+        }
+        fn visit_item_foreign_mod(&mut self, item: &'ast syn::ItemForeignMod) {
+            for foreign in &item.items {
+                match foreign {
+                    syn::ForeignItem::Fn(function)
+                        if is_exported(&function.vis)
+                            && self.signature_is_forbidden(&function.sig) =>
+                    {
+                        self.found
+                            .push(format!("exported foreign fn {}", function.sig.ident));
+                    }
+                    syn::ForeignItem::Static(item)
+                        if is_exported(&item.vis) && self.type_is_forbidden(&item.ty) =>
+                    {
+                        self.found
+                            .push(format!("exported foreign static {}", item.ident));
+                    }
+                    _ => {}
+                }
+            }
+            visit::visit_item_foreign_mod(self, item);
+        }
+        fn visit_item_const(&mut self, item: &'ast syn::ItemConst) {
+            if is_exported(&item.vis) && self.type_is_forbidden(&item.ty) {
+                self.found.push(format!("exported const {}", item.ident));
+            }
+            visit::visit_item_const(self, item);
+        }
+        fn visit_item_static(&mut self, item: &'ast syn::ItemStatic) {
+            if is_exported(&item.vis) && self.type_is_forbidden(&item.ty) {
+                self.found.push(format!("exported static {}", item.ident));
+            }
+            visit::visit_item_static(self, item);
+        }
+        fn visit_item_macro(&mut self, item: &'ast syn::ItemMacro) {
+            if item
+                .attrs
+                .iter()
+                .any(|attribute| attribute.path().is_ident("macro_export"))
+            {
+                self.found.push("exported macro".to_string());
+            }
+            if token_stream_names_forbidden_module_or_alias(&item.mac.tokens, self.tainted_aliases)
+            {
+                self.found
+                    .push("macro tokens name a forbidden type".to_string());
+            }
+            visit::visit_item_macro(self, item);
+        }
+    }
+    let mut visitor = RootVisitor {
+        found: Vec::new(),
+        tainted_aliases: &tainted_aliases,
+        macro_names: &collector.macros,
+    };
+    visitor.visit_file(file);
+    visitor.found
+}
+
+fn token_stream_names_forbidden_module_or_alias(
+    tokens: &proc_macro2::TokenStream,
+    aliases: &std::collections::BTreeSet<String>,
+) -> bool {
+    tokens.clone().into_iter().any(|token| match token {
+        proc_macro2::TokenTree::Ident(ident) => {
+            let ident = ident.to_string();
+            FORBIDDEN_MODULES.contains(&ident.as_str()) || aliases.contains(&ident)
+        }
+        proc_macro2::TokenTree::Group(group) => {
+            token_stream_names_forbidden_module_or_alias(&group.stream(), aliases)
+        }
+        proc_macro2::TokenTree::Punct(_) | proc_macro2::TokenTree::Literal(_) => false,
+    })
+}
+
+fn signature_names_forbidden_module_or_alias(
+    signature: &syn::Signature,
+    aliases: &std::collections::BTreeSet<String>,
+) -> bool {
+    let mut visitor = ForbiddenPathVisitor::new(aliases);
+    visitor.visit_signature(signature);
+    visitor.found
+}
+
+fn generics_names_forbidden_module_or_alias(
+    generics: &syn::Generics,
+    aliases: &std::collections::BTreeSet<String>,
+) -> bool {
+    let mut visitor = ForbiddenPathVisitor::new(aliases);
+    visitor.visit_generics(generics);
+    visitor.found
+}
+
+fn bounds_name_forbidden_module_or_alias(
+    bounds: &syn::punctuated::Punctuated<syn::TypeParamBound, syn::token::Plus>,
+    aliases: &std::collections::BTreeSet<String>,
+) -> bool {
+    let mut visitor = ForbiddenPathVisitor::new(aliases);
+    for bound in bounds {
+        visitor.visit_type_param_bound(bound);
+    }
+    visitor.found
+}
+
+fn trait_item_type_names_forbidden_module_or_alias(
+    item: &syn::TraitItemType,
+    aliases: &std::collections::BTreeSet<String>,
+) -> bool {
+    let mut visitor = ForbiddenPathVisitor::new(aliases);
+    visitor.visit_trait_item_type(item);
+    visitor.found
+}
+
+fn syn_path_names_forbidden_module_or_alias(
+    path: &syn::Path,
+    aliases: &std::collections::BTreeSet<String>,
+) -> bool {
+    let mut visitor = ForbiddenPathVisitor::new(aliases);
+    visitor.visit_path(path);
+    visitor.found
+}
+
+/// Whether a type's path names a forbidden module as a whole segment.
+fn type_names_forbidden_module_or_alias(
+    ty: &Type,
+    aliases: &std::collections::BTreeSet<String>,
+) -> bool {
+    let mut visitor = ForbiddenPathVisitor::new(aliases);
+    visitor.visit_type(ty);
+    visitor.found
+}
+
+struct ForbiddenPathVisitor<'a> {
+    found: bool,
+    aliases: &'a std::collections::BTreeSet<String>,
+}
+
+impl<'a> ForbiddenPathVisitor<'a> {
+    fn new(aliases: &'a std::collections::BTreeSet<String>) -> Self {
+        Self {
+            found: false,
+            aliases,
+        }
+    }
+}
+
+impl<'ast> Visit<'ast> for ForbiddenPathVisitor<'_> {
+    fn visit_path(&mut self, path: &'ast syn::Path) {
+        if path.segments.iter().any(|segment| {
+            FORBIDDEN_MODULES.contains(&segment.ident.to_string().as_str())
+                || self.aliases.contains(&segment.ident.to_string())
+        }) {
+            self.found = true;
+        }
+        visit::visit_path(self, path);
+    }
+}
+
+/// Whether this visibility makes a name reachable from another module.
+fn is_exported(vis: &Visibility) -> bool {
+    !matches!(vis, Visibility::Inherited)
 }
 
 /// Every `#[cfg(...)]` argument applying to module `name`, including from an enclosing
@@ -1179,6 +1661,586 @@ fn lint_no_module_anywhere_implements_a_trait_for_adaptive_event() {
          any module, so this guarantee cannot be enforced in one file. If an impl becomes \
          necessary, allow it here having checked it is not a serialization trait under \
          another name."
+    );
+}
+
+// =============================================================================
+// Boundary 4: a forbidden type cannot be renamed out of reach of the other three
+//
+// Every lint above matches a *name*: `AdaptiveEvent` for the impl sweeps, `adaptive` and
+// `producers` for the reference sweeps. A second name defeats all of them at once, and none of
+// them would report anything - the failure mode is a green test file, which is exactly the
+// class this file exists to stop reproducing. Rather than resolve aliases, the aliases are
+// banned; see `adaptive_event_aliases` and `root_launderings` for why that trade is the right
+// way round.
+// =============================================================================
+
+/// The files exempt from both reference sweeps, and therefore the ones that can launder.
+const ROOT_FILES: &[&str] = &["src/lib.rs", "src/main.rs"];
+
+#[test]
+fn an_alias_for_the_internal_event_is_rejected() {
+    // Mutation probes. Each is an escape that the impl sweeps alone cannot see, because the
+    // impl's self type is not spelled `AdaptiveEvent`.
+    for (label, source) in [
+        (
+            "a bare local alias plus a serde impl on it",
+            "type Ev = AdaptiveEvent;\nimpl serde::Serialize for Ev {}\n",
+        ),
+        (
+            "an alias written through the module path",
+            "type Ev = crate::producers::event::AdaptiveEvent;\n",
+        ),
+        (
+            "an alias reached through super",
+            "mod wire {\n    type Ev = super::AdaptiveEvent;\n}\n",
+        ),
+        (
+            "a renamed import",
+            "use crate::producers::event::AdaptiveEvent as Ev;\n",
+        ),
+        (
+            "a renamed import inside a grouped use tree",
+            "use crate::producers::event::{AdaptiveEvent as Ev, ProducerKey};\n",
+        ),
+        (
+            "an alias declared inside a nested module",
+            "mod outer {\n    mod inner {\n        type Ev = crate::producers::event::AdaptiveEvent;\n    }\n}\n",
+        ),
+    ] {
+        let file = parse_source("probe.rs", source);
+        assert!(
+            !adaptive_event_aliases(&file).is_empty(),
+            "{label}: an alias for the internal event went unreported:\n{source}"
+        );
+    }
+}
+
+#[test]
+fn a_type_that_merely_resembles_the_internal_event_is_not_rejected() {
+    // Near misses, so the prohibition cannot be satisfied by being indiscriminate.
+    for (label, source) in [
+        (
+            "a prefix-sharing type name",
+            "type Ev = AdaptiveEventLog;\n",
+        ),
+        (
+            "an import with no rename",
+            "use crate::producers::event::AdaptiveEvent;\n",
+        ),
+        (
+            "an unrelated alias",
+            "type Zones = std::collections::BTreeMap<String, Zone>;\n",
+        ),
+        (
+            "a rename of something else entirely",
+            "use serde::Serialize as S;\n",
+        ),
+    ] {
+        let file = parse_source("probe.rs", source);
+        assert!(
+            adaptive_event_aliases(&file).is_empty(),
+            "{label}: the alias prohibition over-reached: {:?}\n{source}",
+            adaptive_event_aliases(&file)
+        );
+    }
+}
+
+#[test]
+fn lint_no_source_aliases_the_internal_event() {
+    let mut violations = Vec::new();
+    let mut swept = 0usize;
+    for (path, text) in rust_sources_under("src") {
+        swept += 1;
+        let file = parse_source(&path, &text);
+        for alias in adaptive_event_aliases(&file) {
+            violations.push(format!("{path}: {alias}"));
+        }
+    }
+    assert!(
+        swept > 50,
+        "the sweep covered only {swept} files, which means it is not walking src/"
+    );
+    assert!(
+        violations.is_empty(),
+        "{ADAPTIVE_EVENT} is reachable under a second name, which defeats every impl and \
+         reference lint at once: {violations:?}\nName it directly, or extend the impl sweeps to \
+         follow the alias before allowing one."
+    );
+}
+
+#[test]
+fn a_root_reexport_of_a_forbidden_type_is_rejected() {
+    // The other half. These live in a file both reference sweeps skip, so nothing else looks.
+    for (label, source) in [
+        (
+            "a renamed pub use of a contract type",
+            "pub use crate::adaptive::ProducerDocument as Doc;\n",
+        ),
+        (
+            "an un-renamed pub use",
+            "pub use crate::adaptive::ProducerDocument;\n",
+        ),
+        (
+            "a pub(crate) use of the publication layer",
+            "pub(crate) use crate::producers::ProducerAggregator as Agg;\n",
+        ),
+        (
+            "a pub use of a whole forbidden module",
+            "pub use crate::adaptive;\n",
+        ),
+        (
+            "a public type alias",
+            "pub type Doc = crate::adaptive::ProducerDocument;\n",
+        ),
+        (
+            "a re-export nested in a public shim module",
+            "pub mod shim {\n    pub use crate::adaptive::ProducerDocument as D;\n}\n",
+        ),
+        (
+            "a grouped re-export hiding one forbidden leaf",
+            "pub use crate::{bus::BusEvent, adaptive::ProducerDocument as D};\n",
+        ),
+    ] {
+        let file = parse_source("probe.rs", source);
+        assert!(
+            !root_launderings(&file).is_empty(),
+            "{label}: a root re-export laundered a forbidden type:\n{source}"
+        );
+    }
+}
+
+#[test]
+fn a_root_use_that_launders_nothing_is_not_rejected() {
+    for (label, source) in [
+        (
+            "a private use, which no other module can reach",
+            "use crate::producers::ProducerAggregator;\n",
+        ),
+        (
+            "a public re-export of an unrelated module",
+            "pub use crate::bus::BusEvent;\n",
+        ),
+        (
+            "a prefix-sharing sibling module",
+            "pub use crate::adaptive_extras::Helper;\n",
+        ),
+        (
+            "a public alias of an unrelated type",
+            "pub type Zones = crate::bus::ZoneMap;\n",
+        ),
+    ] {
+        let file = parse_source("probe.rs", source);
+        assert!(
+            root_launderings(&file).is_empty(),
+            "{label}: the re-export prohibition over-reached: {:?}\n{source}",
+            root_launderings(&file)
+        );
+    }
+}
+
+#[test]
+fn the_impl_sweep_alone_is_blind_to_an_aliased_serde_impl() {
+    // The reason the prohibition exists rather than an extension of `trait_impls_for`, kept as
+    // an executable statement rather than a claim in a comment. If `trait_impls_for` ever
+    // learns to resolve aliases, this fails and the prohibition can be reconsidered - which is
+    // the right way for that decision to come back up.
+    let source = "type Ev = AdaptiveEvent;\nimpl serde::Serialize for Ev {}\n";
+    let file = parse_source("probe.rs", source);
+    assert!(
+        trait_impls_for(&file, ADAPTIVE_EVENT).is_empty(),
+        "trait_impls_for now sees through an alias, so the alias prohibition may be redundant"
+    );
+    assert!(
+        !adaptive_event_aliases(&file).is_empty(),
+        "an escape no other lint can see must be caught by the alias prohibition"
+    );
+}
+
+#[test]
+fn the_reference_sweep_alone_is_blind_to_a_laundered_root_reexport() {
+    // The surface half of the escape: `crate::Doc` names neither forbidden module, so the
+    // sweep over `src/` has nothing to report even though this is a contract type in a
+    // serializable position.
+    let surface = parse_source("probe.rs", "use crate::Doc;\nfn f(d: Doc) -> Doc { d }\n");
+    assert!(
+        forbidden_module_references(&surface, module_depth("src/api/mod.rs")).is_empty(),
+        "the reference sweep now resolves a laundered alias, so the root prohibition may be \
+         redundant"
+    );
+    // Which is why it has to be stopped where it is created.
+    let root = parse_source(
+        "src/lib.rs",
+        "pub use crate::adaptive::ProducerDocument as Doc;\n",
+    );
+    assert!(
+        !root_launderings(&root).is_empty(),
+        "the escape must be caught at the root that creates the name"
+    );
+}
+
+#[test]
+fn lint_the_composition_root_launders_no_forbidden_type() {
+    let mut violations = Vec::new();
+    let mut checked = 0usize;
+    for path in ROOT_FILES {
+        let Ok(text) = fs::read_to_string(path) else {
+            continue;
+        };
+        checked += 1;
+        let file = parse_source(path, &text);
+        for laundering in root_launderings(&file) {
+            violations.push(format!("{path}: {laundering}"));
+        }
+    }
+    assert_eq!(
+        checked,
+        ROOT_FILES.len(),
+        "a composition root named in ROOT_FILES was not found, so this lint checked {checked} \
+         of {} files and would pass by reading nothing",
+        ROOT_FILES.len()
+    );
+    assert!(
+        violations.is_empty(),
+        "a crate root re-exports a contract or publication type under a name the reference \
+         sweeps cannot see: {violations:?}\nThe roots are exempt from those sweeps precisely \
+         because they must name these modules to wire them; that exemption does not extend to \
+         handing the names onward."
+    );
+}
+
+#[test]
+fn red_alias_prohibition_sees_through_non_path_type_syntax() {
+    // The alias checker matched only `Type::Path`, so any wrapping syntax slipped past it and
+    // took the impl sweep with it - the impl's self type is then not spelled `AdaptiveEvent`.
+    for (label, source) in [
+        (
+            "a parenthesised alias",
+            "type Ev = (AdaptiveEvent);\nimpl serde::Serialize for Ev {}\n",
+        ),
+        (
+            "a doubly parenthesised alias",
+            "type Ev = ((AdaptiveEvent));\n",
+        ),
+        (
+            "the event as a generic argument",
+            "type Ev = Box<AdaptiveEvent>;\n",
+        ),
+        (
+            "the event inside a nested generic argument",
+            "type Ev = Result<Vec<AdaptiveEvent>, ()>;\n",
+        ),
+        (
+            "the event behind a reference",
+            "type Ev = &'static AdaptiveEvent;\n",
+        ),
+        ("the event in a tuple", "type Ev = (AdaptiveEvent, u8);\n"),
+    ] {
+        let file = parse_source("probe.rs", source);
+        assert!(
+            !adaptive_event_aliases(&file).is_empty(),
+            "{label}: an alias for the internal event went unreported:\n{source}"
+        );
+    }
+}
+
+#[test]
+fn red_root_laundering_covers_exported_function_signatures() {
+    // The root exemption also covers `pub fn`, which the checker never looked at: a public
+    // function whose signature names a contract type hands it to any surface that calls it,
+    // and the reference sweeps skip the roots entirely.
+    for (label, source) in [
+        (
+            "a public function returning a contract type",
+            "pub fn leak() -> crate::adaptive::ProducerDocument { todo!() }\n",
+        ),
+        (
+            "a public function taking one",
+            "pub fn sink(d: crate::adaptive::ProducerDocument) {}\n",
+        ),
+        (
+            "a public function returning the publication layer",
+            "pub fn agg() -> crate::producers::ProducerAggregator { todo!() }\n",
+        ),
+        (
+            "a public function returning it wrapped",
+            "pub fn maybe() -> Option<crate::adaptive::ProducerDocument> { None }\n",
+        ),
+        (
+            "a public const",
+            "pub const D: crate::adaptive::ProducerDocument = todo!();\n",
+        ),
+    ] {
+        let file = parse_source("probe.rs", source);
+        assert!(
+            !root_launderings(&file).is_empty(),
+            "{label}: a root laundered a forbidden type through a signature:\n{source}"
+        );
+    }
+}
+
+#[test]
+fn red_root_laundering_resolves_private_alias_chains_in_exported_signatures() {
+    for (label, source) in [
+        (
+            "a private alias returned publicly",
+            "type Hidden = crate::adaptive::ProducerDocument; pub fn leak() -> Hidden { todo!() }\n",
+        ),
+        (
+            "a transitive private alias returned publicly",
+            "type Hidden = crate::adaptive::ProducerDocument; type MoreHidden = Option<Hidden>; pub fn leak() -> MoreHidden { todo!() }\n",
+        ),
+        (
+            "a private publication alias in a public field",
+            "type Hidden = crate::producers::ProducerSnapshot; pub struct Envelope { pub value: Hidden }\n",
+        ),
+    ] {
+        let file = parse_source("probe.rs", source);
+        assert!(
+            !root_launderings(&file).is_empty(),
+            "{label}: a private alias laundered a forbidden type:\n{source}"
+        );
+    }
+}
+
+#[test]
+fn red_root_laundering_resolves_private_import_aliases_and_shadowing() {
+    for (label, source) in [
+        (
+            "a private import alias returned publicly",
+            "use crate::adaptive::ProducerDocument as Hidden; pub fn leak() -> Hidden { todo!() }\n",
+        ),
+        (
+            "a private import without rename returned publicly",
+            "use crate::adaptive::ProducerDocument; pub fn leak() -> ProducerDocument { todo!() }\n",
+        ),
+        (
+            "a nested benign alias cannot overwrite a forbidden root alias",
+            "type Hidden = crate::adaptive::ProducerDocument; mod nested { type Hidden = u8; } pub fn leak() -> Hidden { todo!() }\n",
+        ),
+        (
+            "a private forbidden glob feeding a public signature",
+            "use crate::adaptive::*; pub fn leak() -> ProducerDocument { todo!() }\n",
+        ),
+        (
+            "a transitive private module alias feeding a public signature",
+            "use crate::adaptive as hidden; use hidden::ProducerDocument as Doc; pub fn leak() -> Doc { todo!() }\n",
+        ),
+        (
+            "a public re-export through a private module alias",
+            "use crate::adaptive as hidden; pub use hidden::ProducerDocument;\n",
+        ),
+        (
+            "a private glob through a private module alias",
+            "use crate::adaptive as hidden; use hidden::*; pub fn leak() -> ProducerDocument { todo!() }\n",
+        ),
+    ] {
+        let file = parse_source("probe.rs", source);
+        assert!(
+            !root_launderings(&file).is_empty(),
+            "{label}: a private binding laundered a forbidden type:\n{source}"
+        );
+    }
+}
+
+#[test]
+fn red_root_laundering_prohibits_exported_macros_in_exempt_roots() {
+    for source in [
+        "#[macro_export] macro_rules! leak { () => { crate::adaptive::ProducerDocument } }\n",
+        "macro_rules! leak { () => { crate::adaptive::ProducerDocument } } pub(crate) use leak;\n",
+        "macro_rules! leak { () => { pub fn leak() -> crate::adaptive::ProducerDocument { todo!() } } } leak!();\n",
+    ] {
+        let file = parse_source("probe.rs", source);
+        assert!(
+            !root_launderings(&file).is_empty(),
+            "an exported macro could launder an arbitrary forbidden path:\n{source}"
+        );
+    }
+}
+
+#[test]
+fn red_root_laundering_covers_exported_aggregate_and_method_signatures() {
+    for (label, source) in [
+        (
+            "a public tuple-struct field",
+            "pub struct Envelope(pub crate::adaptive::ProducerDocument);\n",
+        ),
+        (
+            "a public named struct field",
+            "pub struct Envelope { pub doc: crate::adaptive::ProducerDocument }\n",
+        ),
+        (
+            "a public enum payload",
+            "pub enum Message { Document(crate::adaptive::ProducerDocument) }\n",
+        ),
+        (
+            "a public trait method",
+            "pub trait Source { fn document(&self) -> crate::adaptive::ProducerDocument; }\n",
+        ),
+        (
+            "a public inherent method",
+            "pub struct Root; impl Root { pub fn document(&self) -> crate::adaptive::ProducerDocument { todo!() } }\n",
+        ),
+        (
+            "a public union field",
+            "pub union Envelope { pub doc: std::mem::ManuallyDrop<crate::adaptive::ProducerDocument> }\n",
+        ),
+        (
+            "a public trait associated const",
+            "pub trait Source { const DOCUMENT: crate::adaptive::ProducerDocument; }\n",
+        ),
+        (
+            "a public trait associated type default",
+            "pub trait Source { type Document = crate::adaptive::ProducerDocument; }\n",
+        ),
+        (
+            "a trait impl associated type",
+            "pub struct Root; impl Iterator for Root { type Item = crate::adaptive::ProducerDocument; fn next(&mut self) -> Option<Self::Item> { None } }\n",
+        ),
+        (
+            "a public function where-clause",
+            "pub fn leak<T>() where T: Iterator<Item = crate::adaptive::ProducerDocument> {}\n",
+        ),
+        (
+            "a public trait supertrait bound",
+            "pub trait Source: Iterator<Item = crate::adaptive::ProducerDocument> {}\n",
+        ),
+        (
+            "a public associated-type bound without a default",
+            "pub trait Source { type Documents: Iterator<Item = crate::adaptive::ProducerDocument>; }\n",
+        ),
+        (
+            "a root trait impl on a forbidden publication type",
+            "impl serde::Serialize for crate::producers::ProducerSnapshot { fn serialize<S>(&self, _: S) -> Result<S::Ok, S::Error> where S: serde::Serializer { todo!() } }\n",
+        ),
+        (
+            "a root impl on a private forbidden alias",
+            "type Hidden = crate::producers::ProducerSnapshot; impl Hidden { pub fn leak(&self) {} }\n",
+        ),
+        (
+            "an impl-level where-clause",
+            "pub struct Root<T>(T); impl<T> Root<T> where T: Iterator<Item = crate::adaptive::ProducerDocument> { pub fn ok(&self) {} }\n",
+        ),
+        (
+            "an exported foreign function",
+            "unsafe extern \"Rust\" { pub fn leak() -> crate::adaptive::ProducerDocument; }\n",
+        ),
+    ] {
+        let file = parse_source("probe.rs", source);
+        assert!(
+            !root_launderings(&file).is_empty(),
+            "{label}: a root laundered a forbidden type through an exported aggregate or method:\n{source}"
+        );
+    }
+}
+
+#[test]
+fn red_root_laundering_still_ignores_innocent_signatures() {
+    for (label, source) in [
+        (
+            "a private function naming a forbidden type",
+            "fn wire() -> crate::producers::ProducerAggregator { todo!() }\n",
+        ),
+        (
+            "a public function over unrelated types",
+            "pub fn zones() -> Vec<crate::bus::Zone> { vec![] }\n",
+        ),
+        (
+            "a prefix-sharing sibling module",
+            "pub fn helper() -> crate::adaptive_extras::Helper { todo!() }\n",
+        ),
+    ] {
+        let file = parse_source("probe.rs", source);
+        assert!(
+            root_launderings(&file).is_empty(),
+            "{label}: the root prohibition over-reached: {:?}\n{source}",
+            root_launderings(&file)
+        );
+    }
+}
+
+#[test]
+fn every_adaptive_timestamp_field_is_in_the_admission_validation_ledger() {
+    #[derive(Default)]
+    struct TimestampFieldVisitor {
+        fields: std::collections::BTreeSet<String>,
+    }
+    impl<'ast> Visit<'ast> for TimestampFieldVisitor {
+        fn visit_item_struct(&mut self, item: &'ast syn::ItemStruct) {
+            for (index, field) in item.fields.iter().enumerate() {
+                if type_tail_is(&field.ty, "Timestamp") {
+                    let field_name = field
+                        .ident
+                        .as_ref()
+                        .map_or_else(|| index.to_string(), ToString::to_string);
+                    self.fields.insert(format!("{}.{field_name}", item.ident));
+                }
+            }
+            visit::visit_item_struct(self, item);
+        }
+    }
+
+    let sources = rust_sources_under("src/adaptive");
+    assert!(!sources.is_empty(), "no adaptive sources were inspected");
+    let mut visitor = TimestampFieldVisitor::default();
+    for (path, source) in sources {
+        visitor.visit_file(&parse_source(&path, &source));
+    }
+    let expected = std::collections::BTreeSet::from([
+        "ChangeSet.created_at".to_string(),
+        "ChangeSet.updated_at".to_string(),
+        "Divergence.detected_at".to_string(),
+        "Freshness.observed_at".to_string(),
+        "LaneHealth.last_success".to_string(),
+        "OutcomeTransition.at".to_string(),
+        "Retention.expires_at".to_string(),
+    ]);
+    assert_eq!(
+        visitor.fields, expected,
+        "Timestamp fields changed; add admission validation and a malformed-value counterexample before updating this ledger"
+    );
+}
+
+#[test]
+fn lint_the_run_module_stays_serialization_free_and_std_only() {
+    // `AdapterRunId` and `PublicationOrigin` are stamped onto every ingress `AdaptiveEvent`, so
+    // they are now part of the internal bus's payload shape. The event enum's own guarantee -
+    // that it cannot reach a wire - is only as strong as the types it carries, and none of the
+    // allowlists above look at this file. Held to the same rule: no serde, and nothing from
+    // outside `std`, so a serialization trait cannot arrive as a transitive dependency either.
+    let path = "src/producers/run.rs";
+    let file = parse_file_at(path);
+
+    let foreign: Vec<String> = imports_of(&file)
+        .into_iter()
+        .filter(|import| !import.starts_with("std::"))
+        .collect();
+    assert!(
+        foreign.is_empty(),
+        "{path} imports something outside std: {foreign:?}\nTypes carried by AdaptiveEvent must \
+         stay as unserializable as the event itself."
+    );
+
+    let mut serializable = Vec::new();
+    for item in &file.items {
+        let (name, attrs) = match item {
+            Item::Struct(inner) => (inner.ident.to_string(), &inner.attrs),
+            Item::Enum(inner) => (inner.ident.to_string(), &inner.attrs),
+            _ => continue,
+        };
+        for derive in derives_in(attrs) {
+            if derive.contains("Serialize") || derive.contains("Deserialize") {
+                serializable.push(format!("derive({derive}) on {name}"));
+            }
+        }
+    }
+    assert!(
+        serializable.is_empty(),
+        "{path} derives serde for a type the internal bus carries: {serializable:?}"
+    );
+    assert!(
+        !file.items.is_empty(),
+        "no items were found at all, which means the parse is not reaching {path}"
     );
 }
 

--- a/tests/adaptive_publication_lint.rs
+++ b/tests/adaptive_publication_lint.rs
@@ -332,7 +332,7 @@ fn macro_invocations(file: &File) -> Vec<String> {
 #[derive(Default)]
 struct AttributeVisitor {
     owners: Vec<String>,
-    found: Vec<(String, String)>,
+    found: Vec<(Vec<String>, String)>,
 }
 
 fn item_label(item: &Item) -> String {
@@ -373,12 +373,35 @@ impl<'ast> Visit<'ast> for AttributeVisitor {
         self.owners.pop();
     }
 
+    /// A variant is a distinct location from the enum that contains it.
+    ///
+    /// Attributing a variant's attributes to the enum let a `derive` there inherit the
+    /// enum's permission. A built-in derive in that position does not compile, but a
+    /// proc-macro attribute does — and the policy should say where an attribute *is*
+    /// rather than lean on a later compile.
+    fn visit_variant(&mut self, variant: &'ast syn::Variant) {
+        self.owners.push(format!("variant {}", variant.ident));
+        visit::visit_variant(self, variant);
+        self.owners.pop();
+    }
+
+    /// Fields are tracked for the same reason, though with no reachable exploit today: a
+    /// field is always inside a variant or a struct, and either frame already moves the
+    /// stack away from the one permitted owner. Removing this tracking does not fail any
+    /// probe — stated rather than implied, because a mutation that changes nothing is not
+    /// evidence that the code it changed is load-bearing.
+    fn visit_field(&mut self, field: &'ast syn::Field) {
+        let label = field
+            .ident
+            .as_ref()
+            .map(|ident| format!("field {ident}"))
+            .unwrap_or_else(|| "field".to_string());
+        self.owners.push(label);
+        visit::visit_field(self, field);
+        self.owners.pop();
+    }
+
     fn visit_attribute(&mut self, attr: &'ast Attribute) {
-        let owner = self
-            .owners
-            .last()
-            .cloned()
-            .unwrap_or_else(|| "<file>".to_string());
         let path = attr
             .path()
             .segments
@@ -386,15 +409,34 @@ impl<'ast> Visit<'ast> for AttributeVisitor {
             .map(|segment| segment.ident.to_string())
             .collect::<Vec<_>>()
             .join("::");
-        self.found.push((owner, path));
+        self.found.push((self.owners.clone(), path));
         visit::visit_attribute(self, attr);
     }
 }
 
-fn module_attributes(file: &File) -> Vec<(String, String)> {
+/// Every attribute in `file`, paired with the full owner stack that carries it.
+///
+/// The **stack**, not its last frame. Storing only the innermost label made a nested item
+/// sharing a name indistinguishable from the real one:
+///
+/// ```ignore
+/// mod inner { #[derive(GenerateAdaptiveWire)] enum AdaptiveEvent {} }
+/// #[derive(Debug, Clone)] pub enum AdaptiveEvent {}
+/// ```
+///
+/// Both derives reported the owner `enum AdaptiveEvent`, so the decoy inherited the real
+/// type's permission — and the token audit only inspects `adaptive_event_enum`, which
+/// searches top-level items, so nobody audited the decoy at all. Found by Codex at
+/// `24c9f56`.
+fn module_attributes(file: &File) -> Vec<(Vec<String>, String)> {
     let mut visitor = AttributeVisitor::default();
     visitor.visit_file(file);
     visitor.found
+}
+
+/// The one owner stack permitted to carry a `derive`.
+fn adaptive_event_owner() -> Vec<String> {
+    vec![format!("enum {ADAPTIVE_EVENT}")]
 }
 
 /// Attributes anywhere in `file` that the module-wide policy forbids.
@@ -411,16 +453,20 @@ fn module_attributes(file: &File) -> Vec<(String, String)> {
 /// This is the production gate. The enum-specific checks are kept because they name the
 /// offender more precisely, but they are no longer what carries the guarantee.
 fn disallowed_module_attributes(file: &File) -> Vec<String> {
+    let permitted = adaptive_event_owner();
     let mut rejected = Vec::new();
     for (owner, path) in module_attributes(file) {
+        let where_it_is = owner.join(" > ");
         match path.as_str() {
             "doc" => {}
-            "derive" if owner == format!("enum {ADAPTIVE_EVENT}") => {}
-            _ => rejected.push(format!("#[{path}] on {owner}")),
+            // Depth-exact: the single top-level `enum AdaptiveEvent`, and nothing that
+            // merely shares its name at some other depth.
+            "derive" if owner == permitted => {}
+            _ => rejected.push(format!("#[{path}] on {where_it_is}")),
         }
     }
-    // A derive that is in the right place but holds the wrong token is still forbidden, so
-    // the module-wide policy cannot be satisfied by relocating a bad derive onto the enum.
+    // A derive in the right place holding the wrong token is still forbidden, so the policy
+    // cannot be satisfied by relocating a bad derive onto the enum.
     if let Some(item) = adaptive_event_enum(file) {
         for token in derives_in(&item.attrs) {
             if !ADAPTIVE_EVENT_ALLOWED_DERIVES.contains(&token.as_str()) {
@@ -782,14 +828,14 @@ fn lint_the_internal_event_module_carries_only_allowed_attributes_anywhere() {
 
     // The policy must describe the module, not merely permit it: if the one real derive
     // vanished, the policy would be silently over-broad.
-    let derive_owners: Vec<String> = module_attributes(&file)
+    let derive_owners: Vec<Vec<String>> = module_attributes(&file)
         .into_iter()
         .filter(|(_, path)| path == "derive")
         .map(|(owner, _)| owner)
         .collect();
     assert_eq!(
         derive_owners,
-        vec![format!("enum {ADAPTIVE_EVENT}")],
+        vec![adaptive_event_owner()],
         "the module's derives changed; the policy now describes something else"
     );
 }
@@ -1163,6 +1209,83 @@ fn a_proc_macro_on_any_other_item_cannot_generate_for_adaptive_event() {
             "{label}: a proc macro on another item was admitted:\n{source}"
         );
     }
+}
+
+#[test]
+fn a_nested_decoy_named_adaptive_event_cannot_borrow_the_real_ones_permission() {
+    // The owner was stored as a lossy label — the last frame only — so a *nested* item that
+    // happens to share the name produced the same string as the real one and inherited its
+    // permission to derive. The token audit looks at `adaptive_event_enum`, which searches
+    // top-level items only, so the decoy's derive was audited by nobody.
+    //
+    // Found by Codex at `24c9f56`.
+    let collision = "mod inner {\n    #[derive(GenerateAdaptiveWire)]\n    enum AdaptiveEvent {}\n}\n#[derive(Debug, Clone)]\npub enum AdaptiveEvent {}\n";
+    let file = snippet(collision);
+
+    // The false pass, spelled out: the top-level enum is clean, so every enum-specific
+    // check passes.
+    let item = adaptive_event_enum(&file).expect("top-level enum located");
+    assert_eq!(
+        derives_in(&item.attrs),
+        vec!["Debug".to_string(), "Clone".to_string()],
+        "precondition failed - the top-level enum's derives were not clean"
+    );
+
+    assert!(
+        !disallowed_module_attributes(&file).is_empty(),
+        "a nested decoy sharing the name inherited permission to derive:\n{collision}"
+    );
+
+    // Depth matters, not just the name: the same decoy two modules down.
+    let deeper = "mod a {\n    mod b {\n        #[derive(GenerateAdaptiveWire)]\n        enum AdaptiveEvent {}\n    }\n}\n#[derive(Debug, Clone)]\npub enum AdaptiveEvent {}\n";
+    assert!(
+        !disallowed_module_attributes(&snippet(deeper)).is_empty(),
+        "a decoy two modules down inherited permission:\n{deeper}"
+    );
+
+    // And a decoy carrying an *allowed* derive is still wrong: permission belongs to the
+    // one top-level item, not to anything wearing its name.
+    let allowed_token_decoy = "mod inner {\n    #[derive(Debug)]\n    enum AdaptiveEvent {}\n}\n#[derive(Debug, Clone)]\npub enum AdaptiveEvent {}\n";
+    assert!(
+        !disallowed_module_attributes(&snippet(allowed_token_decoy)).is_empty(),
+        "a nested decoy was permitted to derive at all:\n{allowed_token_decoy}"
+    );
+}
+
+#[test]
+fn attributes_on_variants_and_fields_are_located_precisely() {
+    // A variant or field attribute inherited the enclosing item's label, so a `derive`
+    // there read as a derive on the enum and was permitted. A built-in derive in that
+    // position does not compile — but the policy should say where an attribute *is* rather
+    // than lean on a later compile to catch it, because a proc-macro attribute there does
+    // compile. Raised alongside the decoy finding.
+    for (label, source) in [
+        (
+            "derive on a variant",
+            "pub enum AdaptiveEvent {\n    #[derive(GenerateAdaptiveWire)]\n    A,\n}\n",
+        ),
+        (
+            "derive on a field",
+            "pub enum AdaptiveEvent {\n    A {\n        #[derive(GenerateAdaptiveWire)]\n        x: u8,\n    },\n}\n",
+        ),
+        (
+            "attribute macro on a variant",
+            "pub enum AdaptiveEvent {\n    #[generate_event_wire]\n    A,\n}\n",
+        ),
+    ] {
+        assert!(
+            !disallowed_module_attributes(&snippet(source)).is_empty(),
+            "{label}: an attribute below the item borrowed the item's permission:\n{source}"
+        );
+    }
+
+    // Doc comments in those positions remain fine.
+    let documented = "#[derive(Debug, Clone)]\npub enum AdaptiveEvent {\n    /// variant docs\n    A {\n        /// field docs\n        x: u8,\n    },\n}\n";
+    assert!(
+        disallowed_module_attributes(&snippet(documented)).is_empty(),
+        "documented variants or fields were rejected: {:?}",
+        disallowed_module_attributes(&snippet(documented))
+    );
 }
 
 #[test]

--- a/tests/fixtures/adaptive/command_outcomes.json
+++ b/tests/fixtures/adaptive/command_outcomes.json
@@ -83,19 +83,6 @@
       "write_attempt": "acknowledged_provisional",
       "outcome": "indeterminate",
       "observed": { "epoch": 7, "control_plane": 12, "state": 4207 },
-      "history": [
-        {
-          "from": "disconnected",
-          "to": "indeterminate",
-          "at": "2026-07-30T11:06:31Z",
-          "observed": { "epoch": 7, "control_plane": 12, "state": 4207 },
-          "reason": {
-            "code": "requires_connection",
-            "scope": "lane",
-            "display_text_key": "reason.transport_dropped_after_write"
-          }
-        }
-      ],
       "recovery": "awaiting_readback",
       "reason": {
         "code": "requires_connection",

--- a/tests/fixtures/adaptive/control_removed_after_advance.json
+++ b/tests/fixtures/adaptive/control_removed_after_advance.json
@@ -1,0 +1,85 @@
+{
+  "schema_version": "1.0",
+  "producer": {
+    "producer_id": "hqplayer:living-room",
+    "producer_type": "hqplayer",
+    "epoch": 7
+  },
+  "target": {
+    "role": "dsp_engine",
+    "zone_id": "roon:1601bb42ed14351b99c2926214f6cbb80724"
+  },
+  "revisions": {
+    "control_plane": 13,
+    "state": 4301
+  },
+  "lanes": [
+    { "lane": "native", "state": "connected", "last_success": "2026-07-30T11:18:04Z" }
+  ],
+  "controls": [
+    {
+      "id": "hqplayer.pipeline.mode",
+      "kind": "enumeration",
+      "label_key": "control.pipeline.mode",
+      "values": [
+        {
+          "lane": "observed",
+          "grounding": "grounded",
+          "value": { "type": "choice", "value": "pcm" },
+          "provenance": { "authority": "runtime", "source": "live_protocol", "revision": 4301 }
+        }
+      ],
+      "availability": { "state": "available" },
+      "apply": {
+        "lane": "immediate",
+        "effect": "live_immediate",
+        "disruption": "playback_interruption",
+        "risk": "disruptive",
+        "verification": { "verify_via": "hqplayer.pipeline.mode", "verify_lane": "observed" }
+      }
+    }
+  ],
+  "draft_policy": {
+    "mode": "shared",
+    "on_conflict": "expose_contributors",
+    "retention": {
+      "survives_reconnect": true,
+      "survives_producer_restart": false,
+      "on_epoch_change": "revalidate"
+    }
+  },
+  "change_sets": [
+    {
+      "id": "cs-web-8d40",
+      "producer_id": "hqplayer:living-room",
+      "origin": { "actor_class": "human", "surface": "web", "actor_id": "session-44f1" },
+      "base": { "epoch": 7, "control_plane": 12, "state": 4193 },
+      "generation": 2,
+      "state": "draft",
+      "created_at": "2026-07-30T11:10:00Z",
+      "updated_at": "2026-07-30T11:12:30Z",
+      "entries": [
+        {
+          "control": "hqplayer.pipeline.sdm.shaper",
+          "lane": "staged",
+          "desired": { "type": "choice", "value": "ASDM7EC" },
+          "base_observed": { "type": "choice", "value": "ASDM5EC" },
+          "validity": {
+            "state": "draft_invalid",
+            "reason": {
+              "code": "control_removed",
+              "scope": "draft",
+              "display_text_key": "reason.control_no_longer_exists",
+              "detail": "control hqplayer.pipeline.sdm.shaper is no longer described by this producer document"
+            }
+          }
+        }
+      ],
+      "retention": {
+        "survives_reconnect": true,
+        "survives_producer_restart": false,
+        "on_epoch_change": "revalidate"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Refs #324. OH: 80222d6d

Draft stacked PR. Do not merge or mark ready without explicit maintainer approval.

**Exact head:** `6acb5a60cb9938b9dafae7b033455964d560dede`

**Delivery stack:** #363 → #362 (`feat/issue-323-adaptive-producer-contract`, draft/CLEAN) → #339 (`fix/issue-338-rust-1-97-lint`, draft) → `v3`.

## Outcome

Makes versioned adaptive producer documents first-class aggregator-owned state. Release-profile mutation enters through one bounded actor; adapters hold lossless producer handles, consumers hold a read-only view, and egress broadcasts are invalidation hints only.

This is the foundation for #325 HQPlayer production, #326 adaptive consumers/MCP, and #327 durability/recovery.

## Correctness properties

- Bounded Tokio mpsc ingress with backpressure; no document coalescing or dropped ingress.
- Synchronous allocator-issued adapter-run leases; stale runs cannot publish or retire.
- Namespace ownership is checked before queueing, including detached publication.
- Admission, watermark, retirement, and refusal state are linearized under one actor-owned mutation path.
- Rejected epochs never advance lifecycle authority.
- Retirement through epoch N removes only state/diagnostics at N or lower, covers unseen keys with a producer-wide floor, and preserves newer restarts.
- Equal revisions cannot change content; lane-health-only refresh remains admissible.
- Ended runs project `LastKnown`; public `AdapterStopping` is informational.
- Adapters stop before adaptive ingress closes; accepted commands drain before actor join. Bind and Axum error paths cannot orphan the actor.
- Every adaptive `Timestamp` field has RFC 3339 admission validation plus an AST drift ledger.
- Root/publication lints cover private/transitive aliases, globs, generic/where/supertrait/associated bounds, impl targets, foreign items, and generated/re-exported macros.

## API contract

**No HTTP/SSE/MCP route or payload change.** `src/api/`, `src/bus/`, and `tests/fixtures/api_routes.txt` are unchanged relative to `origin/v3`. No `api-change-approved` label is requested.

The direct aggregator harness is intentionally available only in debug-profile builds for integration-test compatibility. Release builds omit its re-export and mutation methods; the actor lifecycle suite passes in release.

## Verification

- Full `cargo test --all-features --no-fail-fast`: pass
- Actor lifecycle: 25/25 debug and 25/25 release
- Adaptive publication: 107/107
- Boundary lint: 57/57
- API contract: 2/2
- `cargo clippy --lib --all-features -- -D warnings`: pass
- `cargo check --release --all-features`: pass
- `cargo fmt --all -- --check`: pass
- Diff/API isolation checks: pass

Only pre-existing unused-code warnings appear in test support.

## Review

Exact staged head passed independent review and adversarial dissent with zero P1-P4 findings after multiple red/green counterexample rounds. Superego found no blocker. Claude Opus review identified shutdown, timestamp-drift, retirement-ordering, and documentation gaps that are fixed in this head.

Six SHA-anchored solution/execute/ship review+dissent reports are posted below using the established 17-field output contract. CodeRabbit exact-head review is requested after this push.

## Delivery and rollback

This branch has no GitHub Actions run while its PR targets another `feat/` branch; stacked CI begins as prerequisites merge/retarget toward `v3`. Never infer merge authorization from local or CodeRabbit success.

Rollback is a normal revert while #324 remains the stack tip. Nothing persists producer documents yet. Once #325 publishes this contract, rollback must preserve additive compatibility.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added adaptive producer publication with validated, atomic snapshots.
  * Added support for producer status, lane health, revision history, reconnects, and graceful removal.
  * Added visibility into rejected publications and publication corrections.
  * Added support for identifying controls removed while drafts remain active.
* **Bug Fixes**
  * Prevented stale, out-of-order, malformed, or unauthorized updates from replacing valid data.
  * Improved timestamp handling and producer presence reporting across restarts.
* **Documentation**
  * Added design and release guidance for adaptive publication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->