### PR TITLE
fix(347): verify live setters and scope enumerations to the loaded chain

### DIFF
--- a/.oh/issue-347-hqplayer-trustworthy-setters.md
+++ b/.oh/issue-347-hqplayer-trustworthy-setters.md
@@ -19,9 +19,9 @@ field.
 **Key constraint:** no public API route/request/response contract changes, no live appliance, and the
 #322 executable corpus — not current Rust behaviour — is the protocol authority.
 
-**Success:** every supported live setter reports `applied`, `already-set`, `ignored`, `suppressed` or
-`ambiguous` from an authoritative `State` readback; enumerations are scoped to the loaded chain and
-invalidated when it moves; no raw integer reaches a control path.
+**Success:** every supported *enumerated* live setter reports `applied`, `already-set`, `ignored`,
+`suppressed` or `ambiguous` from an authoritative `State` readback; enumerations are scoped to the
+loaded chain and invalidated when it moves; no raw integer reaches a control path.
 
 ## Solution Space
 
@@ -71,13 +71,26 @@ compatibility boundary, never publish or persist it as identity.
   a cache that can name a different filter than the user picked.
 - No PCM/SDM label for the loaded chain. `shaper_label` keeps its existing configured-mode heuristic;
   changing a response *value* has no acceptance criterion and would be an unbudgeted risk.
-- `Ambiguous` is reachable only after a write was attempted and its reply lost — the client then does
-  a bounded readback rather than assuming failure (HQP-C-029).
+- `Ambiguous` is reachable after a write was attempted and its reply lost — the client then does a
+  bounded readback rather than assuming failure (HQP-C-029) — and also when the authoritative field is
+  absent, where nothing can be established either way.
+- **Volume is outside the outcome vocabulary and stays `Result<()>`.** Result-checked, never
+  readback-verified: adaptive volume moves the level on its own, so a readback would manufacture
+  failures, and volume is absolute dB rather than a list index (HQP-C-040). Documented on
+  `SettingOutcome` rather than silently implied, so nothing claims "every setter".
+- The refresh bracket detects a chain that **ended** somewhere other than where it started. A change
+  out and back inside one window would leave both probes agreeing. Nothing observed suggests that is
+  reachable, and the guard is described as "did not straddle a visible transition" rather than as a
+  same-instant snapshot, which nothing short of a daemon-side atomic read could give.
 
 ## Execute
 
-Status: complete. See the PR body for RED/GREEN evidence.
+**Status: in progress at the time of writing.** Two commits exist on
+`fix/issue-347-hqplayer-trustworthy-setters` (RED, then GREEN); nothing is pushed and no PR exists.
+An independent execute audit then raised nine items, addressed as forward work before any further
+commit. RED/GREEN evidence goes in the PR body once it is opened.
 
 ## Review / Dissent
 
-Recorded as PR comments 1–6.
+Not yet performed. The six report comments are written and posted after the PR exists, re-anchored to
+the final head.

--- a/.oh/issue-347-hqplayer-trustworthy-setters.md
+++ b/.oh/issue-347-hqplayer-trustworthy-setters.md
@@ -1,0 +1,83 @@
+# Issue #347 — HQPlayer: verify live setters and scope enumerations to the loaded chain
+
+OH: 80222d6d · epic #311 · stacked on #341 (`feat/issue-341-hqplayer-evidence-ledger`, head
+`6d688bdbcb3fa607ca87a1593dd692e7ba00133a`)
+
+## Aim
+
+A client issues a semantic setting change during source-following playback, and UHC either proves the
+exact setting applied or returns a bounded, truthful non-applied outcome without corrupting a sibling
+setting.
+
+## Problem Statement (confirmed from #347)
+
+**The problem:** `result="OK"` and a mode-keyed list cache are both treated as proof. The daemon can
+acknowledge a setter without applying it; the loaded PCM/SDM chain can move while configured mode
+stays `[source]`; and the one-sided `SetFilter` helpers guess the sibling from a different `State`
+field.
+
+**Key constraint:** no public API route/request/response contract changes, no live appliance, and the
+#322 executable corpus — not current Rust behaviour — is the protocol authority.
+
+**Success:** every supported live setter reports `applied`, `already-set`, `ignored`, `suppressed` or
+`ambiguous` from an authoritative `State` readback; enumerations are scoped to the loaded chain and
+invalidated when it moves; no raw integer reaches a control path.
+
+## Solution Space
+
+### Axis 1 — how a setter outcome is represented
+
+| Option | Level | Approach | Trade-off |
+|---|---|---|---|
+| A | Band-Aid | Keep `Result<()>`, put the distinction in error prose | "Ignored" is indistinguishable from "rejected" to any caller; no type stops a future call site from treating OK as applied |
+| B | Local Optimum | `Result<()>` plus a side-channel counter/log | Observable only out-of-band; a boundary cannot map outcomes |
+| C | Reframe | Adapter setters return `Result<SettingOutcome>`, `#[must_use]`, with `Applied / AlreadySet / Ignored / Suppressed / Ambiguous`; HTTP+MCP boundaries collapse it to today's `{ok:true}` / `{error}` shapes | Every call site must be updated; five variants to keep honest |
+| D | Redesign | Move live-setting ownership to a producer/aggregator contract with an outcome event stream | #347 explicitly defers this to #325/#329; would balloon scope |
+
+**Selected: C.** The issue names four outcomes and requires them "observably … using existing
+internal contracts (no public API change)". A type is the only representation a later call site
+cannot silently discard, and `Result<SettingOutcome>` keeps transport/rejection failures where they
+already are. `AlreadySet` is the fifth because *skipping* a write is a distinct fact from *applying*
+one — the no-op mode skip exists precisely so nothing is sent.
+
+### Axis 2 — how the loaded chain is resolved
+
+| Option | Level | Approach | Trade-off |
+|---|---|---|---|
+| A | Band-Aid | `refresh_lists()` before every setter | 4 extra round trips per write; never *detects* a change, so nothing else can react |
+| B | Local Optimum | Keep the mode-keyed cache, add `State.active_mode` as a second key | Settles by fiat exactly what HQP-C-024 records as **unmeasured**. Rejected on evidence grounds |
+| C | Reframe | **The loaded chain is the enumeration the daemon currently serves.** Per-family fingerprints; a fresh fetch whose fingerprint differs from the cached one *is* a chain transition and invalidates every chain-scoped family | Needs one fresh fetch per control operation; no PCM/SDM *label* falls out |
+| D | Redesign | A chain-identity event on the bus that producers subscribe to | #325/#329 own the producer; premature here |
+
+**Selected: C.** It is independent of configured mode and of rate-pin availability *by construction*,
+it invents no threshold and no unmeasured field reading, and HQP-C-008 (`E0-uhc-live`) already
+settles that enumerations are chain-scoped. The deliberate consequence: UHC identifies *which* chain
+is loaded, not what to *call* it. Nothing in #347 needs the label, and inventing a PCM/SDM classifier
+from rate spans would be the exact failure mode this epic exists to end.
+
+### Axis 3 — the legacy numeric HTTP contract
+
+| Option | Level | Approach | Trade-off |
+|---|---|---|---|
+| A | Band-Aid | Keep the adapter's `parse::<u32>()` fallback | The acceptance criterion forbids it; a stale index silently selects a different setting |
+| B | Reframe | Resolve the number to a **name** at the HTTP boundary against the fresh enumeration, then call the semantic setter | Boundary gains a lookup and a failure mode; request/response contracts unchanged |
+
+**Selected: B.** It is what #347 and HQP-C-063 jointly prescribe: keep the number at the
+compatibility boundary, never publish or persist it as identity.
+
+### Accepted trade-offs
+
+- One fresh enumeration fetch per control operation. Correctness over round trips; the alternative is
+  a cache that can name a different filter than the user picked.
+- No PCM/SDM label for the loaded chain. `shaper_label` keeps its existing configured-mode heuristic;
+  changing a response *value* has no acceptance criterion and would be an unbudgeted risk.
+- `Ambiguous` is reachable only after a write was attempted and its reply lost — the client then does
+  a bounded readback rather than assuming failure (HQP-C-029).
+
+## Execute
+
+Status: complete. See the PR body for RED/GREEN evidence.
+
+## Review / Dissent
+
+Recorded as PR comments 1–6.

--- a/docs/hqplayer-evidence-ledger.md
+++ b/docs/hqplayer-evidence-ledger.md
@@ -108,8 +108,8 @@ were **not executed** and are recorded as gaps in that comment.
 | HQP-C-001 | `SetMode value=` carries the **list index**, not the enum ID: SDM is index 2 while its enum ID is 1 | E0-uhc-live | PR #337 comment 5135836825 · read-via-pr · Embedded 6.0.2 / engine 6.0.4 · 2026-07-30 · idle | test:a_delayed_set_mode_still_clamps_indices_into_the_loaded_chain · test:modes_list_distinguishes_list_index_from_enum_id · fixture:tests/fixtures/hqplayer/hqpd-6.0.4-opal/modes.xml | settled | — |
 | HQP-C-002 | Domain 1 — the **live wire** domain: `State.mode/filter/filter1x/filterNx/shaper/rate` and the **enumerated** setters (`SetMode`, `SetFilter`, `SetShaping`, `SetRate`, `SetJunkFilter`) speak a **list index** into the currently loaded enumeration. Volume is **not** in this domain — it is absolute dB (HQP-C-040). Commands evidenced elsewhere: SetShaping (HQP-C-064), SetJunkFilter (HQP-C-051) | E0-uhc-live | PR #337 comment 5135836825 · read-via-pr · Embedded 6.0.2 / engine 6.0.4 · 2026-07-30 · idle | test:a_filter_name_is_sent_as_the_index_the_observed_list_gives_it · test:a_filter_name_is_not_sent_as_its_enum_id · test:a_delayed_set_mode_still_clamps_indices_into_the_loaded_chain · test:a_rate_valid_in_one_chain_is_refused_in_the_other | settled | — |
 | HQP-C-003 | Domain 2 — the **persistent** domain: `hqplayerd.xml` and the 8088 config form store **enum IDs**, which are not list indices and must never be fed to the live lane | E1-upstream-verified | UHC-SALVAGE reports via `.oh/issue-322-hqplayer-protocol-conformance.md` · read-via-report · hqplayerd 6.0.4 (Opal) · 2026-07-29 · idle | test:the_persistent_configuration_lane_stores_enum_ids_not_list_indices · test:feeding_a_persistent_enum_id_to_the_live_lane_is_rejected | settled | — |
-| HQP-C-004 | Domain 3 — the **client** domain **as designed**: clients exchange setting-appropriate values — semantic names for mode/filter/shaper, Hz for rate, decimal dB for volume — and the adapter owns both numeric conversions. **This is the design rule, not a description of every path today**: see HQP-C-063 | E6-documentary | `.oh/hqplayer-spec.md` layer table · direct · n/a · 2026-02-04 · n/a | test:a_filter_name_is_sent_as_the_index_the_observed_list_gives_it | settled | — |
-| HQP-C-063 | Raw indices **do** cross the client boundary today, in two evidenced places: the legacy numeric route `HqpSettingRequest { name: String, value: u32 }` stringifies its number for name-based lookup (`src/api/mod.rs:825-836`), and the adapter's resolvers fall back to parsing a numeric string as a direct index (`resolve_mode_index:2081`, `resolve_filter_index:2186`, `resolve_shaper_index:2247`) | E6-documentary | `src/api/mod.rs` and `src/adapters/hqplayer.rs` at this head · direct · n/a · 2026-07-30 · n/a | none:#347 removing the raw integer-string fallback from production control paths while keeping the legacy numeric HTTP contract at the compatibility boundary | open | #347 |
+| HQP-C-004 | Domain 3 — the **client** domain: clients exchange setting-appropriate values — semantic names for mode/filter/shaper, Hz for rate, decimal dB for volume — and the adapter owns both numeric conversions. The two paths that broke this rule are gone (HQP-C-063, retired); the one frozen numeric request contract is resolved to a name at the HTTP boundary and never travels inward | E6-documentary | `.oh/hqplayer-spec.md` layer table · direct · n/a · 2026-02-04 · n/a | test:a_filter_name_is_sent_as_the_index_the_observed_list_gives_it · test:a_numeric_string_is_never_accepted_as_a_setting_name | settled | — |
+| HQP-C-063 | Raw indices **did** cross the client boundary, in two evidenced places: the legacy numeric route `HqpSettingRequest { name: String, value: u32 }` stringified its number for name-based lookup (`src/api/mod.rs:825-836`), and the adapter's resolvers fell back to parsing a numeric string as a direct index (`resolve_mode_index:2081`, `resolve_filter_index:2186`, `resolve_shaper_index:2247`) | E6-documentary | `src/api/mod.rs` and `src/adapters/hqplayer.rs` at `6d688bd` · direct · n/a · 2026-07-30 · n/a | test:a_numeric_string_is_never_accepted_as_a_setting_name · test:tests/hqplayer_ledger_lint.rs::no_production_control_path_parses_a_setting_name_as_an_index | retired | #347 |
 | HQP-C-064 | **No conformance expectation drives `set_shaper`**, so the shaper setter's behaviour is L1-observed only — `shaper 24→0→24`, `result="OK"`, readback-verified on the live run — and unpinned hermetically | E0-uhc-live | PR #337 comment 5135836825 · read-via-pr · Embedded 6.0.2 / engine 6.0.4 · 2026-07-30 · idle | none:a conformance expectation that drives `set_shaper` and verifies the readback; the fake already applies `SetShaping` (`model.rs`), so only the expectation is missing | open | #329 |
 | HQP-C-005 | `SetMode` does **not** reset the filter or shaper selections; the fake once modelled that and no evidence supports it | E3-derived | `.oh/issue-322-…` amendment row B14 · direct · hqplayerd 6.0.4 (Opal) · 2026-07-30 · unknown | test:set_mode_does_not_reset_the_filter_and_shaper_selections | settled | — |
 | HQP-C-006 | A mode change reloads the chain, so a list index resolved before it can name a **different** setting after it | E1-upstream-verified | UHC-SALVAGE reports via `.oh/issue-322-…` · read-via-report · hqplayerd 6.0.4 (Opal) · 2026-07-29 · idle | test:a_delayed_set_mode_still_clamps_indices_into_the_loaded_chain · test:the_same_filter_index_selects_a_different_filter_per_loaded_chain | settled | — |
@@ -133,9 +133,9 @@ were **not executed** and are recorded as gaps in that comment.
 |---|---|---|---|---|---|---|
 | HQP-C-015 | `SetRate value=` is the **list index** of the wanted rate in the current chain's list; `RatesItem` carries `rate` in Hz and **no** enum ID; `Status.active_rate` reports Hz | E0-uhc-live | PR #337 comment 5135836825 · read-via-pr · Embedded 6.0.2 / engine 6.0.4 · 2026-07-30 · idle | test:rates_list_reports_hz_and_has_no_enum_id · test:a_rate_valid_in_one_chain_is_refused_in_the_other | settled | — |
 | HQP-C-016 | Rate list index **0 is Auto** (`rate="0"`), and a mode change resets the runtime rate to it — L1 observed `rate 3 → 0` | E0-uhc-live | PR #337 comment 5135836825 · read-via-pr · Embedded 6.0.2 / engine 6.0.4 · 2026-07-30 · idle | test:tier1_requires_rate_index_zero_to_be_auto · test:a_same_mode_set_mode_still_clears_the_rate_pin | settled | — |
-| HQP-C-017 | A **same-mode** `SetMode` still reloads the chain and clears the exact-rate pin, so a no-op mode write is not a no-op | E1-upstream-verified | UHC-SALVAGE-BETA-DEV via `.oh/issue-322-…` · read-via-report · hqplayerd 6.0.4 (Opal) · 2026-07-29 · idle | test:a_same_mode_set_mode_still_clears_the_rate_pin | settled | — |
+| HQP-C-017 | A **same-mode** `SetMode` still reloads the chain and clears the exact-rate pin, so a no-op mode write is not a no-op | E1-upstream-verified | UHC-SALVAGE-BETA-DEV via `.oh/issue-322-…` · read-via-report · hqplayerd 6.0.4 (Opal) · 2026-07-29 · idle | test:a_same_mode_set_mode_still_clears_the_rate_pin · test:a_no_op_mode_write_is_not_sent_so_the_rate_pin_survives | settled | — |
 | HQP-C-018 | Under `[source]` a **non-zero** rate pin is accepted and ignored: the setter answers `OK` and the runtime rate does not move | E1-upstream-verified | UHC-SALVAGE-BETA-DEV via `.oh/issue-322-…` · read-via-report · hqplayerd 6.0.4 (Opal) · 2026-07-29 · idle | test:a_nonzero_rate_pin_under_source_is_accepted_and_ignored | settled | — |
-| HQP-C-019 | Under `[source]` an **Auto** (index 0) rate request is ignored and a readback **cannot tell** — comparing 0 against 0 reports success for a command that did nothing | E1-upstream-verified | UHC-SALVAGE-BETA-DEV via `.oh/issue-322-…` · read-via-report · hqplayerd 6.0.4 (Opal) · 2026-07-29 · idle | test:an_auto_rate_request_under_source_is_ignored_and_readback_cannot_tell | open | #347 |
+| HQP-C-019 | Under `[source]` an **Auto** (index 0) rate request is ignored and a readback **cannot tell** — comparing 0 against 0 reports success for a command that did nothing. The client therefore **suppresses** the write with a stated reason instead of verifying it | E1-upstream-verified | UHC-SALVAGE-BETA-DEV via `.oh/issue-322-…` · read-via-report · hqplayerd 6.0.4 (Opal) · 2026-07-29 · idle | test:an_auto_rate_request_under_source_is_ignored_and_readback_cannot_tell · test:an_auto_rate_request_under_source_is_never_reported_as_applied · test:a_rate_pin_under_source_is_suppressed_before_it_reaches_the_daemon | settled | — |
 | HQP-C-020 | The offered rate list varies wholesale **by mode** — PCM 44.1k–768k against SDM 2.8M–24.6M on L1, with no overlap | E0-uhc-live | PR #337 comment 5135836825 · read-via-pr · Embedded 6.0.2 / engine 6.0.4 · 2026-07-30 · idle | test:a_rate_valid_in_one_chain_is_refused_in_the_other | settled | — |
 | HQP-C-021 | The rate list also depends on the **selected filter**, so mode alone is insufficient to resolve a rate | E1-upstream-verified | UHC-SALVAGE-BETA-DEV §4 via #341 [comment 5126438674](https://github.com/open-horizon-labs/unified-hifi-control/issues/341#issuecomment-5126438674) (`livelane.py:33-38`) · read-via-report · hqplayerd 6.0.4 (Opal) · 2026-07-29 · idle | none:capture GetRates before and after a SetFilter on one device and record which entries change | open | #332 |
 | HQP-C-022 | Whether `GetRates` can be **empty** at all is unsupported by any observation in the audited evidence base | E4-unverified | #341 comment 5126438674 · read-via-issue · n/a · 2026-07-30 · n/a | none:read-only GetRates capture on a daemon with no usable output configured, or upstream confirmation that an empty list is reachable | open | #332 |
@@ -147,7 +147,7 @@ were **not executed** and are recorded as gaps in that comment.
 | HQP-C-023 | `Status.active_mode` **echoes the configured mode** under `[source]`, so it cannot resolve the loaded chain | E1-upstream-verified | UHC-SALVAGE reports via `.oh/issue-322-…:1549-1552` and `model.rs:126`/`:146` at `bc9158e` · read-via-report · hqplayerd 6.0.4 (Opal) · 2026-07-29 · active | test:the_fake_does_not_settle_the_independent_state_and_status_active_mode_semantics | settled | — |
 | HQP-C-024 | What `State.active_mode` reports under `[source]` — the loaded chain or the configured mode — is **unmeasured**, upstream and here | E4-unverified | `.oh/issue-322-…:1738-1740` · direct · unmeasured on any daemon · 2026-07-30 · unknown | test:the_fake_does_not_settle_the_independent_state_and_status_active_mode_semantics · #332:Resolve State.active_mode versus Status.active_mode under configured PCM/SDM and [source]/Auto with PCM and DSD sources | open | #332 |
 | HQP-C-025 | `Status` reports active settings as **display names** while `State` reports numbers, so the two are complementary rather than redundant | E3-derived | `tests/fixtures/hqplayer/hqpd-6.0.4-opal/status_playing_with_metadata.xml` · read-via-report · hqplayerd 6.0.4 (Opal) · 2026-07-29 · unknown | test:status_reports_active_settings_as_display_names | settled | — |
-| HQP-C-026 | UHC's own comment at `src/adapters/hqplayer.rs:2473` calls `Status.active_mode` "unreliable" and instructs using `State`'s — a global rule the evidence does not support | E4-unverified | `src/adapters/hqplayer.rs:2473` · direct · n/a · 2026-07-30 · n/a | none:HQP-C-024 settling, after which the comment states a measured fact or is deleted | open | #347 |
+| HQP-C-026 | UHC's own comment at `src/adapters/hqplayer.rs:2473` called `Status.active_mode` "unreliable" and instructed using `State`'s — a global rule the evidence does not support | E4-unverified | `src/adapters/hqplayer.rs:2473` · direct · n/a · 2026-07-30 · n/a | test:tests/hqplayer_ledger_lint.rs::no_production_comment_settles_the_active_mode_question_by_fiat | retired | #347 |
 
 #### HQP-C-023's playback state was corrected, and the wrong value had already travelled
 
@@ -250,30 +250,34 @@ withdrawn.
 
 Each row below is an `open` or `pending-live` claim, with the acquisition plan the lint requires.
 
-### HQP-C-063 — the client boundary is not yet what HQP-C-004 describes
+### HQP-C-063 — the client boundary now is what HQP-C-004 describes · **fixed here**
 
-HQP-C-004 previously said clients *"never"* exchange list indices or enum IDs. **That is false today**, and
-an independent review caught it. Two evidenced paths:
+**Outcome first:** #347 landed both halves, and the row is `retired` — a status change, not a deletion, so
+a reader arriving from an old link sees what was true and what changed.
+
+HQP-C-004 previously said clients *"never"* exchange list indices or enum IDs. That was false at `6d688bd`,
+and an independent review caught it. Two evidenced paths:
 
 - **The legacy numeric HTTP route.** `HqpSettingRequest` carries `value: u32`, and the handler's own
-  comment reads *"Legacy endpoint - convert numeric value to string for name-based lookups"*
-  (`src/api/mod.rs:825-836`). A client that sends `3` gets `"3"` passed to `set_mode`.
+  comment read *"Legacy endpoint - convert numeric value to string for name-based lookups"*
+  (`src/api/mod.rs:825-836`). A client that sent `3` got `"3"` passed to `set_mode`.
 - **The adapter's numeric-string fallback.** `resolve_mode_index`, `resolve_filter_index` and
-  `resolve_shaper_index` each try `parse::<u32>()` and treat the result as a **direct list index** when the
-  name is not in the cached enumeration (`:2081`, `:2186`, `:2247`).
+  `resolve_shaper_index` each tried `parse::<u32>()` and treated the result as a **direct list index** when
+  the name was not in the cached enumeration (`:2081`, `:2186`, `:2247`).
 
-So HQP-C-004 is now scoped to the **design rule** and this row carries the **current fact**. #347's
-acceptance criteria own both halves precisely: *"Raw integer-string fallback is removed from production
-control paths"*, and *"Preserve the existing numeric legacy HTTP request contract … but keep that numeric
-value at the compatibility boundary and never persist or publish it as adaptive-control identity."*
+**What #347 did, and the shape of the fix.** The request contracts are frozen, so the number is *kept* —
+`HqpAdapter::legacy_index_to_name` resolves it against the enumeration the daemon is serving now and
+returns the **name**, and that is what travels inward. A position the current list does not have is an
+error at the boundary rather than an index forwarded to the wire. The resolvers no longer parse anything.
 
-**Why this row has no executable proof, deliberately.** A check that asserts the fallback still exists
-would fail the moment #347 fixed it — failing on the happy path, which is a poor tripwire. HQP-C-062's
-check is the opposite shape: it fails when a *capability is added*, which genuinely warrants a ledger
-update. The asymmetry is the reason one is executable and the other is not.
+**The proof shape changed with it, and that is the point of the earlier note.** This row previously had no
+executable proof because a check asserting the fallback *still existed* would fail on the happy path. Now
+that the fallback is gone, the tripwire can point the other way and does:
+`no_production_control_path_parses_a_setting_name_as_an_index` fails if a resolver ever parses a name back
+into an index, which is a check that only fires on a regression.
 
-**What would settle it:** #347 landing both halves, after which HQP-C-004's stronger wording becomes true
-and this row retires. Until then the ledger must not describe the intended state as the shipped one.
+**Settled by:** #347. `a_numeric_string_is_never_accepted_as_a_setting_name` drives the three semantic
+setters with `"1"`, `"7"` and `"4"` and requires all three to be refused with nothing on the wire.
 
 ### HQP-C-064 — the shaper setter has no hermetic coverage
 
@@ -313,15 +317,22 @@ fixture's `hardware` marker, then re-provenancing each fixture from the capture.
 produced 144 hardware-enumeration divergences against this corpus, which is the expected result for a
 different DAC chain and does **not** settle the excerpt positions for the Opal profile.
 
-### HQP-C-019 — Auto under `[source]` reports success for an ignored command
+### HQP-C-019 — Auto under `[source]` reported success for an ignored command · **fixed here**
 
-`verify_applied` compares the readback against the requested index; requesting Auto (0) under
-`[source]`, where the daemon ignores the pin and the rate is already 0, compares 0 against 0 and
-reports success. The setter did nothing.
+`verify_applied` compared the readback against the requested index; requesting Auto (0) under `[source]`,
+where the daemon ignores the pin and the rate is already 0, compared 0 against 0 and reported success. The
+setter did nothing.
 
-**What would settle it:** #347 introducing an `ignored` outcome distinct from `applied` and
-`rejected`, at which point this row becomes a client-behaviour claim with a test rather than an
-evidence question. The protocol half is already settled by HQP-C-018.
+**Settled by #347, and not in the way this row expected.** The plan recorded here was an `ignored` outcome
+distinct from `applied` and `rejected`. That outcome exists — `SettingOutcome::Ignored` — but it is *not*
+what fixes this case, because no readback can distinguish "ignored" from "applied" when the requested value
+equals the value already held. What fixes it is refusing to send the write at all: under a configured
+`[source]` mode the client answers `SettingOutcome::Suppressed` naming the mode, and the daemon is never
+asked. Reaching for the outcome type alone would have left the Auto case exactly as blind as before.
+
+The protocol half was already settled by HQP-C-018, and remains asserted directly against the fake, with no
+client in the path — the client no longer sends the pin, so it can no longer demonstrate a daemon ignoring
+it.
 
 ### HQP-C-021 — the rate list's dependence on the selected filter
 
@@ -353,14 +364,22 @@ first a PCM and then a DSD source, reading both fields at each step. Until then 
 chosen here, and `the_fake_does_not_settle_the_independent_state_and_status_active_mode_semantics`
 keeps the harness from choosing one either.
 
-### HQP-C-026 — UHC's own comment states the unsettled rule as settled
+### HQP-C-026 — UHC's own comment stated the unsettled rule as settled · **fixed here**
 
-`src/adapters/hqplayer.rs:2473` reads *"Use State's active_mode (INDEX) - Status's active_mode string
-is unreliable"*. That is HQP-C-024's unmeasured half asserted as fact.
+`src/adapters/hqplayer.rs:2473` read *"Use State's active_mode (INDEX) - Status's active_mode string is
+unreliable"*. That is HQP-C-024's unmeasured half asserted as fact, and #341 deliberately left it alone:
+the file was under remediation on the base branch and a comment-only edit would have conflicted for no
+behavioural gain.
 
-**What would settle it:** HQP-C-024. The comment is left in place deliberately: `src/adapters/hqplayer.rs`
-is under active remediation on the base branch this PR is stacked on, and a comment-only edit there
-would conflict for no behavioural gain. #347 owns the file and the semantics.
+**Retired by #347**, which owns the file. The comment now says what is true — that this is a reporting
+choice between one measured field and one unmeasured one, that #332 owns settling which is right, and that
+**nothing requiring correctness depends on it**: the loaded chain is resolved from the enumerations the
+daemon serves, never from either `active_mode`. HQP-C-024 stays `open` and unaffected; what is retired is
+the claim that UHC's own source asserts it settled.
+
+`no_production_comment_settles_the_active_mode_question_by_fiat` is the tripwire, the mirror of the check
+`the_reference_document_no_longer_settles_the_active_mode_question_by_fiat` already applies to the prose
+document.
 
 ### HQP-C-029 — apply-then-drop is ambiguous delivery
 

--- a/docs/hqplayer-evidence-ledger.md
+++ b/docs/hqplayer-evidence-ledger.md
@@ -110,7 +110,7 @@ were **not executed** and are recorded as gaps in that comment.
 | HQP-C-003 | Domain 2 — the **persistent** domain: `hqplayerd.xml` and the 8088 config form store **enum IDs**, which are not list indices and must never be fed to the live lane | E1-upstream-verified | UHC-SALVAGE reports via `.oh/issue-322-hqplayer-protocol-conformance.md` · read-via-report · hqplayerd 6.0.4 (Opal) · 2026-07-29 · idle | test:the_persistent_configuration_lane_stores_enum_ids_not_list_indices · test:feeding_a_persistent_enum_id_to_the_live_lane_is_rejected | settled | — |
 | HQP-C-004 | Domain 3 — the **client** domain: clients exchange setting-appropriate values — semantic names for mode/filter/shaper, Hz for rate, decimal dB for volume — and the adapter owns both numeric conversions. The two paths that broke this rule are gone (HQP-C-063, retired); the one frozen numeric request contract is resolved to a name at the HTTP boundary and never travels inward | E6-documentary | `.oh/hqplayer-spec.md` layer table · direct · n/a · 2026-02-04 · n/a | test:a_filter_name_is_sent_as_the_index_the_observed_list_gives_it · test:a_numeric_string_is_never_accepted_as_a_setting_name | settled | — |
 | HQP-C-063 | Raw indices **did** cross the client boundary, in two evidenced places: the legacy numeric route `HqpSettingRequest { name: String, value: u32 }` stringified its number for name-based lookup (`src/api/mod.rs:825-836`), and the adapter's resolvers fell back to parsing a numeric string as a direct index (`resolve_mode_index:2081`, `resolve_filter_index:2186`, `resolve_shaper_index:2247`) | E6-documentary | `src/api/mod.rs` and `src/adapters/hqplayer.rs` at `6d688bd` · direct · n/a · 2026-07-30 · n/a | test:a_numeric_string_is_never_accepted_as_a_setting_name · test:tests/hqplayer_ledger_lint.rs::no_production_control_path_parses_a_setting_name_as_an_index | retired | #347 |
-| HQP-C-064 | **No conformance expectation drives `set_shaper`**, so the shaper setter's behaviour is L1-observed only — `shaper 24→0→24`, `result="OK"`, readback-verified on the live run — and unpinned hermetically | E0-uhc-live | PR #337 comment 5135836825 · read-via-pr · Embedded 6.0.2 / engine 6.0.4 · 2026-07-30 · idle | none:a conformance expectation that drives `set_shaper` and verifies the readback; the fake already applies `SetShaping` (`model.rs`), so only the expectation is missing | open | #329 |
+| HQP-C-064 | The shaper setter was L1-observed only — `shaper 24→0→24`, `result="OK"`, readback-verified on the live run — with **no conformance expectation driving `set_shaper`**. It is now driven hermetically, including the readback and the three delivery outcomes | E0-uhc-live | PR #337 comment 5135836825 · read-via-pr · Embedded 6.0.2 / engine 6.0.4 · 2026-07-30 · idle | test:a_write_whose_reply_is_lost_after_the_daemon_applied_it_is_reported_as_applied · test:a_write_whose_delivery_cannot_be_established_is_reported_as_ambiguous · test:an_explicit_rejection_is_not_treated_as_ambiguous_delivery | settled | — |
 | HQP-C-005 | `SetMode` does **not** reset the filter or shaper selections; the fake once modelled that and no evidence supports it | E3-derived | `.oh/issue-322-…` amendment row B14 · direct · hqplayerd 6.0.4 (Opal) · 2026-07-30 · unknown | test:set_mode_does_not_reset_the_filter_and_shaper_selections | settled | — |
 | HQP-C-006 | A mode change reloads the chain, so a list index resolved before it can name a **different** setting after it | E1-upstream-verified | UHC-SALVAGE reports via `.oh/issue-322-…` · read-via-report · hqplayerd 6.0.4 (Opal) · 2026-07-29 · idle | test:a_delayed_set_mode_still_clamps_indices_into_the_loaded_chain · test:the_same_filter_index_selects_a_different_filter_per_loaded_chain | settled | — |
 | HQP-C-007 | Under configured `[source]` the **loaded chain** can move between PCM and SDM while `State.mode` stays 0 | E1-upstream-verified | UHC-SALVAGE-BETA-DEV via `.oh/issue-322-…` · read-via-report · hqplayerd 6.0.4 (Opal) · 2026-07-29 · idle | test:the_loaded_chain_moves_under_source_while_the_configured_mode_stays_source | settled | — |
@@ -279,21 +279,26 @@ into an index, which is a check that only fires on a regression.
 **Settled by:** #347. `a_numeric_string_is_never_accepted_as_a_setting_name` drives the three semantic
 setters with `"1"`, `"7"` and `"4"` and requires all three to be refused with nothing on the wire.
 
-### HQP-C-064 — the shaper setter has no hermetic coverage
+### HQP-C-064 — the shaper setter had no hermetic coverage · **closed here**
 
-Found by **check 34**, which this PR added in response to CodeRabbit's HQP-C-051 finding: every `Set*`
+Found by **check 34**, which #341 added in response to CodeRabbit's HQP-C-051 finding: every `Set*`
 command a claim names must be exercised by one of that claim's own cited proofs. Running it flagged
 `SetShaping` in HQP-C-002, and the reason turned out to be a genuine gap rather than a citation slip —
-**no test in `tests/hqplayer_conformance.rs` calls `adapter.set_shaper`.** Verified directly: `set_mode`
-and `set_rate` are each driven by four expectations; `set_shaper` by none.
+**no test in `tests/hqplayer_conformance.rs` called `adapter.set_shaper`.** Verified directly at the
+time: `set_mode` and `set_rate` were each driven by four expectations; `set_shaper` by none.
 
-So the shaper setter's behaviour rests entirely on L1: `shaper 24→0→24`, `result="OK"`, readback-verified
-against a real daemon. That is good evidence and it is **not** a regression pin — a client change could
-break `set_shaper` today and this suite would stay green.
+So the shaper setter's behaviour rested entirely on L1: `shaper 24→0→24`, `result="OK"`,
+readback-verified against a real daemon. Good evidence, and **not** a regression pin — a client change
+could have broken `set_shaper` and the suite would have stayed green.
 
-**What would settle it:** a conformance expectation that drives `set_shaper` and verifies the readback. The
-fake already applies `SetShaping`, so only the expectation is missing, which makes this a coverage gap
-rather than a capability gap — the same shape as HQP-C-051.
+**Settled by #347**, which drives `set_shaper` through all three delivery outcomes hermetically: a
+reply lost *after* the daemon applied the write (reported applied, because the readback finds it), a
+write whose delivery cannot be established (reported ambiguous, neither success nor a claim that
+nothing happened), and an explicit `result="Error"` (terminal, keeping the daemon's own reason). The
+readback is the thing under test in all three, which is what the gap was.
+
+Row retained rather than deleted, because the *reason* it existed — a claim naming a command none of
+its proofs sent — is the class the check was built to find, and the row is the record of it.
 
 ### HQP-C-011 — does `GetFilters` renumber a name's enum ID between chains?
 

--- a/src/adapters/hqplayer.rs
+++ b/src/adapters/hqplayer.rs
@@ -3039,12 +3039,20 @@ impl HqpAdapter {
                          rather than resolving one chain's indices against another's lists"
                     );
                 }
+                // The retry moved too. There is nothing coherent to publish and no third attempt:
+                // the lists in hand came from the chain before *this* move, and noticing the move
+                // dropped them, so what is left is a state read against nothing. Answering `Ok`
+                // here hands back empty option lists and selections that resolve to nothing,
+                // presented as this daemon's settings — a caller cannot tell that from a daemon
+                // that genuinely offers no filters. The route has always had an error arm; this is
+                // what it is for.
                 Ok(false) => {
-                    tracing::warn!(
-                        "HQPlayer's loaded chain moved again during the re-read; publishing the \
-                         freshly read state against the freshly read lists"
-                    );
-                    state = Some(observed);
+                    let _ = observed;
+                    return Err(anyhow!(
+                        "HQPlayer's loaded chain moved while its settings were being read, and \
+                         again during the re-read; refusing to report settings that belong to no \
+                         single chain"
+                    ));
                 }
                 Err(e) => {
                     tracing::warn!("HQPlayer chain check failed, serving cached enumerations: {e}");

--- a/src/adapters/hqplayer.rs
+++ b/src/adapters/hqplayer.rs
@@ -1075,14 +1075,13 @@ impl FreshFamily {
     }
 
     /// The identity of these contents, derived from them and from nothing else.
+    ///
+    /// Delegates to the same per-family functions [`SemanticFamily`] carries, so a setter's proof and
+    /// the cache cannot disagree about what makes two enumerations the same enumeration.
     fn fingerprint(&self) -> u64 {
         match self {
-            Self::Modes(items) | Self::Shapers(items) => {
-                HqpAdapter::fingerprint(items.iter().map(|i| (i.index, i.name.as_str())))
-            }
-            Self::Filters(items) => {
-                HqpAdapter::fingerprint(items.iter().map(|i| (i.index, i.name.as_str())))
-            }
+            Self::Modes(items) | Self::Shapers(items) => HqpAdapter::list_fingerprint(items),
+            Self::Filters(items) => HqpAdapter::filters_fingerprint(items),
             Self::Rates(items) => HqpAdapter::rates_fingerprint(items),
         }
     }
@@ -1170,6 +1169,57 @@ impl FreshFamily {
             }
         }
     }
+}
+
+/// **What a semantic setter has to prove, gathered per setting family.**
+///
+/// A setter that accepts a *name* and speaks *positions* holds two domains together, and the join is
+/// not durable. `resolve` reads a position out of the enumeration the daemon serves at that moment;
+/// every comparison after it — the `AlreadySet` no-op check, the post-write readback — compares that
+/// **number** against `State`. Under a configured `[source]` mode the loaded chain moves when the
+/// source material does (HQP-C-007), so it can move between those two requests, and where two chains'
+/// lists are the same length a stale position is *in range* and names a different setting
+/// (HQP-C-009). The number then agrees with itself and the setter reports `AlreadySet` or `Applied`
+/// for a value the daemon does not hold.
+///
+/// **The cache generation cannot see this one.** A source-driven transition has no competing cache
+/// writer: nothing invalidates, nothing is overtaken, every guard in
+/// [`HqpAdapter::publish_fresh_family`] passes. What detects it is re-reading the enumeration and
+/// finding a different one.
+///
+/// The five pieces live in one value rather than arriving as five arguments because they have to
+/// agree with each other: `resolve` and `describe` are the two directions of a single mapping,
+/// `fingerprint` is the identity that mapping is only valid inside, and `selected` names the one
+/// `State` field that is authoritative for the setting. Three spellings of "which family is this" is
+/// the shape [`FreshFamily`] was introduced to remove.
+struct SemanticFamily<T: 'static, R: ?Sized + 'static> {
+    /// The setting, named as a caller sees it, for the outcome it reports.
+    what: &'static str,
+    /// Whether one semantic request addresses both 1x and Nx and therefore must name both in a
+    /// negative report.
+    paired: bool,
+    /// Identity of an enumeration: equal for two lists exactly when they resolve every position the
+    /// same way.
+    fingerprint: fn(&[T]) -> u64,
+    /// The position the requested semantic value occupies in a given list.
+    resolve: fn(&[T], &R) -> Result<u32>,
+    /// What the daemon currently holds, read from the field that *is* this setting. A paired setting
+    /// must preserve the difference between two reported positions and an absent position: the
+    /// former disproves application while the latter proves nothing.
+    selected: fn(&HqpState) -> SemanticSelection,
+    /// The semantic value at a position, for the report a human reads.
+    describe: fn(&[T], u32) -> String,
+}
+
+/// The authoritative state observed for one semantic setting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SemanticSelection {
+    /// The setting is reported as one list position.
+    Position(u32),
+    /// A paired setting reports two different positions.
+    Split(u32, u32),
+    /// The authoritative field (or one side of a pair) is absent.
+    Missing,
 }
 
 /// Why a read could not join the `State` it observed to the lists it holds.
@@ -1795,6 +1845,21 @@ impl HqpAdapter {
         self.publish_fresh_family(FreshFamily::Rates(rates.clone()), since)
             .await?;
         Ok(rates)
+    }
+
+    /// Fingerprint of a name-keyed list — modes and shapers.
+    ///
+    /// Its own function for the reason [`Self::rates_fingerprint`] is: the cache and every semantic
+    /// setter's proof compare enumerations, and two spellings of "the same enumeration" is a silent
+    /// way for those two to disagree.
+    fn list_fingerprint(items: &[ListItem]) -> u64 {
+        Self::fingerprint(items.iter().map(|i| (i.index, i.name.as_str())))
+    }
+
+    /// Fingerprint of a filter list. Separate from [`Self::list_fingerprint`] only because
+    /// [`FilterItem`] is a distinct type; the identity is the same `(index, name)` sequence.
+    fn filters_fingerprint(items: &[FilterItem]) -> u64 {
+        Self::fingerprint(items.iter().map(|i| (i.index, i.name.as_str())))
     }
 
     /// Fingerprint of a rate list. Its own function because it is compared in three places and a
@@ -2845,6 +2910,408 @@ impl HqpAdapter {
         }))
     }
 
+    /// The name a modes or shapers list gives a position, for a report rather than for a decision.
+    ///
+    /// A position the list does not have is described as exactly that. It is never rendered as a bare
+    /// number, because a number in a report reads like a value the caller could ask for again.
+    fn list_name_at(items: &[ListItem], index: u32) -> String {
+        items
+            .iter()
+            .find(|i| i.index == index)
+            .map(|i| i.name.clone())
+            .unwrap_or_else(|| format!("no entry at position {index}"))
+    }
+
+    /// [`Self::list_name_at`] for a filter list.
+    fn filter_name_at(items: &[FilterItem], index: u32) -> String {
+        items
+            .iter()
+            .find(|i| i.index == index)
+            .map(|i| i.name.clone())
+            .unwrap_or_else(|| format!("no entry at position {index}"))
+    }
+
+    /// The rate in Hz a rate list gives a position.
+    fn rate_at(items: &[RateItem], index: u32) -> String {
+        items
+            .iter()
+            .find(|i| i.index == index)
+            .map(|i| {
+                if i.rate == 0 {
+                    "Auto".to_string()
+                } else {
+                    i.rate.to_string()
+                }
+            })
+            .unwrap_or_else(|| format!("no entry at position {index}"))
+    }
+
+    /// Resolve a rate in **Hz** against the list the daemon is serving now (HQP-C-015).
+    ///
+    /// The requested value is a `u32` the caller supplied as Hz, so nothing here turns a string into a
+    /// position: this is the Hz-keyed sibling of [`Self::resolve_filter`], not the numeric fallback
+    /// HQP-C-063 records.
+    fn resolve_rate(rates: &[RateItem], requested: &u32) -> Result<u32> {
+        rates
+            .iter()
+            .find(|r| r.rate == *requested)
+            .map(|r| r.index)
+            .ok_or_else(|| {
+                anyhow!(
+                    "Rate {} is not offered for the chain this daemon has loaded",
+                    requested
+                )
+            })
+    }
+
+    /// The mode family: `GetModes` positions against `State.mode`.
+    const MODE: SemanticFamily<ListItem, str> = SemanticFamily {
+        what: "mode",
+        paired: false,
+        fingerprint: Self::list_fingerprint,
+        resolve: Self::resolve_mode,
+        selected: |s| SemanticSelection::Position(u32::from(s.mode)),
+        describe: Self::list_name_at,
+    };
+
+    /// Both filter sides at once. Split and missing pairs are different observations and remain so.
+    const FILTER_PAIR: SemanticFamily<FilterItem, str> = SemanticFamily {
+        what: "filter",
+        paired: true,
+        fingerprint: Self::filters_fingerprint,
+        resolve: Self::resolve_filter,
+        selected: |s| match (s.filter1x, s.filter_nx) {
+            (Some(one_x), Some(nx)) if one_x == nx => SemanticSelection::Position(one_x),
+            (Some(one_x), Some(nx)) => SemanticSelection::Split(one_x, nx),
+            _ => SemanticSelection::Missing,
+        },
+        describe: Self::filter_name_at,
+    };
+
+    /// The 1x side alone.
+    const FILTER_1X: SemanticFamily<FilterItem, str> = SemanticFamily {
+        what: "filter1x",
+        paired: false,
+        fingerprint: Self::filters_fingerprint,
+        resolve: Self::resolve_filter,
+        selected: |s| {
+            s.filter1x
+                .map_or(SemanticSelection::Missing, SemanticSelection::Position)
+        },
+        describe: Self::filter_name_at,
+    };
+
+    /// The Nx side alone.
+    const FILTER_NX: SemanticFamily<FilterItem, str> = SemanticFamily {
+        what: "filterNx",
+        paired: false,
+        fingerprint: Self::filters_fingerprint,
+        resolve: Self::resolve_filter,
+        selected: |s| {
+            s.filter_nx
+                .map_or(SemanticSelection::Missing, SemanticSelection::Position)
+        },
+        describe: Self::filter_name_at,
+    };
+
+    /// The shaper family. On the verified corpus its two chains are the same length and every
+    /// position but `none` names a different modulator in the other chain — `NS9` and `ASDM5` are
+    /// both position 4 — so this family needs no synthetic profile to be wrong quietly.
+    const SHAPER: SemanticFamily<ListItem, str> = SemanticFamily {
+        what: "shaper",
+        paired: false,
+        fingerprint: Self::list_fingerprint,
+        resolve: Self::resolve_shaper,
+        selected: |s| SemanticSelection::Position(s.shaper),
+        describe: Self::list_name_at,
+    };
+
+    /// The rate family, whose request domain is **Hz** rather than a name. Same proof, different
+    /// mapping shape.
+    const RATE: SemanticFamily<RateItem, u32> = SemanticFamily {
+        what: "rate",
+        paired: false,
+        fingerprint: Self::rates_fingerprint,
+        resolve: Self::resolve_rate,
+        selected: |s| SemanticSelection::Position(s.rate),
+        describe: Self::rate_at,
+    };
+
+    /// **Run a semantic setter and prove the semantic value, not the position it travelled as.**
+    ///
+    /// `decide` is the setter itself: it receives the position the request resolved to against a list
+    /// fetched now, and answers with what it did — a no-op, a verified write, a refusal. Everything
+    /// around it is the proof, and the proof is what [`SemanticFamily`] exists for.
+    ///
+    /// The shape is a **bracket**. The enumeration is read, the decision is taken, `State` is read,
+    /// and the enumeration is read again. If the two enumeration identities agree, then no visible
+    /// transition straddled the operation and the `State` observation — which sits between them —
+    /// belongs to that enumeration; the request is then resolved against *that* list and compared
+    /// with the position the daemon actually holds. That comparison is the semantic one. Without it,
+    /// `AlreadySet` and `Applied` rest on a number compared against itself.
+    ///
+    /// `State` is read before the second list on purpose. Read after it, the observation would sit
+    /// outside the bracket and the two identities would bound a window it was not in.
+    ///
+    /// **Bounded at one retry, and it is a retry rather than a second chance to fail.** A transition
+    /// caught once is ordinary — the source moved and the setter re-resolves against the chain that
+    /// is now loaded, which is the self-correcting outcome. Caught twice, the outcome is
+    /// [`SettingOutcome::Ambiguous`]: the write may or may not have landed on the requested value and
+    /// saying either would be a claim. What is never returned from here is `Applied` or `AlreadySet`
+    /// for a value that was not established.
+    ///
+    /// **This is not a compare-and-set.** The protocol has no atomic one: resolution and the write
+    /// are separate commands and another controller can move the daemon between them (#162). An
+    /// out-and-back (ABA) transition can also leave equal opening and closing fingerprints. The
+    /// bracket establishes only "the enumeration did not *visibly* move across this operation and
+    /// the daemon's position resolves to what was asked", which is strictly weaker than atomicity.
+    ///
+    /// The bounded correction amplifies requests: an ordinary semantic write adds a closing list
+    /// read, while one visible transition can perform a second decision/write plus its proof. That
+    /// cost is deliberately capped at one retry.
+    async fn proven_setting<T, R, Fetch, FetchFut, Decide, DecideFut>(
+        &self,
+        family: &SemanticFamily<T, R>,
+        requested: &R,
+        fetch: Fetch,
+        decide: Decide,
+    ) -> Result<SettingOutcome>
+    where
+        R: std::fmt::Display + ?Sized,
+        Fetch: Fn() -> FetchFut,
+        FetchFut: std::future::Future<Output = Result<Vec<T>>>,
+        Decide: Fn(u32) -> DecideFut,
+        DecideFut: std::future::Future<Output = Result<SettingOutcome>>,
+    {
+        let what = family.what;
+        let requested_display = if family.paired {
+            format!("1x={requested},Nx={requested}")
+        } else {
+            requested.to_string()
+        };
+        let mut unsettled: Option<String> = None;
+        // Outcome vocabulary describes the whole operation, not merely its final attempt.
+        // Applied/Ignored mean sent, Ambiguous means delivery was attempted, and
+        // AlreadySet/Suppressed mean no send. Once any attempt may have reached the wire, the whole
+        // operation can never truthfully become AlreadySet or Suppressed.
+        let mut attempted_write = false;
+        let mut acknowledged_write = false;
+        let mut delivery_uncertain = false;
+
+        // Two attempts: one retry, the same bound the read path uses.
+        for _ in 0..2 {
+            let before = match fetch().await {
+                Ok(before) => before,
+                Err(error) if attempted_write => {
+                    return Ok(SettingOutcome::Ambiguous {
+                        what: what.to_string(),
+                        reason: format!(
+                            "an earlier attempt may have reached the wire, but the retry could not \
+                             fetch the {what} enumeration ({error}); whether the daemon now holds \
+                             {requested} is not established"
+                        ),
+                    });
+                }
+                Err(error) => return Err(error),
+            };
+            let identity = (family.fingerprint)(&before);
+            let index = match (family.resolve)(&before, requested) {
+                Ok(index) => index,
+                Err(error) if attempted_write => {
+                    return Ok(SettingOutcome::Ambiguous {
+                        what: what.to_string(),
+                        reason: format!(
+                            "an earlier attempt may have reached the wire, but the retry could not \
+                             resolve {requested} in the {what} enumeration ({error}); whether the \
+                             daemon now holds it is not established"
+                        ),
+                    });
+                }
+                Err(error) => return Err(error),
+            };
+
+            let outcome = match decide(index).await {
+                Ok(outcome) => outcome,
+                Err(error) if attempted_write => {
+                    return Ok(SettingOutcome::Ambiguous {
+                        what: what.to_string(),
+                        reason: format!(
+                            "an earlier attempt may have reached the wire, but the retry's {what} \
+                             decision failed ({error}); whether the daemon now holds {requested} is \
+                             not established"
+                        ),
+                    });
+                }
+                Err(error) => return Err(error),
+            };
+            match &outcome {
+                SettingOutcome::Applied | SettingOutcome::Ignored { .. } => {
+                    attempted_write = true;
+                    acknowledged_write = true;
+                }
+                SettingOutcome::Ambiguous { .. } => {
+                    attempted_write = true;
+                    delivery_uncertain = true;
+                }
+                SettingOutcome::AlreadySet => {}
+                SettingOutcome::Suppressed { .. } if attempted_write => {
+                    return Ok(SettingOutcome::Ambiguous {
+                        what: what.to_string(),
+                        reason: "an earlier attempt may have reached the wire, but the retry was \
+                                 suppressed before the semantic result could be established"
+                            .to_string(),
+                    });
+                }
+                SettingOutcome::Suppressed { .. } => return Ok(outcome),
+            }
+
+            let state = match self.get_state().await {
+                Ok(state) => state,
+                Err(e) => {
+                    unsettled = Some(format!(
+                        "the daemon's State could not be read back after the {what} decision ({e})"
+                    ));
+                    continue;
+                }
+            };
+            let after = match fetch().await {
+                Ok(after) => after,
+                Err(e) => {
+                    unsettled = Some(format!(
+                        "the {what} enumeration could not be re-read after the decision ({e})"
+                    ));
+                    continue;
+                }
+            };
+
+            if (family.fingerprint)(&after) != identity {
+                tracing::info!(
+                    "HQPlayer's {what} enumeration moved while {what} was being set, so the \
+                     position that was written or compared no longer names what was asked for; \
+                     resolving again against the list it serves now"
+                );
+                unsettled = Some(format!(
+                    "the {what} enumeration the request was resolved against is not the one the \
+                     daemon serves now, so the position that was compared does not name {requested} \
+                     any more"
+                ));
+                continue;
+            }
+
+            let index_now = match (family.resolve)(&after, requested) {
+                Ok(index) => index,
+                Err(error) if attempted_write => {
+                    return Ok(SettingOutcome::Ambiguous {
+                        what: what.to_string(),
+                        reason: format!(
+                            "a write may have reached the wire, but {requested} could not be \
+                             resolved in the closing {what} enumeration ({error})"
+                        ),
+                    });
+                }
+                Err(error) => return Err(error),
+            };
+            return match (family.selected)(&state) {
+                SemanticSelection::Position(current) if current == index_now => {
+                    if attempted_write {
+                        Ok(SettingOutcome::Applied)
+                    } else {
+                        Ok(outcome)
+                    }
+                }
+                SemanticSelection::Position(current) if delivery_uncertain => {
+                    Ok(SettingOutcome::Ambiguous {
+                        what: what.to_string(),
+                        reason: format!(
+                            "a {what} write was attempted with uncertain delivery, and the stable \
+                             semantic readback is {} rather than {requested_display}; the write may \
+                             or may not have been delivered",
+                            if family.paired {
+                                let value = (family.describe)(&after, current);
+                                format!("1x={value},Nx={value}")
+                            } else {
+                                (family.describe)(&after, current)
+                            }
+                        ),
+                    })
+                }
+                SemanticSelection::Position(current) if acknowledged_write => {
+                    let observed = (family.describe)(&after, current);
+                    Ok(SettingOutcome::Ignored {
+                        what: what.to_string(),
+                        requested: requested_display.clone(),
+                        observed: if family.paired {
+                            format!("1x={observed},Nx={observed}")
+                        } else {
+                            observed
+                        },
+                    })
+                }
+                SemanticSelection::Position(current) => Ok(SettingOutcome::Suppressed {
+                    what: what.to_string(),
+                    reason: format!(
+                        "nothing was sent: the no-op decision was resolved against a stale mapping; \
+                         the stable semantic value is {} rather than {requested}",
+                        (family.describe)(&after, current)
+                    ),
+                }),
+                SemanticSelection::Split(one_x, nx) if delivery_uncertain => {
+                    Ok(SettingOutcome::Ambiguous {
+                        what: what.to_string(),
+                        reason: format!(
+                            "a {what} write was attempted with uncertain delivery, and State now \
+                             reports a split pair 1x={},Nx={} rather than {requested}",
+                            (family.describe)(&after, one_x),
+                            (family.describe)(&after, nx)
+                        ),
+                    })
+                }
+                SemanticSelection::Split(one_x, nx) if acknowledged_write => {
+                    Ok(SettingOutcome::Ignored {
+                        what: what.to_string(),
+                        requested: requested_display.clone(),
+                        observed: format!(
+                            "1x={},Nx={}",
+                            (family.describe)(&after, one_x),
+                            (family.describe)(&after, nx)
+                        ),
+                    })
+                }
+                SemanticSelection::Split(one_x, nx) => Ok(SettingOutcome::Suppressed {
+                    what: what.to_string(),
+                    reason: format!(
+                        "nothing was sent: the no-op decision was resolved against a stale mapping; \
+                         State reports the split pair 1x={},Nx={} rather than {requested}",
+                        (family.describe)(&after, one_x),
+                        (family.describe)(&after, nx)
+                    ),
+                }),
+                SemanticSelection::Missing => Ok(SettingOutcome::Ambiguous {
+                    what: what.to_string(),
+                    reason: format!(
+                        "the daemon does not report {what} as one value, so whether it now holds \
+                         {requested} cannot be established from its State"
+                    ),
+                }),
+            };
+        }
+
+        Ok(SettingOutcome::Ambiguous {
+            what: what.to_string(),
+            reason: format!(
+                "{}, and the retry met the same thing, so whether the daemon now holds {requested} \
+                 is not established; {}",
+                unsettled.unwrap_or_else(|| format!("the {what} enumeration would not settle"))
+                ,
+                if attempted_write {
+                    "at least one write reached or may have reached the wire"
+                } else {
+                    "no write reached the wire"
+                }
+            ),
+        })
+    }
+
     /// Confirm a setting actually applied, by reading the authoritative `State` field back.
     ///
     /// Verified daemon behaviour: a setter can return `result="OK"` without the setting actually
@@ -3036,28 +3503,40 @@ impl HqpAdapter {
     /// when the mode does not change (HQP-C-017), so an unconditional write destroys a user's pinned
     /// rate for nothing. When a write is performed the chain reloads, so every chain-scoped list is
     /// dropped and the pin the daemon just cleared is re-read rather than remembered.
+    /// The chain-transition hazard [`SemanticFamily`] describes cannot reach *this* family: `GetModes`
+    /// is device-scoped, so the loaded chain moving does not renumber it. What can reshape it is a
+    /// device or profile change — a PCM-only DAC's list has **no** SDM entry and the survivors keep
+    /// their own positions (HQP-C-013) — and an *external* one moves no UHC cache and bumps no
+    /// generation, so the fence does not cover it either. An exemption argued from "this family does
+    /// not move" is the shape of reasoning this issue exists to remove, so mode is proved like the
+    /// rest.
     pub async fn set_mode(&self, mode_name: &str) -> Result<SettingOutcome> {
-        let modes = self.fresh_modes().await?;
-        let mode_index = Self::resolve_mode(&modes, mode_name)?;
+        self.proven_setting(
+            &Self::MODE,
+            mode_name,
+            || self.fresh_modes(),
+            |mode_index| async move {
+                let state = self.get_state().await?;
+                if u32::from(state.mode) == mode_index {
+                    tracing::debug!(
+                        "HQPlayer is already in mode {mode_index}; not writing it, because SetMode \
+                         clears the rate pin even when the mode does not change"
+                    );
+                    return Ok(SettingOutcome::AlreadySet);
+                }
 
-        let state = self.get_state().await?;
-        if u32::from(state.mode) == mode_index {
-            tracing::debug!(
-                "HQPlayer is already in mode {mode_index}; not writing it, because SetMode clears \
-                 the rate pin even when the mode does not change"
-            );
-            return Ok(SettingOutcome::AlreadySet);
-        }
-
-        let xml = Self::build_request("SetMode", &[("value", &mode_index.to_string())]);
-        let outcome = self
-            .write_setting(&xml, "mode", mode_index, |s| Some(u32::from(s.mode)))
-            .await?;
-        // A mode change reloads the chain whatever the readback said, so nothing cached about it
-        // survives. This is also what makes the cleared pin honest: there is no remembered rate to
-        // report, only the one the daemon now holds.
-        self.invalidate_chain_cache().await;
-        Ok(outcome)
+                let xml = Self::build_request("SetMode", &[("value", &mode_index.to_string())]);
+                let outcome = self
+                    .write_setting(&xml, "mode", mode_index, |s| Some(u32::from(s.mode)))
+                    .await?;
+                // A mode change reloads the chain whatever the readback said, so nothing cached
+                // about it survives. This is also what makes the cleared pin honest: there is no
+                // remembered rate to report, only the one the daemon now holds.
+                self.invalidate_chain_cache().await;
+                Ok(outcome)
+            },
+        )
+        .await
     }
 
     /// The request both sides of the pair travel in, built in one place so they cannot drift.
@@ -3124,22 +3603,27 @@ impl HqpAdapter {
     /// It also needs no sibling: both sides are being written, so nothing has to be read out of
     /// `State` first and the refusal in [`Self::set_filter_side`] does not apply here.
     pub async fn set_filter_pair(&self, filter_name: &str) -> Result<SettingOutcome> {
-        let filters = self.fresh_filters().await?;
-        let index = Self::resolve_filter(&filters, filter_name)?;
+        self.proven_setting(
+            &Self::FILTER_PAIR,
+            filter_name,
+            || self.fresh_filters(),
+            |index| async move {
+                let state = self.get_state().await?;
+                if state.filter1x == Some(index) && state.filter_nx == Some(index) {
+                    return Ok(SettingOutcome::AlreadySet);
+                }
 
-        let state = self.get_state().await?;
-        if state.filter1x == Some(index) && state.filter_nx == Some(index) {
-            return Ok(SettingOutcome::AlreadySet);
-        }
-
-        // Both sides are the setting here, so both are verified. Rendered as one value because the
-        // pair is what was requested and reporting half of it back would be the same mistake as
-        // writing half of it.
-        let expected = format!("1x={index},Nx={index}");
-        tracing::debug!("SetFilter (both sides): value={index}, value1x={index}");
-        let xml = Self::filter_request(index, index);
-        self.write_setting(&xml, "filter", expected, Self::filter_pair_observation)
-            .await
+                // Both sides are the setting here, so both are verified. Rendered as one value
+                // because the pair is what was requested and reporting half of it back would be the
+                // same mistake as writing half of it.
+                let expected = format!("1x={index},Nx={index}");
+                tracing::debug!("SetFilter (both sides): value={index}, value1x={index}");
+                let xml = Self::filter_request(index, index);
+                self.write_setting(&xml, "filter", expected, Self::filter_pair_observation)
+                    .await
+            },
+        )
+        .await
     }
 
     /// One side of the filter pair, carrying the authoritative other side with it.
@@ -3150,39 +3634,48 @@ impl HqpAdapter {
     /// overwrote the setting the caller did not touch. When the sibling cannot be established the
     /// write is refused with a reason and nothing is sent.
     async fn set_filter_side(&self, side: FilterSide, filter_name: &str) -> Result<SettingOutcome> {
-        let filters = self.fresh_filters().await?;
-        let index = Self::resolve_filter(&filters, filter_name)?;
+        let family = match side {
+            FilterSide::OneX => &Self::FILTER_1X,
+            FilterSide::Nx => &Self::FILTER_NX,
+        };
         let what = side.field();
+        self.proven_setting(
+            family,
+            filter_name,
+            || self.fresh_filters(),
+            |index| async move {
+                let state = self.get_state().await?;
+                let (Some(current_1x), Some(current_nx)) = (state.filter1x, state.filter_nx) else {
+                    return Ok(SettingOutcome::Suppressed {
+                        what: what.to_string(),
+                        reason: "the daemon's State does not report both filter1x and filterNx, and \
+                                 SetFilter writes both sides at once; sending it would overwrite the \
+                                 sibling with a guess"
+                            .to_string(),
+                    });
+                };
 
-        let state = self.get_state().await?;
-        let (Some(current_1x), Some(current_nx)) = (state.filter1x, state.filter_nx) else {
-            return Ok(SettingOutcome::Suppressed {
-                what: what.to_string(),
-                reason: "the daemon's State does not report both filter1x and filterNx, and \
-                         SetFilter writes both sides at once; sending it would overwrite the sibling \
-                         with a guess"
-                    .to_string(),
-            });
-        };
+                let current = match side {
+                    FilterSide::OneX => current_1x,
+                    FilterSide::Nx => current_nx,
+                };
+                if current == index {
+                    return Ok(SettingOutcome::AlreadySet);
+                }
 
-        let current = match side {
-            FilterSide::OneX => current_1x,
-            FilterSide::Nx => current_nx,
-        };
-        if current == index {
-            return Ok(SettingOutcome::AlreadySet);
-        }
-
-        let (send_nx, send_1x) = match side {
-            FilterSide::OneX => (current_nx, index),
-            FilterSide::Nx => (index, current_1x),
-        };
-        tracing::debug!("SetFilter: value={send_nx} (Nx), value1x={send_1x} (1x)");
-        let xml = Self::filter_request(send_nx, send_1x);
-        self.write_setting(&xml, what, index, |s| match side {
-            FilterSide::OneX => s.filter1x,
-            FilterSide::Nx => s.filter_nx,
-        })
+                let (send_nx, send_1x) = match side {
+                    FilterSide::OneX => (current_nx, index),
+                    FilterSide::Nx => (index, current_1x),
+                };
+                tracing::debug!("SetFilter: value={send_nx} (Nx), value1x={send_1x} (1x)");
+                let xml = Self::filter_request(send_nx, send_1x);
+                self.write_setting(&xml, what, index, |s| match side {
+                    FilterSide::OneX => s.filter1x,
+                    FilterSide::Nx => s.filter_nx,
+                })
+                .await
+            },
+        )
         .await
     }
 
@@ -3233,16 +3726,22 @@ impl HqpAdapter {
 
     /// Set the shaper (the modulator, under an SDM chain) by semantic name.
     pub async fn set_shaper(&self, shaper_name: &str) -> Result<SettingOutcome> {
-        let shapers = self.fresh_shapers().await?;
-        let shaper_index = Self::resolve_shaper(&shapers, shaper_name)?;
+        self.proven_setting(
+            &Self::SHAPER,
+            shaper_name,
+            || self.fresh_shapers(),
+            |shaper_index| async move {
+                if self.get_state().await?.shaper == shaper_index {
+                    return Ok(SettingOutcome::AlreadySet);
+                }
 
-        if self.get_state().await?.shaper == shaper_index {
-            return Ok(SettingOutcome::AlreadySet);
-        }
-
-        let xml = Self::build_request("SetShaping", &[("value", &shaper_index.to_string())]);
-        self.write_setting(&xml, "shaper", shaper_index, |s| Some(s.shaper))
-            .await
+                let xml =
+                    Self::build_request("SetShaping", &[("value", &shaper_index.to_string())]);
+                self.write_setting(&xml, "shaper", shaper_index, |s| Some(s.shaper))
+                    .await
+            },
+        )
+        .await
     }
 
     /// Whether the daemon's **configured** mode is the source-following one.
@@ -3271,38 +3770,37 @@ impl HqpAdapter {
     /// rate is already 0 compares 0 against 0, so a readback reports success for a command that did
     /// nothing (HQP-C-019).
     pub async fn set_rate(&self, rate_value: u32) -> Result<SettingOutcome> {
-        let modes = self.fresh_modes().await?;
-        let state = self.get_state().await?;
-        if let Some(mode_name) = Self::configured_source_mode(&modes, &state) {
-            return Ok(SettingOutcome::Suppressed {
-                what: "rate".to_string(),
-                reason: format!(
-                    "the configured mode is '{mode_name}', in which the daemon acknowledges a rate \
-                     pin and applies nothing — the rate is governed by persistent configuration \
-                     there, so the write was not sent"
-                ),
-            });
-        }
+        // The pin is a name-to-position problem like every other setter's, so it is proved like one.
+        // Source-mode suppression lives inside the decision so every retry re-evaluates it before a
+        // write; checking only once outside the bracket would let a transition to `[source]` during
+        // the first attempt send a pin on the retry.
+        self.proven_setting(
+            &Self::RATE,
+            &rate_value,
+            || self.fresh_rates(),
+            |index| async move {
+                let modes = self.fresh_modes().await?;
+                let state = self.get_state().await?;
+                if let Some(mode_name) = Self::configured_source_mode(&modes, &state) {
+                    return Ok(SettingOutcome::Suppressed {
+                        what: "rate".to_string(),
+                        reason: format!(
+                            "the configured mode is '{mode_name}', in which the daemon acknowledges \
+                             a rate pin and applies nothing — the rate is governed by persistent \
+                             configuration there, so the write was not sent"
+                        ),
+                    });
+                }
+                if state.rate == index {
+                    return Ok(SettingOutcome::AlreadySet);
+                }
 
-        let rates = self.fresh_rates().await?;
-        let index = rates
-            .iter()
-            .find(|r| r.rate == rate_value)
-            .map(|r| r.index)
-            .ok_or_else(|| {
-                anyhow!(
-                    "Rate {} is not offered for the chain this daemon has loaded",
-                    rate_value
-                )
-            })?;
-
-        if state.rate == index {
-            return Ok(SettingOutcome::AlreadySet);
-        }
-
-        let xml = Self::build_request("SetRate", &[("value", &index.to_string())]);
-        self.write_setting(&xml, "rate", index, |s| Some(s.rate))
-            .await
+                let xml = Self::build_request("SetRate", &[("value", &index.to_string())]);
+                self.write_setting(&xml, "rate", index, |s| Some(s.rate))
+                    .await
+            },
+        )
+        .await
     }
 
     /// Turn a legacy numeric setting value into the semantic name it denotes **right now**.

--- a/src/adapters/hqplayer.rs
+++ b/src/adapters/hqplayer.rs
@@ -3174,7 +3174,7 @@ impl HqpAdapter {
                 SettingOutcome::Suppressed { .. } => return Ok(outcome),
             }
 
-            let state = match self.get_state().await {
+            let mut state = match self.get_state().await {
                 Ok(state) => state,
                 Err(e) => {
                     unsettled = Some(format!(
@@ -3192,6 +3192,23 @@ impl HqpAdapter {
                             reason: format!(
                                 "a {what} write may have reached the wire, but the configured mode \
                                  could not be resolved during final proof ({error})"
+                            ),
+                        });
+                    }
+                    Err(error) => return Err(error),
+                };
+                // GetModes carries capabilities, not the configured selection. Re-read State after
+                // that reconnect-capable request so a controller changing mode immediately after
+                // the earlier proof reply cannot leave us proving rate through stale mode/rate
+                // fields. The remaining post-State race is the protocol's non-atomic boundary.
+                state = match self.get_state().await {
+                    Ok(state) => state,
+                    Err(error) if attempted_write => {
+                        return Ok(SettingOutcome::Ambiguous {
+                            what: what.to_string(),
+                            reason: format!(
+                                "a {what} write may have reached the wire, but State could not be \
+                                 re-read after the final modes fetch ({error})"
                             ),
                         });
                     }

--- a/src/adapters/hqplayer.rs
+++ b/src/adapters/hqplayer.rs
@@ -1529,12 +1529,18 @@ impl HqpAdapter {
     /// *movement*, and with nothing cached there is no movement to report. This one is about
     /// *presence*, and it has to be asked again after the reads — a reconnect between the two
     /// empties the cache behind the answer.
+    ///
+    /// A missing `rates_fingerprint` counts as incomplete too. Current writers update it in lockstep
+    /// with `rates`, so this is defensive invariant enforcement rather than a separately reachable
+    /// state today. It is what the lists were filled *from*: without it there is nothing for
+    /// [`Self::chain_still_matches_cache`] to compare against and the lists would be unanchored.
     async fn chain_lists_incomplete(&self) -> bool {
         let cached = self.state.read().await;
         cached.modes.is_empty()
             || cached.filters.is_empty()
             || cached.shapers.is_empty()
             || cached.rates.is_empty()
+            || cached.rates_fingerprint.is_none()
     }
 
     /// Whether the daemon's chain still matches the one the cache was filled from, **publishing

--- a/src/adapters/hqplayer.rs
+++ b/src/adapters/hqplayer.rs
@@ -1514,14 +1514,18 @@ impl HqpAdapter {
         )
     }
 
-    /// Ask whether the loaded chain has moved, and **publish nothing either way**.
+    /// Whether the daemon's chain still matches the one the cache was filled from, **publishing
+    /// nothing either way**. Drops the cache when it does not.
     ///
-    /// The read path's probe. Deliberately not [`Self::fresh_rates`], which caches what it fetched:
+    /// The read path's check. Deliberately not [`Self::fresh_rates`], which caches what it fetched:
     /// caching here would publish one family on its own, so a poll that detected a transition would
     /// leave a caller holding the new chain's rates beside no filters and no shapers — a partial view,
     /// offered as a whole one. Detection and publication are separate jobs, and [`Self::refresh_lists`]
     /// owns the second.
-    async fn chain_probe(&self) -> Result<()> {
+    ///
+    /// Nothing cached yet reads as a match: there is no previous observation for the daemon to
+    /// contradict, and the caller's own lazy fill is what settles it.
+    async fn chain_still_matches_cache(&self) -> Result<bool> {
         let fingerprint = Self::rates_fingerprint(&self.get_rates().await?);
         let previous = self.state.read().await.rates_fingerprint;
         if previous.is_some_and(|p| p != fingerprint) {
@@ -1530,8 +1534,9 @@ impl HqpAdapter {
                  chain-scoped list"
             );
             self.invalidate_chain_cache().await;
+            return Ok(false);
         }
-        Ok(())
+        Ok(true)
     }
 
     /// Refresh every cached list, publishing **one coherent snapshot or none at all**.
@@ -2579,17 +2584,6 @@ impl HqpAdapter {
         Ok(outcome)
     }
 
-    /// Send `SetFilter` with **both** arguments.
-    ///
-    /// The daemon's `SetFilter` writes both sides: `value` alone sets 1x and Nx together, and
-    /// `value1x` splits them. There is therefore no such thing as a one-sided write on the wire — a
-    /// caller that omits the sibling is overwriting it with whatever it passed as `value`. Taking both
-    /// indices is what makes that impossible to express, rather than merely discouraged.
-    ///
-    /// **Indices in, and no readback.** This is the raw form: it resolves no name and confirms
-    /// nothing, so it is not a control path. Every advertised surface goes through
-    /// [`Self::set_filter_1x`] or [`Self::set_filter_nx`], which resolve a semantic name against the
-    /// loaded chain's list and verify the result.
     /// The request both sides of the pair travel in, built in one place so they cannot drift.
     fn filter_request(value_nx: u32, value1x: u32) -> String {
         let nx = value_nx.to_string();
@@ -2597,11 +2591,41 @@ impl HqpAdapter {
         Self::build_request("SetFilter", &[("value", &nx), ("value1x", &one_x)])
     }
 
-    pub async fn set_filter(&self, value_nx: u32, value1x: u32) -> Result<()> {
+    /// The observable both sides of the pair are verified against, as one value.
+    ///
+    /// The pair is what was requested, so reporting half of it back would be the same mistake as
+    /// writing half of it. `None` when the daemon reports neither sibling — `verify_applied` turns an
+    /// absent field into `Ambiguous`, which is what "nothing can be established" honestly is.
+    fn filter_pair_observation(state: &HqpState) -> Option<String> {
+        match (state.filter1x, state.filter_nx) {
+            (Some(one_x), Some(nx)) => Some(format!("1x={one_x},Nx={nx}")),
+            _ => None,
+        }
+    }
+
+    /// Send `SetFilter` with **both** arguments, by index.
+    ///
+    /// The daemon's `SetFilter` writes both sides: `value` alone sets 1x and Nx together, and
+    /// `value1x` splits them. There is therefore no such thing as a one-sided write on the wire — a
+    /// caller that omits the sibling is overwriting it with whatever it passed as `value`. Taking both
+    /// indices is what makes that impossible to express, rather than merely discouraged.
+    ///
+    /// **Indices in — and that is the only thing this form gives up.** It answered `Ok(())` on
+    /// `result="OK"` alone until an independent review pointed out that a public method doing so is a
+    /// false success whatever it is called, so it is verified like every other write: `OK` is not
+    /// proof of application here any more than anywhere else (HQP-C-028).
+    ///
+    /// Every advertised surface goes through [`Self::set_filter_1x`], [`Self::set_filter_nx`] or
+    /// [`Self::set_filter_pair`], which additionally resolve a semantic name against the loaded
+    /// chain's list. This form exists for a caller that already holds indices — the conformance
+    /// suite's cross-lane checks, which feed a persistent-domain enum ID to the live lane and require
+    /// it to be refused.
+    pub async fn set_filter(&self, value_nx: u32, value1x: u32) -> Result<SettingOutcome> {
         tracing::debug!("SetFilter: value={value_nx} (Nx), value1x={value1x} (1x)");
-        self.send_command(&Self::filter_request(value_nx, value1x))
-            .await?;
-        Ok(())
+        let expected = format!("1x={value1x},Nx={value_nx}");
+        let xml = Self::filter_request(value_nx, value1x);
+        self.write_setting(&xml, "filter", expected, Self::filter_pair_observation)
+            .await
     }
 
     /// Set only the 1x filter, preserving the Nx filter the daemon reports.
@@ -2638,15 +2662,8 @@ impl HqpAdapter {
         let expected = format!("1x={index},Nx={index}");
         tracing::debug!("SetFilter (both sides): value={index}, value1x={index}");
         let xml = Self::filter_request(index, index);
-        self.write_setting(&xml, "filter", expected, |s| {
-            match (s.filter1x, s.filter_nx) {
-                (Some(one_x), Some(nx)) => Some(format!("1x={one_x},Nx={nx}")),
-                // Absent rather than mismatched: `verify_applied` turns a field the daemon never
-                // reports into `Ambiguous`, which is the truthful answer when nothing can be seen.
-                _ => None,
-            }
-        })
-        .await
+        self.write_setting(&xml, "filter", expected, Self::filter_pair_observation)
+            .await
     }
 
     /// One side of the filter pair, carrying the authoritative other side with it.
@@ -2974,34 +2991,77 @@ impl HqpAdapter {
 
     /// Get full pipeline status
     pub async fn get_pipeline_status(&self) -> Result<PipelineStatus> {
-        // Core data: State + Status (2 TCP commands)
-        let state = self.get_state().await?;
-        let playback_status = self.get_playback_status().await.unwrap_or_default();
-
-        // Chain probe. The lists this view publishes are scoped to the chain the daemon has *loaded*,
-        // and under `[source]` that chain moves without `State.mode` moving at all (HQP-C-007) — so
-        // "refresh when a list is empty" served the previous chain's options indefinitely, and a UI
-        // offering PCM filters over a loaded DSD chain is a lie a user acts on.
+        // `State` reports settings as **list indices**, and an index means nothing apart from the list
+        // it came from. So the lists are settled first and `State` is read after them, then the chain
+        // is checked once more: if it moved while `State` was being read, the index and the list
+        // describe different chains and neither answer is the daemon's.
         //
-        // The rate list is the probe because it is the smallest chain-scoped enumeration and the two
-        // chains' rate lists were observed disjoint (HQP-C-020). Its fingerprint changing drops every
-        // chain-scoped cache, which the lazy fill below then repopulates. A probe failure is not fatal
-        // to a read: the caller still gets `State` and `Status`.
-        if let Err(e) = self.chain_probe().await {
-            tracing::warn!("HQPlayer chain probe failed, serving cached enumerations: {e}");
-        }
+        // Reading `State` first — as this did — is the same misselection this issue exists to end,
+        // arriving through the read path and needing no write at all: under `[source]` the chain moves
+        // without `State.mode` moving (HQP-C-007), so a pre-transition index was resolved against
+        // post-transition lists.
+        //
+        // The rate list is the check because it is the smallest chain-scoped enumeration and the two
+        // chains' rate lists were observed disjoint (HQP-C-020). One retry, not a loop: a daemon whose
+        // chain is flapping would otherwise hold this open, and after the retry the lists and `State`
+        // are at least read in the right order.
+        //
+        // **Residual, and it cannot be closed from here.** The check confirms the chain is the same
+        // *now* as when the lists were published; a move out and back inside that window leaves it
+        // agreeing. Only a daemon-side atomic snapshot could do better, and the protocol has none.
+        let mut state = None;
+        let mut playback_status = HqpStatus::default();
+        for attempt in 0..2 {
+            // Lazy-fill whatever is missing — on the first read after connect, that is all of it.
+            let needs_lists = {
+                let cached = self.state.read().await;
+                cached.modes.is_empty()
+                    || cached.filters.is_empty()
+                    || cached.shapers.is_empty()
+                    || cached.rates.is_empty()
+            };
+            if needs_lists {
+                self.refresh_lists().await;
+            }
 
-        // Lazy-fill whatever the probe left empty — on the first read after connect, that is all of it.
-        let needs_lists = {
-            let cached = self.state.read().await;
-            cached.modes.is_empty()
-                || cached.filters.is_empty()
-                || cached.shapers.is_empty()
-                || cached.rates.is_empty()
-        };
-        if needs_lists {
-            self.refresh_lists().await;
+            let observed = self.get_state().await?;
+            playback_status = self.get_playback_status().await.unwrap_or_default();
+
+            // A check failure is not fatal to a read: the caller still gets `State` and `Status`.
+            match self.chain_still_matches_cache().await {
+                Ok(true) => {
+                    state = Some(observed);
+                    break;
+                }
+                Ok(false) if attempt == 0 => {
+                    tracing::info!(
+                        "HQPlayer's loaded chain moved while its state was being read; re-reading \
+                         rather than resolving one chain's indices against another's lists"
+                    );
+                }
+                Ok(false) => {
+                    tracing::warn!(
+                        "HQPlayer's loaded chain moved again during the re-read; publishing the \
+                         freshly read state against the freshly read lists"
+                    );
+                    state = Some(observed);
+                }
+                Err(e) => {
+                    tracing::warn!("HQPlayer chain check failed, serving cached enumerations: {e}");
+                    state = Some(observed);
+                }
+            }
+            if state.is_some() {
+                break;
+            }
         }
+        let state = match state {
+            Some(state) => state,
+            // Unreachable in practice: the loop only leaves this `None` by exhausting both attempts
+            // without setting it, and the second attempt always sets it. Read it once more rather
+            // than unwrap, so a future edit to the loop cannot turn a logic slip into a panic.
+            None => self.get_state().await?,
+        };
 
         // Lazy-load volume range if not cached
         let needs_vol_range = {

--- a/src/adapters/hqplayer.rs
+++ b/src/adapters/hqplayer.rs
@@ -1198,6 +1198,9 @@ struct SemanticFamily<T: 'static, R: ?Sized + 'static> {
     /// Whether one semantic request addresses both 1x and Nx and therefore must name both in a
     /// negative report.
     paired: bool,
+    /// Whether the final proof must reject configured source-following mode. Rate pins are accepted
+    /// and ignored there, including the numerically indistinguishable Auto case.
+    refuses_source_mode: bool,
     /// Identity of an enumeration: equal for two lists exactly when they resolve every position the
     /// same way.
     fingerprint: fn(&[T]) -> u64,
@@ -2968,6 +2971,7 @@ impl HqpAdapter {
     const MODE: SemanticFamily<ListItem, str> = SemanticFamily {
         what: "mode",
         paired: false,
+        refuses_source_mode: false,
         fingerprint: Self::list_fingerprint,
         resolve: Self::resolve_mode,
         selected: |s| SemanticSelection::Position(u32::from(s.mode)),
@@ -2978,6 +2982,7 @@ impl HqpAdapter {
     const FILTER_PAIR: SemanticFamily<FilterItem, str> = SemanticFamily {
         what: "filter",
         paired: true,
+        refuses_source_mode: false,
         fingerprint: Self::filters_fingerprint,
         resolve: Self::resolve_filter,
         selected: |s| match (s.filter1x, s.filter_nx) {
@@ -2992,6 +2997,7 @@ impl HqpAdapter {
     const FILTER_1X: SemanticFamily<FilterItem, str> = SemanticFamily {
         what: "filter1x",
         paired: false,
+        refuses_source_mode: false,
         fingerprint: Self::filters_fingerprint,
         resolve: Self::resolve_filter,
         selected: |s| {
@@ -3005,6 +3011,7 @@ impl HqpAdapter {
     const FILTER_NX: SemanticFamily<FilterItem, str> = SemanticFamily {
         what: "filterNx",
         paired: false,
+        refuses_source_mode: false,
         fingerprint: Self::filters_fingerprint,
         resolve: Self::resolve_filter,
         selected: |s| {
@@ -3020,6 +3027,7 @@ impl HqpAdapter {
     const SHAPER: SemanticFamily<ListItem, str> = SemanticFamily {
         what: "shaper",
         paired: false,
+        refuses_source_mode: false,
         fingerprint: Self::list_fingerprint,
         resolve: Self::resolve_shaper,
         selected: |s| SemanticSelection::Position(s.shaper),
@@ -3031,6 +3039,7 @@ impl HqpAdapter {
     const RATE: SemanticFamily<RateItem, u32> = SemanticFamily {
         what: "rate",
         paired: false,
+        refuses_source_mode: true,
         fingerprint: Self::rates_fingerprint,
         resolve: Self::resolve_rate,
         selected: |s| SemanticSelection::Position(s.rate),
@@ -3174,6 +3183,40 @@ impl HqpAdapter {
                     continue;
                 }
             };
+            if family.refuses_source_mode {
+                let modes = match self.fresh_modes().await {
+                    Ok(modes) => modes,
+                    Err(error) if attempted_write => {
+                        return Ok(SettingOutcome::Ambiguous {
+                            what: what.to_string(),
+                            reason: format!(
+                                "a {what} write may have reached the wire, but the configured mode \
+                                 could not be resolved during final proof ({error})"
+                            ),
+                        });
+                    }
+                    Err(error) => return Err(error),
+                };
+                if let Some(mode_name) = Self::configured_source_mode(&modes, &state) {
+                    if attempted_write {
+                        return Ok(SettingOutcome::Ambiguous {
+                            what: what.to_string(),
+                            reason: format!(
+                                "a {what} write reached or may have reached the wire, but final \
+                                 proof observed configured mode '{mode_name}', where the daemon \
+                                 acknowledges rate pins and applies nothing"
+                            ),
+                        });
+                    }
+                    return Ok(SettingOutcome::Suppressed {
+                        what: what.to_string(),
+                        reason: format!(
+                            "nothing was sent, and final proof observed configured mode \
+                             '{mode_name}', where a rate pin cannot be established"
+                        ),
+                    });
+                }
+            }
             let after = match fetch().await {
                 Ok(after) => after,
                 Err(e) => {

--- a/src/adapters/hqplayer.rs
+++ b/src/adapters/hqplayer.rs
@@ -1002,7 +1002,68 @@ pub struct MatrixProfile {
     pub name: String,
 }
 
-/// Internal adapter state
+/// The identity of a complete set of cached chain-scoped enumerations.
+///
+/// Four fingerprints rather than one. The rate list alone is the right *probe* for a chain move —
+/// smallest chain-scoped enumeration, and the two chains' rate lists were observed disjoint
+/// (HQP-C-020) — and it is the wrong *identity*, because a profile load can replace filters and
+/// shapers while leaving rates byte-identical. A read that captured only the rates would accept such
+/// a replacement as the set it started from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ChainIdentity {
+    modes: u64,
+    filters: u64,
+    shapers: u64,
+    rates: u64,
+}
+
+/// The four cached chain-scoped families, taken together, at one instant.
+///
+/// Returned by [`HqpAdapter::verified_chain_snapshot`] so that what a read *verified* and what it
+/// *publishes* are the same values rather than two reads of the same cache.
+#[derive(Debug, Clone)]
+struct ChainSnapshot {
+    modes: Vec<ListItem>,
+    filters: Vec<FilterItem>,
+    shapers: Vec<ListItem>,
+    rates: Vec<RateItem>,
+}
+
+/// Why a read could not join the `State` it observed to the lists it holds.
+///
+/// Named cases rather than a bare `bool`, because they do not mean the same thing: only `Moved` is
+/// the daemon contradicting the cache, and only that one justifies dropping it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ChainProofFailure {
+    /// A family went missing mid-read — a reconnect, most likely.
+    Partial,
+    /// The daemon's live rate list is not the one the cached lists were read from.
+    Moved,
+    /// A complete, coherent, *different* set is in the cache: it was replaced mid-read.
+    Replaced,
+}
+
+impl std::fmt::Display for ChainProofFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let reason = match self {
+            Self::Partial => {
+                "its setting lists were dropped while its state was being read, most likely by a \
+                 reconnect"
+            }
+            Self::Moved => {
+                "its loaded chain moved while its state was being read, so the rate list it serves \
+                 now is not the one those lists came from"
+            }
+            Self::Replaced => {
+                "its setting lists were replaced while its state was being read, so that state's \
+                 indices belong to a set this read never verified"
+            }
+        };
+        f.write_str(reason)
+    }
+}
+
+/// Internal adapter state.
 #[allow(dead_code)]
 struct HqpAdapterState {
     instance_name: Option<String>,
@@ -1400,6 +1461,15 @@ impl HqpAdapter {
     /// events that reload a chain can also be a different device.
     async fn invalidate_chain_cache(&self) {
         let mut state = self.state.write().await;
+        Self::clear_chain_cache(&mut state);
+    }
+
+    /// The clearing itself, on a lock the caller already holds.
+    ///
+    /// Split out because [`Self::verified_chain_snapshot`] must decide *and* act inside one lock: a
+    /// proof that dropped the lock to call [`Self::invalidate_chain_cache`] would be judging one
+    /// cache and clearing whatever happened to be there a moment later.
+    fn clear_chain_cache(state: &mut HqpAdapterState) {
         state.modes.clear();
         state.filters.clear();
         state.shapers.clear();
@@ -1487,8 +1557,10 @@ impl HqpAdapter {
 
     /// Fetch the loaded chain's rate list from the daemon and cache it.
     ///
-    /// Also the **chain probe** used by the read path: it is the smallest chain-scoped enumeration and
-    /// the two chains' rate lists were observed disjoint (HQP-C-020, `E0-uhc-live`). The residual is
+    /// The rate list is also what the read path and [`Self::refresh_lists`] **probe** with — through
+    /// a bare [`Self::get_rates`] rather than through here, since a probe must publish nothing — for
+    /// the reason this list is the chosen one: it is the smallest chain-scoped enumeration and the
+    /// two chains' rate lists were observed disjoint (HQP-C-020, `E0-uhc-live`). The residual is
     /// stated rather than hidden: the offered rates also depend on the selected filter (HQP-C-021), so
     /// a filter change can move this fingerprint without the chain having moved. That direction is
     /// harmless — it costs a refetch of lists that were about to be re-read anyway. The opposite
@@ -1522,50 +1594,130 @@ impl HqpAdapter {
         )
     }
 
-    /// Whether any chain-scoped family is missing from the cache.
+    /// The identity of the **whole** cached chain-scoped set, as one comparable value.
     ///
-    /// Separate from [`Self::chain_still_matches_cache`] because they answer different questions and
-    /// conflating them is how an empty cache passed for an unchanged one: that check is about
-    /// *movement*, and with nothing cached there is no movement to report. This one is about
-    /// *presence*, and it has to be asked again after the reads — a reconnect between the two
-    /// empties the cache behind the answer.
+    /// All four fingerprints, not the rate list alone. A rates-only identity answers "did the chain
+    /// move" and cannot answer "is this the same set I looked at a moment ago": a profile load can
+    /// replace the filters and shapers while leaving the rates untouched (which is exactly the case
+    /// `a_profile_load_whose_refresh_fails_does_not_leave_the_previous_profiles_lists_in_place`
+    /// covers), and that replacement is invisible to a rates comparison.
     ///
-    /// A missing `rates_fingerprint` counts as incomplete too. Current writers update it in lockstep
-    /// with `rates`, so this is defensive invariant enforcement rather than a separately reachable
-    /// state today. It is what the lists were filled *from*: without it there is nothing for
-    /// [`Self::chain_still_matches_cache`] to compare against and the lists would be unanchored.
-    async fn chain_lists_incomplete(&self) -> bool {
-        let cached = self.state.read().await;
-        cached.modes.is_empty()
-            || cached.filters.is_empty()
-            || cached.shapers.is_empty()
-            || cached.rates.is_empty()
-            || cached.rates_fingerprint.is_none()
+    /// `None` means the set is **not** a set: a family is empty, or a family is present without the
+    /// fingerprint it was filled from, which would leave it unanchored. Presence and identity are the
+    /// same question asked once here, because a partial cache has no identity to compare — which is
+    /// what let an emptied cache pass for an unchanged one when the two were asked separately.
+    fn chain_identity_of(state: &HqpAdapterState) -> Option<ChainIdentity> {
+        if state.modes.is_empty()
+            || state.filters.is_empty()
+            || state.shapers.is_empty()
+            || state.rates.is_empty()
+        {
+            return None;
+        }
+        Some(ChainIdentity {
+            modes: state.modes_fingerprint?,
+            filters: state.filters_fingerprint?,
+            shapers: state.shapers_fingerprint?,
+            rates: state.rates_fingerprint?,
+        })
     }
 
-    /// Whether the daemon's chain still matches the one the cache was filled from, **publishing
-    /// nothing either way**. Drops the cache when it does not.
+    /// [`Self::chain_identity_of`] against the live cache.
+    async fn chain_identity(&self) -> Option<ChainIdentity> {
+        Self::chain_identity_of(&*self.state.read().await)
+    }
+
+    /// **The read path's proof, and the thing it proves is a value, not a verdict.**
     ///
-    /// The read path's check. Deliberately not [`Self::fresh_rates`], which caches what it fetched:
-    /// caching here would publish one family on its own, so a poll that detected a transition would
-    /// leave a caller holding the new chain's rates beside no filters and no shapers — a partial view,
-    /// offered as a whole one. Detection and publication are separate jobs, and [`Self::refresh_lists`]
-    /// owns the second.
+    /// A check that returns `bool` and leaves its caller to fetch the data again has proved nothing
+    /// about what the caller then publishes: the cache it re-reads is a *later* cache, and a
+    /// concurrent profile load, reconnect, `fresh_*` publication or [`Self::refresh_lists`] can have
+    /// replaced it in between with one that is complete, self-consistent, and describes a different
+    /// configuration entirely. Re-checking presence does not help — a complete replacement is present.
+    /// So verification and extraction happen under **one** lock, and what comes back is the exact set
+    /// that was verified.
     ///
-    /// Nothing cached yet reads as a match: there is no previous observation for the daemon to
-    /// contradict, and the caller's own lazy fill is what settles it.
-    async fn chain_still_matches_cache(&self) -> Result<bool> {
-        let fingerprint = Self::rates_fingerprint(&self.get_rates().await?);
-        let previous = self.state.read().await.rates_fingerprint;
-        if previous.is_some_and(|p| p != fingerprint) {
+    /// Three ways it can fail, and the difference between them decides whether the cache is dropped:
+    ///
+    /// * **Partial** — a family went missing, which is what a reconnect leaves behind. Nothing to
+    ///   drop; the caller refills.
+    /// * **Replaced** — the set is coherent and complete but is not the one this read captured. The
+    ///   cache is not known to be wrong; it is simply newer than this read, and dropping it would
+    ///   punish whoever published it for winning a race. This read fails; the cache stands.
+    /// * **Moved** — after establishing that the current cache is still the captured set, the
+    ///   daemon's live rate list contradicts it. That is the daemon disagreeing with the cache, so
+    ///   the cache is wrong and goes.
+    ///
+    /// Classification order matters because the probe was fetched before this lock was acquired. A
+    /// newer complete cache can arrive after the probe; that is `Replaced`, even if its rates differ
+    /// from the old probe, and it must survive. Only when `current == captured` does the probe describe
+    /// the same read generation and have authority to invalidate that cache as `Moved`.
+    ///
+    /// Residual, unchanged and unclosable from here: the probe establishes that the daemon's rate list
+    /// now matches the one these lists were read from. A move out and back inside the window leaves it
+    /// agreeing. Only a daemon-side atomic snapshot could do better, and the protocol has none.
+    async fn verified_chain_snapshot(
+        &self,
+        captured: ChainIdentity,
+        probe: &[RateItem],
+    ) -> std::result::Result<ChainSnapshot, ChainProofFailure> {
+        let probe_fingerprint = Self::rates_fingerprint(probe);
+        let mut state = self.state.write().await;
+
+        let Some(current) = Self::chain_identity_of(&state) else {
+            return Err(ChainProofFailure::Partial);
+        };
+
+        // The probe predates this lock. If another complete set won the race, it is newer than the
+        // probe and must not be invalidated merely because the old observation differs from it.
+        if current != captured {
+            return Err(ChainProofFailure::Replaced);
+        }
+
+        if current.rates != probe_fingerprint {
             tracing::info!(
                 "HQPlayer rate enumeration changed: the loaded chain moved, dropping every \
                  chain-scoped list"
             );
-            self.invalidate_chain_cache().await;
-            return Ok(false);
+            Self::clear_chain_cache(&mut state);
+            return Err(ChainProofFailure::Moved);
         }
-        Ok(true)
+
+        Ok(ChainSnapshot {
+            modes: state.modes.clone(),
+            filters: state.filters.clone(),
+            shapers: state.shapers.clone(),
+            rates: state.rates.clone(),
+        })
+    }
+
+    /// Fetch the volume range if it is not cached yet, and report what the cache holds afterwards.
+    ///
+    /// **Reconnect-capable, and therefore not something the read may do after proving coherence.** A
+    /// lost reply here takes `send_command` through `mark_disconnected` and `connect`, and both
+    /// invalidate every chain-scoped list because a session's indices must not outlive it. Done
+    /// before the proof, that is merely a fill the read then has to do; done after it, it empties the
+    /// cache the proof was about and the read publishes four empty lists as this daemon's settings.
+    ///
+    /// A failure is not the read's failure. The range is not chain-scoped and nothing joins it to a
+    /// list index; a daemon that will not answer `VolumeRange` still has settings worth reporting, and
+    /// the default renders as a fixed-volume device rather than as a wrong one.
+    async fn ensure_volume_range(&self) -> VolumeRange {
+        let cached = { self.state.read().await.volume_range.clone() };
+        if let Some(range) = cached {
+            return range;
+        }
+        match self.get_volume_range().await {
+            Ok(range) => {
+                let mut state = self.state.write().await;
+                state.volume_range = Some(range.clone());
+                range
+            }
+            Err(e) => {
+                tracing::debug!("HQPlayer volume range unavailable ({e}); reporting fixed volume");
+                VolumeRange::default()
+            }
+        }
     }
 
     /// Refresh every cached list, publishing **one coherent snapshot or none at all**.
@@ -3029,36 +3181,61 @@ impl HqpAdapter {
     /// Get full pipeline status
     pub async fn get_pipeline_status(&self) -> Result<PipelineStatus> {
         // `State` reports settings as **list indices**, and an index means nothing apart from the list
-        // it came from. So the lists are settled first and `State` is read after them, then the chain
-        // is checked once more: if it moved while `State` was being read, the index and the list
-        // describe different chains and neither answer is the daemon's.
+        // it came from. So this read has one job beyond fetching: to establish that the `State` it
+        // publishes and the lists it resolves that state through describe **the same loaded chain**,
+        // and to publish exactly the values that establishment covered.
         //
-        // Reading `State` first — as this did — is the same misselection this issue exists to end,
-        // arriving through the read path and needing no write at all: under `[source]` the chain moves
-        // without `State.mode` moving (HQP-C-007), so a pre-transition index was resolved against
-        // post-transition lists.
+        // Reading `State` first — as this once did — is the same misselection this issue exists to
+        // end, arriving through the read path and needing no write at all: under `[source]` the chain
+        // moves without `State.mode` moving (HQP-C-007), so a pre-transition index was resolved
+        // against post-transition lists.
         //
-        // The rate list is the check because it is the smallest chain-scoped enumeration and the two
-        // chains' rate lists were observed disjoint (HQP-C-020). One retry, not a loop: a daemon whose
-        // chain is flapping would otherwise hold this open, and after the retry the lists and `State`
-        // are at least read in the right order.
+        // The order below is the whole design, and each step is where it is for a reason:
         //
-        // **Residual, and it cannot be closed from here.** The check confirms the chain is the same
+        // 1. **The volume range first**, because fetching it can reconnect, and a reconnect empties
+        //    every chain-scoped list. Anything reconnect-capable has to happen before coherence is
+        //    established, never after it — a proof followed by a reconnect is a proof about a cache
+        //    that no longer exists. It used to run last, between the check and the publication, which
+        //    made four empty lists the *deterministic* answer to a lost `VolumeRange` reply on the
+        //    first read of a connection.
+        // 2. **Fill if needed and capture the identity** of all four families — fingerprints, not
+        //    contents — before reading `State`. Four and not just the rates: a profile load can
+        //    replace filters and shapers while leaving the rate list untouched, and a rates-only
+        //    identity cannot see it. A required fill that does not settle is the read's failure, not
+        //    a quieter version of success.
+        // 3. **`State` and `Status`.**
+        // 4. **Probe the daemon's rate list**, which is the chain-movement check: smallest
+        //    chain-scoped enumeration, and the two chains' were observed disjoint (HQP-C-020).
+        // 5. **Prove and take the snapshot under one lock**, and project from *that* — never from a
+        //    later read of the cache. A verdict plus a re-read is two moments, and a concurrent
+        //    profile load, reconnect, `fresh_*` publication or refresh can replace the cache between
+        //    them with a complete, coherent, entirely different set. Presence cannot distinguish that
+        //    case; identity can.
+        //
+        // One retry for the whole read, not per step: a daemon whose chain is flapping would
+        // otherwise hold this open. A first unsettled arm explicitly continues; a proven snapshot
+        // breaks; an exhausted arm returns an error. There is no third attempt or fall-through read.
+        //
+        // **Residual, and it cannot be closed from here.** The probe confirms the chain is the same
         // *now* as when the lists were published; a move out and back inside that window leaves it
         // agreeing. Only a daemon-side atomic snapshot could do better, and the protocol has none.
-        // Every arm below is terminal — it breaks with a settled pair or returns — so there is no
-        // state to carry out of the loop and no "what if it fell through" case to answer for. An
-        // earlier shape carried an `Option` and re-read `State` if it were somehow `None`, which was
-        // unreachable and would have cost a round trip to discover that.
         let mut retried = false;
-        let (state, playback_status) = loop {
-            // Lazy-fill whatever is missing — on the first read after connect, that is all of it.
-            let needs_lists = self.chain_lists_incomplete().await;
-            // A *required* fill that does not settle is the read's failure, not a quieter version of
-            // success. With nothing cached there is no previous fingerprint for the chain check to
-            // contradict, so it correctly answers "unchanged" — it is a check about movement — and
-            // the fill is then the only thing between a caller and four empty lists.
-            if needs_lists && !self.refresh_lists().await {
+        let (state, playback_status, snapshot, vol_range) = loop {
+            // (1) Reconnect-capable, so it goes ahead of everything the proof will cover. On the
+            // first read of a connection this is always a real request.
+            let vol_range = self.ensure_volume_range().await;
+
+            // (2) asks one question: *is there a complete set, and what is its identity*. Lazy-fill
+            // only if there is not — on the first read after connect
+            // that is all of it — and then ask again rather than assuming the fill settled, since a
+            // reconnect can empty the cache between publishing it and looking at it. A required fill
+            // that does not settle is the read's failure, not a quieter version of success: with no
+            // cache there is nothing to publish but four empty lists.
+            let mut captured = self.chain_identity().await;
+            if captured.is_none() && self.refresh_lists().await {
+                captured = self.chain_identity().await;
+            }
+            let Some(captured) = captured else {
                 if !retried {
                     tracing::info!(
                         "HQPlayer's setting lists did not settle; re-reading once before giving up"
@@ -3070,69 +3247,28 @@ impl HqpAdapter {
                     "HQPlayer's setting lists could not be read as one coherent set; refusing to \
                      report a pipeline with no settings in it, which is not what this daemon offers"
                 ));
-            }
+            };
 
+            // (3)
             let observed = self.get_state().await?;
             let observed_status = self.get_playback_status().await.unwrap_or_default();
 
-            match self.chain_still_matches_cache().await {
-                // The chain has not moved — but "has not moved" is not "is there". The fill decision
-                // above was made before these reads, and a reconnect during them empties the cache
-                // behind it: `mark_disconnected` and `connect` both invalidate, because a session's
-                // list indices must not outlive it. The check then waves the read through *correctly*,
-                // since with no previous fingerprint there is no movement to report — it is a check
-                // about change, not about presence. So presence is checked here, where it is known.
-                Ok(true) if self.chain_lists_incomplete().await => {
-                    if !retried {
-                        tracing::info!(
-                            "HQPlayer's setting lists were dropped while its state was being read, \
-                             most likely by a reconnect; re-reading"
-                        );
-                        retried = true;
-                        continue;
-                    }
-                    return Err(anyhow!(
-                        "HQPlayer's setting lists could not be read as one coherent set; refusing to \
-                         report a pipeline with no settings in it, which is not what this daemon \
-                         offers"
-                    ));
-                }
-                Ok(true) => break (observed, observed_status),
-                Ok(false) if !retried => {
-                    tracing::info!(
-                        "HQPlayer's loaded chain moved while its state was being read; re-reading \
-                         rather than resolving one chain's indices against another's lists"
-                    );
-                    retried = true;
-                }
-                // The retry moved too. There is nothing coherent to publish and no third attempt:
-                // the lists in hand came from the chain before *this* move, and noticing the move
-                // dropped them, so what is left is a state read against nothing. Answering `Ok`
-                // here hands back empty option lists and selections that resolve to nothing,
-                // presented as this daemon's settings — a caller cannot tell that from a daemon
-                // that genuinely offers no filters. The route has always had an error arm; this is
-                // what it is for.
-                Ok(false) => {
-                    return Err(anyhow!(
-                        "HQPlayer's loaded chain moved while its settings were being read, and \
-                         again during the re-read; refusing to report settings that belong to no \
-                         single chain"
-                    ))
-                }
-                // A check that could not run is not a check that passed. "The cache was not
-                // invalidated, so the lists are still the ones the state was read against" is true
-                // about the *cache* and answers nothing about the *daemon*: whether it still has
-                // that chain loaded is exactly what the failed request was asked. An explicit
-                // `result="Error"` here is terminal in `send_command` — no retry, no disconnect, no
-                // invalidation — so the cache survives looking entirely usable, and a view projected
-                // through it is indistinguishable from a verified one. A `warn!` does not make it
-                // one. Same bound as every other unsettled read here: one re-read, then say so.
+            // (4) A probe that could not run is not a probe that passed. "The cache was not
+            // invalidated, so the lists are still the ones the state was read against" is true about
+            // the *cache* and answers nothing about the *daemon*: whether it still has that chain
+            // loaded is exactly what the failed request was asked. An explicit `result="Error"` is
+            // terminal in `send_command` — no retry, no disconnect, no invalidation — so the cache
+            // survives looking entirely usable, and a view projected through it is indistinguishable
+            // from a verified one. A `warn!` does not make it one.
+            let probe = match self.get_rates().await {
+                Ok(probe) => probe,
                 Err(e) if !retried => {
                     tracing::info!(
                         "HQPlayer's chain check could not be run ({e}); re-reading rather than \
                          resolving its indices against lists nothing has confirmed they belong to"
                     );
                     retried = true;
+                    continue;
                 }
                 Err(e) => {
                     return Err(anyhow!(
@@ -3142,32 +3278,44 @@ impl HqpAdapter {
                          resolved through"
                     ))
                 }
+            };
+
+            // (5) The proof hands back the values it proved. Nothing below re-reads the cache.
+            match self.verified_chain_snapshot(captured, &probe).await {
+                Ok(snapshot) => break (observed, observed_status, snapshot, vol_range),
+                Err(reason) if !retried => {
+                    tracing::info!(
+                        "HQPlayer's settings did not hold still while they were being read \
+                         ({reason}); re-reading rather than publishing a state and a set of lists \
+                         that were never shown to belong together"
+                    );
+                    retried = true;
+                }
+                // The retry did not settle either. There is nothing coherent to publish and no third
+                // attempt. Answering `Ok` here hands back empty or unrelated option lists and
+                // selections that resolve to nothing, presented as this daemon's settings — a caller
+                // cannot tell that from a daemon that genuinely offers no filters. The route has
+                // always had an error arm; this is what it is for.
+                Err(reason) => {
+                    return Err(anyhow!(
+                        "HQPlayer's settings could not be read as one coherent set — {reason}, and \
+                         again during the re-read; refusing to report a loaded chain's indices \
+                         resolved through setting lists that belong to another"
+                    ))
+                }
             }
         };
 
-        // Lazy-load volume range if not cached
-        let needs_vol_range = {
-            let cached = self.state.read().await;
-            cached.volume_range.is_none()
-        };
-        if needs_vol_range {
-            if let Ok(vr) = self.get_volume_range().await {
-                let mut cached = self.state.write().await;
-                cached.volume_range = Some(vr);
-            }
-        }
-
-        // Use cached data
-        let (modes, filters, shapers, rates, vol_range) = {
-            let cached = self.state.read().await;
-            (
-                cached.modes.clone(),
-                cached.filters.clone(),
-                cached.shapers.clone(),
-                cached.rates.clone(),
-                cached.volume_range.clone().unwrap_or_default(),
-            )
-        };
+        // The proven snapshot, and nothing else. Re-reading `self.state` here is what this shape
+        // exists to prevent: it would discard the set the proof covered in favour of whatever the
+        // cache holds at this later moment. `hqplayer_pipeline_projection_lint` fails the build if it
+        // creeps back.
+        let ChainSnapshot {
+            modes,
+            filters,
+            shapers,
+            rates,
+        } = snapshot;
 
         // State returns INDEX for filters and shapers (not value!)
         // See hqp-control help: --set-filter <index> [index1x]
@@ -4578,5 +4726,375 @@ mod parse_attr_scope_tests {
         let truncated = "<State song='a>b state=\"1\"";
         assert_eq!(framing::root_open_tag(truncated), None);
         assert_eq!(HqpAdapter::parse_attr(truncated, "state"), None);
+    }
+}
+
+/// The identity-and-snapshot rule the pipeline read rests on (issue #347, Opus dissent at `b7a7a1a`).
+///
+/// These reach past the adapter's public surface deliberately. The rule is about **which cache** a
+/// verified state is joined to, and the window it closes is between two moments inside one function:
+/// no sequence of public calls can place a second actor in that window without a production hook, and
+/// a test-only hook would be testing the hook. What *can* be pinned honestly is the primitive — that
+/// the proof answers about the cache it hands back, that four fingerprints and not one decide whether
+/// a set is the same set, and that only the daemon contradicting the cache is grounds for dropping it.
+///
+/// The structural half of the same rule — that the projection never re-reads what the proof returned —
+/// is `tests/hqplayer_pipeline_projection_lint.rs`, which is red at `b7a7a1a`.
+#[cfg(test)]
+// The crate denies `expect` because a panic in production is not an error report. In a test a panic
+// *is* the report, and an `expect` whose message states the precondition it is asserting is clearer
+// than a `match` that fabricates a fallback the test would then silently pass against.
+#[allow(clippy::expect_used)]
+mod chain_identity_tests {
+    use super::*;
+
+    fn mode(index: u32, name: &str) -> ListItem {
+        ListItem {
+            index,
+            name: name.to_string(),
+            value: 0,
+        }
+    }
+
+    fn filter(index: u32, name: &str) -> FilterItem {
+        FilterItem {
+            index,
+            name: name.to_string(),
+            value: 0,
+            arg: 0,
+        }
+    }
+
+    fn rate(index: u32, rate: u32) -> RateItem {
+        RateItem { index, rate }
+    }
+
+    /// A complete, self-consistent cache: every family filled and fingerprinted from its contents,
+    /// which is the invariant every writer in the adapter maintains.
+    fn cache_of(
+        modes: Vec<ListItem>,
+        filters: Vec<FilterItem>,
+        shapers: Vec<ListItem>,
+        rates: Vec<RateItem>,
+    ) -> HqpAdapterState {
+        HqpAdapterState {
+            modes_fingerprint: Some(HqpAdapter::fingerprint(
+                modes.iter().map(|m| (m.index, m.name.as_str())),
+            )),
+            filters_fingerprint: Some(HqpAdapter::fingerprint(
+                filters.iter().map(|f| (f.index, f.name.as_str())),
+            )),
+            shapers_fingerprint: Some(HqpAdapter::fingerprint(
+                shapers.iter().map(|s| (s.index, s.name.as_str())),
+            )),
+            rates_fingerprint: Some(HqpAdapter::rates_fingerprint(&rates)),
+            modes,
+            filters,
+            shapers,
+            rates,
+            ..HqpAdapterState::default()
+        }
+    }
+
+    fn pcm_cache() -> HqpAdapterState {
+        cache_of(
+            vec![mode(0, "[source]"), mode(1, "PCM")],
+            vec![filter(0, "sinc-M"), filter(1, "poly-sinc-xtr")],
+            vec![mode(0, "NS9"), mode(1, "NS5")],
+            vec![rate(0, 44100), rate(1, 48000)],
+        )
+    }
+
+    /// **The rule the rate list alone cannot express.** A profile load can replace the filters and the
+    /// shapers while leaving the rate list byte-identical — that is not hypothetical, it is what
+    /// `a_profile_load_whose_refresh_fails_does_not_leave_the_previous_profiles_lists_in_place`
+    /// exercises end to end — and a read that captured only the rates would accept the replacement as
+    /// the set it started from and join its `State`'s filter index to another profile's filter list.
+    #[test]
+    fn a_replaced_filter_list_is_a_different_set_even_when_the_rates_did_not_move() {
+        let before = pcm_cache();
+        let after = cache_of(
+            before.modes.clone(),
+            // A different profile's filters, at the same positions.
+            vec![filter(0, "closed-form"), filter(1, "gauss-long")],
+            before.shapers.clone(),
+            before.rates.clone(),
+        );
+
+        let before_id =
+            HqpAdapter::chain_identity_of(&before).expect("a complete set has identity");
+        let after_id = HqpAdapter::chain_identity_of(&after).expect("a complete set has identity");
+
+        assert_eq!(
+            before_id.rates, after_id.rates,
+            "precondition: the rate list is untouched, so a rates-only identity sees no change at all"
+        );
+        assert_ne!(
+            before_id, after_id,
+            "but the set is not the same set, and the identity a read captures has to say so"
+        );
+    }
+
+    /// The same rule for the other two families, so the identity cannot be narrowed to "rates and
+    /// filters" either.
+    #[test]
+    fn a_replaced_shaper_or_mode_list_is_also_a_different_set() {
+        let before = pcm_cache();
+        let shapers_moved = cache_of(
+            before.modes.clone(),
+            before.filters.clone(),
+            vec![mode(0, "ASDM7"), mode(1, "ASDM5")],
+            before.rates.clone(),
+        );
+        let modes_moved = cache_of(
+            vec![mode(0, "[source]"), mode(1, "SDM")],
+            before.filters.clone(),
+            before.shapers.clone(),
+            before.rates.clone(),
+        );
+
+        let before_id = HqpAdapter::chain_identity_of(&before).expect("identity");
+        assert_ne!(
+            before_id,
+            HqpAdapter::chain_identity_of(&shapers_moved).expect("identity"),
+            "the shaper list decides what a shaper index names"
+        );
+        assert_ne!(
+            before_id,
+            HqpAdapter::chain_identity_of(&modes_moved).expect("identity"),
+            "and the mode list decides what a mode index names"
+        );
+    }
+
+    /// Presence is not a separate question asked separately — that separation is how an emptied cache
+    /// passed for an unchanged one. A set that is missing a family has no identity to compare, so the
+    /// proof cannot pass it whatever else is true.
+    #[test]
+    fn a_cache_missing_any_family_has_no_identity() {
+        for drop_one in 0..4 {
+            let mut state = pcm_cache();
+            match drop_one {
+                0 => state.modes.clear(),
+                1 => state.filters.clear(),
+                2 => state.shapers.clear(),
+                _ => state.rates.clear(),
+            }
+            assert!(
+                HqpAdapter::chain_identity_of(&state).is_none(),
+                "family {drop_one} is empty, so this is not a set"
+            );
+        }
+    }
+
+    /// A family present without the fingerprint it was filled from is unanchored: there is nothing to
+    /// compare it against, so it cannot take part in an identity. Current writers keep the two in
+    /// lockstep, which makes this defensive rather than presently reachable — and it is the invariant
+    /// that keeps it that way.
+    #[test]
+    fn a_family_without_the_fingerprint_it_was_filled_from_has_no_identity() {
+        for drop_one in 0..4 {
+            let mut state = pcm_cache();
+            match drop_one {
+                0 => state.modes_fingerprint = None,
+                1 => state.filters_fingerprint = None,
+                2 => state.shapers_fingerprint = None,
+                _ => state.rates_fingerprint = None,
+            }
+            assert!(
+                HqpAdapter::chain_identity_of(&state).is_none(),
+                "fingerprint {drop_one} is missing, so that family is unanchored"
+            );
+        }
+    }
+
+    /// An adapter whose cache is a given complete set, and nothing else. No socket, no config: these
+    /// tests are about the proof, and the proof is a decision about memory.
+    async fn adapter_with_cache(cache: HqpAdapterState) -> HqpAdapter {
+        let adapter = HqpAdapter::new(crate::bus::create_bus());
+        let mut state = adapter.state.write().await;
+        state.modes = cache.modes;
+        state.filters = cache.filters;
+        state.shapers = cache.shapers;
+        state.rates = cache.rates;
+        state.modes_fingerprint = cache.modes_fingerprint;
+        state.filters_fingerprint = cache.filters_fingerprint;
+        state.shapers_fingerprint = cache.shapers_fingerprint;
+        state.rates_fingerprint = cache.rates_fingerprint;
+        drop(state);
+        adapter
+    }
+
+    /// The proof's whole point: it returns **the set it verified**, so what a caller publishes and
+    /// what was proved coherent are the same values rather than two reads of the same cache.
+    #[tokio::test]
+    async fn the_proof_hands_back_the_exact_set_it_verified() {
+        let cache = pcm_cache();
+        let expected = cache.filters.clone();
+        let probe = cache.rates.clone();
+        let adapter = adapter_with_cache(cache).await;
+        let captured = adapter.chain_identity().await.expect("a complete cache");
+
+        let snapshot = adapter
+            .verified_chain_snapshot(captured, &probe)
+            .await
+            .expect("an unchanged cache and an agreeing probe are a verified read");
+
+        assert_eq!(
+            snapshot
+                .filters
+                .iter()
+                .map(|f| f.name.as_str())
+                .collect::<Vec<_>>(),
+            expected.iter().map(|f| f.name.as_str()).collect::<Vec<_>>(),
+            "the returned snapshot is what the caller projects; it must be the verified contents"
+        );
+        assert_eq!(snapshot.modes.len(), 2);
+        assert_eq!(snapshot.shapers.len(), 2);
+        assert_eq!(snapshot.rates.len(), 2);
+    }
+
+    /// **The race the dissent names.** A complete, coherent, *different* cache is in place by the time
+    /// the proof runs — a profile load, a reconnect's refill or another poll's refresh got there
+    /// first. Presence says yes; the rate probe says yes, because this replacement did not touch the
+    /// rates. Only the captured identity can refuse it, and refuse it it must: the `State` this read
+    /// holds was reported against the *other* set.
+    ///
+    /// And the new cache stays. It is not known to be wrong — it is merely newer than this read, and
+    /// dropping it would make one read's bad luck into everyone's refetch.
+    #[tokio::test]
+    async fn a_cache_replaced_mid_read_fails_this_read_and_is_left_in_place() {
+        let before = pcm_cache();
+        let probe = before.rates.clone();
+        let adapter = adapter_with_cache(before).await;
+        let captured = adapter.chain_identity().await.expect("a complete cache");
+
+        // The replacement: a complete set from another profile, same rate list.
+        let replacement = cache_of(
+            vec![mode(0, "[source]"), mode(1, "PCM")],
+            vec![filter(0, "closed-form"), filter(1, "gauss-long")],
+            vec![mode(0, "NS9"), mode(1, "NS5")],
+            probe.clone(),
+        );
+        {
+            let mut state = adapter.state.write().await;
+            state.filters = replacement.filters.clone();
+            state.filters_fingerprint = replacement.filters_fingerprint;
+        }
+
+        let outcome = adapter.verified_chain_snapshot(captured, &probe).await;
+
+        assert_eq!(
+            outcome.err(),
+            Some(ChainProofFailure::Replaced),
+            "a complete replacement is present and unmoved, and it is still not the set this read \
+             captured; publishing its lists against the captured state's indices is the \
+             misselection this issue exists to end"
+        );
+        let state = adapter.state.read().await;
+        assert_eq!(
+            state
+                .filters
+                .iter()
+                .map(|f| f.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["closed-form", "gauss-long"],
+            "and the newer set stands: this read failed, the cache did not"
+        );
+    }
+
+    /// The probe is an observation taken **before** the proof acquires the cache lock. If another
+    /// reader publishes a complete newer set after that observation, the probe can disagree with
+    /// the cache simply because it describes the set this read started from. That is `Replaced`, not
+    /// evidence that the newer cache is stale, even when the replacement also has different rates.
+    ///
+    /// Classification order is therefore correctness, not presentation: compare the current
+    /// four-family identity with the captured identity first. Only when they are the same set may a
+    /// disagreeing live probe invalidate it.
+    #[tokio::test]
+    async fn an_old_probe_never_clears_a_newer_complete_cache_with_different_rates() {
+        let before = pcm_cache();
+        let old_probe = before.rates.clone();
+        let adapter = adapter_with_cache(before).await;
+        let captured = adapter.chain_identity().await.expect("a complete cache");
+
+        let replacement = cache_of(
+            vec![mode(0, "[source]"), mode(2, "SDM")],
+            vec![filter(0, "poly-sinc-gauss-hires-lp"), filter(1, "sinc-L")],
+            vec![mode(0, "ASDM7"), mode(1, "ASDM5")],
+            vec![rate(0, 2_822_400), rate(1, 5_644_800)],
+        );
+        let replacement_id =
+            HqpAdapter::chain_identity_of(&replacement).expect("the replacement is complete");
+        {
+            let mut state = adapter.state.write().await;
+            state.modes = replacement.modes;
+            state.filters = replacement.filters;
+            state.shapers = replacement.shapers;
+            state.rates = replacement.rates;
+            state.modes_fingerprint = replacement.modes_fingerprint;
+            state.filters_fingerprint = replacement.filters_fingerprint;
+            state.shapers_fingerprint = replacement.shapers_fingerprint;
+            state.rates_fingerprint = replacement.rates_fingerprint;
+        }
+
+        let outcome = adapter.verified_chain_snapshot(captured, &old_probe).await;
+
+        assert_eq!(
+            outcome.err(),
+            Some(ChainProofFailure::Replaced),
+            "the old probe and newer cache belong to different read generations; this read must be \
+             retried without accusing the newer set of contradicting the daemon"
+        );
+        assert_eq!(
+            adapter.chain_identity().await,
+            Some(replacement_id),
+            "a probe taken before the replacement is not grounds to erase the complete cache that \
+             replaced it"
+        );
+    }
+
+    /// The one failure that *is* grounds for dropping the cache: the daemon's live rate list
+    /// contradicts the rates currently cached. That is the daemon disagreeing with the cache, so the
+    /// cache is wrong — and the next read must refill rather than compare against it again.
+    #[tokio::test]
+    async fn a_probe_that_contradicts_the_cached_rates_drops_the_cache() {
+        let cache = pcm_cache();
+        let adapter = adapter_with_cache(cache).await;
+        let captured = adapter.chain_identity().await.expect("a complete cache");
+        // The other chain's rates (HQP-C-020: the two were observed disjoint).
+        let probe = vec![rate(0, 2822400), rate(1, 5644800)];
+
+        let outcome = adapter.verified_chain_snapshot(captured, &probe).await;
+
+        assert_eq!(
+            outcome.err(),
+            Some(ChainProofFailure::Moved),
+            "the daemon is serving a rate list these lists were not read from"
+        );
+        assert!(
+            adapter.chain_identity().await.is_none(),
+            "a cache the daemon contradicts must not survive to be compared against again"
+        );
+    }
+
+    /// The mirror of the case above, and the one that keeps the rule from degrading into "any
+    /// difference drops the cache": an unchanged set with an agreeing probe leaves everything alone.
+    #[tokio::test]
+    async fn a_verified_read_changes_nothing() {
+        let cache = pcm_cache();
+        let probe = cache.rates.clone();
+        let adapter = adapter_with_cache(cache).await;
+        let captured = adapter.chain_identity().await.expect("a complete cache");
+
+        adapter
+            .verified_chain_snapshot(captured, &probe)
+            .await
+            .expect("verified");
+
+        assert_eq!(
+            adapter.chain_identity().await,
+            Some(captured),
+            "proving a read must not disturb the cache it proved"
+        );
     }
 }

--- a/src/adapters/hqplayer.rs
+++ b/src/adapters/hqplayer.rs
@@ -1210,6 +1210,14 @@ impl HqpAdapter {
                 state.filters.clear();
                 state.shapers.clear();
                 state.rates.clear();
+                // The fingerprints go with the lists they describe. Left behind, they would be one
+                // daemon's enumeration identity used to judge whether *another* daemon's chain had
+                // moved — a comparison with no meaning, and the presence check downstream would be
+                // the only thing left standing between that and a published answer.
+                state.modes_fingerprint = None;
+                state.filters_fingerprint = None;
+                state.shapers_fingerprint = None;
+                state.rates_fingerprint = None;
                 state.volume_range = None;
                 state.profiles.clear();
                 state.hidden_fields.clear();
@@ -1512,6 +1520,21 @@ impl HqpAdapter {
                 .zip(labels.iter())
                 .map(|(r, label)| (r.index, label.as_str())),
         )
+    }
+
+    /// Whether any chain-scoped family is missing from the cache.
+    ///
+    /// Separate from [`Self::chain_still_matches_cache`] because they answer different questions and
+    /// conflating them is how an empty cache passed for an unchanged one: that check is about
+    /// *movement*, and with nothing cached there is no movement to report. This one is about
+    /// *presence*, and it has to be asked again after the reads — a reconnect between the two
+    /// empties the cache behind the answer.
+    async fn chain_lists_incomplete(&self) -> bool {
+        let cached = self.state.read().await;
+        cached.modes.is_empty()
+            || cached.filters.is_empty()
+            || cached.shapers.is_empty()
+            || cached.rates.is_empty()
     }
 
     /// Whether the daemon's chain still matches the one the cache was filled from, **publishing
@@ -3024,13 +3047,7 @@ impl HqpAdapter {
         let mut retried = false;
         let (state, playback_status) = loop {
             // Lazy-fill whatever is missing — on the first read after connect, that is all of it.
-            let needs_lists = {
-                let cached = self.state.read().await;
-                cached.modes.is_empty()
-                    || cached.filters.is_empty()
-                    || cached.shapers.is_empty()
-                    || cached.rates.is_empty()
-            };
+            let needs_lists = self.chain_lists_incomplete().await;
             // A *required* fill that does not settle is the read's failure, not a quieter version of
             // success. With nothing cached there is no previous fingerprint for the chain check to
             // contradict, so it correctly answers "unchanged" — it is a check about movement — and
@@ -3053,6 +3070,27 @@ impl HqpAdapter {
             let observed_status = self.get_playback_status().await.unwrap_or_default();
 
             match self.chain_still_matches_cache().await {
+                // The chain has not moved — but "has not moved" is not "is there". The fill decision
+                // above was made before these reads, and a reconnect during them empties the cache
+                // behind it: `mark_disconnected` and `connect` both invalidate, because a session's
+                // list indices must not outlive it. The check then waves the read through *correctly*,
+                // since with no previous fingerprint there is no movement to report — it is a check
+                // about change, not about presence. So presence is checked here, where it is known.
+                Ok(true) if self.chain_lists_incomplete().await => {
+                    if !retried {
+                        tracing::info!(
+                            "HQPlayer's setting lists were dropped while its state was being read, \
+                             most likely by a reconnect; re-reading"
+                        );
+                        retried = true;
+                        continue;
+                    }
+                    return Err(anyhow!(
+                        "HQPlayer's setting lists could not be read as one coherent set; refusing to \
+                         report a pipeline with no settings in it, which is not what this daemon \
+                         offers"
+                    ));
+                }
                 Ok(true) => break (observed, observed_status),
                 Ok(false) if !retried => {
                     tracing::info!(
@@ -3649,10 +3687,17 @@ impl HqpAdapter {
                     if response.status().is_client_error() || response.status().is_server_error() {
                         return Err(anyhow!("Profile load failed: {}", response.status()));
                     }
-                    // Refresh cached lists after profile change. A refresh that does not settle
-                    // leaves the cache empty rather than stale, and the next pipeline read is what
-                    // reports that — the profile load itself succeeded and saying otherwise would
-                    // be a different lie.
+                    // A profile replaces the daemon's settings wholesale, so everything cached from
+                    // before it describes a configuration that no longer exists. Dropped *first*,
+                    // because `refresh_lists` deliberately leaves an existing cache alone when it
+                    // cannot publish a coherent replacement — right for a transient read, and here it
+                    // would preserve exactly the lists that just stopped being true.
+                    //
+                    // This held by accident before: a failing refresh times out, and the timeout path
+                    // invalidates. That is a side effect of a different concern, and the rate-based
+                    // chain check would not have caught what it missed — a profile can change filters
+                    // and shapers while leaving the rate list alone. CodeRabbit found the gap.
+                    self.invalidate_chain_cache().await;
                     if !self.refresh_lists().await {
                         tracing::warn!(
                             "HQPlayer profile loaded, but its setting lists did not settle; the \
@@ -3669,7 +3714,8 @@ impl HqpAdapter {
             return Err(anyhow!("Profile load failed: {}", response.status()));
         }
 
-        // Refresh cached lists after profile change; see the note on the retry path above.
+        // Drop then refresh; see the note on the retry path above for why the order matters.
+        self.invalidate_chain_cache().await;
         if !self.refresh_lists().await {
             tracing::warn!(
                 "HQPlayer profile loaded, but its setting lists did not settle; the next read will \

--- a/src/adapters/hqplayer.rs
+++ b/src/adapters/hqplayer.rs
@@ -677,6 +677,137 @@ pub struct HqpState {
     pub matrix_profile: String,
 }
 
+/// What a live setting write actually did.
+///
+/// `result="OK"` is not proof of application (HQP-C-028), and equality with pre-existing state is not
+/// proof either (HQP-C-019): requesting Auto under `[source]`, where the rate is already Auto and the
+/// daemon ignores the pin, compares 0 against 0 and looks like success. So the four things a write can
+/// turn out to be are named separately rather than collapsed into `Ok`/`Err`, and the caller decides
+/// which of them counts as success on its surface.
+///
+/// An explicit `result="Error"` stays an `Err` — [`HqpAdapter::check_result`] raises it inside
+/// `send_command`, so it is a transport-level failure with the daemon's own reason attached, and it is
+/// distinguishable from every variant here by being an `Err` at all.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[must_use = "an unexamined outcome is a setting reported as applied when it may not have been"]
+pub enum SettingOutcome {
+    /// Sent, acknowledged, and the authoritative `State` field now reads the requested value.
+    Applied,
+    /// **Nothing was sent.** The authoritative `State` field already read the requested value.
+    ///
+    /// Distinct from [`Self::Applied`] because for `SetMode` it is not an optimisation but a
+    /// correctness requirement: a same-mode `SetMode` still clears the exact-rate pin (HQP-C-017), so
+    /// writing a mode the daemon is already in destroys user state for nothing.
+    AlreadySet,
+    /// Sent and acknowledged, and the authoritative field never moved.
+    Ignored {
+        what: String,
+        requested: String,
+        observed: String,
+    },
+    /// **Never sent, and nothing mutated.** The client refused, with a stated reason.
+    Suppressed { what: String, reason: String },
+    /// The write was attempted and its outcome cannot be established — a lost reply is ambiguous
+    /// delivery, never proof of non-application (HQP-C-029).
+    Ambiguous { what: String, reason: String },
+}
+
+impl SettingOutcome {
+    /// Whether the authoritative state now carries the requested value.
+    pub fn is_applied(&self) -> bool {
+        matches!(self, Self::Applied | Self::AlreadySet)
+    }
+
+    /// Collapse to the `Result<()>` the HTTP and MCP surfaces already answer with, so no response
+    /// contract changes: anything that is not applied becomes an error carrying the stated reason.
+    pub fn into_applied_result(self) -> Result<()> {
+        match self {
+            Self::Applied | Self::AlreadySet => Ok(()),
+            Self::Ignored {
+                what,
+                requested,
+                observed,
+            } => Err(anyhow!(
+                "HQPlayer accepted {what} but {what} still reads {observed} instead of {requested}; \
+                 refusing to report an unverified change"
+            )),
+            Self::Suppressed { what, reason } => {
+                Err(anyhow!("HQPlayer {what} was not changed: {reason}"))
+            }
+            Self::Ambiguous { what, reason } => Err(anyhow!(
+                "HQPlayer {what} may or may not have changed: {reason}"
+            )),
+        }
+    }
+}
+
+/// The daemon answered `result="Error"`: an **explicit rejection**, carrying its own reason.
+///
+/// A distinct type rather than a message, because the difference is load-bearing. A rejection is
+/// terminal — the daemon saw the request, refused it, and nothing changed — while a lost reply is
+/// *ambiguous delivery*: the daemon may have accepted, logged and acted on the request and then sent
+/// nothing (HQP-C-029). One must not be retried or read back; the other must. Telling them apart by
+/// matching on error text is how that distinction quietly stops holding.
+///
+/// `Display` is unchanged from the message this replaced, so a caller reading the string sees exactly
+/// what it saw before.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HqpRejected {
+    /// The request element the daemon echoed back.
+    pub element: String,
+    /// The reason it carried as element text, when it carried one.
+    pub reason: Option<String>,
+}
+
+impl std::fmt::Display for HqpRejected {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.reason {
+            Some(reason) => write!(f, "HQPlayer rejected {}: {}", self.element, reason),
+            None => write!(f, "HQPlayer rejected {} (no reason given)", self.element),
+        }
+    }
+}
+
+impl std::error::Error for HqpRejected {}
+
+/// The semantic family of a mode entry, so a caller never depends on a list position.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ModeFamily {
+    /// Follow the source: the daemon's `[source]`.
+    Source,
+    Pcm,
+    /// Sigma-delta modulation, which the daemon names `"SDM (DSD)"` and callers ask for as `"DSD"`.
+    Sdm,
+}
+
+/// A setting family whose **legacy** HTTP request contract carries a list position rather than a name.
+///
+/// Named so the compatibility boundary is a visible, single place rather than a habit. See
+/// [`HqpAdapter::legacy_index_to_name`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LegacySettingFamily {
+    Mode,
+    Filter,
+    Shaper,
+}
+
+/// Which half of the filter pair a one-sided request is aimed at.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FilterSide {
+    OneX,
+    Nx,
+}
+
+impl FilterSide {
+    /// The `State` field that is authoritative for this side, named as the caller sees it.
+    fn field(self) -> &'static str {
+        match self {
+            Self::OneX => "filter1x",
+            Self::Nx => "filterNx",
+        }
+    }
+}
+
 /// HQPlayer info
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct HqpInfo {
@@ -872,6 +1003,21 @@ struct HqpAdapterState {
     filters: Vec<FilterItem>,
     shapers: Vec<ListItem>,
     rates: Vec<RateItem>,
+    /// Fingerprints of the enumerations these caches were filled from.
+    ///
+    /// **This is how the loaded chain is identified.** The chain is not derived from the configured
+    /// mode — under `[source]` those are different questions (HQP-C-007) — nor from `State.active_mode`,
+    /// whose semantics under `[source]` are unmeasured (HQP-C-024) and which UHC therefore must not
+    /// read as an answer. It is derived from the only authority that is settled: the enumerations are
+    /// chain-scoped and change wholesale when the chain does (HQP-C-008, `E0-uhc-live`). So a freshly
+    /// fetched list whose fingerprint differs from the cached one **is** a chain transition, and every
+    /// other chain-scoped family is stale from that moment.
+    ///
+    /// `None` means "never observed", which is not a transition.
+    modes_fingerprint: Option<u64>,
+    filters_fingerprint: Option<u64>,
+    shapers_fingerprint: Option<u64>,
+    rates_fingerprint: Option<u64>,
     volume_range: Option<VolumeRange>,
     // Web client state for profiles
     profiles: Vec<HqpProfile>,
@@ -909,6 +1055,10 @@ impl Default for HqpAdapterState {
             filters: Vec::new(),
             shapers: Vec::new(),
             rates: Vec::new(),
+            modes_fingerprint: None,
+            filters_fingerprint: None,
+            shapers_fingerprint: None,
+            rates_fingerprint: None,
             volume_range: None,
             profiles: Vec::new(),
             hidden_fields: HashMap::new(),
@@ -1133,6 +1283,11 @@ impl HqpAdapter {
             .map_err(|_| anyhow!("Connection timeout"))?
             .map_err(|e| anyhow!("Connection failed: {}", e))?;
 
+        // A new session inherits nothing. The daemon may have restarted onto another profile, been
+        // reconfigured, or simply followed the source onto the other chain while UHC was away, and a
+        // list index cached before the drop names a different setting in every one of those cases.
+        self.invalidate_chain_cache().await;
+
         let (read_half, write_half) = stream.into_split();
         let reader = BufReader::new(read_half);
 
@@ -1193,6 +1348,8 @@ impl HqpAdapter {
             state.connected = false;
             (state.host.clone(), state.instance_name.clone())
         };
+        // Nothing observed through the old session may outlive it.
+        self.invalidate_chain_cache().await;
 
         {
             let mut conn = self.connection.lock().await;
@@ -1209,56 +1366,140 @@ impl HqpAdapter {
         }
     }
 
-    /// Refresh cached lists (modes, filters, shapers, rates)
-    /// Call this after profile changes
-    async fn refresh_lists(&self) {
-        let modes = match self.get_modes().await {
-            Ok(m) => {
-                tracing::debug!("Fetched {} modes", m.len());
-                m
-            }
-            Err(e) => {
-                tracing::warn!("Failed to fetch modes: {}", e);
-                Vec::new()
-            }
-        };
-        let filters = match self.get_filters().await {
-            Ok(f) => {
-                tracing::debug!("Fetched {} filters", f.len());
-                f
-            }
-            Err(e) => {
-                tracing::warn!("Failed to fetch filters: {}", e);
-                Vec::new()
-            }
-        };
-        let shapers = match self.get_shapers().await {
-            Ok(s) => {
-                tracing::debug!("Fetched {} shapers", s.len());
-                s
-            }
-            Err(e) => {
-                tracing::warn!("Failed to fetch shapers: {}", e);
-                Vec::new()
-            }
-        };
-        let rates = match self.get_rates().await {
-            Ok(r) => {
-                tracing::debug!("Fetched {} rates", r.len());
-                r
-            }
-            Err(e) => {
-                tracing::warn!("Failed to fetch rates: {}", e);
-                Vec::new()
-            }
-        };
-
+    /// Drop every cached chain-scoped enumeration.
+    ///
+    /// Called when the loaded chain has moved, when a mode write has reloaded it, and on connect and
+    /// disconnect — a reconnected session may be talking to a restarted daemon, a different profile,
+    /// or the same daemon after the source moved the chain while UHC was away, and a list index from
+    /// the previous session names a **different** setting in any of those cases (HQP-C-006, HQP-C-009).
+    ///
+    /// `modes` is device-scoped rather than chain-scoped, so it is dropped here only because the same
+    /// events that reload a chain can also be a different device.
+    async fn invalidate_chain_cache(&self) {
         let mut state = self.state.write().await;
-        state.modes = modes;
-        state.filters = filters;
-        state.shapers = shapers;
-        state.rates = rates;
-        tracing::debug!("Refreshed HQPlayer lists cache");
+        state.modes.clear();
+        state.filters.clear();
+        state.shapers.clear();
+        state.rates.clear();
+        state.modes_fingerprint = None;
+        state.filters_fingerprint = None;
+        state.shapers_fingerprint = None;
+        state.rates_fingerprint = None;
+        tracing::debug!("Invalidated HQPlayer chain-scoped enumeration cache");
+    }
+
+    /// Identity of an enumeration, as `(index, label)` pairs in the order the daemon served them.
+    ///
+    /// Both halves matter: a chain that offers the same names in a different order is a different
+    /// chain for every purpose a list index is used for.
+    fn fingerprint<'a>(entries: impl Iterator<Item = (u32, &'a str)>) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        for (index, label) in entries {
+            index.hash(&mut hasher);
+            label.hash(&mut hasher);
+        }
+        hasher.finish()
+    }
+
+    /// Record a freshly fetched enumeration and report whether the loaded chain moved.
+    ///
+    /// The comparison is against the **previous fingerprint of the same family**; a family never
+    /// observed before cannot be a transition. When one does move, every other chain-scoped family is
+    /// dropped rather than refetched here: the caller may not need them, and a lazy refill keeps a
+    /// control path to one enumeration fetch.
+    async fn note_enumeration(&self, family: &str, fingerprint: u64) -> bool {
+        let previous = {
+            let state = self.state.read().await;
+            match family {
+                "modes" => state.modes_fingerprint,
+                "filters" => state.filters_fingerprint,
+                "shapers" => state.shapers_fingerprint,
+                _ => state.rates_fingerprint,
+            }
+        };
+        let changed = previous.is_some_and(|p| p != fingerprint);
+        if changed {
+            tracing::info!(
+                "HQPlayer {family} enumeration changed: the loaded chain moved, dropping every \
+                 chain-scoped list"
+            );
+            self.invalidate_chain_cache().await;
+        }
+        changed
+    }
+
+    /// Fetch the modes list from the daemon and cache it, noticing a device change.
+    async fn fresh_modes(&self) -> Result<Vec<ListItem>> {
+        let modes = self.get_modes().await?;
+        let fingerprint = Self::fingerprint(modes.iter().map(|m| (m.index, m.name.as_str())));
+        self.note_enumeration("modes", fingerprint).await;
+        let mut state = self.state.write().await;
+        state.modes = modes.clone();
+        state.modes_fingerprint = Some(fingerprint);
+        Ok(modes)
+    }
+
+    /// Fetch the loaded chain's filter list from the daemon and cache it.
+    async fn fresh_filters(&self) -> Result<Vec<FilterItem>> {
+        let filters = self.get_filters().await?;
+        let fingerprint = Self::fingerprint(filters.iter().map(|f| (f.index, f.name.as_str())));
+        self.note_enumeration("filters", fingerprint).await;
+        let mut state = self.state.write().await;
+        state.filters = filters.clone();
+        state.filters_fingerprint = Some(fingerprint);
+        Ok(filters)
+    }
+
+    /// Fetch the loaded chain's shaper list from the daemon and cache it.
+    async fn fresh_shapers(&self) -> Result<Vec<ListItem>> {
+        let shapers = self.get_shapers().await?;
+        let fingerprint = Self::fingerprint(shapers.iter().map(|s| (s.index, s.name.as_str())));
+        self.note_enumeration("shapers", fingerprint).await;
+        let mut state = self.state.write().await;
+        state.shapers = shapers.clone();
+        state.shapers_fingerprint = Some(fingerprint);
+        Ok(shapers)
+    }
+
+    /// Fetch the loaded chain's rate list from the daemon and cache it.
+    ///
+    /// Also the **chain probe** used by the read path: it is the smallest chain-scoped enumeration and
+    /// the two chains' rate lists were observed disjoint (HQP-C-020, `E0-uhc-live`). The residual is
+    /// stated rather than hidden: the offered rates also depend on the selected filter (HQP-C-021), so
+    /// a filter change can move this fingerprint without the chain having moved. That direction is
+    /// harmless — it costs a refetch of lists that were about to be re-read anyway. The opposite
+    /// direction, a chain move that leaves the rate list byte-identical, is what would be missed, and
+    /// no observation suggests it is reachable.
+    async fn fresh_rates(&self) -> Result<Vec<RateItem>> {
+        let rates = self.get_rates().await?;
+        let labels: Vec<String> = rates.iter().map(|r| r.rate.to_string()).collect();
+        let fingerprint = Self::fingerprint(
+            rates
+                .iter()
+                .zip(labels.iter())
+                .map(|(r, label)| (r.index, label.as_str())),
+        );
+        self.note_enumeration("rates", fingerprint).await;
+        let mut state = self.state.write().await;
+        state.rates = rates.clone();
+        state.rates_fingerprint = Some(fingerprint);
+        Ok(rates)
+    }
+
+    /// Refresh every cached list. Used after a profile load, which can change all of them.
+    async fn refresh_lists(&self) {
+        for (family, outcome) in [
+            ("modes", self.fresh_modes().await.map(|v| v.len())),
+            ("filters", self.fresh_filters().await.map(|v| v.len())),
+            ("shapers", self.fresh_shapers().await.map(|v| v.len())),
+            ("rates", self.fresh_rates().await.map(|v| v.len())),
+        ] {
+            match outcome {
+                Ok(n) => tracing::debug!("Fetched {n} {family}"),
+                Err(e) => tracing::warn!("Failed to fetch {family}: {e}"),
+            }
+        }
     }
 
     /// Ensure connection is established, reconnecting if needed
@@ -1282,6 +1523,7 @@ impl HqpAdapter {
             state.connected = false;
             (state.host.clone(), state.instance_name.clone())
         };
+        self.invalidate_chain_cache().await;
 
         {
             let mut conn = self.connection.lock().await;
@@ -1309,10 +1551,10 @@ impl HqpAdapter {
         match Self::parse_attr(response, "result").as_deref() {
             Some("Error") => {
                 let element = framing::root_element(response).unwrap_or_else(|| "?".to_string());
-                match framing::root_text(response) {
-                    Some(reason) => Err(anyhow!("HQPlayer rejected {}: {}", element, reason)),
-                    None => Err(anyhow!("HQPlayer rejected {} (no reason given)", element)),
-                }
+                Err(anyhow!(HqpRejected {
+                    element,
+                    reason: framing::root_text(response),
+                }))
             }
             _ => Ok(()),
         }
@@ -2004,294 +2246,460 @@ impl HqpAdapter {
         }))
     }
 
-    /// Confirm a setting actually applied, by reading `State` back.
+    /// Confirm a setting actually applied, by reading the authoritative `State` field back.
     ///
-    /// Verified daemon behaviour: "a setter can return `result=\"OK\"` without the setting actually
-    /// applying. Never trust `result=\"OK\"` alone; confirm via `State` readback." A change can also
-    /// land a poll later than the acknowledgement, so this polls rather than checking once, reusing
-    /// the injected retry policy instead of introducing another knob.
+    /// Verified daemon behaviour: a setter can return `result="OK"` without the setting actually
+    /// applying, so `OK` alone is never proof (HQP-C-028). A change can also land a poll later than the
+    /// acknowledgement, so this polls rather than checking once, reusing the injected retry policy
+    /// instead of introducing another knob.
     ///
-    /// Returns an error when the setting never appears, so a caller can never be told about a change
-    /// that did not happen.
-    async fn verify_applied<F>(&self, what: &str, expected_index: u32, matches: F) -> Result<()>
+    /// Returns [`SettingOutcome::Ignored`] rather than an error when the value never appears: a write
+    /// the daemon acknowledged and dropped is a different fact from one it rejected, and a caller that
+    /// wants them collapsed asks for that with [`SettingOutcome::into_applied_result`].
+    ///
+    /// `observe` must read the field that *is* the setting. It deliberately has no fallback to a
+    /// related field: reading a sibling when the authoritative one is absent is how a readback confirms
+    /// something it never checked.
+    async fn verify_applied<T, F>(
+        &self,
+        what: &str,
+        expected: T,
+        observe: F,
+    ) -> Result<SettingOutcome>
     where
-        F: Fn(&HqpState) -> Option<u32>,
+        T: PartialEq + std::fmt::Display,
+        F: Fn(&HqpState) -> Option<T>,
     {
         let timeouts = self.timeouts().await;
-        let mut last_seen = None;
+        let mut last_seen: Option<T> = None;
 
         for attempt in 0..timeouts.max_attempts.max(1) {
             if attempt > 0 {
                 tokio::time::sleep(timeouts.reconnect_delay).await;
             }
             let state = self.get_state().await?;
-            let seen = matches(&state);
-            if seen == Some(expected_index) {
-                return Ok(());
+            let seen = observe(&state);
+            if seen.as_ref() == Some(&expected) {
+                return Ok(SettingOutcome::Applied);
             }
             last_seen = seen;
         }
 
-        Err(anyhow!(
-            "HQPlayer accepted {} but {} still reads {} instead of {}; refusing to report an \
-             unverified change",
-            what,
-            what,
-            last_seen
+        Ok(SettingOutcome::Ignored {
+            what: what.to_string(),
+            requested: expected.to_string(),
+            observed: last_seen
                 .map(|v| v.to_string())
                 .unwrap_or_else(|| "nothing".to_string()),
-            expected_index
-        ))
+        })
     }
 
-    /// Set mode by name (e.g., "PCM", "DSD", "[source]")
-    /// Resolves name to INDEX and sends to HQPlayer.
-    /// CLI confirms: `--set-mode <index>`
+    /// Write a setting and establish what it did, including when the reply never arrives.
     ///
-    /// NOTE: Mode changes affect available filters, shapers, and rates.
-    /// We refresh the cached lists after changing mode.
-    pub async fn set_mode(&self, mode_name: &str) -> Result<()> {
-        let mode_index = self.resolve_mode_index(mode_name).await?;
-        let xml = Self::build_request("SetMode", &[("value", &mode_index.to_string())]);
-        self.send_command(&xml).await?;
-        self.verify_applied("mode", mode_index, |s| Some(u32::from(s.mode)))
-            .await?;
-        // Mode change affects available filters/shapers/rates - refresh lists
-        self.refresh_lists().await;
-        Ok(())
-    }
-
-    /// Resolve mode name to INDEX, checking cache first then fetching if needed
-    /// ModesItem has: index (0,1,2), name, value (-1,0,1) - index ≠ value!
-    async fn resolve_mode_index(&self, mode_name: &str) -> Result<u32> {
-        // First try to find by name in cached modes (case-insensitive)
-        let cached_index = {
-            let state = self.state.read().await;
-            state
-                .modes
-                .iter()
-                .find(|m| m.name.eq_ignore_ascii_case(mode_name))
-                .map(|m| m.index)
-        };
-
-        if let Some(idx) = cached_index {
-            return Ok(idx);
-        }
-
-        // Not found in cache - try parsing as integer (direct index)
-        if let Ok(idx) = mode_name.parse::<u32>() {
-            return Ok(idx);
-        }
-
-        // Try refreshing mode list and searching again
-        let modes = self.get_modes().await?;
-        modes
-            .iter()
-            .find(|m| m.name.eq_ignore_ascii_case(mode_name))
-            .map(|m| m.index)
-            .ok_or_else(|| {
-                let available: Vec<_> = modes.iter().map(|m| m.name.as_str()).collect();
-                anyhow::anyhow!(
-                    "Mode '{}' not found. Available: {}",
-                    mode_name,
-                    available.join(", ")
-                )
-            })
-    }
-
-    /// Set filter (low-level) - takes INDEX values
+    /// Three outcomes come out of the send itself:
     ///
-    /// - value: sets the Nx (non-1x) filter by INDEX
-    /// - value1x: if provided, also sets the 1x filter by INDEX
+    /// * a reply — the ordinary path, and readback decides between `Applied` and `Ignored`;
+    /// * an explicit [`HqpRejected`] — terminal, propagated as the error it is, nothing changed;
+    /// * anything else (timeout, dropped connection, malformed reply) — **ambiguous delivery**. On
+    ///   HQPlayer Embedded 6.0.4 a `SetMode` was accepted, logged and acted on while the daemon sent
+    ///   no response and later dropped the connection (HQP-C-029), so treating silence as failure is
+    ///   as wrong as treating `OK` as success. The state is read back regardless: if the setting is
+    ///   there, the write landed and is reported as applied; if it is not, the outcome is
+    ///   `Ambiguous` — which is neither a success nor a claim that nothing happened.
     ///
-    /// HQPlayer CLI confirms: `--set-filter <index> [index1x]`
-    /// State returns INDEX for filter fields, so read from State and send back unchanged.
-    pub async fn set_filter(&self, value: u32, value1x: Option<u32>) -> Result<()> {
-        let value_str = value.to_string();
-        let mut attrs = vec![("value", value_str.as_str())];
-
-        let value1x_str;
-        if let Some(v1x) = value1x {
-            value1x_str = v1x.to_string();
-            attrs.push(("value1x", value1x_str.as_str()));
-        }
-
-        let xml = Self::build_request("SetFilter", &attrs);
-        tracing::debug!(
-            "SetFilter: value={} (Nx), value1x={:?} (1x) | XML: {}",
-            value,
-            value1x,
-            xml.trim()
-        );
-        self.send_command(&xml).await?;
-        Ok(())
-    }
-
-    /// Set only the 1x filter, preserving current Nx filter index
-    /// Accepts filter name (e.g., "poly-sinc-lp") or index as string
-    pub async fn set_filter_1x(&self, filter_name: &str) -> Result<()> {
-        let filter_index = self.resolve_filter_index(filter_name).await?;
-        let state = self.get_state().await?;
-        // State returns INDEX for filters
-        let current_nx_index = state.filter_nx.unwrap_or(state.filter);
-        tracing::debug!(
-            "set_filter_1x: name='{}' resolved_index={}, state.filter_nx={:?}, state.filter={}, using current_nx={}",
-            filter_name, filter_index, state.filter_nx, state.filter, current_nx_index
-        );
-        self.set_filter(current_nx_index, Some(filter_index))
-            .await?;
-        self.verify_applied("filter1x", filter_index, |s| s.filter1x.or(Some(s.filter)))
-            .await
-    }
-
-    /// Set only the Nx filter, preserving current 1x filter index
-    /// Accepts filter name (e.g., "poly-sinc-lp") or index as string
-    pub async fn set_filter_nx(&self, filter_name: &str) -> Result<()> {
-        let filter_index = self.resolve_filter_index(filter_name).await?;
-        // State returns INDEX for filters
-        let state = self.get_state().await?;
-        let current_1x_index = state.filter1x.unwrap_or(state.filter);
-        tracing::debug!(
-            "set_filter_nx: name='{}' resolved_index={}, state.filter1x={:?}, state.filter={}, using current_1x={}",
-            filter_name, filter_index, state.filter1x, state.filter, current_1x_index
-        );
-        self.set_filter(filter_index, Some(current_1x_index))
-            .await?;
-        self.verify_applied("filterNx", filter_index, |s| s.filter_nx.or(Some(s.filter)))
-            .await
-    }
-
-    /// Resolve filter name to INDEX, checking cache first then fetching if needed
-    async fn resolve_filter_index(&self, filter_name: &str) -> Result<u32> {
-        // First try to find by name in cached filters
-        let cached_result = {
-            let state = self.state.read().await;
-            state
-                .filters
-                .iter()
-                .find(|f| f.name == filter_name)
-                .map(|f| (f.index, f.value))
-        };
-
-        if let Some((idx, val)) = cached_result {
-            tracing::debug!(
-                "resolve_filter_index: '{}' -> index={}, value={} (from cache)",
-                filter_name,
-                idx,
-                val
-            );
-            return Ok(idx);
-        }
-
-        // Not found in cache - try parsing as integer (direct index)
-        if let Ok(idx) = filter_name.parse::<u32>() {
-            tracing::debug!(
-                "resolve_filter_index: '{}' parsed as direct index={}",
-                filter_name,
-                idx
-            );
-            return Ok(idx);
-        }
-
-        // Try refreshing filter list and searching again
-        let filters = self.get_filters().await?;
-        let result = filters
-            .iter()
-            .find(|f| f.name == filter_name)
-            .map(|f| (f.index, f.value));
-
-        match result {
-            Some((idx, val)) => {
-                tracing::debug!(
-                    "resolve_filter_index: '{}' -> index={}, value={} (after refresh)",
-                    filter_name,
-                    idx,
-                    val
+    /// The readback reconnects on its own (`get_state` goes through `ensure_connected`), so this is
+    /// also the recovery path, not just the reporting one.
+    ///
+    /// Only absolute writes reach here. A relative one-shot is never retried after its write is
+    /// attempted (HQP-C-030), and `send_command` enforces that separately.
+    async fn write_setting<T, F>(
+        &self,
+        xml: &str,
+        what: &str,
+        expected: T,
+        observe: F,
+    ) -> Result<SettingOutcome>
+    where
+        T: PartialEq + std::fmt::Display + Clone,
+        F: Fn(&HqpState) -> Option<T>,
+    {
+        match self.send_command(xml).await {
+            Ok(_) => self.verify_applied(what, expected, observe).await,
+            Err(e) if e.downcast_ref::<HqpRejected>().is_some() => Err(e),
+            Err(e) => {
+                tracing::warn!(
+                    "HQPlayer {what} write got no usable reply ({e}); reading the state back, \
+                     because a lost reply is not proof the daemon did not apply it"
                 );
-                Ok(idx)
+                match self.verify_applied(what, expected, observe).await {
+                    Ok(SettingOutcome::Applied) => Ok(SettingOutcome::Applied),
+                    _ => Ok(SettingOutcome::Ambiguous {
+                        what: what.to_string(),
+                        reason: format!(
+                            "the write was attempted but drew no usable reply ({e}), and the \
+                             daemon's state does not show it; it may or may not have been applied"
+                        ),
+                    }),
+                }
             }
-            None => Err(anyhow::anyhow!(
-                "Filter '{}' not found in available filters",
-                filter_name
+        }
+    }
+
+    /// The semantic family a mode name belongs to, matched by prefix and alias rather than position.
+    ///
+    /// Positions are unsafe: a DAC without DSD capability yields a modes list with **no** SDM entry and
+    /// the survivors keep their own indices, so a caller assuming index 2 is SDM finds something on one
+    /// device and the wrong thing on another (HQP-C-013). Names are not exact either — the daemon
+    /// reports `"SDM (DSD)"`, so equality against `"SDM"` or `"DSD"` fails on the device that has it.
+    ///
+    /// `None` means "no family recognised", which includes every string of digits. That is deliberate:
+    /// a bare integer is not a mode name, and treating one as a list index is what HQP-C-063 records.
+    fn mode_family(name: &str) -> Option<ModeFamily> {
+        let trimmed = name.trim().to_ascii_lowercase();
+        let bare = trimmed.trim_start_matches('[').trim_end_matches(']');
+        if bare == "source" {
+            return Some(ModeFamily::Source);
+        }
+        if trimmed.starts_with("pcm") {
+            return Some(ModeFamily::Pcm);
+        }
+        if trimmed.starts_with("sdm") || trimmed.starts_with("dsd") {
+            return Some(ModeFamily::Sdm);
+        }
+        None
+    }
+
+    /// Resolve a mode name against the list the daemon is serving **now**.
+    ///
+    /// Exact match first, then semantic family. A family match must be unambiguous: if a daemon ever
+    /// offered two SDM entries, picking one of them silently would be the positional assumption this
+    /// exists to remove, so it is refused instead.
+    fn resolve_mode(modes: &[ListItem], requested: &str) -> Result<u32> {
+        if let Some(exact) = modes
+            .iter()
+            .find(|m| m.name.eq_ignore_ascii_case(requested))
+        {
+            return Ok(exact.index);
+        }
+        let available = || {
+            modes
+                .iter()
+                .map(|m| m.name.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        let wanted = Self::mode_family(requested).ok_or_else(|| {
+            anyhow!(
+                "Mode '{}' is not a mode this daemon offers. Available: {}",
+                requested,
+                available()
+            )
+        })?;
+        let mut matches = modes
+            .iter()
+            .filter(|m| Self::mode_family(&m.name) == Some(wanted));
+        match (matches.next(), matches.next()) {
+            (Some(only), None) => Ok(only.index),
+            (Some(_), Some(_)) => Err(anyhow!(
+                "Mode '{}' matches more than one entry this daemon offers, so no single one can be \
+                 chosen without guessing. Available: {}",
+                requested,
+                available()
+            )),
+            _ => Err(anyhow!(
+                "Mode '{}' is not offered by this daemon. Available: {}",
+                requested,
+                available()
             )),
         }
     }
 
-    /// Set shaper - sends INDEX to HQPlayer
-    /// Accepts shaper name (e.g., "ASDM7") or index as string
-    /// HQPlayer CLI confirms: `--set-shaping <index>`
-    pub async fn set_shaper(&self, shaper_name: &str) -> Result<()> {
-        let shaper_index = self.resolve_shaper_index(shaper_name).await?;
-        let xml = Self::build_request("SetShaping", &[("value", &shaper_index.to_string())]);
-        self.send_command(&xml).await?;
-        self.verify_applied("shaper", shaper_index, |s| Some(s.shaper))
-            .await
+    /// Set mode by semantic name — `"PCM"`, `"DSD"`, `"[source]"`, or the daemon's own `"SDM (DSD)"`.
+    ///
+    /// Resolved against the list the daemon serves now and sent as that list's **index** (HQP-C-001).
+    ///
+    /// A mode the daemon is already in is **not written**. `SetMode` clears the exact-rate pin even
+    /// when the mode does not change (HQP-C-017), so an unconditional write destroys a user's pinned
+    /// rate for nothing. When a write is performed the chain reloads, so every chain-scoped list is
+    /// dropped and the pin the daemon just cleared is re-read rather than remembered.
+    pub async fn set_mode(&self, mode_name: &str) -> Result<SettingOutcome> {
+        let modes = self.fresh_modes().await?;
+        let mode_index = Self::resolve_mode(&modes, mode_name)?;
+
+        let state = self.get_state().await?;
+        if u32::from(state.mode) == mode_index {
+            tracing::debug!(
+                "HQPlayer is already in mode {mode_index}; not writing it, because SetMode clears \
+                 the rate pin even when the mode does not change"
+            );
+            return Ok(SettingOutcome::AlreadySet);
+        }
+
+        let xml = Self::build_request("SetMode", &[("value", &mode_index.to_string())]);
+        let outcome = self
+            .write_setting(&xml, "mode", mode_index, |s| Some(u32::from(s.mode)))
+            .await?;
+        // A mode change reloads the chain whatever the readback said, so nothing cached about it
+        // survives. This is also what makes the cleared pin honest: there is no remembered rate to
+        // report, only the one the daemon now holds.
+        self.invalidate_chain_cache().await;
+        Ok(outcome)
     }
 
-    /// Resolve shaper name to INDEX, checking cache first then fetching if needed
-    async fn resolve_shaper_index(&self, shaper_name: &str) -> Result<u32> {
-        // First try to find by name in cached shapers
-        let cached_index = {
-            let state = self.state.read().await;
-            state
-                .shapers
-                .iter()
-                .find(|s| s.name == shaper_name)
-                .map(|s| s.index)
+    /// Send `SetFilter` with **both** arguments.
+    ///
+    /// The daemon's `SetFilter` writes both sides: `value` alone sets 1x and Nx together, and
+    /// `value1x` splits them. There is therefore no such thing as a one-sided write on the wire — a
+    /// caller that omits the sibling is overwriting it with whatever it passed as `value`. Taking both
+    /// indices is what makes that impossible to express, rather than merely discouraged.
+    ///
+    /// **Indices in, and no readback.** This is the raw form: it resolves no name and confirms
+    /// nothing, so it is not a control path. Every advertised surface goes through
+    /// [`Self::set_filter_1x`] or [`Self::set_filter_nx`], which resolve a semantic name against the
+    /// loaded chain's list and verify the result.
+    /// The request both sides of the pair travel in, built in one place so they cannot drift.
+    fn filter_request(value_nx: u32, value1x: u32) -> String {
+        let nx = value_nx.to_string();
+        let one_x = value1x.to_string();
+        Self::build_request("SetFilter", &[("value", &nx), ("value1x", &one_x)])
+    }
+
+    pub async fn set_filter(&self, value_nx: u32, value1x: u32) -> Result<()> {
+        tracing::debug!("SetFilter: value={value_nx} (Nx), value1x={value1x} (1x)");
+        self.send_command(&Self::filter_request(value_nx, value1x))
+            .await?;
+        Ok(())
+    }
+
+    /// Set only the 1x filter, preserving the Nx filter the daemon reports.
+    pub async fn set_filter_1x(&self, filter_name: &str) -> Result<SettingOutcome> {
+        self.set_filter_side(FilterSide::OneX, filter_name).await
+    }
+
+    /// Set only the Nx filter, preserving the 1x filter the daemon reports.
+    pub async fn set_filter_nx(&self, filter_name: &str) -> Result<SettingOutcome> {
+        self.set_filter_side(FilterSide::Nx, filter_name).await
+    }
+
+    /// One side of the filter pair, carrying the authoritative other side with it.
+    ///
+    /// The sibling comes from `State`'s own `filter1x`/`filterNx` and from nowhere else. The previous
+    /// implementation substituted the legacy combined `filter` field when a sibling was absent, which
+    /// is a **guess**: `filter` tracks the most recently set of the two, so the guess silently
+    /// overwrote the setting the caller did not touch. When the sibling cannot be established the
+    /// write is refused with a reason and nothing is sent.
+    async fn set_filter_side(&self, side: FilterSide, filter_name: &str) -> Result<SettingOutcome> {
+        let filters = self.fresh_filters().await?;
+        let index = Self::resolve_filter(&filters, filter_name)?;
+        let what = side.field();
+
+        let state = self.get_state().await?;
+        let (Some(current_1x), Some(current_nx)) = (state.filter1x, state.filter_nx) else {
+            return Ok(SettingOutcome::Suppressed {
+                what: what.to_string(),
+                reason: "the daemon's State does not report both filter1x and filterNx, and \
+                         SetFilter writes both sides at once; sending it would overwrite the sibling \
+                         with a guess"
+                    .to_string(),
+            });
         };
 
-        if let Some(idx) = cached_index {
-            return Ok(idx);
+        let current = match side {
+            FilterSide::OneX => current_1x,
+            FilterSide::Nx => current_nx,
+        };
+        if current == index {
+            return Ok(SettingOutcome::AlreadySet);
         }
 
-        // Not found in cache - try parsing as integer (direct index)
-        if let Ok(idx) = shaper_name.parse::<u32>() {
-            return Ok(idx);
-        }
+        let (send_nx, send_1x) = match side {
+            FilterSide::OneX => (current_nx, index),
+            FilterSide::Nx => (index, current_1x),
+        };
+        tracing::debug!("SetFilter: value={send_nx} (Nx), value1x={send_1x} (1x)");
+        let xml = Self::filter_request(send_nx, send_1x);
+        self.write_setting(&xml, what, index, |s| match side {
+            FilterSide::OneX => s.filter1x,
+            FilterSide::Nx => s.filter_nx,
+        })
+        .await
+    }
 
-        // Try refreshing shaper list and searching again
-        let shapers = self.get_shapers().await?;
-        shapers
+    /// Resolve a filter name against the list the daemon is serving **now**.
+    ///
+    /// No numeric fallback. A list index that arrives as a name is not a name — it is a number from
+    /// some other chain, some other daemon, or a guess, and accepting it is how a stale index silently
+    /// selects a different filter (HQP-C-009, HQP-C-063).
+    fn resolve_filter(filters: &[FilterItem], requested: &str) -> Result<u32> {
+        filters
             .iter()
-            .find(|s| s.name == shaper_name)
-            .map(|s| s.index)
+            .find(|f| f.name == requested)
+            .or_else(|| {
+                filters
+                    .iter()
+                    .find(|f| f.name.eq_ignore_ascii_case(requested))
+            })
+            .map(|f| f.index)
             .ok_or_else(|| {
-                anyhow::anyhow!("Shaper '{}' not found in available shapers", shaper_name)
+                anyhow!(
+                    "Filter '{}' is not in the list this daemon is serving for the chain it has \
+                     loaded",
+                    requested
+                )
             })
     }
 
-    /// Set sample rate
-    /// The value parameter is the actual rate (e.g., 48000), but HQPlayer's SetRate
-    /// command expects the index from the rates list, so we look it up.
-    pub async fn set_rate(&self, rate_value: u32) -> Result<()> {
-        // Look up the index for this rate value from cached rates
-        let index = {
-            let state = self.state.read().await;
-            state
-                .rates
-                .iter()
-                .find(|r| r.rate == rate_value)
-                .map(|r| r.index)
-        };
-
-        let index = match index {
-            Some(idx) => idx,
-            None => {
-                // Rate not found in cached list - maybe cache is stale, try refreshing
-                let rates = self.get_rates().await?;
-                rates
+    /// Resolve a shaper name against the list the daemon is serving **now**. No numeric fallback,
+    /// for the same reason as [`Self::resolve_filter`].
+    fn resolve_shaper(shapers: &[ListItem], requested: &str) -> Result<u32> {
+        shapers
+            .iter()
+            .find(|s| s.name == requested)
+            .or_else(|| {
+                shapers
                     .iter()
-                    .find(|r| r.rate == rate_value)
-                    .map(|r| r.index)
-                    .ok_or_else(|| {
-                        anyhow::anyhow!("Rate {} not found in available rates", rate_value)
-                    })?
-            }
-        };
+                    .find(|s| s.name.eq_ignore_ascii_case(requested))
+            })
+            .map(|s| s.index)
+            .ok_or_else(|| {
+                anyhow!(
+                    "Shaper '{}' is not in the list this daemon is serving for the chain it has \
+                     loaded",
+                    requested
+                )
+            })
+    }
+
+    /// Set the shaper (the modulator, under an SDM chain) by semantic name.
+    pub async fn set_shaper(&self, shaper_name: &str) -> Result<SettingOutcome> {
+        let shapers = self.fresh_shapers().await?;
+        let shaper_index = Self::resolve_shaper(&shapers, shaper_name)?;
+
+        if self.get_state().await?.shaper == shaper_index {
+            return Ok(SettingOutcome::AlreadySet);
+        }
+
+        let xml = Self::build_request("SetShaping", &[("value", &shaper_index.to_string())]);
+        self.write_setting(&xml, "shaper", shaper_index, |s| Some(s.shaper))
+            .await
+    }
+
+    /// Whether the daemon's **configured** mode is the source-following one.
+    ///
+    /// Read from the modes list the daemon is serving now, by semantic family — never from a list
+    /// position, and never from `State.active_mode`, whose meaning under `[source]` is unmeasured
+    /// (HQP-C-024). Returns the daemon's own name for the mode so a refusal can quote it.
+    fn configured_source_mode(modes: &[ListItem], state: &HqpState) -> Option<String> {
+        modes
+            .iter()
+            .find(|m| m.index == u32::from(state.mode))
+            .filter(|m| Self::mode_family(&m.name) == Some(ModeFamily::Source))
+            .map(|m| m.name.clone())
+    }
+
+    /// Pin the sample rate, in Hz.
+    ///
+    /// The Hz value is resolved to the **list index** the loaded chain gives it (HQP-C-015), against a
+    /// list fetched now rather than a cached one — the offered rates change wholesale with the chain
+    /// (HQP-C-020).
+    ///
+    /// Under a configured `[source]` mode the write is **suppressed and never sent**. The daemon
+    /// answers `OK` there and applies nothing (HQP-C-018); what governs the rate in that mode is a
+    /// persistent configuration limit for which no wire command exists, so no retry can succeed. The
+    /// Auto case is why suppression rather than readback is the answer: requesting index 0 when the
+    /// rate is already 0 compares 0 against 0, so a readback reports success for a command that did
+    /// nothing (HQP-C-019).
+    pub async fn set_rate(&self, rate_value: u32) -> Result<SettingOutcome> {
+        let modes = self.fresh_modes().await?;
+        let state = self.get_state().await?;
+        if let Some(mode_name) = Self::configured_source_mode(&modes, &state) {
+            return Ok(SettingOutcome::Suppressed {
+                what: "rate".to_string(),
+                reason: format!(
+                    "the configured mode is '{mode_name}', in which the daemon acknowledges a rate \
+                     pin and applies nothing — the rate is governed by persistent configuration \
+                     there, so the write was not sent"
+                ),
+            });
+        }
+
+        let rates = self.fresh_rates().await?;
+        let index = rates
+            .iter()
+            .find(|r| r.rate == rate_value)
+            .map(|r| r.index)
+            .ok_or_else(|| {
+                anyhow!(
+                    "Rate {} is not offered for the chain this daemon has loaded",
+                    rate_value
+                )
+            })?;
+
+        if state.rate == index {
+            return Ok(SettingOutcome::AlreadySet);
+        }
 
         let xml = Self::build_request("SetRate", &[("value", &index.to_string())]);
-        self.send_command(&xml).await?;
-        self.verify_applied("rate", index, |s| Some(s.rate)).await
+        self.write_setting(&xml, "rate", index, |s| Some(s.rate))
+            .await
+    }
+
+    /// Turn a legacy numeric setting value into the semantic name it denotes **right now**.
+    ///
+    /// `POST /hqplayer/setting` carries `value: u32` and `POST /hqp/pipeline` accepts a JSON number,
+    /// and both request contracts are frozen. So the number is kept — at this boundary, and only
+    /// here. It is resolved against the enumeration the daemon is serving for the chain it has
+    /// loaded, and what continues inward is the **name**.
+    ///
+    /// That is the whole of HQP-C-063's fix. The number never becomes an identity: it is not cached,
+    /// not published, and not passed to a setter. A position that the current list does not have is
+    /// an error rather than something forwarded and hoped about — which is what the removed
+    /// `parse::<u32>()` fallback did, and why a stale number could select a different setting.
+    pub async fn legacy_index_to_name(
+        &self,
+        family: LegacySettingFamily,
+        index: u32,
+    ) -> Result<String> {
+        let (name, count) = match family {
+            LegacySettingFamily::Mode => {
+                let modes = self.fresh_modes().await?;
+                (
+                    modes
+                        .iter()
+                        .find(|m| m.index == index)
+                        .map(|m| m.name.clone()),
+                    modes.len(),
+                )
+            }
+            LegacySettingFamily::Filter => {
+                let filters = self.fresh_filters().await?;
+                (
+                    filters
+                        .iter()
+                        .find(|f| f.index == index)
+                        .map(|f| f.name.clone()),
+                    filters.len(),
+                )
+            }
+            LegacySettingFamily::Shaper => {
+                let shapers = self.fresh_shapers().await?;
+                (
+                    shapers
+                        .iter()
+                        .find(|s| s.index == index)
+                        .map(|s| s.name.clone()),
+                    shapers.len(),
+                )
+            }
+        };
+        name.ok_or_else(|| {
+            anyhow!(
+                "{:?} position {} is not in the {}-entry list this daemon is serving now",
+                family,
+                index,
+                count
+            )
+        })
     }
 
     /// Set volume in whole dB.
@@ -2402,8 +2810,20 @@ impl HqpAdapter {
         let state = self.get_state().await?;
         let playback_status = self.get_playback_status().await.unwrap_or_default();
 
-        // Lazy-load lists if not cached (first request after connect)
-        // Check ALL lists - if any are empty, we need to refresh
+        // Chain probe. The lists this view publishes are scoped to the chain the daemon has *loaded*,
+        // and under `[source]` that chain moves without `State.mode` moving at all (HQP-C-007) — so
+        // "refresh when a list is empty" served the previous chain's options indefinitely, and a UI
+        // offering PCM filters over a loaded DSD chain is a lie a user acts on.
+        //
+        // The rate list is the probe because it is the smallest chain-scoped enumeration and the two
+        // chains' rate lists were observed disjoint (HQP-C-020). Its fingerprint changing drops every
+        // chain-scoped cache, which the lazy fill below then repopulates. A probe failure is not fatal
+        // to a read: the caller still gets `State` and `Status`.
+        if let Err(e) = self.fresh_rates().await {
+            tracing::warn!("HQPlayer chain probe failed, serving cached enumerations: {e}");
+        }
+
+        // Lazy-fill whatever the probe left empty — on the first read after connect, that is all of it.
         let needs_lists = {
             let cached = self.state.read().await;
             cached.modes.is_empty()
@@ -2472,8 +2892,17 @@ impl HqpAdapter {
                 state: state_str.to_string(),
                 // State.mode and State.active_mode are INDEX (0,1,2) - look up by ModesItem.index
                 mode: get_mode_by_index(state.mode),
-                // Use State's active_mode (INDEX) - Status's active_mode string is unreliable
-                // (shows "[source]" even when actually outputting DSD)
+                // `State.active_mode`, resolved through the modes list. This is a **reporting choice
+                // between two fields whose semantics are not both measured**, not a statement that one
+                // is right: `Status.active_mode` is measured to echo the configured mode under
+                // `[source]` (HQP-C-023), and what `State.active_mode` reports there has never been
+                // measured by anyone (HQP-C-024). An earlier comment here called the `Status` field
+                // "unreliable" and instructed always using this one, which asserted the unmeasured half
+                // as fact; #332 owns settling it.
+                //
+                // Nothing that has to be *correct* depends on this field. The loaded chain — which
+                // decides every enumeration below — is resolved from the enumerations the daemon
+                // serves, never from either `active_mode`.
                 active_mode: get_mode_by_index(state.active_mode),
                 active_filter: playback_status.active_filter.clone(),
                 active_shaper: playback_status.active_shaper.clone(),
@@ -3019,13 +3448,50 @@ impl HqpAdapter {
         }))
     }
 
-    /// Get current matrix profile
+    /// The matrix profile the daemon currently has selected.
+    ///
+    /// The authority is the observed **`State.matrix_profile`** field, not `MatrixGetProfile`: #341
+    /// records no versioned evidence that the supported daemon implements that command consistently,
+    /// and #347 says explicitly not to treat it as the current-profile authority until it does.
+    ///
+    /// The `index` is *derived* by resolving that name against the list the daemon is serving now — it
+    /// is a position in a list, so it is only meaningful alongside the list it came from and is never
+    /// stored. A name the fresh list does not contain yields `None` rather than a profile carrying
+    /// some other entry's index: nothing in the list is selected, and reporting index 0 would name
+    /// whatever sits first, which on the observed corpus is `Default`.
     pub async fn get_matrix_profile(&self) -> Result<Option<MatrixProfile>> {
+        let current = self.get_state().await?.matrix_profile;
+        if current.is_empty() {
+            // No selection. The empty field is the default identity and is not list position 0.
+            return Ok(None);
+        }
+        let profiles = self.get_matrix_profiles().await?;
+        let resolved = profiles.into_iter().find(|p| p.name == current);
+        if resolved.is_none() {
+            tracing::warn!(
+                "HQPlayer reports matrix profile {current:?}, which its own MatrixListProfiles does \
+                 not contain; reporting no selection rather than another profile's index"
+            );
+        }
+        Ok(resolved)
+    }
+
+    /// Ask the daemon what `MatrixGetProfile` reports.
+    ///
+    /// **This is an observation, not the authority.** [`Self::get_matrix_profile`] reads
+    /// `State.matrix_profile`, because #341 records no versioned evidence that the supported daemon
+    /// implements `MatrixGetProfile` consistently and #347 forbids assuming it does. This method
+    /// exists so the tier-1 read-only capture lane can *watch* what the command says and diff it
+    /// against `State` — which is how that question gets settled by evidence instead of by assumption.
+    ///
+    /// No control path calls it, and
+    /// `no_production_code_treats_matrix_get_profile_as_the_current_selection` keeps it that way.
+    pub async fn read_matrix_get_profile(&self) -> Result<Option<MatrixProfile>> {
         let xml = Self::build_request("MatrixGetProfile", &[]);
         let response = self.send_command(&xml).await?;
 
-        // HQPlayer returns current profile - try both 'value' (as per Node.js reference)
-        // and 'name' attribute for compatibility
+        // Both `value` (the Node.js reference's reading) and `name` are accepted, because which one
+        // the daemon uses is part of what this lane is capturing.
         let index = Self::parse_attr_u32(&response, "index");
         let name =
             Self::parse_attr(&response, "value").or_else(|| Self::parse_attr(&response, "name"));
@@ -3036,19 +3502,40 @@ impl HqpAdapter {
         }
     }
 
-    /// Set matrix profile by index - converts index to name for HQPlayer
-    /// HQPlayer's MatrixSetProfile expects profile NAME, not index
-    pub async fn set_matrix_profile(&self, profile_index: u32) -> Result<()> {
-        // Get the list of profiles and find the name for this index
+    /// Select a matrix profile by its position in the daemon's current list.
+    ///
+    /// **This is the compatibility boundary and nothing else.** The legacy HTTP routes carry a
+    /// number, so the number is accepted here, resolved against the list the daemon is serving now,
+    /// and immediately turned into the semantic name that goes on the wire. The number is never
+    /// stored, never published as identity, and never reaches the daemon.
+    pub async fn set_matrix_profile(&self, profile_index: u32) -> Result<SettingOutcome> {
         let profiles = self.get_matrix_profiles().await?;
-        let profile = profiles
+        let name = profiles
             .iter()
             .find(|p| p.index == profile_index)
-            .ok_or_else(|| anyhow::anyhow!("Matrix profile index {} not found", profile_index))?;
+            .map(|p| p.name.clone())
+            .ok_or_else(|| {
+                anyhow!(
+                    "Matrix profile {} is not a position in the list this daemon is serving now",
+                    profile_index
+                )
+            })?;
+        self.set_matrix_profile_named(&name).await
+    }
 
-        let xml = Self::build_request("MatrixSetProfile", &[("value", &profile.name)]);
-        self.send_command(&xml).await?;
-        Ok(())
+    /// Select a matrix profile by name, verifying against the authoritative `State` field.
+    ///
+    /// `MatrixSetProfile` takes the name, and like every other setter its `result="OK"` is not proof
+    /// of application (HQP-C-028) — so the write is confirmed by reading `State.matrix_profile` back.
+    pub async fn set_matrix_profile_named(&self, name: &str) -> Result<SettingOutcome> {
+        if self.get_state().await?.matrix_profile == name {
+            return Ok(SettingOutcome::AlreadySet);
+        }
+        let xml = Self::build_request("MatrixSetProfile", &[("value", name)]);
+        self.write_setting(&xml, "matrix profile", name.to_string(), |s| {
+            Some(s.matrix_profile.clone())
+        })
+        .await
     }
 
     /// Get name of this instance (if set)

--- a/src/adapters/hqplayer.rs
+++ b/src/adapters/hqplayer.rs
@@ -876,7 +876,12 @@ pub struct VolumeRange {
 }
 
 /// Mode/Filter/Shaper item
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// `PartialEq` because a freshly fetched family is compared against the cached one *whole*, not
+/// only through its fingerprint. The fingerprint covers `(index, name)` — the pair a list index is
+/// resolved through — so two lists agreeing on it can still differ in the fields it does not cover,
+/// and a publisher that skipped the write on a fingerprint match alone would drop those silently.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ListItem {
     pub index: u32,
     pub name: String,
@@ -884,14 +889,14 @@ pub struct ListItem {
 }
 
 /// Rate item
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RateItem {
     pub index: u32,
     pub rate: u32,
 }
 
 /// Filter item with arg
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FilterItem {
     pub index: u32,
     pub name: String,
@@ -1009,24 +1014,162 @@ pub struct MatrixProfile {
 /// (HQP-C-020) — and it is the wrong *identity*, because a profile load can replace filters and
 /// shapers while leaving rates byte-identical. A read that captured only the rates would accept such
 /// a replacement as the set it started from.
+///
+/// And a generation alongside them, because four fingerprints are still not enough. They describe
+/// *what* is cached, and a clear-then-refill can arrive back at the same four — the same daemon
+/// reloading the same configuration — while the event that emptied the cache has changed the
+/// session, the profile or the loaded chain, and therefore changed `State`. Contents alone cannot
+/// distinguish "untouched" from "torn down and rebuilt identically"; only a counter of fillings can,
+/// and that distinction is what a read holding a pre-clear identity and a post-clear `State` needs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct ChainIdentity {
     modes: u64,
     filters: u64,
     shapers: u64,
     rates: u64,
+    generation: u64,
 }
 
-/// The four cached chain-scoped families, taken together, at one instant.
+/// The four chain-scoped families, taken together, as one value.
 ///
 /// Returned by [`HqpAdapter::verified_chain_snapshot`] so that what a read *verified* and what it
-/// *publishes* are the same values rather than two reads of the same cache.
+/// *publishes* are the same values rather than two reads of the same cache, and accepted by
+/// [`HqpAdapter::publish_chain_snapshot`] so that a gathered set is offered to the cache as one
+/// thing rather than four assignments that could each be judged separately.
 #[derive(Debug, Clone)]
 struct ChainSnapshot {
     modes: Vec<ListItem>,
     filters: Vec<FilterItem>,
     shapers: Vec<ListItem>,
     rates: Vec<RateItem>,
+}
+
+/// **One** freshly fetched chain-scoped family, on its way into the cache.
+///
+/// The counterpart of [`ChainSnapshot`] for the single-family path, and one value rather than a
+/// `(family_name, list, fingerprint)` triple for a specific reason: those three had drifted apart.
+/// The removed `note_enumeration` took a `&str` to decide *which* previous fingerprint to compare,
+/// while its caller separately assigned the list and separately assigned a fingerprint it had
+/// computed itself — three spellings of "which family is this" that nothing made agree, passed
+/// across two different lock acquisitions. Here the family, the contents and the fingerprint are one
+/// value, the fingerprint is derived from the contents rather than accepted alongside them (the
+/// invariant [`HqpAdapter::chain_identity_of`] rests on), and the whole decision happens under one
+/// lock in [`HqpAdapter::publish_fresh_family`].
+#[derive(Debug, Clone)]
+enum FreshFamily {
+    Modes(Vec<ListItem>),
+    Filters(Vec<FilterItem>),
+    Shapers(Vec<ListItem>),
+    Rates(Vec<RateItem>),
+}
+
+impl FreshFamily {
+    /// The daemon's name for this family, for the line a transition logs.
+    fn label(&self) -> &'static str {
+        match self {
+            Self::Modes(_) => "modes",
+            Self::Filters(_) => "filters",
+            Self::Shapers(_) => "shapers",
+            Self::Rates(_) => "rates",
+        }
+    }
+
+    /// The identity of these contents, derived from them and from nothing else.
+    fn fingerprint(&self) -> u64 {
+        match self {
+            Self::Modes(items) | Self::Shapers(items) => {
+                HqpAdapter::fingerprint(items.iter().map(|i| (i.index, i.name.as_str())))
+            }
+            Self::Filters(items) => {
+                HqpAdapter::fingerprint(items.iter().map(|i| (i.index, i.name.as_str())))
+            }
+            Self::Rates(items) => HqpAdapter::rates_fingerprint(items),
+        }
+    }
+
+    /// The fingerprint the cache currently holds for *this* family, or `None` if it holds none —
+    /// which is what a family never fetched and a family just cleared both look like.
+    fn cached_fingerprint(&self, state: &HqpAdapterState) -> Option<u64> {
+        match self {
+            Self::Modes(_) => state.modes_fingerprint,
+            Self::Filters(_) => state.filters_fingerprint,
+            Self::Shapers(_) => state.shapers_fingerprint,
+            Self::Rates(_) => state.rates_fingerprint,
+        }
+    }
+
+    /// Whether these contents are, element for element, what the cache already holds.
+    ///
+    /// Asked in addition to the fingerprint rather than instead of it. The fingerprint answers "does
+    /// this list resolve indices the same way"; this answers "is writing it a no-op", and only the
+    /// second licenses skipping the write.
+    fn matches_cache(&self, state: &HqpAdapterState) -> bool {
+        match self {
+            Self::Modes(items) => *items == state.modes,
+            Self::Filters(items) => *items == state.filters,
+            Self::Shapers(items) => *items == state.shapers,
+            Self::Rates(items) => *items == state.rates,
+        }
+    }
+
+    /// Whether this reply resolves every position exactly as the cached winner does.
+    ///
+    /// Narrower than [`Self::matches_cache`]: a setter only needs the `(index, semantic value)`
+    /// mapping to be current. If a complete refresh overtook this fetch but published that exact
+    /// mapping, the reply is safe to resolve through even if non-routing metadata differs. The
+    /// winner remains authoritative and is never rewritten by this check.
+    fn resolves_like_cache(&self, state: &HqpAdapterState) -> bool {
+        match self {
+            Self::Modes(items) => items
+                .iter()
+                .map(|item| (item.index, item.name.as_str()))
+                .eq(state
+                    .modes
+                    .iter()
+                    .map(|item| (item.index, item.name.as_str()))),
+            Self::Filters(items) => items
+                .iter()
+                .map(|item| (item.index, item.name.as_str()))
+                .eq(state
+                    .filters
+                    .iter()
+                    .map(|item| (item.index, item.name.as_str()))),
+            Self::Shapers(items) => items
+                .iter()
+                .map(|item| (item.index, item.name.as_str()))
+                .eq(state
+                    .shapers
+                    .iter()
+                    .map(|item| (item.index, item.name.as_str()))),
+            Self::Rates(items) => items
+                .iter()
+                .map(|item| (item.index, item.rate))
+                .eq(state.rates.iter().map(|item| (item.index, item.rate))),
+        }
+    }
+
+    /// Install these contents **and** the fingerprint derived from them, together, so that no path
+    /// can leave a family anchored to an identity it was not filled from.
+    fn install(self, state: &mut HqpAdapterState, fingerprint: u64) {
+        match self {
+            Self::Modes(items) => {
+                state.modes = items;
+                state.modes_fingerprint = Some(fingerprint);
+            }
+            Self::Filters(items) => {
+                state.filters = items;
+                state.filters_fingerprint = Some(fingerprint);
+            }
+            Self::Shapers(items) => {
+                state.shapers = items;
+                state.shapers_fingerprint = Some(fingerprint);
+            }
+            Self::Rates(items) => {
+                state.rates = items;
+                state.rates_fingerprint = Some(fingerprint);
+            }
+        }
+    }
 }
 
 /// Why a read could not join the `State` it observed to the lists it holds.
@@ -1094,6 +1237,14 @@ struct HqpAdapterState {
     filters_fingerprint: Option<u64>,
     shapers_fingerprint: Option<u64>,
     rates_fingerprint: Option<u64>,
+    /// How many times the chain-scoped cache has been cleared or filled, ever.
+    ///
+    /// Fingerprints say *what* is cached; this says *which filling of it* that is. The two are not
+    /// the same question, and the difference is what a writer holding a set gathered off-lock needs:
+    /// an invalidate-and-refill can land byte-identical fingerprints from a different profile load,
+    /// session or poll, and nothing in the contents distinguishes that from the cache never having
+    /// been touched. Monotonic, bumped on every clear and every publication, and never reset.
+    chain_generation: u64,
     volume_range: Option<VolumeRange>,
     // Web client state for profiles
     profiles: Vec<HqpProfile>,
@@ -1135,6 +1286,7 @@ impl Default for HqpAdapterState {
             filters_fingerprint: None,
             shapers_fingerprint: None,
             rates_fingerprint: None,
+            chain_generation: 0,
             volume_range: None,
             profiles: Vec::new(),
             hidden_fields: HashMap::new(),
@@ -1267,18 +1419,12 @@ impl HqpAdapter {
                 // Clear ALL instance-specific cached data when switching hosts
                 state.info = None;
                 state.last_state = None;
-                state.modes.clear();
-                state.filters.clear();
-                state.shapers.clear();
-                state.rates.clear();
-                // The fingerprints go with the lists they describe. Left behind, they would be one
-                // daemon's enumeration identity used to judge whether *another* daemon's chain had
-                // moved — a comparison with no meaning, and the presence check downstream would be
-                // the only thing left standing between that and a published answer.
-                state.modes_fingerprint = None;
-                state.filters_fingerprint = None;
-                state.shapers_fingerprint = None;
-                state.rates_fingerprint = None;
+                // Through the common helper rather than by hand. The lists, the fingerprints that
+                // anchor them and the generation that dates them are one fact in three parts — a
+                // second spelling of the clearing is how one of the three gets left behind, and a
+                // fingerprint left behind is one daemon's enumeration identity used to judge whether
+                // *another* daemon's chain had moved.
+                Self::clear_chain_cache(&mut state);
                 state.volume_range = None;
                 state.profiles.clear();
                 state.hidden_fields.clear();
@@ -1468,7 +1614,14 @@ impl HqpAdapter {
     ///
     /// Split out because [`Self::verified_chain_snapshot`] must decide *and* act inside one lock: a
     /// proof that dropped the lock to call [`Self::invalidate_chain_cache`] would be judging one
-    /// cache and clearing whatever happened to be there a moment later.
+    /// cache and clearing whatever happened to be there a moment later. Every clearing in the
+    /// adapter goes through here, including `configure`'s, so that the generation bump cannot be
+    /// forgotten at one of them.
+    ///
+    /// The bump is unconditional, including when there was nothing to clear. "The cache was already
+    /// empty" is not the same as "nothing happened to it": a gather in flight was reading a daemon
+    /// that has since been reconnected or reconfigured, and declining to publish is the cheap,
+    /// retryable outcome while publishing a set from before the event is the expensive one.
     fn clear_chain_cache(state: &mut HqpAdapterState) {
         state.modes.clear();
         state.filters.clear();
@@ -1478,7 +1631,23 @@ impl HqpAdapter {
         state.filters_fingerprint = None;
         state.shapers_fingerprint = None;
         state.rates_fingerprint = None;
+        Self::bump_chain_generation(state);
         tracing::debug!("Invalidated HQPlayer chain-scoped enumeration cache");
+    }
+
+    /// Record that the chain-scoped cache is no longer the filling it was.
+    ///
+    /// Wrapping rather than saturating: a token is compared only across one bounded gather/read, so
+    /// an ABA collision would require 2^64 cache events during that operation. Saturating would be
+    /// strictly worse — after reaching `MAX`, every later clear/publication would remain `MAX` and
+    /// become invisible to every in-flight guard.
+    fn bump_chain_generation(state: &mut HqpAdapterState) {
+        state.chain_generation = state.chain_generation.wrapping_add(1);
+    }
+
+    /// The current chain-cache generation, for a caller about to gather off-lock.
+    async fn chain_generation(&self) -> u64 {
+        self.state.read().await.chain_generation
     }
 
     /// Identity of an enumeration, as `(index, label)` pairs in the order the daemon served them.
@@ -1495,63 +1664,117 @@ impl HqpAdapter {
         hasher.finish()
     }
 
-    /// Record a freshly fetched enumeration and report whether the loaded chain moved.
+    /// Offer **one** freshly fetched family to the cache — or refuse it, and tell the caller so.
     ///
-    /// The comparison is against the **previous fingerprint of the same family**; a family never
-    /// observed before cannot be a transition. When one does move, every other chain-scoped family is
-    /// dropped rather than refetched here: the caller may not need them, and a lazy refill keeps a
-    /// control path to one enumeration fetch.
-    async fn note_enumeration(&self, family: &str, fingerprint: u64) -> bool {
-        let previous = {
-            let state = self.state.read().await;
-            match family {
-                "modes" => state.modes_fingerprint,
-                "filters" => state.filters_fingerprint,
-                "shapers" => state.shapers_fingerprint,
-                _ => state.rates_fingerprint,
+    /// The single-family counterpart of [`Self::publish_chain_snapshot`], and the same three
+    /// decisions taken in the same place: is this fetch still current, did the family move, and what
+    /// gets written. `since` is the generation the fetch was issued against, captured before the
+    /// request went out, so the window this covers is the whole round trip.
+    ///
+    /// **Under one write lock, and that is the substance of it rather than a detail of it.** These
+    /// decisions used to be three separate lock acquisitions — a read to fetch the previous
+    /// fingerprint, an `invalidate_chain_cache` if it had moved, a write to assign — and between any
+    /// two of them a profile load, a reconnect or another poll's refresh could publish a complete
+    /// set. Two distinct outcomes followed. If the replacement landed before the fingerprint read,
+    /// the comparison found the *winner's* fingerprint, disagreed with it, and dropped the winner to
+    /// install one family: a partial cache. If it landed between the read and the write, nothing
+    /// disagreed with anything and the write simply overwrote one family of the winner's set,
+    /// leaving three families from the new profile beside one from the old — **complete, coherent to
+    /// every presence check, and agreeing with a rate probe whenever the two profiles offer the same
+    /// rates, which is ordinary** (HQP-C-021). Held under one lock, neither interleaving exists;
+    /// checked against `since`, neither outcome is reachable even so.
+    ///
+    /// **An overtaken fetch is an `Err`, not a quiet `Ok`.** The list does not merely fail to reach
+    /// the cache — it must not reach the *caller* either. Every `fresh_*` hands its list back to a
+    /// setter that resolves a name against it and sends the resulting **position** to the daemon
+    /// (HQP-C-001). A position in a list the daemon has stopped serving names a different setting,
+    /// which is this issue. So the loser reports its loss, the caller gets an error it can retry,
+    /// and — the same asymmetry [`Self::verified_chain_snapshot`] applies to `Replaced` — the winner
+    /// is not touched.
+    ///
+    /// **A family that reads the same is not a cache event.** No clearing, no change, no bump: the
+    /// generation is what in-flight gathers and reads compare against, so bumping it for a
+    /// confirmation would invalidate their work and manufacture the very race it exists to detect —
+    /// and the ordinary outcome of a setter's refetch is exactly the list already cached. Contents
+    /// are compared whole rather than by fingerprint alone, because the fingerprint covers
+    /// `(index, name)` and a write can be a no-op only if *nothing* in the family differs. A family
+    /// with no previous fingerprint is a family being filled, never a confirmation.
+    ///
+    /// The fingerprint is derived from the contents here, never accepted from the caller, for the
+    /// reason [`Self::publish_chain_snapshot`] derives its four.
+    async fn publish_fresh_family(&self, fresh: FreshFamily, since: u64) -> Result<()> {
+        let fingerprint = fresh.fingerprint();
+        let mut state = self.state.write().await;
+
+        if state.chain_generation != since {
+            // A full refresh can win while this single-family request is in flight. The generation
+            // says the fetch may no longer be trusted *by default*, but when the winner is anchored
+            // to the same routing fingerprint and the complete semantic mapping agrees element for
+            // element, resolving through the reply selects exactly what resolving through the
+            // winner would select. Accept the reply without publishing it or changing the winner's
+            // generation. Any changed mapping remains a hard error below.
+            if fresh.cached_fingerprint(&state) == Some(fingerprint)
+                && fresh.resolves_like_cache(&state)
+            {
+                return Ok(());
             }
-        };
-        let changed = previous.is_some_and(|p| p != fingerprint);
-        if changed {
-            tracing::info!(
-                "HQPlayer {family} enumeration changed: the loaded chain moved, dropping every \
-                 chain-scoped list"
-            );
-            self.invalidate_chain_cache().await;
+            return Err(anyhow!(
+                "HQPlayer's {} list was read against a set of lists that has since been cleared or \
+                 replaced, so the positions in it are no longer this daemon's; refusing to cache it \
+                 or to resolve a setting through it",
+                fresh.label()
+            ));
         }
-        changed
+
+        let previous = fresh.cached_fingerprint(&state);
+
+        // The daemon confirmed what is already there. Nothing happened to the cache, so nothing is
+        // recorded as having happened to it.
+        if previous == Some(fingerprint) && fresh.matches_cache(&state) {
+            return Ok(());
+        }
+
+        // This family moved, so every other chain-scoped list is the previous chain's and goes.
+        // Refetching them here would put a second round trip on a control path; the next read
+        // refills lazily.
+        if previous.is_some_and(|p| p != fingerprint) {
+            tracing::info!(
+                "HQPlayer {} enumeration changed: the loaded chain moved, dropping every \
+                 chain-scoped list",
+                fresh.label()
+            );
+            Self::clear_chain_cache(&mut state);
+        }
+
+        fresh.install(&mut state, fingerprint);
+        Self::bump_chain_generation(&mut state);
+        Ok(())
     }
 
     /// Fetch the modes list from the daemon and cache it, noticing a device change.
     async fn fresh_modes(&self) -> Result<Vec<ListItem>> {
+        let since = self.chain_generation().await;
         let modes = self.get_modes().await?;
-        let fingerprint = Self::fingerprint(modes.iter().map(|m| (m.index, m.name.as_str())));
-        self.note_enumeration("modes", fingerprint).await;
-        let mut state = self.state.write().await;
-        state.modes = modes.clone();
-        state.modes_fingerprint = Some(fingerprint);
+        self.publish_fresh_family(FreshFamily::Modes(modes.clone()), since)
+            .await?;
         Ok(modes)
     }
 
     /// Fetch the loaded chain's filter list from the daemon and cache it.
     async fn fresh_filters(&self) -> Result<Vec<FilterItem>> {
+        let since = self.chain_generation().await;
         let filters = self.get_filters().await?;
-        let fingerprint = Self::fingerprint(filters.iter().map(|f| (f.index, f.name.as_str())));
-        self.note_enumeration("filters", fingerprint).await;
-        let mut state = self.state.write().await;
-        state.filters = filters.clone();
-        state.filters_fingerprint = Some(fingerprint);
+        self.publish_fresh_family(FreshFamily::Filters(filters.clone()), since)
+            .await?;
         Ok(filters)
     }
 
     /// Fetch the loaded chain's shaper list from the daemon and cache it.
     async fn fresh_shapers(&self) -> Result<Vec<ListItem>> {
+        let since = self.chain_generation().await;
         let shapers = self.get_shapers().await?;
-        let fingerprint = Self::fingerprint(shapers.iter().map(|s| (s.index, s.name.as_str())));
-        self.note_enumeration("shapers", fingerprint).await;
-        let mut state = self.state.write().await;
-        state.shapers = shapers.clone();
-        state.shapers_fingerprint = Some(fingerprint);
+        self.publish_fresh_family(FreshFamily::Shapers(shapers.clone()), since)
+            .await?;
         Ok(shapers)
     }
 
@@ -1567,18 +1790,10 @@ impl HqpAdapter {
     /// direction, a chain move that leaves the rate list byte-identical, is what would be missed, and
     /// no observation suggests it is reachable.
     async fn fresh_rates(&self) -> Result<Vec<RateItem>> {
+        let since = self.chain_generation().await;
         let rates = self.get_rates().await?;
-        let labels: Vec<String> = rates.iter().map(|r| r.rate.to_string()).collect();
-        let fingerprint = Self::fingerprint(
-            rates
-                .iter()
-                .zip(labels.iter())
-                .map(|(r, label)| (r.index, label.as_str())),
-        );
-        self.note_enumeration("rates", fingerprint).await;
-        let mut state = self.state.write().await;
-        state.rates = rates.clone();
-        state.rates_fingerprint = Some(fingerprint);
+        self.publish_fresh_family(FreshFamily::Rates(rates.clone()), since)
+            .await?;
         Ok(rates)
     }
 
@@ -1602,6 +1817,12 @@ impl HqpAdapter {
     /// `a_profile_load_whose_refresh_fails_does_not_leave_the_previous_profiles_lists_in_place`
     /// covers), and that replacement is invisible to a rates comparison.
     ///
+    /// And the generation, because even four fingerprints describe only the contents. An
+    /// invalidate-and-refill that lands byte-identical lists is still a *different filling*, and the
+    /// event behind it — a reconnect, a profile load, a mode write — is one that moves `State`. A
+    /// read holding the pre-clear identity and the post-clear `State` must not have those two
+    /// compare equal.
+    ///
     /// `None` means the set is **not** a set: a family is empty, or a family is present without the
     /// fingerprint it was filled from, which would leave it unanchored. Presence and identity are the
     /// same question asked once here, because a partial cache has no identity to compare — which is
@@ -1619,6 +1840,7 @@ impl HqpAdapter {
             filters: state.filters_fingerprint?,
             shapers: state.shapers_fingerprint?,
             rates: state.rates_fingerprint?,
+            generation: state.chain_generation,
         })
     }
 
@@ -1643,7 +1865,10 @@ impl HqpAdapter {
     ///   drop; the caller refills.
     /// * **Replaced** — the set is coherent and complete but is not the one this read captured. The
     ///   cache is not known to be wrong; it is simply newer than this read, and dropping it would
-    ///   punish whoever published it for winning a race. This read fails; the cache stands.
+    ///   punish whoever published it for winning a race. This read fails; the cache stands. A refill
+    ///   whose four fingerprints happen to match is `Replaced` too, on the generation: the lists
+    ///   reading the same does not make the `State` observed after the clearing event belong to the
+    ///   set observed before it.
     /// * **Moved** — after establishing that the current cache is still the captured set, the
     ///   daemon's live rate list contradicts it. That is the daemon disagreeing with the cache, so
     ///   the cache is wrong and goes.
@@ -1748,13 +1973,28 @@ impl HqpAdapter {
     /// transition", not "the four replies came from one instant", which nothing short of an atomic
     /// daemon-side snapshot could establish.
     ///
+    /// **And the bracket does not make this writer safe to publish, which is the other guard.** Both
+    /// probes agreeing says the *daemon's chain* held still; it says nothing about the *cache*, which
+    /// this writer has not been holding a lock on for the whole gather. An invalidation and a
+    /// complete refill from a new profile can land in that window, and if the two profiles' rate
+    /// lists agree — ordinary, since the offered rates follow the filter (HQP-C-021) — the bracket is
+    /// satisfied by a set that is now the previous profile's. So the generation is captured before
+    /// the first reply is requested and re-checked under the publication lock: see
+    /// [`Self::publish_chain_snapshot`], which is where the set is actually installed or dropped.
+    ///
     /// **Returns whether a complete, coherent snapshot was published.** The caller has to be able to
-    /// tell: a refresh that publishes nothing leaves the cache exactly as it found it, and when the
-    /// caller *needed* that fill — a first read after connect, or one after an invalidation — what it
-    /// is left holding is nothing at all. Swallowing that turned "I could not read this" into "this
-    /// daemon offers no filters", which is the ambiguity every other guard here exists to refuse.
+    /// tell: a refresh that publishes nothing leaves the cache as it *is* — usually exactly as this
+    /// refresh found it, and, when an overtaking writer is what stopped it, holding that writer's
+    /// newer set instead. Either way, when the caller *needed* the fill — a first read after connect,
+    /// or one after an invalidation — it may be left holding nothing at all. Swallowing that turned
+    /// "I could not read this" into "this daemon offers no filters", which is the ambiguity every
+    /// other guard here exists to refuse.
     #[must_use = "a refresh that did not settle leaves the cache empty, which is not the same as a daemon with no settings"]
     async fn refresh_lists(&self) -> bool {
+        // Captured before the first reply is asked for, so the window this covers is the whole
+        // gather rather than the part of it after some later moment.
+        let since = self.chain_generation().await;
+
         let gathered = async {
             // Opening probe. The rate list is the bracket for the same reason it is the read path's
             // chain probe: smallest chain-scoped enumeration, and the two chains' rate lists were
@@ -1790,10 +2030,6 @@ impl HqpAdapter {
             return false;
         }
 
-        let modes_fp = Self::fingerprint(modes.iter().map(|m| (m.index, m.name.as_str())));
-        let filters_fp = Self::fingerprint(filters.iter().map(|f| (f.index, f.name.as_str())));
-        let shapers_fp = Self::fingerprint(shapers.iter().map(|s| (s.index, s.name.as_str())));
-
         tracing::debug!(
             "Refreshed HQPlayer lists: {} modes, {} filters, {} shapers, {} rates",
             modes.len(),
@@ -1802,15 +2038,66 @@ impl HqpAdapter {
             rates.len()
         );
 
+        self.publish_chain_snapshot(
+            ChainSnapshot {
+                modes,
+                filters,
+                shapers,
+                rates,
+            },
+            since,
+        )
+        .await
+    }
+
+    /// Install a gathered set as the chain-scoped cache, **unless the cache moved on while it was
+    /// being gathered**. Reports whether it was published.
+    ///
+    /// `since` is the generation the gather started from. A publication is a claim about the daemon
+    /// as it was during the gather, and the gather happens off this lock: by the time the writer
+    /// arrives here, an invalidation and a complete refill from a new profile can already have
+    /// landed. Publishing anyway replaces a current set with one read before the change — and does
+    /// so *invisibly*, because both sets are complete and self-consistent, and the four-family
+    /// identity cannot tell "cached from the old profile" from "cached now" when the profiles happen
+    /// to agree. A later read then captures the overwritten cache, probes rates that never moved,
+    /// and reports the old profile's names for the new profile's `State`, with every guard passing.
+    ///
+    /// So the loser reports its loss and the winner is untouched. This is deliberately the *same*
+    /// asymmetry [`Self::verified_chain_snapshot`] applies to `Replaced`: whoever is holding the
+    /// older observation yields, and a cache that is not known to be wrong is not dropped.
+    ///
+    /// Fingerprints are derived here from the contents being installed rather than accepted from the
+    /// caller, because "every family is fingerprinted from what is in it" is the invariant the whole
+    /// identity comparison rests on, and a caller that computed one of the four from something else
+    /// would break it silently.
+    #[must_use = "an unpublished gather leaves the cache as it found it, and the caller wanted it filled"]
+    async fn publish_chain_snapshot(&self, gathered: ChainSnapshot, since: u64) -> bool {
         let mut state = self.state.write().await;
-        state.modes = modes;
-        state.filters = filters;
-        state.shapers = shapers;
-        state.rates = rates;
-        state.modes_fingerprint = Some(modes_fp);
-        state.filters_fingerprint = Some(filters_fp);
-        state.shapers_fingerprint = Some(shapers_fp);
-        state.rates_fingerprint = Some(rates_fp);
+
+        if state.chain_generation != since {
+            tracing::warn!(
+                "HQPlayer's setting lists were replaced while this refresh was reading them; \
+                 keeping the newer set rather than overwriting it with one read from before the \
+                 change"
+            );
+            return false;
+        }
+
+        state.modes_fingerprint = Some(Self::fingerprint(
+            gathered.modes.iter().map(|m| (m.index, m.name.as_str())),
+        ));
+        state.filters_fingerprint = Some(Self::fingerprint(
+            gathered.filters.iter().map(|f| (f.index, f.name.as_str())),
+        ));
+        state.shapers_fingerprint = Some(Self::fingerprint(
+            gathered.shapers.iter().map(|s| (s.index, s.name.as_str())),
+        ));
+        state.rates_fingerprint = Some(Self::rates_fingerprint(&gathered.rates));
+        state.modes = gathered.modes;
+        state.filters = gathered.filters;
+        state.shapers = gathered.shapers;
+        state.rates = gathered.rates;
+        Self::bump_chain_generation(&mut state);
         true
     }
 
@@ -3232,7 +3519,21 @@ impl HqpAdapter {
             // that does not settle is the read's failure, not a quieter version of success: with no
             // cache there is nothing to publish but four empty lists.
             let mut captured = self.chain_identity().await;
-            if captured.is_none() && self.refresh_lists().await {
+            if captured.is_none() {
+                // The re-read is unconditional, and the refresh's verdict is a log line rather than
+                // a gate. `refresh_lists` returns `false` for two situations that have nothing in
+                // common: it could not gather a set, or it *was overtaken* — a profile load, a
+                // reconnect's refill or another poll's refresh published a complete set while this
+                // one was reading, and the loser declined to overwrite it. In the second the cache
+                // ends up filled, by the winner, which is the whole point of yielding to it. Reading
+                // the cache only on `true` would throw that winner away, spend the retry, and report
+                // "no coherent set" about a daemon whose lists were sitting complete in the cache.
+                if !self.refresh_lists().await {
+                    tracing::debug!(
+                        "HQPlayer's list refresh published nothing; reading the cache anyway, \
+                         since a refresh that lost a race leaves the winner's set in place"
+                    );
+                }
                 captured = self.chain_identity().await;
             }
             let Some(captured) = captured else {
@@ -4907,6 +5208,40 @@ mod chain_identity_tests {
         }
     }
 
+    /// A generation token only has to distinguish cache events that can overlap one in-flight
+    /// gather/read. Saturating at `u64::MAX` would make the very next clear or publication invisible
+    /// forever: `MAX -> MAX`. Wrapping keeps every adjacent event distinct; an ABA collision would
+    /// require 2^64 cache mutations during that one bounded operation.
+    #[test]
+    fn the_generation_counter_never_stalls_at_the_integer_ceiling() {
+        let mut state = HqpAdapterState {
+            chain_generation: u64::MAX,
+            ..HqpAdapterState::default()
+        };
+
+        HqpAdapter::bump_chain_generation(&mut state);
+        assert_eq!(
+            state.chain_generation, 0,
+            "the event after MAX must still produce a distinct token; saturation would make it \
+             invisible to every in-flight publication"
+        );
+        HqpAdapter::bump_chain_generation(&mut state);
+        assert_eq!(
+            state.chain_generation, 1,
+            "and the counter must continue advancing after the wrap"
+        );
+    }
+
+    /// The four families of a cache, as the value a gather hands to the publisher.
+    fn gathered(cache: &HqpAdapterState) -> ChainSnapshot {
+        ChainSnapshot {
+            modes: cache.modes.clone(),
+            filters: cache.filters.clone(),
+            shapers: cache.shapers.clone(),
+            rates: cache.rates.clone(),
+        }
+    }
+
     /// An adapter whose cache is a given complete set, and nothing else. No socket, no config: these
     /// tests are about the proof, and the proof is a decision about memory.
     async fn adapter_with_cache(cache: HqpAdapterState) -> HqpAdapter {
@@ -5095,6 +5430,517 @@ mod chain_identity_tests {
             adapter.chain_identity().await,
             Some(captured),
             "proving a read must not disturb the cache it proved"
+        );
+    }
+
+    /// **The write-side twin of `a_cache_replaced_mid_read_fails_this_read_and_is_left_in_place`,
+    /// and the one the read-side guard cannot cover.** `refresh_lists` gathers five replies off the
+    /// state lock and only then takes it. Everything the read path does to avoid overwriting a
+    /// winner happens on the *read* side; the refresh writer, having taken no position on what it
+    /// was replacing, used to assign all four families unconditionally.
+    ///
+    /// So: a profile load lands while the gather is in flight, invalidating the cache and refilling
+    /// it from the new profile. The gather's closing `GetRates` then returns — the rate list is
+    /// unchanged across the two profiles (HQP-C-021 makes that ordinary), so the bracket agrees with
+    /// itself and the old writer publishes the *previous* profile's filters and shapers over the
+    /// new profile's. Nothing downstream can detect it: a later read captures that cache, probes,
+    /// finds the rates agreeing, and reports the old profile's filter name for a `State` produced by
+    /// the new one. Confidently, which is the part that matters.
+    ///
+    /// Only the generation can refuse this. The four fingerprints cannot: the winner is complete,
+    /// self-consistent and — on the rates — identical.
+    ///
+    /// **Label: client-red.** Found by CodeRabbit at `9b1fdfe`.
+    #[tokio::test]
+    async fn a_gather_overtaken_by_a_newer_profile_publishes_nothing_and_leaves_the_winner() {
+        let old_profile = pcm_cache();
+        let unchanged_rates = old_profile.rates.clone();
+        let old_modes = old_profile.modes.clone();
+        // What the five replies will amount to, gathered off the state lock.
+        let stale_gather = gathered(&old_profile);
+        let adapter = adapter_with_cache(old_profile).await;
+
+        // The gather begins: this is the cache its replies were asked on behalf of.
+        let since = adapter.chain_generation().await;
+
+        // Mid-gather: a profile load drops the cache and republishes it from the new profile. Same
+        // rates — a profile can move the filters and shapers while leaving the rate list alone.
+        adapter.invalidate_chain_cache().await;
+        let winner = cache_of(
+            old_modes,
+            vec![filter(0, "closed-form"), filter(1, "gauss-long")],
+            vec![mode(0, "ASDM7"), mode(1, "ASDM5")],
+            unchanged_rates,
+        );
+        assert!(
+            adapter
+                .publish_chain_snapshot(gathered(&winner), adapter.chain_generation().await)
+                .await,
+            "precondition: the newer profile's set publishes, since nothing overtook it"
+        );
+        let winner_id = adapter
+            .chain_identity()
+            .await
+            .expect("the winner is the cache now");
+
+        // And only now does the old gather reach the lock.
+        let published = adapter.publish_chain_snapshot(stale_gather, since).await;
+
+        assert!(
+            !published,
+            "the cache this gather set out to fill has been filled by someone newer; publishing \
+             over it would replace a current set with one read before the profile changed"
+        );
+        assert_eq!(
+            adapter.chain_identity().await,
+            Some(winner_id),
+            "and the winner is left exactly as it was — an overtaken writer reports its loss to its \
+             caller, it does not take the cache down with it"
+        );
+        assert_eq!(
+            adapter
+                .state
+                .read()
+                .await
+                .filters
+                .iter()
+                .map(|f| f.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["closed-form", "gauss-long"],
+            "which is to say: the new profile's filters, not the ones this gather was holding"
+        );
+    }
+
+    /// The other half of the same rule, and the half a refill-shaped test cannot reach: an
+    /// invalidation with **nothing** published after it must stop an overtaken gather too.
+    ///
+    /// That is the reconnect, not the profile load. `connect`, `disconnect` and `mark_disconnected`
+    /// all drop the cache and leave it empty, and a gather straddling one of them read some of its
+    /// five replies through a session that has since ended — through a daemon that may have
+    /// restarted, been reconfigured, or followed the source onto the other chain while UHC was away.
+    /// Publishing that set fills an emptied cache with exactly the lists the emptying was for.
+    ///
+    /// Written because the mutation check found it: deleting the bump from `clear_chain_cache` left
+    /// the two races above still passing, since in both of them the *refill's* bump does the work.
+    /// Only a clearing with no refill isolates the clearing's own bump.
+    #[tokio::test]
+    async fn an_invalidation_with_no_refill_stops_an_overtaken_gather_as_well() {
+        let cache = pcm_cache();
+        let stale_gather = gathered(&cache);
+        let adapter = adapter_with_cache(cache).await;
+        let since = adapter.chain_generation().await;
+
+        // Mid-gather the session dropped. Nothing refills it — a reconnect leaves the cache empty
+        // and the next read fills it.
+        adapter.invalidate_chain_cache().await;
+
+        let published = adapter.publish_chain_snapshot(stale_gather, since).await;
+
+        assert!(
+            !published,
+            "these lists were read through a session that has ended; an empty cache is not an \
+             invitation to fill it with them"
+        );
+        assert!(
+            adapter.chain_identity().await.is_none(),
+            "and the cache stays empty, so the next read refills it from the daemon it is actually \
+             talking to"
+        );
+    }
+
+    /// The generation is part of the **identity**, not just a publication guard, and this is why.
+    ///
+    /// A profile load, a reconnect or a mode write clears the cache and refills it. That refill can
+    /// come back byte-identical in all four families — the same daemon reloading the same
+    /// configuration is the ordinary case, not a contrived one — while `State` is emphatically not
+    /// the same: the session, the profile and the loaded chain behind it all changed, which is the
+    /// event that made the cache be dropped in the first place.
+    ///
+    /// A read that captured the pre-clear cache and then observed `State` therefore holds a `State`
+    /// from after the event and an identity from before it. On fingerprints alone those two caches
+    /// compare equal and the read passes, joining that `State`'s indices to lists it never saw
+    /// filled. The generation is the only thing in the identity that separates "untouched" from
+    /// "torn down and rebuilt to look the same".
+    #[tokio::test]
+    async fn a_byte_identical_refill_is_still_a_replacement_for_a_read_that_captured_the_old_cache()
+    {
+        let cache = pcm_cache();
+        let probe = cache.rates.clone();
+        let refill = gathered(&cache);
+        let adapter = adapter_with_cache(cache).await;
+        let captured = adapter.chain_identity().await.expect("a complete cache");
+
+        // Torn down and rebuilt from the same four lists.
+        adapter.invalidate_chain_cache().await;
+        assert!(
+            adapter
+                .publish_chain_snapshot(refill, adapter.chain_generation().await)
+                .await,
+            "precondition: the refill publishes"
+        );
+
+        let outcome = adapter.verified_chain_snapshot(captured, &probe).await;
+
+        assert_eq!(
+            outcome.err(),
+            Some(ChainProofFailure::Replaced),
+            "the lists read the same, and they are still not the filling this read captured; the \
+             `State` it holds was reported after the event that emptied that one"
+        );
+        assert!(
+            adapter.chain_identity().await.is_some(),
+            "the refill is the current cache and is not known to be wrong; this read retries, the \
+             cache stands"
+        );
+    }
+
+    /// The four families of a cache, each as the value a **single-family** fetch would hand the
+    /// publisher — which is what a setter's `fresh_*` does, as opposed to `refresh_lists`' whole set.
+    fn each_family(cache: &HqpAdapterState) -> Vec<FreshFamily> {
+        vec![
+            FreshFamily::Modes(cache.modes.clone()),
+            FreshFamily::Filters(cache.filters.clone()),
+            FreshFamily::Shapers(cache.shapers.clone()),
+            FreshFamily::Rates(cache.rates.clone()),
+        ]
+    }
+
+    /// **The single-family twin of
+    /// `a_gather_overtaken_by_a_newer_profile_publishes_nothing_and_leaves_the_winner`, and the one
+    /// with a wire consequence.** `refresh_lists` publishes a whole set and returns a `bool`;
+    /// `fresh_filters` publishes *one* family and hands the list **back to a setter**, which resolves
+    /// a filter name to a position in it and sends that position to the daemon.
+    ///
+    /// So: a setter's `GetFilters` goes out against the loaded profile. While the reply is in flight
+    /// a profile load clears the cache and refills it completely from the new profile — same rate
+    /// list, which is ordinary, since a profile can move the filters and shapers and leave the
+    /// offered rates alone (HQP-C-021). The reply then arrives holding the *previous* profile's
+    /// filters.
+    ///
+    /// Two things must not happen, and both did. The cache must not be disturbed: the winner is
+    /// complete, current, and not known to be wrong. And the list must not be returned to the setter,
+    /// because the index it resolves a name to is a position in a list the daemon is no longer
+    /// serving — HQP-C-001's misselection, arriving through the write path.
+    ///
+    /// The damage the old shape could do had two shapes, depending on where the profile load landed
+    /// inside the publisher. Landing before the previous-fingerprint read, it left a *partial* cache:
+    /// the fingerprints disagreed, so every family was dropped and only this one refilled. Landing
+    /// *between* that read and the write — two separate lock acquisitions, which is what made the
+    /// window — it left a **complete mixed** cache: three families from the new profile and one from
+    /// the old, with nothing missing for a later read to notice and a rate probe that agrees. One
+    /// guard closes both, and closes the second by construction: the comparison and the write happen
+    /// under one lock, and the generation captured before the request decides whether either runs.
+    ///
+    /// **Label: client-red.**
+    #[tokio::test]
+    async fn a_stale_filter_fetch_overtaken_by_a_complete_winner_is_refused_and_leaves_it_alone() {
+        let old_profile = pcm_cache();
+        let unchanged_rates = old_profile.rates.clone();
+        let old_modes = old_profile.modes.clone();
+        // What `GetFilters` returned, off the state lock: the profile that was loaded at the time.
+        let stale_filters = FreshFamily::Filters(old_profile.filters.clone());
+        let adapter = adapter_with_cache(old_profile).await;
+
+        // The request goes out. This is the cache it was asked on behalf of.
+        let since = adapter.chain_generation().await;
+
+        // Mid-flight: a profile load drops the cache and republishes it complete from the new
+        // profile, leaving the rate list untouched.
+        adapter.invalidate_chain_cache().await;
+        let winner = cache_of(
+            old_modes,
+            vec![filter(0, "closed-form"), filter(1, "gauss-long")],
+            vec![mode(0, "ASDM7"), mode(1, "ASDM5")],
+            unchanged_rates,
+        );
+        assert!(
+            adapter
+                .publish_chain_snapshot(gathered(&winner), adapter.chain_generation().await)
+                .await,
+            "precondition: the newer profile's set publishes, since nothing overtook it"
+        );
+        let winner_id = adapter
+            .chain_identity()
+            .await
+            .expect("the winner is the cache now");
+
+        // And only now does the overtaken reply reach the lock.
+        let outcome = adapter.publish_fresh_family(stale_filters, since).await;
+
+        assert!(
+            outcome.is_err(),
+            "this list was read against a cache that has since been replaced; publishing it is one \
+             fault and handing it back to the setter that will resolve an index through it is the \
+             other, so the fetch fails and the caller re-reads"
+        );
+        assert_eq!(
+            adapter.chain_identity().await,
+            Some(winner_id),
+            "and the winner is left exactly as it was — identity and all. An overtaken fetch \
+             reports its loss to its caller; it does not clear the cache, refill one family of it, \
+             or leave three families from one profile beside a fourth from another"
+        );
+        assert_eq!(
+            adapter
+                .state
+                .read()
+                .await
+                .filters
+                .iter()
+                .map(|f| f.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["closed-form", "gauss-long"],
+            "which is to say: the new profile's filters, not the ones this fetch was holding"
+        );
+    }
+
+    /// A concurrent full refresh can outrun a single-family fetch without changing the mapping the
+    /// setter is about to use. This is the ordinary empty-cache race after connect or a mode change:
+    /// the poll fills all four families while the user's `GetFilters` is in flight. Refusing that
+    /// reply merely because the generation advanced turns a safe click into a 500; accepting it is
+    /// safe only when the winner resolves every index to the same semantic name.
+    #[tokio::test]
+    async fn an_overtaken_fresh_family_that_resolves_like_the_winner_is_still_usable() {
+        let winner = pcm_cache();
+        let same_filters = FreshFamily::Filters(winner.filters.clone());
+        let adapter = adapter_with_cache(HqpAdapterState::default()).await;
+
+        // The setter's request starts against the empty cache.
+        let since = adapter.chain_generation().await;
+
+        // A pipeline poll wins the race and fills a complete, coherent cache from the same daemon
+        // and chain before the setter's reply reaches the publisher.
+        assert!(
+            adapter
+                .publish_chain_snapshot(gathered(&winner), since)
+                .await,
+            "precondition: the full refresh wins and publishes"
+        );
+        let winner_id = adapter
+            .chain_identity()
+            .await
+            .expect("the winner published all four families");
+
+        adapter
+            .publish_fresh_family(same_filters, since)
+            .await
+            .expect(
+                "the generation moved, but the winner maps every filter index to the same name; \
+                 the setter can safely resolve through the reply rather than returning a 500",
+            );
+
+        assert_eq!(
+            adapter.chain_identity().await,
+            Some(winner_id),
+            "accepting an equivalent reply must not rewrite or re-date the complete winner"
+        );
+    }
+
+    /// The full-snapshot publisher's generation bump is the fence that stops a single-family fetch
+    /// issued against an empty cache from clearing a newer complete winner. Unlike the profile-load
+    /// races above, there is no preceding invalidation bump here: deleting the publication bump is
+    /// therefore sufficient to make the stale writer pass its guard and reduce the cache to one
+    /// family.
+    #[tokio::test]
+    async fn a_full_snapshot_fill_fences_an_older_fresh_family_with_a_different_mapping() {
+        let winner = pcm_cache();
+        let stale_modes = FreshFamily::Modes(vec![mode(0, "[source]"), mode(1, "SDM (DSD)")]);
+        let adapter = adapter_with_cache(HqpAdapterState::default()).await;
+        let since = adapter.chain_generation().await;
+
+        assert!(
+            adapter
+                .publish_chain_snapshot(gathered(&winner), since)
+                .await,
+            "precondition: a full refresh fills the empty cache"
+        );
+        let winner_id = adapter
+            .chain_identity()
+            .await
+            .expect("the full refresh published a complete winner");
+
+        assert!(
+            adapter
+                .publish_fresh_family(stale_modes, since)
+                .await
+                .is_err(),
+            "the full publication must advance the generation so an older, different mapping is \
+             refused"
+        );
+        assert_eq!(
+            adapter.chain_identity().await,
+            Some(winner_id),
+            "the stale family must not clear the complete winner and leave a partial cache"
+        );
+    }
+
+    /// The same rule for **every** family, because the guard is one shared piece of code and a
+    /// per-family spelling of it is how three of the four keep it and the fourth quietly does not.
+    ///
+    /// The cache event here is a bare invalidation with nothing published after it — the reconnect
+    /// rather than the profile load. `connect`, `disconnect` and `mark_disconnected` all clear and
+    /// leave the cache empty, and a fetch straddling one of them was answered by a session that has
+    /// ended. An empty cache is not an invitation to refill one family of it with a list read
+    /// through a daemon that may since have restarted, been reconfigured, or followed the source
+    /// onto the other chain.
+    #[tokio::test]
+    async fn every_family_refuses_a_fetch_the_cache_has_outrun() {
+        for fresh in each_family(&pcm_cache()) {
+            let family = fresh.label();
+            let adapter = adapter_with_cache(pcm_cache()).await;
+            let since = adapter.chain_generation().await;
+
+            // Mid-fetch the session dropped.
+            adapter.invalidate_chain_cache().await;
+
+            let outcome = adapter.publish_fresh_family(fresh, since).await;
+
+            assert!(
+                outcome.is_err(),
+                "the {family} list was fetched against a cache that has since been cleared; it \
+                 must reach neither the cache nor the setter that asked for it"
+            );
+            assert!(
+                adapter.chain_identity().await.is_none(),
+                "and the clearing stands: the {family} fetch did not refill the cache behind the \
+                 back of the event that emptied it"
+            );
+        }
+    }
+
+    /// **A refetch that changes nothing is not a cache event, and treating it as one is not merely
+    /// wasteful — it is wrong.** The generation is what an in-flight gather and an in-flight read
+    /// compare against, so bumping it invalidates *their* work: a `refresh_lists` or a `fresh_*`
+    /// that started a moment earlier is now told the cache moved, drops what it read and returns a
+    /// failure, and `get_pipeline_status` spends its one retry on it.
+    ///
+    /// Every setter begins with a `fresh_*`, and the overwhelmingly common outcome of one is the
+    /// list the cache already holds — the chain has not moved between two clicks. So the old
+    /// unconditional bump made the *ordinary* case manufacture the very race the generation exists
+    /// to detect. Byte-identical contents with no clearing in between is not a new filling of the
+    /// cache; it is the same filling, confirmed.
+    #[tokio::test]
+    async fn a_fresh_family_identical_to_the_cached_one_is_not_a_new_filling_of_the_cache() {
+        let cache = pcm_cache();
+        let same_filters = FreshFamily::Filters(cache.filters.clone());
+        let adapter = adapter_with_cache(cache).await;
+        let before = adapter
+            .chain_identity()
+            .await
+            .expect("a complete cache has identity");
+
+        adapter
+            .publish_fresh_family(same_filters, adapter.chain_generation().await)
+            .await
+            .expect("nothing overtook this fetch and the daemon served what was already cached");
+
+        assert_eq!(
+            adapter.chain_identity().await,
+            Some(before),
+            "the daemon confirmed the list the cache was already holding; nothing was cleared and \
+             nothing was replaced, so no reader or writer in flight has been given a reason to \
+             throw away what it read"
+        );
+    }
+
+    /// The no-op path requires whole-family equality, not merely equality of the routing
+    /// fingerprint. Filter flags are not currently projected to clients, but they are part of the
+    /// daemon's enumeration and the cache must not silently discard a fresh value just because its
+    /// `(index, name)` mapping stayed put.
+    #[tokio::test]
+    async fn changed_family_metadata_is_published_even_when_the_mapping_fingerprint_is_unchanged() {
+        let cache = pcm_cache();
+        let mut changed_filters = cache.filters.clone();
+        changed_filters[0].value = 7;
+        changed_filters[0].arg = 9;
+        let adapter = adapter_with_cache(cache).await;
+        let before = adapter.chain_generation().await;
+
+        adapter
+            .publish_fresh_family(FreshFamily::Filters(changed_filters.clone()), before)
+            .await
+            .expect("nothing overtook the fetch; only non-routing metadata changed");
+
+        let state = adapter.state.read().await;
+        assert_eq!(
+            state.filters, changed_filters,
+            "a fingerprint match must not turn changed family contents into a no-op"
+        );
+        assert_ne!(
+            state.chain_generation, before,
+            "publishing changed contents must fence readers that captured the earlier filling"
+        );
+        assert!(
+            HqpAdapter::chain_identity_of(&state).is_some(),
+            "the routing mapping did not move, so the other three families remain a coherent set"
+        );
+    }
+
+    /// The other half of that rule, and the half that keeps it from being "never bump". A family
+    /// whose fingerprint moved *is* a different chain: the other three families' indices belong to
+    /// the chain that just went away, so they go with it, and the generation has to say so loudly
+    /// enough that anything holding the previous set stops trusting it.
+    #[tokio::test]
+    async fn a_fresh_family_that_moved_clears_the_rest_and_advances_the_generation() {
+        let adapter = adapter_with_cache(pcm_cache()).await;
+        let before = adapter.chain_generation().await;
+        let moved = FreshFamily::Filters(vec![filter(0, "closed-form"), filter(1, "gauss-long")]);
+
+        adapter
+            .publish_fresh_family(moved, before)
+            .await
+            .expect("nothing overtook this fetch; the daemon simply served a different list");
+
+        assert_ne!(
+            adapter.chain_generation().await,
+            before,
+            "the loaded chain moved under this cache, which is exactly the event an in-flight \
+             gather or read must be told about"
+        );
+        assert!(
+            adapter.chain_identity().await.is_none(),
+            "and the other three families went with it: their indices name settings in the chain \
+             that is no longer loaded, so the next read refills rather than mixing them with this \
+             one"
+        );
+        assert_eq!(
+            adapter
+                .state
+                .read()
+                .await
+                .filters
+                .iter()
+                .map(|f| f.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["closed-form", "gauss-long"],
+            "the family that was actually fetched is published, not dropped along with the rest — \
+             the caller asked for it and is about to resolve a name against it"
+        );
+    }
+
+    /// The no-op short-circuit is conditioned on there being a **previous fingerprint** to match,
+    /// not on the contents alone. A family the cache does not hold is a family being filled, and a
+    /// filling is a cache event however familiar the list looks: the clearing that emptied it was
+    /// one, and whatever was in flight across it has to see both.
+    #[tokio::test]
+    async fn refilling_a_cleared_family_advances_the_generation_even_with_the_same_list() {
+        let cache = pcm_cache();
+        let same_filters = FreshFamily::Filters(cache.filters.clone());
+        let adapter = adapter_with_cache(cache).await;
+
+        adapter.invalidate_chain_cache().await;
+        let after_clear = adapter.chain_generation().await;
+
+        adapter
+            .publish_fresh_family(same_filters, after_clear)
+            .await
+            .expect("the fetch was issued after the clearing, so nothing has outrun it");
+
+        assert_ne!(
+            adapter.chain_generation().await,
+            after_clear,
+            "an empty family becoming a filled one is a filling, and the list reading the same as \
+             the one cleared a moment ago does not make it the same filling"
         );
     }
 }

--- a/src/adapters/hqplayer.rs
+++ b/src/adapters/hqplayer.rs
@@ -1566,7 +1566,14 @@ impl HqpAdapter {
     /// cycle — and the honest description of this guard is "the set did not straddle a visible
     /// transition", not "the four replies came from one instant", which nothing short of an atomic
     /// daemon-side snapshot could establish.
-    async fn refresh_lists(&self) {
+    ///
+    /// **Returns whether a complete, coherent snapshot was published.** The caller has to be able to
+    /// tell: a refresh that publishes nothing leaves the cache exactly as it found it, and when the
+    /// caller *needed* that fill — a first read after connect, or one after an invalidation — what it
+    /// is left holding is nothing at all. Swallowing that turned "I could not read this" into "this
+    /// daemon offers no filters", which is the ambiguity every other guard here exists to refuse.
+    #[must_use = "a refresh that did not settle leaves the cache empty, which is not the same as a daemon with no settings"]
+    async fn refresh_lists(&self) -> bool {
         let gathered = async {
             // Opening probe. The rate list is the bracket for the same reason it is the read path's
             // chain probe: smallest chain-scoped enumeration, and the two chains' rate lists were
@@ -1589,7 +1596,7 @@ impl HqpAdapter {
                     "HQPlayer list refresh incomplete ({e}); publishing nothing rather than a cache \
                      mixing one chain's entries with another's"
                 );
-                return;
+                return false;
             }
         };
 
@@ -1599,7 +1606,7 @@ impl HqpAdapter {
                 "HQPlayer's loaded chain moved while its lists were being read; publishing nothing \
                  rather than a set that straddles the change"
             );
-            return;
+            return false;
         }
 
         let modes_fp = Self::fingerprint(modes.iter().map(|m| (m.index, m.name.as_str())));
@@ -1623,6 +1630,7 @@ impl HqpAdapter {
         state.filters_fingerprint = Some(filters_fp);
         state.shapers_fingerprint = Some(shapers_fp);
         state.rates_fingerprint = Some(rates_fp);
+        true
     }
 
     /// Ensure connection is established, reconnecting if needed
@@ -3009,9 +3017,12 @@ impl HqpAdapter {
         // **Residual, and it cannot be closed from here.** The check confirms the chain is the same
         // *now* as when the lists were published; a move out and back inside that window leaves it
         // agreeing. Only a daemon-side atomic snapshot could do better, and the protocol has none.
-        let mut state = None;
-        let mut playback_status = HqpStatus::default();
-        for attempt in 0..2 {
+        // Every arm below is terminal — it breaks with a settled pair or returns — so there is no
+        // state to carry out of the loop and no "what if it fell through" case to answer for. An
+        // earlier shape carried an `Option` and re-read `State` if it were somehow `None`, which was
+        // unreachable and would have cost a round trip to discover that.
+        let mut retried = false;
+        let (state, playback_status) = loop {
             // Lazy-fill whatever is missing — on the first read after connect, that is all of it.
             let needs_lists = {
                 let cached = self.state.read().await;
@@ -3020,24 +3031,35 @@ impl HqpAdapter {
                     || cached.shapers.is_empty()
                     || cached.rates.is_empty()
             };
-            if needs_lists {
-                self.refresh_lists().await;
+            // A *required* fill that does not settle is the read's failure, not a quieter version of
+            // success. With nothing cached there is no previous fingerprint for the chain check to
+            // contradict, so it correctly answers "unchanged" — it is a check about movement — and
+            // the fill is then the only thing between a caller and four empty lists.
+            if needs_lists && !self.refresh_lists().await {
+                if !retried {
+                    tracing::info!(
+                        "HQPlayer's setting lists did not settle; re-reading once before giving up"
+                    );
+                    retried = true;
+                    continue;
+                }
+                return Err(anyhow!(
+                    "HQPlayer's setting lists could not be read as one coherent set; refusing to \
+                     report a pipeline with no settings in it, which is not what this daemon offers"
+                ));
             }
 
             let observed = self.get_state().await?;
-            playback_status = self.get_playback_status().await.unwrap_or_default();
+            let observed_status = self.get_playback_status().await.unwrap_or_default();
 
-            // A check failure is not fatal to a read: the caller still gets `State` and `Status`.
             match self.chain_still_matches_cache().await {
-                Ok(true) => {
-                    state = Some(observed);
-                    break;
-                }
-                Ok(false) if attempt == 0 => {
+                Ok(true) => break (observed, observed_status),
+                Ok(false) if !retried => {
                     tracing::info!(
                         "HQPlayer's loaded chain moved while its state was being read; re-reading \
                          rather than resolving one chain's indices against another's lists"
                     );
+                    retried = true;
                 }
                 // The retry moved too. There is nothing coherent to publish and no third attempt:
                 // the lists in hand came from the chain before *this* move, and noticing the move
@@ -3047,28 +3069,20 @@ impl HqpAdapter {
                 // that genuinely offers no filters. The route has always had an error arm; this is
                 // what it is for.
                 Ok(false) => {
-                    let _ = observed;
                     return Err(anyhow!(
                         "HQPlayer's loaded chain moved while its settings were being read, and \
                          again during the re-read; refusing to report settings that belong to no \
                          single chain"
-                    ));
+                    ))
                 }
+                // A check that could not run is not a check that failed: the cache was not
+                // invalidated, so the lists are still the ones the state was read against. The
+                // caller gets the read, and the log says the guarantee was weaker this time.
                 Err(e) => {
                     tracing::warn!("HQPlayer chain check failed, serving cached enumerations: {e}");
-                    state = Some(observed);
+                    break (observed, observed_status);
                 }
             }
-            if state.is_some() {
-                break;
-            }
-        }
-        let state = match state {
-            Some(state) => state,
-            // Unreachable in practice: the loop only leaves this `None` by exhausting both attempts
-            // without setting it, and the second attempt always sets it. Read it once more rather
-            // than unwrap, so a future edit to the loop cannot turn a logic slip into a panic.
-            None => self.get_state().await?,
         };
 
         // Lazy-load volume range if not cached
@@ -3635,8 +3649,16 @@ impl HqpAdapter {
                     if response.status().is_client_error() || response.status().is_server_error() {
                         return Err(anyhow!("Profile load failed: {}", response.status()));
                     }
-                    // Refresh cached lists after profile change
-                    self.refresh_lists().await;
+                    // Refresh cached lists after profile change. A refresh that does not settle
+                    // leaves the cache empty rather than stale, and the next pipeline read is what
+                    // reports that — the profile load itself succeeded and saying otherwise would
+                    // be a different lie.
+                    if !self.refresh_lists().await {
+                        tracing::warn!(
+                            "HQPlayer profile loaded, but its setting lists did not settle; the \
+                             next read will refill them"
+                        );
+                    }
                     return Ok(());
                 }
             }
@@ -3647,8 +3669,13 @@ impl HqpAdapter {
             return Err(anyhow!("Profile load failed: {}", response.status()));
         }
 
-        // Refresh cached lists after profile change
-        self.refresh_lists().await;
+        // Refresh cached lists after profile change; see the note on the retry path above.
+        if !self.refresh_lists().await {
+            tracing::warn!(
+                "HQPlayer profile loaded, but its setting lists did not settle; the next read will \
+                 refill them"
+            );
+        }
         Ok(())
     }
 

--- a/src/adapters/hqplayer.rs
+++ b/src/adapters/hqplayer.rs
@@ -681,13 +681,28 @@ pub struct HqpState {
 ///
 /// `result="OK"` is not proof of application (HQP-C-028), and equality with pre-existing state is not
 /// proof either (HQP-C-019): requesting Auto under `[source]`, where the rate is already Auto and the
-/// daemon ignores the pin, compares 0 against 0 and looks like success. So the four things a write can
-/// turn out to be are named separately rather than collapsed into `Ok`/`Err`, and the caller decides
-/// which of them counts as success on its surface.
+/// daemon ignores the pin, compares 0 against 0 and looks like success. So each distinct thing a write
+/// can turn out to be gets its own name rather than being collapsed into `Ok`/`Err`, and the caller
+/// decides which of them counts as success on its surface. There are five, below, plus a sixth case
+/// that is deliberately not one of them:
 ///
 /// An explicit `result="Error"` stays an `Err` — [`HqpAdapter::check_result`] raises it inside
-/// `send_command`, so it is a transport-level failure with the daemon's own reason attached, and it is
-/// distinguishable from every variant here by being an `Err` at all.
+/// `send_command` as a typed [`HqpRejected`], so it carries the daemon's own reason and is
+/// distinguishable from every variant here by being an `Err` at all. It is not a variant because a
+/// rejection is not an outcome of a *setting*: nothing was set, nothing is unknown, and there is
+/// nothing to read back.
+///
+/// # What this does not cover, and why
+///
+/// **Volume is outside this vocabulary and stays `Result<()>`.** `Volume`, `VolumeUp`, `VolumeDown`
+/// and `VolumeMute` are result-checked but never readback-verified, which is a #322 decision this
+/// issue keeps rather than an omission: a fixed-volume daemon answers an explicit `result="Error"`
+/// that `check_result` already surfaces, and with **adaptive volume engaged the daemon moves the
+/// level on its own** (`VolumeRange.adaptive`), so a readback comparison would manufacture failures
+/// for writes that landed exactly as asked. Volume is also absolute dB rather than a list index
+/// (HQP-C-040), so it is not in the enumerated-setting domain these outcomes describe at all. Claiming
+/// "every setter reports an outcome" would therefore be an overclaim; the enumerated live settings —
+/// mode, filter 1x/Nx, shaper, rate, matrix profile — are what this covers.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[must_use = "an unexamined outcome is a setting reported as applied when it may not have been"]
 pub enum SettingOutcome {
@@ -1487,19 +1502,122 @@ impl HqpAdapter {
         Ok(rates)
     }
 
-    /// Refresh every cached list. Used after a profile load, which can change all of them.
-    async fn refresh_lists(&self) {
-        for (family, outcome) in [
-            ("modes", self.fresh_modes().await.map(|v| v.len())),
-            ("filters", self.fresh_filters().await.map(|v| v.len())),
-            ("shapers", self.fresh_shapers().await.map(|v| v.len())),
-            ("rates", self.fresh_rates().await.map(|v| v.len())),
-        ] {
-            match outcome {
-                Ok(n) => tracing::debug!("Fetched {n} {family}"),
-                Err(e) => tracing::warn!("Failed to fetch {family}: {e}"),
-            }
+    /// Fingerprint of a rate list. Its own function because it is compared in three places and a
+    /// second spelling of it would be a silent way for two of them to disagree.
+    fn rates_fingerprint(items: &[RateItem]) -> u64 {
+        let labels: Vec<String> = items.iter().map(|r| r.rate.to_string()).collect();
+        Self::fingerprint(
+            items
+                .iter()
+                .zip(labels.iter())
+                .map(|(r, label)| (r.index, label.as_str())),
+        )
+    }
+
+    /// Ask whether the loaded chain has moved, and **publish nothing either way**.
+    ///
+    /// The read path's probe. Deliberately not [`Self::fresh_rates`], which caches what it fetched:
+    /// caching here would publish one family on its own, so a poll that detected a transition would
+    /// leave a caller holding the new chain's rates beside no filters and no shapers — a partial view,
+    /// offered as a whole one. Detection and publication are separate jobs, and [`Self::refresh_lists`]
+    /// owns the second.
+    async fn chain_probe(&self) -> Result<()> {
+        let fingerprint = Self::rates_fingerprint(&self.get_rates().await?);
+        let previous = self.state.read().await.rates_fingerprint;
+        if previous.is_some_and(|p| p != fingerprint) {
+            tracing::info!(
+                "HQPlayer rate enumeration changed: the loaded chain moved, dropping every \
+                 chain-scoped list"
+            );
+            self.invalidate_chain_cache().await;
         }
+        Ok(())
+    }
+
+    /// Refresh every cached list, publishing **one coherent snapshot or none at all**.
+    ///
+    /// Deliberately *not* four calls to the `fresh_*` helpers. Each of those notices a chain change
+    /// and invalidates the other families, so a sequence of them could clear a family it had already
+    /// published a moment earlier and leave the cache holding a mix — some entries from the chain
+    /// before the change and some from after. A mixed cache is worse than a stale one: a stale one is
+    /// wrong in a way a fingerprint comparison can still detect, and a mixed one has already been
+    /// published as a single view of a single daemon.
+    ///
+    /// So all four are gathered first and the write lock is taken once. If any family fails, nothing
+    /// is published and the previous cache stands — a transient failure must not be able to blank half
+    /// the view, which is exactly what assigning an empty vector per family used to do.
+    ///
+    /// **Taking the lock once does not by itself make the set coherent, and the gather is bracketed
+    /// because of that.** The four replies arrive one after another, so they are four moments rather
+    /// than one, and a source change landing between two of them yields a set that mixes the chains —
+    /// atomic *publication* of an already-mixed set is no better than a mixed publication. So the rate
+    /// list is read at both ends of the window and the set is published only if the two agree. If they
+    /// do not, the chain moved during the gather, nothing is published, and the next poll re-reads
+    /// from a settled daemon.
+    ///
+    /// Residual, stated: the bracket detects a chain that *ended* somewhere other than where it
+    /// started. A change out and back within the same window would leave both probes agreeing. Nothing
+    /// observed suggests that is reachable — a chain follows the source material, not a client's poll
+    /// cycle — and the honest description of this guard is "the set did not straddle a visible
+    /// transition", not "the four replies came from one instant", which nothing short of an atomic
+    /// daemon-side snapshot could establish.
+    async fn refresh_lists(&self) {
+        let gathered = async {
+            // Opening probe. The rate list is the bracket for the same reason it is the read path's
+            // chain probe: smallest chain-scoped enumeration, and the two chains' rate lists were
+            // observed disjoint (HQP-C-020).
+            let opening = self.get_rates().await?;
+            let modes = self.get_modes().await?;
+            let filters = self.get_filters().await?;
+            let shapers = self.get_shapers().await?;
+            // Closing probe, and the rate list that gets published: it is the one inside the window's
+            // far edge.
+            let rates = self.get_rates().await?;
+            Ok::<_, anyhow::Error>((opening, modes, filters, shapers, rates))
+        }
+        .await;
+
+        let (opening, modes, filters, shapers, rates) = match gathered {
+            Ok(all) => all,
+            Err(e) => {
+                tracing::warn!(
+                    "HQPlayer list refresh incomplete ({e}); publishing nothing rather than a cache \
+                     mixing one chain's entries with another's"
+                );
+                return;
+            }
+        };
+
+        let rates_fp = Self::rates_fingerprint(&rates);
+        if Self::rates_fingerprint(&opening) != rates_fp {
+            tracing::warn!(
+                "HQPlayer's loaded chain moved while its lists were being read; publishing nothing \
+                 rather than a set that straddles the change"
+            );
+            return;
+        }
+
+        let modes_fp = Self::fingerprint(modes.iter().map(|m| (m.index, m.name.as_str())));
+        let filters_fp = Self::fingerprint(filters.iter().map(|f| (f.index, f.name.as_str())));
+        let shapers_fp = Self::fingerprint(shapers.iter().map(|s| (s.index, s.name.as_str())));
+
+        tracing::debug!(
+            "Refreshed HQPlayer lists: {} modes, {} filters, {} shapers, {} rates",
+            modes.len(),
+            filters.len(),
+            shapers.len(),
+            rates.len()
+        );
+
+        let mut state = self.state.write().await;
+        state.modes = modes;
+        state.filters = filters;
+        state.shapers = shapers;
+        state.rates = rates;
+        state.modes_fingerprint = Some(modes_fp);
+        state.filters_fingerprint = Some(filters_fp);
+        state.shapers_fingerprint = Some(shapers_fp);
+        state.rates_fingerprint = Some(rates_fp);
     }
 
     /// Ensure connection is established, reconnecting if needed
@@ -2257,6 +2375,12 @@ impl HqpAdapter {
     /// the daemon acknowledged and dropped is a different fact from one it rejected, and a caller that
     /// wants them collapsed asks for that with [`SettingOutcome::into_applied_result`].
     ///
+    /// When the authoritative field is **absent** rather than merely different, the answer is
+    /// [`SettingOutcome::Ambiguous`] instead. Those are not the same fact: a field reporting another
+    /// value proves the write did not take, while a field the daemon does not report at all proves
+    /// nothing either way, and calling the second "ignored" would assert a failure that was never
+    /// observed.
+    ///
     /// `observe` must read the field that *is* the setting. It deliberately has no fallback to a
     /// related field: reading a sibling when the authoritative one is absent is how a readback confirms
     /// something it never checked.
@@ -2282,16 +2406,25 @@ impl HqpAdapter {
             if seen.as_ref() == Some(&expected) {
                 return Ok(SettingOutcome::Applied);
             }
-            last_seen = seen;
+            if seen.is_some() {
+                last_seen = seen;
+            }
         }
 
-        Ok(SettingOutcome::Ignored {
-            what: what.to_string(),
-            requested: expected.to_string(),
-            observed: last_seen
-                .map(|v| v.to_string())
-                .unwrap_or_else(|| "nothing".to_string()),
-        })
+        match last_seen {
+            Some(observed) => Ok(SettingOutcome::Ignored {
+                what: what.to_string(),
+                requested: expected.to_string(),
+                observed: observed.to_string(),
+            }),
+            None => Ok(SettingOutcome::Ambiguous {
+                what: what.to_string(),
+                reason: format!(
+                    "the daemon does not report {what}, so whether it now holds {expected} cannot \
+                     be established from its State"
+                ),
+            }),
+        }
     }
 
     /// Write a setting and establish what it did, including when the reply never arrives.
@@ -2479,6 +2612,41 @@ impl HqpAdapter {
     /// Set only the Nx filter, preserving the 1x filter the daemon reports.
     pub async fn set_filter_nx(&self, filter_name: &str) -> Result<SettingOutcome> {
         self.set_filter_side(FilterSide::Nx, filter_name).await
+    }
+
+    /// Set **both** filter sides to the same name, in one `SetFilter`.
+    ///
+    /// The legacy `POST /hqplayer/setting` route's `filter` setting means "both sides". Doing that as
+    /// two one-sided writes can half-apply — the 1x write lands and the Nx write is rejected, ignored,
+    /// or lost — leaving the daemon on a pair the caller never asked for and no single outcome that
+    /// describes it. One `SetFilter` carrying both indices cannot half-apply on the wire.
+    ///
+    /// It also needs no sibling: both sides are being written, so nothing has to be read out of
+    /// `State` first and the refusal in [`Self::set_filter_side`] does not apply here.
+    pub async fn set_filter_pair(&self, filter_name: &str) -> Result<SettingOutcome> {
+        let filters = self.fresh_filters().await?;
+        let index = Self::resolve_filter(&filters, filter_name)?;
+
+        let state = self.get_state().await?;
+        if state.filter1x == Some(index) && state.filter_nx == Some(index) {
+            return Ok(SettingOutcome::AlreadySet);
+        }
+
+        // Both sides are the setting here, so both are verified. Rendered as one value because the
+        // pair is what was requested and reporting half of it back would be the same mistake as
+        // writing half of it.
+        let expected = format!("1x={index},Nx={index}");
+        tracing::debug!("SetFilter (both sides): value={index}, value1x={index}");
+        let xml = Self::filter_request(index, index);
+        self.write_setting(&xml, "filter", expected, |s| {
+            match (s.filter1x, s.filter_nx) {
+                (Some(one_x), Some(nx)) => Some(format!("1x={one_x},Nx={nx}")),
+                // Absent rather than mismatched: `verify_applied` turns a field the daemon never
+                // reports into `Ambiguous`, which is the truthful answer when nothing can be seen.
+                _ => None,
+            }
+        })
+        .await
     }
 
     /// One side of the filter pair, carrying the authoritative other side with it.
@@ -2819,7 +2987,7 @@ impl HqpAdapter {
         // chains' rate lists were observed disjoint (HQP-C-020). Its fingerprint changing drops every
         // chain-scoped cache, which the lazy fill below then repopulates. A probe failure is not fatal
         // to a read: the caller still gets `State` and `Status`.
-        if let Err(e) = self.fresh_rates().await {
+        if let Err(e) = self.chain_probe().await {
             tracing::warn!("HQPlayer chain probe failed, serving cached enumerations: {e}");
         }
 

--- a/src/adapters/hqplayer.rs
+++ b/src/adapters/hqplayer.rs
@@ -3119,12 +3119,28 @@ impl HqpAdapter {
                          single chain"
                     ))
                 }
-                // A check that could not run is not a check that failed: the cache was not
-                // invalidated, so the lists are still the ones the state was read against. The
-                // caller gets the read, and the log says the guarantee was weaker this time.
+                // A check that could not run is not a check that passed. "The cache was not
+                // invalidated, so the lists are still the ones the state was read against" is true
+                // about the *cache* and answers nothing about the *daemon*: whether it still has
+                // that chain loaded is exactly what the failed request was asked. An explicit
+                // `result="Error"` here is terminal in `send_command` — no retry, no disconnect, no
+                // invalidation — so the cache survives looking entirely usable, and a view projected
+                // through it is indistinguishable from a verified one. A `warn!` does not make it
+                // one. Same bound as every other unsettled read here: one re-read, then say so.
+                Err(e) if !retried => {
+                    tracing::info!(
+                        "HQPlayer's chain check could not be run ({e}); re-reading rather than \
+                         resolving its indices against lists nothing has confirmed they belong to"
+                    );
+                    retried = true;
+                }
                 Err(e) => {
-                    tracing::warn!("HQPlayer chain check failed, serving cached enumerations: {e}");
-                    break (observed, observed_status);
+                    return Err(anyhow!(
+                        "HQPlayer's loaded chain could not be verified while its settings were \
+                         being read, and again during the re-read ({e}); refusing to report \
+                         settings whose indices were never checked against the lists they are \
+                         resolved through"
+                    ))
                 }
             }
         };

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -914,6 +914,30 @@ pub async fn hqp_setting_handler(
     State(state): State<AppState>,
     Json(req): Json<HqpSettingRequest>,
 ) -> impl IntoResponse {
+    // This endpoint's accepted names, exactly as it has always accepted them. The numeric applier
+    // below is shared with `POST /hqp/pipeline`, which additionally accepts `dither` — sharing the
+    // applier must not quietly widen *this* route, so the gate is here and the error text is the one
+    // it already answered with.
+    const ACCEPTED: [&str; 8] = [
+        "mode",
+        "filter",
+        "filter1x",
+        "filterNx",
+        "filternx",
+        "shaper",
+        "samplerate",
+        "rate",
+    ];
+    if !ACCEPTED.contains(&req.name.as_str()) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!("Unknown setting: {}", req.name),
+            }),
+        )
+            .into_response();
+    }
+
     let result = hqp_apply_legacy_setting(&state, &req.name, req.value).await;
 
     match result {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -827,28 +827,94 @@ pub struct HqpSettingRequest {
     pub value: u32,
 }
 
+/// Apply one legacy numeric setting, resolving the number to a name at this boundary.
+///
+/// Shared by `POST /hqplayer/setting` and the numeric arm of `POST /hqp/pipeline` so there is exactly
+/// one place a list position is interpreted, and it is a place with the daemon's current enumeration
+/// in hand. `samplerate` is the exception by contract: its number is **Hz**, not a position.
+async fn hqp_apply_legacy_setting(
+    state: &AppState,
+    setting: &str,
+    value: u32,
+) -> anyhow::Result<()> {
+    use crate::adapters::hqplayer::LegacySettingFamily;
+
+    let hqp = &state.hqplayer;
+    let outcome = match setting {
+        "mode" => {
+            let name = hqp
+                .legacy_index_to_name(LegacySettingFamily::Mode, value)
+                .await?;
+            hqp.set_mode(&name).await?
+        }
+        "filter" => {
+            // Both sides to the same filter. The 1x write is verified before the Nx one is sent, so a
+            // half-applied pair is reported rather than silently left behind.
+            let name = hqp
+                .legacy_index_to_name(LegacySettingFamily::Filter, value)
+                .await?;
+            hqp.set_filter_1x(&name).await?.into_applied_result()?;
+            hqp.set_filter_nx(&name).await?
+        }
+        "filter1x" => {
+            let name = hqp
+                .legacy_index_to_name(LegacySettingFamily::Filter, value)
+                .await?;
+            hqp.set_filter_1x(&name).await?
+        }
+        "filterNx" | "filternx" => {
+            let name = hqp
+                .legacy_index_to_name(LegacySettingFamily::Filter, value)
+                .await?;
+            hqp.set_filter_nx(&name).await?
+        }
+        "shaper" | "dither" => {
+            let name = hqp
+                .legacy_index_to_name(LegacySettingFamily::Shaper, value)
+                .await?;
+            hqp.set_shaper(&name).await?
+        }
+        // By contract this number is Hz, not a list position.
+        "samplerate" | "rate" => hqp.set_rate(value).await?,
+        other => return Err(anyhow::anyhow!("Unknown setting: {}", other)),
+    };
+    outcome.into_applied_result()
+}
+
+/// Apply one setting given as a semantic name, which is the modern contract.
+async fn hqp_apply_named_setting(
+    state: &AppState,
+    setting: &str,
+    value: &str,
+) -> anyhow::Result<()> {
+    let hqp = &state.hqplayer;
+    let outcome = match setting {
+        "mode" => hqp.set_mode(value).await?,
+        "filter1x" => hqp.set_filter_1x(value).await?,
+        "filterNx" | "filternx" => hqp.set_filter_nx(value).await?,
+        "shaper" | "dither" => hqp.set_shaper(value).await?,
+        "samplerate" | "rate" => {
+            let hz: u32 = value.parse().map_err(|_| {
+                anyhow::anyhow!("Invalid rate value (expected Hz like 48000, 96000): {value}")
+            })?;
+            hqp.set_rate(hz).await?
+        }
+        other => return Err(anyhow::anyhow!("Unknown setting: {}", other)),
+    };
+    outcome.into_applied_result()
+}
+
 /// POST /hqplayer/setting - Change HQPlayer pipeline setting (legacy endpoint)
+///
+/// The request contract carries `value: u32` and is frozen, so this is the **compatibility boundary**:
+/// the number is resolved into the semantic name the daemon's current enumeration gives that position,
+/// and the name is what goes inward. Nothing downstream ever sees the number, and a position the
+/// current list does not have is an error here rather than an index forwarded to the wire.
 pub async fn hqp_setting_handler(
     State(state): State<AppState>,
     Json(req): Json<HqpSettingRequest>,
 ) -> impl IntoResponse {
-    // Legacy endpoint - convert numeric value to string for name-based lookups
-    let value_str = req.value.to_string();
-    let result = match req.name.as_str() {
-        "mode" => state.hqplayer.set_mode(&value_str).await,
-        "filter" => {
-            // Sets both 1x and Nx to the same filter - propagate first error if any
-            match state.hqplayer.set_filter_1x(&value_str).await {
-                Ok(()) => state.hqplayer.set_filter_nx(&value_str).await,
-                Err(e) => Err(e),
-            }
-        }
-        "filter1x" => state.hqplayer.set_filter_1x(&value_str).await,
-        "filterNx" | "filternx" => state.hqplayer.set_filter_nx(&value_str).await,
-        "shaper" => state.hqplayer.set_shaper(&value_str).await,
-        "samplerate" | "rate" => state.hqplayer.set_rate(req.value).await,
-        _ => Err(anyhow::anyhow!("Unknown setting: {}", req.name)),
-    };
+    let result = hqp_apply_legacy_setting(&state, &req.name, req.value).await;
 
     match result {
         Ok(()) => (StatusCode::OK, Json(serde_json::json!({"ok": true}))).into_response(),
@@ -874,28 +940,6 @@ pub async fn hqp_pipeline_update_handler(
     State(state): State<AppState>,
     Json(req): Json<HqpPipelineRequest>,
 ) -> impl IntoResponse {
-    // Convert value to string - all settings now use name-based lookups
-    let value_str: String = match &req.value {
-        serde_json::Value::Number(n) => n.to_string(),
-        serde_json::Value::String(s) => s.clone(),
-        _ => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(ErrorResponse {
-                    error: "Invalid value type".to_string(),
-                }),
-            )
-                .into_response()
-        }
-    };
-
-    // For samplerate, we still need the numeric Hz value
-    let rate_value: u32 = match &req.value {
-        serde_json::Value::Number(n) => n.as_u64().unwrap_or(0) as u32,
-        serde_json::Value::String(s) => s.parse::<u32>().unwrap_or(0),
-        _ => 0,
-    };
-
     let valid_settings = [
         "mode",
         "samplerate",
@@ -914,14 +958,32 @@ pub async fn hqp_pipeline_update_handler(
             .into_response();
     }
 
-    let result = match req.setting.as_str() {
-        "mode" => state.hqplayer.set_mode(&value_str).await,
-        "filter1x" => state.hqplayer.set_filter_1x(&value_str).await,
-        "filterNx" | "filternx" => state.hqplayer.set_filter_nx(&value_str).await,
-        "shaper" => state.hqplayer.set_shaper(&value_str).await,
-        "samplerate" => state.hqplayer.set_rate(rate_value).await,
-        "dither" => state.hqplayer.set_shaper(&value_str).await, // dither uses same API
-        _ => Err(anyhow::anyhow!("Unknown setting: {}", req.setting)),
+    // The request contract accepts a string or a number, and the two mean different things. A string
+    // is a semantic name and travels inward unchanged. A **number** is a list position for every
+    // family except `samplerate`, whose number is Hz — so it is resolved to a name here, at the
+    // boundary, against the enumeration the daemon is serving now. Stringifying the number and
+    // letting a resolver parse it back out was the fallback HQP-C-063 records: it made a stale or
+    // guessed position select whatever now sits there.
+    let result = match &req.value {
+        serde_json::Value::Number(n) => match n.as_u64() {
+            Some(v) if v <= u64::from(u32::MAX) => {
+                hqp_apply_legacy_setting(&state, &req.setting, v as u32).await
+            }
+            _ => Err(anyhow::anyhow!(
+                "Invalid numeric value for {}: {n}",
+                req.setting
+            )),
+        },
+        serde_json::Value::String(s) => hqp_apply_named_setting(&state, &req.setting, s).await,
+        _ => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: "Invalid value type".to_string(),
+                }),
+            )
+                .into_response()
+        }
     };
 
     match result {
@@ -1031,7 +1093,12 @@ pub async fn hqp_set_matrix_profile_handler(
     State(state): State<AppState>,
     Json(req): Json<HqpMatrixProfileRequest>,
 ) -> impl IntoResponse {
-    match state.hqplayer.set_matrix_profile(req.profile).await {
+    match state
+        .hqplayer
+        .set_matrix_profile(req.profile)
+        .await
+        .and_then(|o| o.into_applied_result())
+    {
         Ok(()) => (StatusCode::OK, Json(serde_json::json!({"ok": true}))).into_response(),
         Err(e) => (
             StatusCode::BAD_REQUEST,
@@ -1828,7 +1895,11 @@ pub async fn hqp_instance_set_matrix_profile_handler(
         }
     };
 
-    match adapter.set_matrix_profile(req.value).await {
+    match adapter
+        .set_matrix_profile(req.value)
+        .await
+        .and_then(|o| o.into_applied_result())
+    {
         Ok(()) => (
             StatusCode::OK,
             Json(serde_json::json!({"ok": true, "instance": name, "value": req.value})),

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -848,13 +848,13 @@ async fn hqp_apply_legacy_setting(
             hqp.set_mode(&name).await?
         }
         "filter" => {
-            // Both sides to the same filter. The 1x write is verified before the Nx one is sent, so a
-            // half-applied pair is reported rather than silently left behind.
+            // Both sides to the same filter, in **one** `SetFilter`. Two one-sided writes could
+            // half-apply — the first lands, the second is rejected or lost — leaving the daemon on a
+            // pair nobody asked for; a single request carrying both indices cannot.
             let name = hqp
                 .legacy_index_to_name(LegacySettingFamily::Filter, value)
                 .await?;
-            hqp.set_filter_1x(&name).await?.into_applied_result()?;
-            hqp.set_filter_nx(&name).await?
+            hqp.set_filter_pair(&name).await?
         }
         "filter1x" => {
             let name = hqp

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -589,13 +589,15 @@ impl ServerHandler for HifiMcpHandler {
             }
 
             HifiTools::HifiHqplayerSetPipelineTool(args) => {
-                // All settings now use name-based lookups - adapter handles conversion
-                // Only samplerate needs numeric parsing (Hz value)
-                let result = match args.setting.as_str() {
-                    "mode" => {
-                        // Accepts name like "PCM", "DSD", "[source]"
-                        self.state.hqplayer.set_mode(&args.value).await
-                    }
+                // Every setting is named, never numbered: the MCP contract has always been semantic,
+                // and the adapter now refuses a bare integer rather than treating it as a list
+                // position. `SettingOutcome` is what makes reporting truthful here — a write the
+                // daemon acknowledged and dropped, or one the client suppressed with a reason, is an
+                // error to this surface exactly as it is to the HTTP one.
+                let outcome = match args.setting.as_str() {
+                    // Accepts a name like "PCM", "DSD", "[source]" — the daemon's own "SDM (DSD)"
+                    // resolves from "DSD" by semantic alias.
+                    "mode" => self.state.hqplayer.set_mode(&args.value).await,
                     "filter1x" | "filter_1x" => {
                         self.state.hqplayer.set_filter_1x(&args.value).await
                     }
@@ -621,7 +623,7 @@ impl ServerHandler for HifiMcpHandler {
                     }
                 };
 
-                match result {
+                match outcome.and_then(|o| o.into_applied_result()) {
                     Ok(()) => Ok(Self::text_result(format!(
                         "Set {} to {}",
                         args.setting, args.value

--- a/tests/client_harness.rs
+++ b/tests/client_harness.rs
@@ -1315,3 +1315,108 @@ mod integration {
         println!("iOS: Got HQPlayer profiles");
     }
 }
+
+// =============================================================================
+// The two HQPlayer setting routes accept different name sets, and share an applier (#347)
+//
+// `POST /hqplayer/setting` and the numeric arm of `POST /hqp/pipeline` were made to share one
+// applier so a list position is interpreted in exactly one place. The applier has to accept
+// `dither`, because /hqp/pipeline always has — and /hqplayer/setting never has. Sharing the code
+// therefore silently added an accepted name to a frozen request contract. Found in self-review of
+// the diff rather than by a test, which is why these exist: the fix that followed had none.
+//
+// Asserted on the **response body**, not only the status, because both the widening and the fix
+// answer 4xx/5xx here — an unconfigured adapter fails too. Only the message says which path ran.
+// =============================================================================
+
+#[cfg(test)]
+mod hqplayer_setting_route_contract {
+    use super::*;
+
+    /// `dither` is not a name this route has ever accepted, and it must still be refused **by the
+    /// route**, before anything reaches the adapter.
+    #[tokio::test]
+    async fn the_legacy_setting_route_still_refuses_a_name_it_never_accepted() {
+        let app = create_test_app().await;
+        let (status, body) = post_json(
+            &app,
+            "/hqplayer/setting",
+            &json!({ "name": "dither", "value": 3 }),
+        )
+        .await;
+
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "an unknown setting name is a bad request, as it always was. Body: {body}"
+        );
+        let json = assert_json("POST /hqplayer/setting (unknown name)", &body);
+        assert_eq!(
+            json.get("error").and_then(Value::as_str),
+            Some("Unknown setting: dither"),
+            "the exact message this route already answered with — a different one means the name \
+             was accepted and something downstream refused it instead, which is the widening. \
+             Body: {body}"
+        );
+    }
+
+    /// The control for the check above: the gate must refuse only what the route never accepted.
+    /// `shaper` **is** one of its names, so it must get past the gate and fail downstream on the
+    /// unconfigured adapter instead.
+    #[tokio::test]
+    async fn the_legacy_setting_route_still_accepts_the_names_it_always_had() {
+        let app = create_test_app().await;
+        for name in ["mode", "filter", "filter1x", "filterNx", "shaper", "rate"] {
+            let (_, body) = post_json(
+                &app,
+                "/hqplayer/setting",
+                &json!({ "name": name, "value": 1 }),
+            )
+            .await;
+            assert!(
+                !body.contains("Unknown setting"),
+                "`{name}` is one of this route's own names and must reach the adapter; refusing it \
+                 would be the gate over-reaching. Body: {body}"
+            );
+        }
+    }
+
+    /// And the other side of the shared applier: `/hqp/pipeline` keeps accepting `dither`, so the
+    /// fix narrowed one route rather than both.
+    #[tokio::test]
+    async fn the_pipeline_route_still_accepts_dither() {
+        let app = create_test_app().await;
+        let (_, body) = post_json(
+            &app,
+            "/hqp/pipeline",
+            &json!({ "setting": "dither", "value": "NS9" }),
+        )
+        .await;
+
+        assert!(
+            !body.contains("Invalid setting"),
+            "`dither` is one of /hqp/pipeline's valid settings and must stay one — this route's \
+             own gate rejects with `Invalid setting`. Body: {body}"
+        );
+    }
+
+    /// `/hqp/pipeline`'s own gate is unchanged too: a setting it never accepted is still refused
+    /// with its own wording, which is a different message from the other route's.
+    #[tokio::test]
+    async fn the_pipeline_route_still_refuses_a_setting_it_never_accepted() {
+        let app = create_test_app().await;
+        let (status, body) = post_json(
+            &app,
+            "/hqp/pipeline",
+            &json!({ "setting": "convolution", "value": "on" }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(
+            body.contains("Invalid setting"),
+            "each route keeps its own rejection wording; sharing an applier must not merge them. \
+             Body: {body}"
+        );
+    }
+}

--- a/tests/hqplayer_conformance.rs
+++ b/tests/hqplayer_conformance.rs
@@ -8310,13 +8310,13 @@ async fn a_rate_pin_cleared_after_the_readback_is_not_reported_as_applied() {
         "precondition: no pin yet, so the pin below is a real write"
     );
 
-    // Three `State`/`Status` renders from now, which is this client's proof read: the mode write lands
-    // and takes the rate pin with it. `[source]` is chosen because it leaves the loaded chain alone —
-    // so the rate enumeration is untouched and the bracket has nothing to notice.
+    // Three `State`/`Status` renders from now, which is this client's proof read: the same-mode write
+    // lands and takes the rate pin with it. PCM is deliberately written again so the loaded chain and
+    // rate enumeration stay untouched and only the semantic value comparison can notice the clear.
     h.model
         .arm(|f| f.apply_after_polls.push(("SetMode".to_string(), 3)));
     h.model
-        .respond("<SetMode value=\"0\"/>")
+        .respond("<SetMode value=\"1\"/>")
         .expect("the fake answers SetMode");
 
     let outcome = h
@@ -8328,7 +8328,7 @@ async fn a_rate_pin_cleared_after_the_readback_is_not_reported_as_applied() {
     let daemon = h.model.state();
     assert_eq!(
         (daemon.mode_index, daemon.rate_index),
-        (0, 0),
+        (1, 0),
         "precondition: the other controller's mode write landed and cleared the pin. If this fails \
          the poll budget has drifted and the test is no longer about what it says"
     );
@@ -8601,12 +8601,59 @@ async fn a_rate_retry_that_enters_source_never_sends_a_second_pin() {
         SettingOutcome::Ambiguous { what, reason } => {
             assert_eq!(what, "rate");
             assert!(
-                reason.contains("earlier attempt") && reason.contains("suppressed"),
-                "the operation must disclose both the prior wire attempt and retry refusal; got: \
-                 {reason}"
+                reason.contains("wire")
+                    && reason.contains("final proof")
+                    && reason.contains("[source]"),
+                "the operation must disclose both the prior wire attempt and final source-mode \
+                 refusal; got: {reason}"
             );
         }
         other => panic!("a write followed by a suppressed retry is ambiguous: {other:?}"),
+    }
+    h.stop();
+}
+
+/// The source check and `SetRate` are separate protocol commands. Another controller can select
+/// `[source]` after the decision's `State` reply; the daemon then acknowledges Auto, applies no pin,
+/// and keeps rate position zero. Numeric readback and an unchanged rate list both look successful.
+///
+/// **Label: client-red.** Found by CodeRabbit at `78c8e97`.
+#[tokio::test]
+async fn a_rate_write_that_enters_source_after_the_decision_is_not_applied() {
+    let h = Harness::verified().await;
+    h.model.external_change(|s| {
+        s.rate_index = 1;
+        s.active_rate_hz = 44_100;
+    });
+    h.model.arm(|f| f.source_refuses_rate_pin = true);
+    h.model.switch_mode_after_request("State", 0);
+
+    let outcome = h
+        .adapter
+        .set_rate(0)
+        .await
+        .expect("a raced source transition is an outcome");
+
+    assert_eq!(
+        h.model.request_count("SetRate"),
+        1,
+        "the decision saw PCM and therefore reached the wire"
+    );
+    assert_eq!(
+        (h.model.state().mode_index, h.model.state().rate_index),
+        (0, 0),
+        "the external source transition landed before the ignored Auto pin"
+    );
+    match outcome {
+        SettingOutcome::Ambiguous { what, reason } => {
+            assert_eq!(what, "rate");
+            assert!(
+                reason.contains("source") && reason.contains("wire"),
+                "the outcome must disclose both the final source mode and prior wire attempt; got: \
+                 {reason}"
+            );
+        }
+        other => panic!("a rate pin attempted under final `[source]` is not applied: {other:?}"),
     }
     h.stop();
 }

--- a/tests/hqplayer_conformance.rs
+++ b/tests/hqplayer_conformance.rs
@@ -7305,12 +7305,7 @@ async fn a_profile_load_whose_refresh_fails_does_not_leave_the_previous_profiles
     let web = FakeConfigWeb::start(CONFIG_PAGE_RAW_LANE, PROFILE_PAGE_SEMANTIC_LANE).await;
     let h = Harness::start(
         VERIFIED_PROFILE,
-        WirePolicy {
-            // Declared, not yet live: the cache below has to fill successfully first, or the test
-            // would be about a daemon that never worked rather than one that stopped.
-            silent_for_element_when_armed: Some("GetShapers".to_string()),
-            ..WirePolicy::default()
-        },
+        WirePolicy::default(),
         HqpTimeouts {
             max_attempts: 1,
             ..fast_timeouts()
@@ -7349,8 +7344,21 @@ async fn a_profile_load_whose_refresh_fails_does_not_leave_the_previous_profiles
         "precondition: the pre-load shapers are cached, got {stale:?}"
     );
 
-    // The profile load succeeds; the refresh that follows it cannot complete.
-    h.server.arm_element_silence();
+    // The profile load succeeds; the refresh that follows it cannot complete. Armed only now, after
+    // the cache above filled successfully — otherwise the test would be about a daemon that never
+    // worked rather than one that stopped.
+    h.model.arm(|f| {
+        // One rejection breaks the eager post-load refresh; two more cover the read path's bounded
+        // retry. On the broken implementation only the first is consumed because the stale cache
+        // makes the read skip both fills. On the fixed implementation the cache is empty, so the
+        // read must either establish fresh lists or fail explicitly rather than publish the old ones.
+        for _ in 0..3 {
+            f.reject_next.push((
+                "GetShapers".to_string(),
+                "post-profile refresh refused".to_string(),
+            ));
+        }
+    });
     h.adapter
         .load_profile("raw-a")
         .await
@@ -7402,6 +7410,13 @@ async fn a_profile_load_whose_refresh_fails_does_not_leave_the_previous_profiles
 /// `isolate_config_dir` exists to protect a real user's config, not to test persistence.
 ///
 /// The adapter keeps its credentials in memory throughout, which is what the caller actually needs.
+///
+/// Two callers of this helper running at once would defeat it: `UHC_CONFIG_DIR` is one process-wide
+/// variable, so the second one's restore writes back whichever value it happened to read — the
+/// *other* caller's scratch path, already deleted — and every later `HqpAdapter::new` reads from a
+/// directory that no longer exists. The lock below makes the redirect-and-restore one indivisible
+/// step. It is async because the `configure` it wraps is, and holding a `std::sync::Mutex` across an
+/// await would block the runtime worker rather than yield it.
 async fn configure_without_persisting(
     adapter: &HqpAdapter,
     host: &str,
@@ -7410,6 +7425,13 @@ async fn configure_without_persisting(
     user: &str,
     password: &str,
 ) {
+    static CONFIG_DIR_LOCK: std::sync::OnceLock<tokio::sync::Mutex<()>> =
+        std::sync::OnceLock::new();
+    let _guard = CONFIG_DIR_LOCK
+        .get_or_init(|| tokio::sync::Mutex::new(()))
+        .lock()
+        .await;
+
     let previous = std::env::var("UHC_CONFIG_DIR").expect("the suite isolates the config dir");
     let scratch = std::path::Path::new(&previous).join(format!(
         "no-persist-{}-{:?}",

--- a/tests/hqplayer_conformance.rs
+++ b/tests/hqplayer_conformance.rs
@@ -6912,37 +6912,36 @@ async fn a_chain_change_during_a_list_refresh_publishes_nothing_rather_than_a_mi
     h.model
         .switch_chain_after_request("GetFilters", LoadedChain::Pcm);
 
-    let straddled = h.adapter.get_pipeline_status().await.expect("pipeline");
-
-    let filters: Vec<&str> = straddled
-        .settings
-        .filter1x
-        .options
-        .iter()
-        .map(|o| o.value.as_str())
-        .collect();
-    let shapers: Vec<&str> = straddled
-        .settings
-        .shaper
-        .options
-        .iter()
-        .map(|o| o.value.as_str())
-        .collect();
-    assert!(
-        !(filters.contains(&"sinc-Lh") && shapers.contains(&"NS9")),
-        "a set straddling the change must not be published: these are the SDM chain's filters beside \
-         the PCM chain's shapers, offered together as one daemon's settings. filters={filters:?} \
-         shapers={shapers:?}"
-    );
-    // ...and it must not have passed by *partial* publication either. Refusing the straddling set has
-    // to mean publishing none of it: a view carrying one family and not the other three is still
-    // handed to a caller as this daemon's settings, and a check that only forbade the mixed pair
-    // would be satisfied by a family having been blanked on the way past.
-    let populated = published_families(&straddled);
-    assert!(
-        populated.is_empty() || populated.len() == 4,
-        "a refused refresh must publish nothing, not a part. Published: {populated:?}"
-    );
+    match h.adapter.get_pipeline_status().await {
+        // Refusing the straddling set means publishing none of it — and since this read needed that
+        // set, it has nothing left to answer with. A view carrying one family and not the other
+        // three, or all four empty, is still handed to a caller as this daemon's settings.
+        Err(e) => assert!(
+            e.to_string().contains("lists") || e.to_string().contains("chain"),
+            "the failure must name what could not be settled. Got: {e}"
+        ),
+        Ok(straddled) => {
+            let filters: Vec<&str> = straddled
+                .settings
+                .filter1x
+                .options
+                .iter()
+                .map(|o| o.value.as_str())
+                .collect();
+            let shapers: Vec<&str> = straddled
+                .settings
+                .shaper
+                .options
+                .iter()
+                .map(|o| o.value.as_str())
+                .collect();
+            panic!(
+                "a read whose only enumeration set straddled a chain change must not be reported as \
+                 a successful one. filters={filters:?} shapers={shapers:?} families={:?}",
+                published_families(&straddled)
+            );
+        }
+    }
 
     // And the client recovers: the daemon is settled on PCM now, so the next poll publishes a
     // coherent PCM set rather than staying blank.
@@ -6969,14 +6968,19 @@ async fn a_chain_change_during_a_list_refresh_publishes_nothing_rather_than_a_mi
     h.stop();
 }
 
-/// One family failing must not publish the other three. A refresh is a set or it is nothing: leaving
-/// a caller with fresh filters beside an empty shaper list tells it the daemon offers no modulators,
-/// which is a different and worse falsehood than "not read yet".
+/// One family failing must not publish the other three, **and must not be reported as a successful
+/// read either**. A refresh is a set or it is nothing: leaving a caller with fresh filters beside an
+/// empty shaper list tells it the daemon offers no modulators, and answering `Ok` with *all four*
+/// empty tells it the daemon offers nothing at all. Both are falsehoods a caller acts on; "not read
+/// yet" is not something a `PipelineStatus` can express.
 ///
-/// **Label: client-red.** The previous refresh assigned an empty vector per failed family and
-/// published the rest.
+/// This test previously asserted `Ok` with nothing published, which pinned the second falsehood as
+/// expected behaviour — the same ambiguity the bounded-retry fix rejects, reached through the lazy
+/// fill instead. CodeRabbit found it.
+///
+/// **Label: client-red.**
 #[tokio::test]
-async fn a_single_failed_family_publishes_no_part_of_the_refresh() {
+async fn a_single_failed_family_fails_the_read_rather_than_publishing_an_empty_one() {
     let h = Harness::start(
         VERIFIED_PROFILE,
         WirePolicy {
@@ -6991,18 +6995,57 @@ async fn a_single_failed_family_publishes_no_part_of_the_refresh() {
     .await;
     h.adapter.connect().await.expect("connect");
 
-    let pipeline = h
-        .adapter
-        .get_pipeline_status()
-        .await
-        .expect("a failed family must not fail the whole read");
+    match h.adapter.get_pipeline_status().await {
+        Err(e) => assert!(
+            e.to_string().contains("lists"),
+            "the failure must say the setting lists could not be read, rather than surfacing as \
+             some unrelated error. Got: {e}"
+        ),
+        Ok(published) => {
+            let families = published_families(&published);
+            panic!(
+                "a fill that never settled must not be reported as a successful read. It published \
+                 {families:?}, with {} filter options and {} shaper options — a caller cannot tell \
+                 that from a daemon that genuinely offers neither",
+                published.settings.filter1x.options.len(),
+                published.settings.shaper.options.len()
+            );
+        }
+    }
+    h.stop();
+}
 
-    let populated = published_families(&pipeline);
+/// The same hole reached through the **first** read after connect, where there is no cache at all.
+///
+/// With nothing cached there is no previous fingerprint, so the chain check has nothing to
+/// contradict and answers "unchanged" — correctly, since it is a check about *movement*. That makes
+/// the required lazy fill the only thing standing between a caller and an empty answer, so its
+/// failure has to be the read's failure.
+///
+/// **Label: client-red.**
+#[tokio::test]
+async fn a_first_read_whose_required_fill_never_settles_is_not_reported_as_success() {
+    let h = Harness::start(
+        VERIFIED_PROFILE,
+        WirePolicy {
+            silent_for_element: Some("GetFilters".to_string()),
+            ..WirePolicy::default()
+        },
+        HqpTimeouts {
+            max_attempts: 1,
+            ..fast_timeouts()
+        },
+    )
+    .await;
+    h.adapter.connect().await.expect("connect");
+
+    let outcome = h.adapter.get_pipeline_status().await;
 
     assert!(
-        populated.is_empty(),
-        "the shaper fetch failed, so no part of that refresh may be published — a partially filled \
-         cache is offered to callers as a complete one. Published anyway: {populated:?}"
+        outcome.is_err(),
+        "the very first read has no cache to fall back on, so a fill that did not settle leaves \
+         nothing to publish; it published {:?} instead",
+        outcome.map(|p| published_families(&p))
     );
     h.stop();
 }

--- a/tests/hqplayer_conformance.rs
+++ b/tests/hqplayer_conformance.rs
@@ -42,7 +42,8 @@ use mock_servers::hqplayer::corpus::{
     self, LEGACY_PROFILE, SYNTHETIC_HAZARD_PROFILE, VERIFIED_PROFILE,
 };
 use mock_servers::hqplayer::model::{
-    request_attr, ActiveModeReporting, DaemonModel, DocumentStyle, LoadedChain, Metadata,
+    request_attr, ActiveModeReporting, DaemonModel, DocumentStyle, FilterFieldReporting, LoadedChain,
+    Metadata,
 };
 use mock_servers::hqplayer::tier1;
 use mock_servers::hqplayer::wire::{Chunking, Disruption, Responder, WirePolicy, WireServer};
@@ -5869,4 +5870,761 @@ async fn serve_one_canned_line(line: &str) -> u16 {
         }
     });
     port
+}
+
+// =============================================================================
+// Issue #347 — trustworthy live setters, and enumerations scoped to the LOADED chain
+//
+// #322 made these situations expressible; every client-side consequence is owned here. Each test
+// below is labelled the way #322 labelled its own: **client-red** for an expectation that fails
+// against the pre-#347 adapter, **client-pin** for a property that already holds and is pinned so it
+// cannot regress. No test asserts elapsed wall-clock time and none contacts a real daemon.
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+// The `[source]` rate pin — suppressed with a stated reason, never sent
+// -----------------------------------------------------------------------------
+
+/// Under a configured `[source]` mode the daemon answers `SetRate` with `OK` and applies nothing
+/// (HQP-C-018). Retrying cannot help — what governs the rate there is a persistent config limit with
+/// no wire command — so the honest client behaviour is to **not send it** and say why.
+///
+/// Before #347 the client sent the pin and let readback arithmetic produce a failure whose message
+/// named an index, not a reason.
+///
+/// **Label: client-red.** **Provenance of the daemon behaviour: derived-upstream, tier-2-only,
+/// pending #332.**
+#[tokio::test]
+async fn a_rate_pin_under_source_is_suppressed_before_it_reaches_the_daemon() {
+    let h = Harness::verified().await;
+    h.model.external_change(|s| {
+        s.mode_index = 0; // configured `[source]`
+        s.playback = 2;
+    });
+    h.model.arm(|f| f.source_refuses_rate_pin = true);
+
+    let outcome = h.adapter.set_rate(705600).await;
+
+    assert_eq!(
+        h.model.request_count("SetRate"),
+        0,
+        "a write the daemon is known to ignore in this mode must not be put on the wire at all; \
+         sending it and failing on readback is a true outcome reached for no stated reason"
+    );
+    let err = outcome
+        .map(|_| ())
+        .expect_err("an unsent write must never be reported as applied");
+    let message = err.to_string();
+    assert!(
+        message.contains("[source]"),
+        "the refusal must name the configured mode that causes it, so an operator can act on it \
+         rather than reading an index comparison. Got: {message}"
+    );
+    h.stop();
+}
+
+/// The narrow case readback **cannot** catch: Auto (index 0) requested under `[source]`, where the
+/// rate is already 0. Expected 0 against observed 0 is a match, so the pre-#347 client reported
+/// success for a command that did nothing (HQP-C-019).
+///
+/// **Label: client-red.**
+#[tokio::test]
+async fn an_auto_rate_request_under_source_is_never_reported_as_applied() {
+    let h = Harness::verified().await;
+    h.model.external_change(|s| {
+        s.mode_index = 0;
+        s.playback = 2;
+    });
+    h.model.arm(|f| f.source_refuses_rate_pin = true);
+    assert_eq!(
+        h.model.state().rate_index,
+        0,
+        "precondition: the rate must already be unpinned, which is what makes readback blind"
+    );
+
+    let outcome = h.adapter.set_rate(0).await;
+
+    assert_eq!(
+        h.model.request_count("SetRate"),
+        0,
+        "Auto is suppressed under `[source]` exactly like any other pin"
+    );
+    assert!(
+        outcome.map(|_| ()).is_err(),
+        "equality with pre-existing state is not proof that a setter applied; before #347 this \
+         reported success because it compared 0 against 0"
+    );
+    h.stop();
+}
+
+/// A rate pin in a configured PCM or SDM mode is ordinary and must still work — the suppression is
+/// **mode-conditional**, not a blanket refusal to pin rates.
+///
+/// **Label: client-pin.**
+#[tokio::test]
+async fn a_rate_pin_outside_source_is_still_sent_and_verified() {
+    let h = Harness::verified().await;
+    h.adapter.set_rate(44100).await.expect("a PCM rate pin");
+    assert_eq!(
+        h.model.state().rate_index,
+        1,
+        "the PCM list gives 44100 index 1 and the daemon must actually have moved there"
+    );
+    h.stop();
+}
+
+// -----------------------------------------------------------------------------
+// Mode writes — skipped when they are no-ops, honest about the pin when performed
+// -----------------------------------------------------------------------------
+
+/// `SetMode` clears the exact-rate pin even when the mode does not change (HQP-C-017), so writing
+/// the mode a daemon is already in destroys user state for nothing.
+///
+/// **Label: client-red.** Before #347 the client sent it unconditionally.
+#[tokio::test]
+async fn a_no_op_mode_write_is_not_sent_so_the_rate_pin_survives() {
+    let h = Harness::verified().await;
+    h.adapter.set_rate(44100).await.expect("pin a PCM rate");
+    let pinned = h.model.state();
+    assert_ne!(pinned.rate_index, 0, "precondition: the pin must be set");
+
+    // The daemon is already in PCM.
+    h.adapter
+        .set_mode("PCM")
+        .await
+        .expect("a mode that is already running is trivially satisfied");
+
+    assert_eq!(
+        h.model.request_count("SetMode"),
+        0,
+        "no `SetMode` may reach a daemon already in that mode: the write is not a no-op on the \
+         daemon, it clears the rate pin"
+    );
+    assert_eq!(
+        h.model.state().rate_index,
+        pinned.rate_index,
+        "and the user's pin must survive"
+    );
+    h.stop();
+}
+
+/// A mode write that really changes the mode is sent, and the pin it clears is reported as cleared
+/// rather than remembered.
+///
+/// **Label: client-pin** for the pipeline value — #322's `refresh_lists` already re-read it — and
+/// **client-red** for the untouched-pin half, which only holds once the no-op skip exists.
+#[tokio::test]
+async fn a_performed_mode_write_reports_the_cleared_rate_pin_honestly() {
+    let h = Harness::verified().await;
+    h.adapter.set_rate(44100).await.expect("pin a PCM rate");
+
+    h.adapter
+        .set_mode("SDM (DSD)")
+        .await
+        .expect("a real mode change");
+
+    assert_eq!(
+        h.model.request_count("SetMode"),
+        1,
+        "a mode change that is not a no-op must be sent exactly once"
+    );
+    assert_eq!(
+        h.model.state().rate_index,
+        0,
+        "the daemon clears the pin on a mode change"
+    );
+    let pipeline = h.adapter.get_pipeline_status().await.expect("pipeline");
+    assert_eq!(
+        pipeline.settings.samplerate.selected.value.as_str(),
+        "0",
+        "the client must report the rate the daemon now holds — Auto — and never the rate the user \
+         pinned before the chain reloaded"
+    );
+    assert!(
+        pipeline
+            .settings
+            .samplerate
+            .options
+            .iter()
+            .any(|o| o.value == "2822400"),
+        "and the offered rates must be the newly loaded chain's, got {:?}",
+        pipeline
+            .settings
+            .samplerate
+            .options
+            .iter()
+            .map(|o| o.value.as_str())
+            .collect::<Vec<_>>()
+    );
+    h.stop();
+}
+
+/// The daemon names the DSD mode `"SDM (DSD)"`, so a caller asking for `"DSD"` or `"SDM"` must reach
+/// it by **semantic alias**, never by assuming a list position (HQP-C-013's device fixture is why
+/// position is unsafe).
+///
+/// **Label: client-red.** Before #347 only an exact name matched, and a bare integer was accepted
+/// instead.
+#[tokio::test]
+async fn a_mode_alias_resolves_through_the_daemons_own_name() {
+    for requested in ["DSD", "SDM", "sdm (dsd)"] {
+        let h = Harness::verified().await;
+        h.adapter
+            .set_mode(requested)
+            .await
+            .unwrap_or_else(|e| panic!("`{requested}` must resolve to the daemon's SDM entry: {e}"));
+        assert_eq!(
+            h.model.state().mode_index,
+            2,
+            "`{requested}` must reach the list index the daemon gives `SDM (DSD)`, which is 2 here \
+             and is not a position any client may assume"
+        );
+        h.stop();
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Enumerations scoped to the LOADED chain
+// -----------------------------------------------------------------------------
+
+/// The headline hazard, end to end through the real client.
+///
+/// The cache is populated the ordinary way — `get_pipeline_status()`, which both
+/// `GET /hqplayer/pipeline` and the MCP status tool already call. The source then moves the loaded
+/// chain while configured `[source]` keeps `State.mode` at 0, so nothing prompts a mode-keyed cache
+/// to re-read. A name from the **previous** chain must now fail to resolve rather than being sent as
+/// a stale index that names a different filter in the chain now loaded.
+///
+/// The synthetic profile is what makes this a silent misselection instead of a loud rejection: every
+/// index resolves in both chains and always to a different name.
+///
+/// **Label: client-red.** Observed pre-fix on #347 comment 5125934210: `ok=true` while the daemon
+/// ended on a filter nobody asked for.
+#[tokio::test]
+async fn a_source_driven_chain_change_invalidates_the_cached_filter_list() {
+    let h = Harness::start(
+        SYNTHETIC_HAZARD_PROFILE,
+        WirePolicy::default(),
+        fast_timeouts(),
+    )
+    .await;
+    h.adapter.connect().await.expect("connect");
+    h.model.external_change(|s| {
+        s.mode_index = 0; // configured `[source]`
+        s.playback = 2;
+    });
+    // The ordinary cache-populating read.
+    h.adapter
+        .get_pipeline_status()
+        .await
+        .expect("pipeline populates the list cache");
+
+    h.model.source_loads_chain(LoadedChain::Sdm);
+    let before = h.model.state();
+
+    let outcome = h.adapter.set_filter_nx("SYN-pcm-7").await;
+
+    assert!(
+        outcome.map(|_| ()).is_err(),
+        "a filter name that exists only in the chain that is no longer loaded must not resolve; \
+         before #347 it resolved from the stale cache to index 7 and selected `SYN-sdm-7`"
+    );
+    assert_eq!(
+        h.model.state().filter_nx_index,
+        before.filter_nx_index,
+        "and nothing may have been mutated on the way to that refusal"
+    );
+    h.stop();
+}
+
+/// The other half: after the same chain change, a name that **is** in the newly loaded chain
+/// resolves to *that* chain's index.
+///
+/// **Label: client-red.** Before #347 the stale cache had no `SYN-sdm-*` entry, so the resolver fell
+/// through to a fresh fetch and happened to be right — but only because the name was absent. The
+/// assertion here is on the index actually sent, which is what the previous test shows the stale
+/// path getting wrong.
+#[tokio::test]
+async fn after_a_chain_change_a_filter_resolves_against_the_newly_loaded_list() {
+    let h = Harness::start(
+        SYNTHETIC_HAZARD_PROFILE,
+        WirePolicy::default(),
+        fast_timeouts(),
+    )
+    .await;
+    h.adapter.connect().await.expect("connect");
+    h.model.external_change(|s| {
+        s.mode_index = 0;
+        s.playback = 2;
+    });
+    h.adapter.get_pipeline_status().await.expect("pipeline");
+    h.model.source_loads_chain(LoadedChain::Sdm);
+
+    h.adapter
+        .set_filter_nx("SYN-sdm-3")
+        .await
+        .expect("a name in the loaded chain must resolve");
+
+    assert_eq!(
+        request_attr(
+            &h.model.last_request("SetFilter").expect("SetFilter sent"),
+            "value"
+        )
+        .as_deref(),
+        Some("3"),
+        "the index sent must come from the chain the daemon has loaded now"
+    );
+    h.stop();
+}
+
+/// The same name occupies **different positions** in the two chains of the observed Opal corpus:
+/// `poly-sinc-gauss-long` is index 7 under PCM and index 1 under SDM. That is the evidenced form of
+/// the hazard, and it is the one a cache cannot survive.
+///
+/// **Label: client-red.**
+#[tokio::test]
+async fn a_name_present_in_both_chains_is_sent_with_the_loaded_chains_index() {
+    let h = Harness::verified().await;
+    h.model.external_change(|s| {
+        s.mode_index = 0;
+        s.playback = 2;
+    });
+    h.adapter.get_pipeline_status().await.expect("pipeline");
+    assert_eq!(
+        corpus::index_of(
+            &corpus::document(VERIFIED_PROFILE, "filters_pcm"),
+            "FiltersItem",
+            "poly-sinc-gauss-long",
+        ),
+        Some(7),
+        "precondition: the PCM list gives this name index 7"
+    );
+
+    h.model.source_loads_chain(LoadedChain::Sdm);
+    h.adapter
+        .set_filter_nx("poly-sinc-gauss-long")
+        .await
+        .expect("the name is in both chains");
+
+    assert_eq!(
+        request_attr(
+            &h.model.last_request("SetFilter").expect("SetFilter sent"),
+            "value"
+        )
+        .as_deref(),
+        Some("1"),
+        "the SDM list gives the same name index 1; sending 7 would select a different filter, and \
+         sending 7 is what the stale cache did"
+    );
+    h.stop();
+}
+
+/// A chain change invalidates the **shaper and rate** lists as well, not only the filter list — the
+/// acceptance criterion names all three. Asserted through the read surface every client actually
+/// polls, because that is where a stale list is published as truth.
+///
+/// **Label: client-red.** Before #347 `get_pipeline_status` refreshed only when a list was *empty*,
+/// so it served the previous chain's options indefinitely.
+#[tokio::test]
+async fn a_chain_change_invalidates_the_shaper_and_rate_lists_the_pipeline_publishes() {
+    let h = Harness::verified().await;
+    h.model.external_change(|s| {
+        s.mode_index = 0;
+        s.playback = 2;
+    });
+    let pcm = h.adapter.get_pipeline_status().await.expect("pipeline");
+    assert!(
+        pcm.settings.shaper.options.iter().any(|o| o.value == "NS9"),
+        "precondition: the PCM chain's shapers are what is cached first"
+    );
+
+    h.model.source_loads_chain(LoadedChain::Sdm);
+    let sdm = h.adapter.get_pipeline_status().await.expect("pipeline");
+
+    let shapers: Vec<&str> = sdm
+        .settings
+        .shaper
+        .options
+        .iter()
+        .map(|o| o.value.as_str())
+        .collect();
+    assert!(
+        shapers.contains(&"ASDM7") && !shapers.contains(&"NS9"),
+        "the modulators of the loaded SDM chain must replace the PCM shapers wholesale, got \
+         {shapers:?}"
+    );
+    let rates: Vec<&str> = sdm
+        .settings
+        .samplerate
+        .options
+        .iter()
+        .map(|o| o.value.as_str())
+        .collect();
+    assert!(
+        rates.contains(&"2822400") && !rates.contains(&"44100"),
+        "and so must the rates, got {rates:?}"
+    );
+    let filters: Vec<&str> = sdm
+        .settings
+        .filter1x
+        .options
+        .iter()
+        .map(|o| o.value.as_str())
+        .collect();
+    assert!(
+        filters.contains(&"sinc-Lh") && !filters.contains(&"IIR"),
+        "and the filters, got {filters:?}"
+    );
+    h.stop();
+}
+
+/// A reconnect must not inherit the previous session's enumerations. The daemon may have been
+/// reconfigured, restarted onto another profile, or simply moved chain while UHC was away.
+///
+/// **Label: client-red.** Before #347 `connect()` left the cache exactly as the dropped session had
+/// left it.
+#[tokio::test]
+async fn a_reconnect_invalidates_the_cached_enumerations() {
+    let h = Harness::start(
+        SYNTHETIC_HAZARD_PROFILE,
+        WirePolicy::default(),
+        fast_timeouts(),
+    )
+    .await;
+    h.adapter.connect().await.expect("connect");
+    h.model.external_change(|s| {
+        s.mode_index = 0;
+        s.playback = 2;
+    });
+    h.adapter.get_pipeline_status().await.expect("pipeline");
+
+    h.adapter.disconnect().await;
+    h.model.source_loads_chain(LoadedChain::Sdm);
+    h.adapter.connect().await.expect("reconnect");
+
+    let pipeline = h
+        .adapter
+        .get_pipeline_status()
+        .await
+        .expect("pipeline after reconnect");
+    let filters: Vec<&str> = pipeline
+        .settings
+        .filter1x
+        .options
+        .iter()
+        .map(|o| o.value.as_str())
+        .collect();
+    assert!(
+        filters.iter().all(|f| f.starts_with("SYN-sdm-")),
+        "a reconnected session must re-read the enumerations rather than resume the previous \
+         session's, got {filters:?}"
+    );
+    h.stop();
+}
+
+// -----------------------------------------------------------------------------
+// `SetFilter` carries both sides, or refuses without mutating
+// -----------------------------------------------------------------------------
+
+/// When `State` does not report the sibling filter, the pre-#347 client substituted the legacy
+/// combined `filter` field and sent it as the sibling — a guess, and #322's audit recorded it as
+/// defect C5. A guessed sibling silently overwrites the setting the user did not touch.
+///
+/// **Label: client-red.**
+#[tokio::test]
+async fn a_filter_write_is_refused_without_mutation_when_the_sibling_is_unknowable() {
+    let h = Harness::verified().await;
+    h.model
+        .set_filter_field_reporting(FilterFieldReporting::CombinedOnly);
+    let before = h.model.state();
+
+    let outcome = h.adapter.set_filter_1x("poly-sinc-lp").await;
+
+    assert!(
+        outcome.map(|_| ()).is_err(),
+        "with the Nx sibling unknowable the write must be refused, not guessed"
+    );
+    assert_eq!(
+        h.model.request_count("SetFilter"),
+        0,
+        "and refused *before* anything reaches the daemon: `SetFilter` writes both sides, so a \
+         guessed sibling is a silent overwrite of a setting nobody asked to change"
+    );
+    assert_eq!(
+        (
+            h.model.state().filter_1x_index,
+            h.model.state().filter_nx_index
+        ),
+        (before.filter_1x_index, before.filter_nx_index),
+        "nothing may have moved"
+    );
+    h.stop();
+}
+
+/// The ordinary path: a one-sided request still puts **both** arguments on the wire, taken from the
+/// authoritative `State` rather than from the client's cache.
+///
+/// **Label: client-pin.**
+#[tokio::test]
+async fn a_one_sided_filter_write_carries_both_authoritative_arguments() {
+    let h = Harness::verified().await;
+    let before = h.model.state();
+    h.adapter
+        .set_filter_1x("poly-sinc-xtr")
+        .await
+        .expect("SetFilter");
+
+    let sent = h.model.last_request("SetFilter").expect("SetFilter sent");
+    assert_eq!(
+        (
+            request_attr(&sent, "value").as_deref(),
+            request_attr(&sent, "value1x").as_deref()
+        ),
+        (Some(before.filter_nx_index.to_string().as_str()), Some("11")),
+        "both sides go on the wire together: the requested 1x index, and the Nx index the daemon \
+         itself reports. Sent: {sent}"
+    );
+    h.stop();
+}
+
+// -----------------------------------------------------------------------------
+// Semantic names only — no raw integer identity on a control path
+// -----------------------------------------------------------------------------
+
+/// A bare integer is not a setting name. The pre-#347 resolvers parsed one and used it as a **direct
+/// list index**, so a client that had a stale number — or simply guessed — silently selected
+/// whatever now sat at that position (HQP-C-063).
+///
+/// **Label: client-red.**
+#[tokio::test]
+async fn a_numeric_string_is_never_accepted_as_a_setting_name() {
+    let h = Harness::verified().await;
+
+    assert!(
+        h.adapter.set_mode("1").await.map(|_| ()).is_err(),
+        "`1` is not a mode name"
+    );
+    assert!(
+        h.adapter.set_filter_nx("7").await.map(|_| ()).is_err(),
+        "`7` is not a filter name"
+    );
+    assert!(
+        h.adapter.set_shaper("4").await.map(|_| ()).is_err(),
+        "`4` is not a shaper name"
+    );
+    assert_eq!(
+        (
+            h.model.request_count("SetMode"),
+            h.model.request_count("SetFilter"),
+            h.model.request_count("SetShaping")
+        ),
+        (0, 0, 0),
+        "and none of them may reach the daemon as a raw index"
+    );
+    h.stop();
+}
+
+// -----------------------------------------------------------------------------
+// Matrix profiles — semantic identity, State as the authority
+// -----------------------------------------------------------------------------
+
+/// `MatrixGetProfile` is **not** the current-profile authority. #347 says so explicitly, and #341
+/// records no versioned evidence that the supported daemon implements it consistently. The observed
+/// `State.matrix_profile` field is the authority.
+///
+/// **Label: client-red.** Before #347 the client asked `MatrixGetProfile` and published its answer.
+#[tokio::test]
+async fn the_current_matrix_profile_is_read_from_state_not_matrix_get_profile() {
+    let h = Harness::verified().await;
+    h.model
+        .arm(|f| f.matrix_current_override = Some("Speakers".to_string()));
+    h.model
+        .external_change(|s| s.matrix_profile = "Rock &amp; Roll".to_string());
+
+    let current = h
+        .adapter
+        .get_matrix_profile()
+        .await
+        .expect("current profile")
+        .expect("a profile is selected");
+
+    assert_eq!(
+        (current.name.as_str(), current.index),
+        ("Rock & Roll", 2),
+        "the authority is `State.matrix_profile`, and its index comes from resolving that name \
+         against the fresh list — not from whatever `MatrixGetProfile` reports"
+    );
+    h.stop();
+}
+
+/// A matrix profile the daemon acknowledges but never applies is not success.
+///
+/// **Label: client-red.** Before #347 `set_matrix_profile` sent the name and returned `Ok` on the
+/// `result="OK"` alone, with no readback at all.
+#[tokio::test]
+async fn a_matrix_profile_accepted_but_unchanged_is_not_reported_as_applied() {
+    let h = Harness::verified().await;
+    h.model
+        .arm(|f| f.accept_but_ignore.push("MatrixSetProfile".to_string()));
+
+    let outcome = h.adapter.set_matrix_profile(1).await;
+
+    assert!(
+        h.model.request_count("MatrixSetProfile") > 0,
+        "the write must actually have been attempted: this is a daemon-side no-op"
+    );
+    assert_eq!(
+        h.model.state().matrix_profile.as_str(),
+        "Default",
+        "precondition: the daemon really did not move"
+    );
+    assert!(
+        outcome.map(|_| ()).is_err(),
+        "`result=\"OK\"` is not proof of application for the matrix family either"
+    );
+    h.stop();
+}
+
+/// A current profile the daemon's own list does not contain must not be published carrying some
+/// **other** profile's index. The pre-#347 read fell back to index 0, which is `Default` — so a UI
+/// showed `Default` selected while the daemon was on something else entirely.
+///
+/// **Label: client-red.**
+#[tokio::test]
+async fn a_current_matrix_profile_absent_from_the_fresh_list_is_not_given_another_profiles_index() {
+    let h = Harness::verified().await;
+    h.model
+        .arm(|f| f.matrix_current_override = Some("Ghost".to_string()));
+    h.model
+        .external_change(|s| s.matrix_profile = "Ghost".to_string());
+
+    let current = h.adapter.get_matrix_profile().await.expect("current");
+
+    assert!(
+        current.is_none(),
+        "a name absent from the fresh list is not a selectable identity, and index 0 belongs to \
+         `Default`; got {current:?}"
+    );
+    h.stop();
+}
+
+/// The legacy numeric request stays a **compatibility input**: it is resolved against the fresh list
+/// into a semantic name, and the name is what goes on the wire.
+///
+/// **Label: client-pin** for the wire form, **client-red** for the freshness — the pre-#347 code
+/// fetched the list but never verified the outcome.
+#[tokio::test]
+async fn a_matrix_profile_write_sends_the_semantic_name_and_verifies_the_readback() {
+    let h = Harness::verified().await;
+    h.adapter
+        .set_matrix_profile(2)
+        .await
+        .expect("a profile in the fresh list");
+
+    assert_eq!(
+        request_attr(
+            &h.model
+                .last_request("MatrixSetProfile")
+                .expect("MatrixSetProfile sent"),
+            "value"
+        )
+        .as_deref(),
+        Some("Rock &amp; Roll"),
+        "the semantic name goes on the wire, escaped as the daemon escapes it — never the number"
+    );
+    assert_eq!(
+        h.model.state().matrix_profile.as_str(),
+        "Rock &amp; Roll",
+        "and the authoritative field must actually carry it"
+    );
+    h.stop();
+}
+
+/// An externally-made profile switch is visible on the next read, and an empty
+/// `State.matrix_profile` is the default identity rather than a list position.
+///
+/// **Label: client-pin.**
+#[tokio::test]
+async fn an_external_matrix_switch_is_visible_and_an_empty_profile_is_no_selection() {
+    let h = Harness::verified().await;
+    h.model
+        .external_change(|s| s.matrix_profile = "Speakers".to_string());
+    let current = h
+        .adapter
+        .get_matrix_profile()
+        .await
+        .expect("current")
+        .expect("selected");
+    assert_eq!((current.index, current.name.as_str()), (1, "Speakers"));
+
+    h.model.external_change(|s| s.matrix_profile = String::new());
+    assert!(
+        h.adapter
+            .get_matrix_profile()
+            .await
+            .expect("current")
+            .is_none(),
+        "an empty profile field is the default/no-selection identity, not index 0"
+    );
+    h.stop();
+}
+
+/// An explicit daemon rejection of a matrix write is reported as the error it is.
+///
+/// **Label: client-pin.**
+#[tokio::test]
+async fn a_rejected_matrix_profile_write_reports_the_daemon_reason() {
+    let h = Harness::verified().await;
+    h.model.arm(|f| {
+        f.reject_next.push((
+            "MatrixSetProfile".to_string(),
+            "profile in use".to_string(),
+        ))
+    });
+
+    let err = h
+        .adapter
+        .set_matrix_profile(1)
+        .await
+        .map(|_| ())
+        .expect_err("an explicit rejection is a failure");
+    assert!(
+        err.to_string().contains("profile in use"),
+        "the daemon's own reason must survive to the caller, got: {err}"
+    );
+    h.stop();
+}
+
+// -----------------------------------------------------------------------------
+// Bounded, non-wedging failure
+// -----------------------------------------------------------------------------
+
+/// A malformed reply fails that command and leaves the connection usable, so later polling is not
+/// wedged. The oversized case is pinned by
+/// `an_unbounded_reply_is_rejected_by_an_explicit_byte_cap_and_the_next_command_still_works`; this is
+/// its malformed sibling.
+///
+/// **Label: client-pin.**
+#[tokio::test]
+async fn a_malformed_reply_does_not_wedge_later_polling() {
+    let h = Harness::with_policy(WirePolicy {
+        malformed_for_element: Some(("State".to_string(), "</Status>".to_string())),
+        ..WirePolicy::default()
+    })
+    .await;
+
+    assert!(
+        h.adapter.get_state().await.is_err(),
+        "precondition: the malformed reply must fail its own command"
+    );
+    let info = h
+        .adapter
+        .get_info()
+        .await
+        .expect("a later command must still be answered");
+    assert_eq!(
+        info.product, "Signalyst HQPlayer Embedded",
+        "and it must read the daemon's real reply rather than leftovers"
+    );
+    h.stop();
 }

--- a/tests/hqplayer_conformance.rs
+++ b/tests/hqplayer_conformance.rs
@@ -7511,3 +7511,135 @@ async fn a_reconnect_during_the_reads_does_not_publish_the_cache_it_emptied() {
     }
     h.stop();
 }
+
+/// A chain check that **could not run** is not a chain check that passed.
+///
+/// The final `GetRates` is the whole basis for joining `State`'s indices to the cached enumerations:
+/// it is what establishes that the list a selection is resolved through belongs to the chain the
+/// daemon had loaded when it reported that selection. An explicit `result="Error"` on it is terminal
+/// in `send_command` — it does not retry, does not disconnect and does not invalidate — so the cache
+/// survives intact and looks entirely usable. That is precisely what makes swallowing it dangerous:
+/// the published view is indistinguishable from a verified one, and a caller has no way to see that
+/// the join was never checked.
+///
+/// The earlier reading was "the cache was not invalidated, so the lists are still the ones the state
+/// was read against". That is true about the *cache* and says nothing about the *daemon*: the lists
+/// are unchanged locally, while whether the daemon still has that chain loaded is exactly the
+/// question the failed request was asked. A `warn!` is not a substitute for an answer.
+///
+/// So it takes the same shape as every other unsettled read here — one bounded retry, then an error.
+///
+/// **Label: client-red.** Found by CodeRabbit at `619dee4`. Before this, a rejected final `GetRates`
+/// was logged and the state was projected through the cached lists anyway.
+#[tokio::test]
+async fn a_final_chain_check_that_cannot_run_twice_is_reported_rather_than_published() {
+    let h = Harness::verified().await;
+    let before = h
+        .adapter
+        .get_pipeline_status()
+        .await
+        .expect("the cache fills while the daemon is healthy");
+    assert_eq!(
+        published_families(&before).len(),
+        4,
+        "precondition: a complete cache, so the read below skips its fill and the only `GetRates` \
+         left in it is the chain check"
+    );
+    let rates_before = h.model.request_count("GetRates");
+
+    // Two rejections: the first catches the read's chain check, the second catches the retry's. The
+    // daemon stays up throughout — an explicit rejection is not a transport failure — so nothing
+    // invalidates and the cache remains fully populated and inviting.
+    h.model.arm(|f| {
+        for _ in 0..2 {
+            f.reject_next
+                .push(("GetRates".to_string(), "chain check refused".to_string()));
+        }
+    });
+
+    let outcome = h.adapter.get_pipeline_status().await;
+
+    match outcome {
+        Err(e) => {
+            let message = e.to_string();
+            assert!(
+                message.contains("chain"),
+                "the failure must say what could not be established — that the loaded chain could \
+                 not be verified — rather than surfacing as some unrelated read error. Got: \
+                 {message}"
+            );
+            assert_eq!(
+                h.model.request_count("GetRates") - rates_before,
+                2,
+                "the bound is one retry, not zero and not a loop: a first unverifiable check is \
+                 re-read once before the read gives up"
+            );
+        }
+        Ok(published) => {
+            let families = published_families(&published);
+            panic!(
+                "a read whose chain check never ran must not be published as a verified one. It \
+                 published {families:?}, with filter1x selected as {:?} out of {} options — \
+                 indices joined to lists nothing confirmed belong to the same chain",
+                published.settings.filter1x.selected.value,
+                published.settings.filter1x.options.len()
+            );
+        }
+    }
+    h.stop();
+}
+
+/// The bound is a **retry**, not a second way to fail. A single unverifiable chain check followed by
+/// one that runs and passes leaves the read with exactly what it needs — a state and a set of lists
+/// confirmed to describe the same loaded chain — and that read is published.
+///
+/// This is the other half of the check above, and it is what keeps the fix from degrading into
+/// "any failed request fails the read": the request count is asserted, so a read that published
+/// without a *successful* check cannot pass by publishing the same four families the swallowing
+/// version did.
+///
+/// **Label: client-red.** Before this, the retry did not exist: the first rejection was logged and
+/// the cached lists were published unverified, so coherence was never established at all.
+#[tokio::test]
+async fn a_final_chain_check_that_runs_on_the_retry_publishes_the_verified_read() {
+    let h = Harness::verified().await;
+    let before = h
+        .adapter
+        .get_pipeline_status()
+        .await
+        .expect("the cache fills while the daemon is healthy");
+    assert_eq!(
+        published_families(&before).len(),
+        4,
+        "precondition: a complete cache, so the read below skips its fill"
+    );
+    let rates_before = h.model.request_count("GetRates");
+
+    h.model.arm(|f| {
+        f.reject_next
+            .push(("GetRates".to_string(), "chain check refused".to_string()))
+    });
+
+    let published = h
+        .adapter
+        .get_pipeline_status()
+        .await
+        .expect("a check that runs on the retry and passes is a verified read");
+
+    assert_eq!(
+        h.model.request_count("GetRates") - rates_before,
+        2,
+        "the publication must rest on a check that actually ran: one rejected, one answered. A \
+         single request would mean the rejection was swallowed and nothing was verified"
+    );
+    assert_eq!(
+        published_families(&published).len(),
+        4,
+        "a verified read publishes the complete set"
+    );
+    assert_eq!(
+        published.settings.filter1x.selected.value, before.settings.filter1x.selected.value,
+        "and the daemon did not move, so the verified selection is the one it held all along"
+    );
+    h.stop();
+}

--- a/tests/hqplayer_conformance.rs
+++ b/tests/hqplayer_conformance.rs
@@ -2999,15 +2999,15 @@ async fn tier1_takes_the_config_profile_evidence_from_the_raw_page_not_the_seman
     let web = FakeConfigWeb::start(CONFIG_PAGE_RAW_LANE, PROFILE_PAGE_SEMANTIC_LANE).await;
     let h = Harness::start(VERIFIED_PROFILE, WirePolicy::default(), fast_timeouts()).await;
     h.adapter.connect().await.expect("connect to fake daemon");
-    h.adapter
-        .configure(
-            "127.0.0.1".to_string(),
-            Some(h.server.port()),
-            Some(web.port),
-            Some("conformance".to_string()),
-            Some("conformance".to_string()),
-        )
-        .await;
+    configure_without_persisting(
+        &h.adapter,
+        "127.0.0.1",
+        h.server.port(),
+        web.port,
+        "conformance",
+        "conformance",
+    )
+    .await;
 
     let capture = tier1::capture(&h.adapter).await.expect("capture");
     let profiles = capture
@@ -3038,15 +3038,15 @@ async fn tier1_reports_a_divergence_when_the_semantic_parser_disagrees_with_the_
     let web = FakeConfigWeb::start(CONFIG_PAGE_RAW_LANE, PROFILE_PAGE_SEMANTIC_LANE).await;
     let h = Harness::start(VERIFIED_PROFILE, WirePolicy::default(), fast_timeouts()).await;
     h.adapter.connect().await.expect("connect to fake daemon");
-    h.adapter
-        .configure(
-            "127.0.0.1".to_string(),
-            Some(h.server.port()),
-            Some(web.port),
-            Some("conformance".to_string()),
-            Some("conformance".to_string()),
-        )
-        .await;
+    configure_without_persisting(
+        &h.adapter,
+        "127.0.0.1",
+        h.server.port(),
+        web.port,
+        "conformance",
+        "conformance",
+    )
+    .await;
 
     let capture = tier1::capture(&h.adapter).await.expect("capture");
     let report = tier1::diff(&capture, VERIFIED_PROFILE);
@@ -7277,6 +7277,213 @@ async fn a_chain_that_moves_on_both_the_read_and_the_retry_is_reported_rather_th
                  caller cannot tell that from a daemon that genuinely offers nothing",
                 published.settings.filter1x.selected.value,
                 published.settings.filter1x.options.len()
+            );
+        }
+    }
+    h.stop();
+}
+
+/// A profile load replaces the daemon's settings wholesale — filters, shapers and rates can all
+/// change — so the enumerations cached from before it are describing a configuration that no longer
+/// exists. `refresh_lists` deliberately leaves an existing cache alone when it cannot publish a
+/// coherent replacement, which is right for a *transient* read and wrong here: what it preserves is
+/// the pre-load lists, and the next read then finds them non-empty, skips its required fill, and
+/// resolves the new profile's `State` indices through the old profile's options.
+///
+/// The chain check does not save it. That check compares **rates**, and a profile that changes
+/// filters or shapers while leaving the rate list alone passes it — so the stale answer is not just
+/// published, it is published confidently.
+///
+/// **Label: client-red.** Found by CodeRabbit at `d4acddf`, and it falsified a comment I had just
+/// written claiming a failed post-load refresh "leaves the cache empty rather than stale".
+#[tokio::test]
+async fn a_profile_load_whose_refresh_fails_does_not_leave_the_previous_profiles_lists_in_place() {
+    // This test is what made the shared-config coupling bite: supplying credentials leaked them to
+    // every adapter built afterwards, and `tier1_checks_every_family_adr_003_requires` then attempted
+    // a config read against a web server that had already stopped, recording `config_form` as neither
+    // compared nor an accepted limit. See `configure_without_persisting`.
+    let web = FakeConfigWeb::start(CONFIG_PAGE_RAW_LANE, PROFILE_PAGE_SEMANTIC_LANE).await;
+    let h = Harness::start(
+        VERIFIED_PROFILE,
+        WirePolicy {
+            // Declared, not yet live: the cache below has to fill successfully first, or the test
+            // would be about a daemon that never worked rather than one that stopped.
+            silent_for_element_when_armed: Some("GetShapers".to_string()),
+            ..WirePolicy::default()
+        },
+        HqpTimeouts {
+            max_attempts: 1,
+            ..fast_timeouts()
+        },
+    )
+    .await;
+    h.adapter.connect().await.expect("connect");
+    configure_without_persisting(
+        &h.adapter,
+        "127.0.0.1",
+        h.server.port(),
+        web.port,
+        "conformance",
+        "conformance",
+    )
+    .await;
+    h.adapter
+        .connect()
+        .await
+        .expect("reconnect after configure");
+
+    let before = h
+        .adapter
+        .get_pipeline_status()
+        .await
+        .expect("the cache fills while the daemon is healthy");
+    let stale: Vec<&str> = before
+        .settings
+        .shaper
+        .options
+        .iter()
+        .map(|o| o.value.as_str())
+        .collect();
+    assert!(
+        stale.contains(&"NS9"),
+        "precondition: the pre-load shapers are cached, got {stale:?}"
+    );
+
+    // The profile load succeeds; the refresh that follows it cannot complete.
+    h.server.arm_element_silence();
+    h.adapter
+        .load_profile("raw-a")
+        .await
+        .expect("the POST succeeded, so the profile load did");
+
+    match h.adapter.get_pipeline_status().await {
+        Err(e) => assert!(
+            e.to_string().contains("lists"),
+            "the read must say the setting lists could not be established. Got: {e}"
+        ),
+        Ok(published) => {
+            let offered: Vec<&str> = published
+                .settings
+                .shaper
+                .options
+                .iter()
+                .map(|o| o.value.as_str())
+                .collect();
+            panic!(
+                "after a profile load, the previous profile's options must never be published as \
+                 the current ones — and the rate-based chain check cannot catch this, because a \
+                 profile can change filters and shapers while leaving rates alone. Offered \
+                 {offered:?}"
+            );
+        }
+    }
+    h.stop();
+    web.stop();
+}
+
+/// Run `configure` with the persisted-config path pointed somewhere nothing else reads.
+///
+/// **`configure` persists web credentials to one file per process, and every `HqpAdapter::new` reads
+/// it.** So a test that supplies credentials hands them to every adapter built afterwards — pointing
+/// at a web port that dies with that test — and because `configure` never *clears* credentials, the
+/// next test's own `configure` re-saves the inherited ones and the leak outlives its source. A
+/// tier-1 capture that inherits them then attempts a `/config` read that cannot succeed, and records
+/// a required claim as unverified: `tier1_checks_every_family_adr_003_requires` fails.
+///
+/// Two narrower attempts failed before this one, and the reason is worth keeping. Deleting the file
+/// after `configure`, and snapshot-and-restore around it, both only *narrow* the window — it stays as
+/// wide as the gap between two syscalls, and with hundreds of tests building adapters concurrently
+/// that gap is hit. Measured: the suite failed roughly four runs in eight.
+///
+/// This instead makes the race **benign**. While the credentialed write happens, the shared path
+/// points at a scratch directory: a concurrent `HqpAdapter::new` reads an absent file and gets no
+/// credentials, which is exactly what it should have; a concurrent `configure` writes a config
+/// nothing reads back, and nothing in this suite asserts that the file survives —
+/// `isolate_config_dir` exists to protect a real user's config, not to test persistence.
+///
+/// The adapter keeps its credentials in memory throughout, which is what the caller actually needs.
+async fn configure_without_persisting(
+    adapter: &HqpAdapter,
+    host: &str,
+    port: u16,
+    web_port: u16,
+    user: &str,
+    password: &str,
+) {
+    let previous = std::env::var("UHC_CONFIG_DIR").expect("the suite isolates the config dir");
+    let scratch = std::path::Path::new(&previous).join(format!(
+        "no-persist-{}-{:?}",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    std::fs::create_dir_all(&scratch).expect("scratch config dir");
+    std::env::set_var("UHC_CONFIG_DIR", &scratch);
+    adapter
+        .configure(
+            host.to_string(),
+            Some(port),
+            Some(web_port),
+            Some(user.to_string()),
+            Some(password.to_string()),
+        )
+        .await;
+    std::env::set_var("UHC_CONFIG_DIR", &previous);
+    let _ = std::fs::remove_dir_all(&scratch);
+}
+
+/// The lazy fill is decided **before** the reads, and a reconnect during them empties the cache
+/// behind that decision: both `mark_disconnected` and `connect` invalidate, because a session's list
+/// indices must not outlive it. So a read that found the cache complete can reach the publish step
+/// holding nothing — and the chain check waves it through, correctly, because with no previous
+/// fingerprint there is no *movement* to report. It is a check about change, not about presence.
+///
+/// Found while probing why the profile-load case would not go red: the mechanism that saved it there
+/// is this same invalidation, and following it the other way turns up a live hole rather than a
+/// theoretical one.
+///
+/// **Label: client-red.**
+#[tokio::test]
+async fn a_reconnect_during_the_reads_does_not_publish_the_cache_it_emptied() {
+    let h = Harness::start(
+        VERIFIED_PROFILE,
+        WirePolicy {
+            disruption: Disruption::DropNextReplyOnce,
+            ..WirePolicy::default()
+        },
+        fast_timeouts(),
+    )
+    .await;
+    h.adapter.connect().await.expect("connect");
+    let before = h
+        .adapter
+        .get_pipeline_status()
+        .await
+        .expect("the cache fills while the daemon is healthy");
+    assert_eq!(
+        published_families(&before).len(),
+        4,
+        "precondition: a complete cache, so the fill below is skipped"
+    );
+
+    // The next request draws no reply. The client reconnects and retries inside `send_command` — and
+    // both halves of that invalidate, so by the time the read reaches the publish step the cache the
+    // fill decision was made against is gone.
+    h.server.arm_disruption();
+
+    match h.adapter.get_pipeline_status().await {
+        Err(e) => assert!(
+            e.to_string().contains("lists") || e.to_string().contains("chain"),
+            "the failure must name what could not be established. Got: {e}"
+        ),
+        Ok(published) => {
+            let families = published_families(&published);
+            assert_eq!(
+                families.len(),
+                4,
+                "a read may recover and publish a complete set, but it must never publish the \
+                 remains of a cache a reconnect emptied under it. Published {families:?}, with \
+                 filter1x selected as {:?}",
+                published.settings.filter1x.selected.value
             );
         }
     }

--- a/tests/hqplayer_conformance.rs
+++ b/tests/hqplayer_conformance.rs
@@ -6857,3 +6857,222 @@ async fn an_explicit_rejection_is_not_treated_as_ambiguous_delivery() {
     );
     h.stop();
 }
+
+// -----------------------------------------------------------------------------
+// A published enumeration set is coherent, or it is not published
+// -----------------------------------------------------------------------------
+
+/// Which chain-scoped families the pipeline view actually offers options for.
+///
+/// The unit of publication is the **set**: a view carrying one family and not the others has still
+/// been handed to a caller as this daemon's settings, so "some but not all" is the shape both checks
+/// below forbid.
+fn published_families(
+    pipeline: &unified_hifi_control::adapters::hqplayer::PipelineStatus,
+) -> Vec<&'static str> {
+    [
+        ("mode", !pipeline.settings.mode.options.is_empty()),
+        ("filter1x", !pipeline.settings.filter1x.options.is_empty()),
+        ("shaper", !pipeline.settings.shaper.options.is_empty()),
+        (
+            "samplerate",
+            !pipeline.settings.samplerate.options.is_empty(),
+        ),
+    ]
+    .into_iter()
+    .filter(|(_, full)| *full)
+    .map(|(name, _)| name)
+    .collect()
+}
+
+/// Four lists read one after another are four moments, not one. A source change landing between two
+/// of them yields a set that mixes the chains — SDM filters offered next to PCM shapers — and
+/// publishing that under one lock is no better than publishing it in pieces: it has still been
+/// handed over as a single view of a single daemon.
+///
+/// The change is triggered by a request rather than by the test's own timeline, because that is the
+/// only way to land it *inside* the window.
+///
+/// **Label: client-red.** Before the bracket, the refresh published modes and SDM filters from before
+/// the change and PCM shapers and rates from after it.
+#[tokio::test]
+async fn a_chain_change_during_a_list_refresh_publishes_nothing_rather_than_a_mixed_set() {
+    let h = Harness::verified().await;
+    h.model.external_change(|s| {
+        s.mode_index = 0; // configured `[source]`
+        s.playback = 2;
+    });
+    // Fill the cache from the PCM chain the ordinary way.
+    h.adapter.get_pipeline_status().await.expect("pipeline");
+
+    // The chain moves to SDM, which the next poll's probe will notice and act on...
+    h.model.source_loads_chain(LoadedChain::Sdm);
+    // ...and then moves back, mid-refresh, right after the filter list has been served. So the
+    // refresh sees SDM filters and PCM shapers.
+    h.model
+        .switch_chain_after_request("GetFilters", LoadedChain::Pcm);
+
+    let straddled = h.adapter.get_pipeline_status().await.expect("pipeline");
+
+    let filters: Vec<&str> = straddled
+        .settings
+        .filter1x
+        .options
+        .iter()
+        .map(|o| o.value.as_str())
+        .collect();
+    let shapers: Vec<&str> = straddled
+        .settings
+        .shaper
+        .options
+        .iter()
+        .map(|o| o.value.as_str())
+        .collect();
+    assert!(
+        !(filters.contains(&"sinc-Lh") && shapers.contains(&"NS9")),
+        "a set straddling the change must not be published: these are the SDM chain's filters beside \
+         the PCM chain's shapers, offered together as one daemon's settings. filters={filters:?} \
+         shapers={shapers:?}"
+    );
+    // ...and it must not have passed by *partial* publication either. Refusing the straddling set has
+    // to mean publishing none of it: a view carrying one family and not the other three is still
+    // handed to a caller as this daemon's settings, and a check that only forbade the mixed pair
+    // would be satisfied by a family having been blanked on the way past.
+    let populated = published_families(&straddled);
+    assert!(
+        populated.is_empty() || populated.len() == 4,
+        "a refused refresh must publish nothing, not a part. Published: {populated:?}"
+    );
+
+    // And the client recovers: the daemon is settled on PCM now, so the next poll publishes a
+    // coherent PCM set rather than staying blank.
+    let settled = h.adapter.get_pipeline_status().await.expect("pipeline");
+    let filters: Vec<&str> = settled
+        .settings
+        .filter1x
+        .options
+        .iter()
+        .map(|o| o.value.as_str())
+        .collect();
+    let shapers: Vec<&str> = settled
+        .settings
+        .shaper
+        .options
+        .iter()
+        .map(|o| o.value.as_str())
+        .collect();
+    assert!(
+        filters.contains(&"IIR") && shapers.contains(&"NS9"),
+        "refusing to publish a straddling set must not wedge the view: once the chain settles, the \
+         next read publishes it. filters={filters:?} shapers={shapers:?}"
+    );
+    h.stop();
+}
+
+/// One family failing must not publish the other three. A refresh is a set or it is nothing: leaving
+/// a caller with fresh filters beside an empty shaper list tells it the daemon offers no modulators,
+/// which is a different and worse falsehood than "not read yet".
+///
+/// **Label: client-red.** The previous refresh assigned an empty vector per failed family and
+/// published the rest.
+#[tokio::test]
+async fn a_single_failed_family_publishes_no_part_of_the_refresh() {
+    let h = Harness::start(
+        VERIFIED_PROFILE,
+        WirePolicy {
+            silent_for_element: Some("GetShapers".to_string()),
+            ..WirePolicy::default()
+        },
+        HqpTimeouts {
+            max_attempts: 1,
+            ..fast_timeouts()
+        },
+    )
+    .await;
+    h.adapter.connect().await.expect("connect");
+
+    let pipeline = h
+        .adapter
+        .get_pipeline_status()
+        .await
+        .expect("a failed family must not fail the whole read");
+
+    let populated = published_families(&pipeline);
+
+    assert!(
+        populated.is_empty(),
+        "the shaper fetch failed, so no part of that refresh may be published — a partially filled \
+         cache is offered to callers as a complete one. Published anyway: {populated:?}"
+    );
+    h.stop();
+}
+
+/// The legacy `filter` setting means *both sides*, and it must reach the daemon as **one**
+/// `SetFilter`. Two one-sided writes can half-apply — the first lands, the second is rejected,
+/// ignored or lost — leaving the daemon on a pair nobody asked for.
+///
+/// **Label: client-red.** The first form of this route wrote 1x and then Nx.
+#[tokio::test]
+async fn the_legacy_both_sides_filter_write_is_a_single_command() {
+    let h = Harness::verified().await;
+    let before = h.model.state();
+    assert_eq!(
+        (before.filter_1x_index, before.filter_nx_index),
+        (6, 6),
+        "precondition: the observed corpus starts both sides on index 6"
+    );
+
+    h.adapter
+        .set_filter_pair("poly-sinc-xtr")
+        .await
+        .applied()
+        .expect("both sides to one filter");
+
+    assert_eq!(
+        h.model.request_count("SetFilter"),
+        1,
+        "both sides go in one request, so the pair cannot half-apply on the wire"
+    );
+    let sent = h.model.last_request("SetFilter").expect("SetFilter sent");
+    assert_eq!(
+        (
+            request_attr(&sent, "value").as_deref(),
+            request_attr(&sent, "value1x").as_deref()
+        ),
+        (Some("11"), Some("11")),
+        "and it carries the same index on both sides. Sent: {sent}"
+    );
+    let after = h.model.state();
+    assert_eq!(
+        (after.filter_1x_index, after.filter_nx_index),
+        (11, 11),
+        "the daemon must end with both sides on the requested filter"
+    );
+    h.stop();
+}
+
+/// A both-sides write the daemon acknowledges and drops is not success, and the failure names both
+/// sides rather than half of them.
+///
+/// **Label: client-pin** for the refusal, **client-red** for the pair being one verified unit.
+#[tokio::test]
+async fn a_both_sides_filter_write_that_is_ignored_reports_both_sides() {
+    let h = Harness::verified().await;
+    h.model
+        .arm(|f| f.accept_but_ignore.push("SetFilter".to_string()));
+
+    let err = h
+        .adapter
+        .set_filter_pair("poly-sinc-xtr")
+        .await
+        .applied()
+        .expect_err("an acknowledged-but-dropped pair is not applied");
+
+    let message = err.to_string();
+    assert!(
+        message.contains("1x=11,Nx=11") && message.contains("1x=6,Nx=6"),
+        "the error must name the pair asked for and the pair observed, so a half-applied write and \
+         an ignored one are distinguishable. Got: {message}"
+    );
+    h.stop();
+}

--- a/tests/hqplayer_conformance.rs
+++ b/tests/hqplayer_conformance.rs
@@ -8657,3 +8657,43 @@ async fn a_rate_write_that_enters_source_after_the_decision_is_not_applied() {
     }
     h.stop();
 }
+
+/// Fetching `GetModes` after the final proof `State` does not make that earlier state current: the
+/// available modes list is device-scoped and does not carry the configured selection. A controller
+/// can select `[source]` immediately after the proof reply while the rate list stays on PCM.
+///
+/// **Label: client-red.** Found by CodeRabbit at `5f0e2b9`.
+#[tokio::test]
+async fn a_rate_proof_rechecks_state_after_fetching_modes() {
+    let h = Harness::verified().await;
+    h.model.external_change(|s| {
+        s.rate_index = 1;
+        s.active_rate_hz = 44_100;
+    });
+    // Decision State, write readback State, then proof State. The first two transitions are no-ops;
+    // the third lands `[source]` immediately after the stale proof reply.
+    h.model.switch_mode_after_request("State", 1);
+    h.model.switch_mode_after_request("State", 1);
+    h.model.switch_mode_after_request("State", 0);
+
+    let outcome = h
+        .adapter
+        .set_rate(0)
+        .await
+        .expect("a raced final proof is an outcome");
+
+    assert_eq!(h.model.request_count("SetRate"), 1);
+    assert_eq!(h.model.state().mode_index, 0);
+    match outcome {
+        SettingOutcome::Ambiguous { what, reason } => {
+            assert_eq!(what, "rate");
+            assert!(
+                reason.contains("[source]") && reason.contains("wire"),
+                "the post-modes State must expose the final source mode and prior write; got: \
+                 {reason}"
+            );
+        }
+        other => panic!("a stale pre-modes State cannot prove the Auto pin: {other:?}"),
+    }
+    h.stop();
+}

--- a/tests/hqplayer_conformance.rs
+++ b/tests/hqplayer_conformance.rs
@@ -7076,3 +7076,110 @@ async fn a_both_sides_filter_write_that_is_ignored_reports_both_sides() {
     );
     h.stop();
 }
+
+// -----------------------------------------------------------------------------
+// The indices and the lists they are resolved against must describe the same chain
+// (CodeRabbit, review of 2eb699e)
+// -----------------------------------------------------------------------------
+
+/// `State` reports settings as **list indices**, and an index is only meaningful beside the list it
+/// came from. Reading `State` *before* settling the enumerations means a pre-transition index is
+/// resolved against post-transition lists — the same misselection this issue exists to end, arriving
+/// through the read path instead of the write path, and needing no write at all.
+///
+/// The Opal corpus is what makes it observable: its SDM excerpt is shorter than its PCM one, so an
+/// index the daemon clamps across the transition resolves to nothing in the list that is then used.
+///
+/// **Label: client-red.** Before this, the published 1x filter was empty while the daemon held
+/// `poly-sinc-xtr`.
+#[tokio::test]
+async fn a_chain_change_between_the_state_read_and_the_list_read_is_not_published() {
+    let h = Harness::verified().await;
+    h.model.external_change(|s| {
+        s.mode_index = 0; // configured `[source]`
+        s.playback = 2;
+        // Index 7 exists in the 12-entry PCM excerpt and not in the 5-entry SDM one, so the daemon
+        // clamps it across the transition and the two chains disagree about what 7 means.
+        s.filter_1x_index = 7;
+        s.filter_nx_index = 7;
+    });
+    let before = h.adapter.get_pipeline_status().await.expect("pipeline");
+    assert_eq!(
+        before.settings.filter1x.selected.value.as_str(),
+        "poly-sinc-gauss-long",
+        "precondition: the PCM chain's list gives index 7 this name"
+    );
+
+    // The source moves the chain in the gap the client cannot see: after `State` has answered and
+    // before the enumerations are read.
+    h.model
+        .switch_chain_after_request("State", LoadedChain::Sdm);
+
+    let after = h.adapter.get_pipeline_status().await.expect("pipeline");
+
+    let held = h.model.state().filter_1x_index;
+    let truth = corpus::enum_entries(
+        &corpus::document(VERIFIED_PROFILE, "filters_sdm"),
+        "FiltersItem",
+    )
+    .into_iter()
+    .find(|e| e.index == held)
+    .map(|e| e.name)
+    .expect("the daemon's own index resolves in the chain it now has loaded");
+
+    assert_eq!(
+        after.settings.filter1x.selected.value, truth,
+        "the published selection must be what the daemon's current index names in the chain it \
+         currently has loaded; an index read before the lists were settled belongs to neither"
+    );
+    h.stop();
+}
+
+/// The raw index form of `SetFilter` is an escape hatch, not a control path — but an escape hatch
+/// that answers `Ok(())` on `result="OK"` alone is a false success with a public name on it. It goes
+/// through the same verification as every other write.
+///
+/// **Label: client-red.** Before this it reported success for a write the daemon acknowledged and
+/// dropped.
+#[tokio::test]
+async fn a_raw_filter_write_the_daemon_acknowledges_and_drops_is_not_reported_as_success() {
+    let h = Harness::verified().await;
+    h.model
+        .arm(|f| f.accept_but_ignore.push("SetFilter".to_string()));
+    let before = h.model.state();
+    assert_ne!(
+        before.filter_nx_index, 2,
+        "precondition: the requested index must differ from the one held, or a readback proves \
+         nothing either way"
+    );
+
+    let outcome = h.adapter.set_filter(2, 2).await;
+
+    assert!(
+        h.model.request_count("SetFilter") > 0,
+        "the write must actually have been attempted: this is a daemon-side no-op"
+    );
+    assert_eq!(
+        (
+            h.model.state().filter_1x_index,
+            h.model.state().filter_nx_index
+        ),
+        (before.filter_1x_index, before.filter_nx_index),
+        "precondition: the daemon really did not move"
+    );
+    // Strengthened from `outcome.is_err()` after the fix landed: the RED was captured against the
+    // pre-fix `Result<()>`, where an ignored write was `Ok(())`. The collapse is what every
+    // advertised surface applies, so this asserts what a client would see — and additionally that
+    // the outcome is `Ignored` rather than some other non-success, which the bare `is_err()` could
+    // not distinguish.
+    assert!(
+        matches!(outcome, Ok(SettingOutcome::Ignored { .. })),
+        "an acknowledged-but-dropped write is `Ignored` — not applied, and not a transport failure"
+    );
+    assert!(
+        outcome.applied().is_err(),
+        "`result=\"OK\"` is not proof of application on the raw path either — and a public method \
+         that says otherwise is the false success this issue exists to remove"
+    );
+    h.stop();
+}

--- a/tests/hqplayer_conformance.rs
+++ b/tests/hqplayer_conformance.rs
@@ -7643,3 +7643,71 @@ async fn a_final_chain_check_that_runs_on_the_retry_publishes_the_verified_read(
     );
     h.stop();
 }
+
+/// **The proof is not the end of the read.** Everything the read does *after* proving coherence is
+/// still able to destroy it, and the lazy `VolumeRange` fill is exactly that: a network request,
+/// issued once the chain check has already passed, on the way to the projection.
+///
+/// A lost reply to it is not exotic. `send_command` calls `mark_disconnected`, which invalidates
+/// every chain-scoped list because a session's indices must not outlive it, then reconnects — and
+/// `connect` invalidates again for the same reason. The read then clones four empty vectors and
+/// hands them back as `Ok`, having proved a coherence that no longer describes anything it is
+/// publishing.
+///
+/// This is reachable on the **first** read of a connection, which is the only read that has to fetch
+/// the volume range at all: nothing is cached, so the request is always made. No chain movement, no
+/// profile load, no concurrency — one dropped reply.
+///
+/// The assertion is deliberately two-sided. Recovering and publishing a complete set is a fine
+/// answer, and so is refusing; what is forbidden is the third thing, an `Ok` carrying none of the
+/// daemon's settings, which a caller cannot tell from a daemon that offers none.
+///
+/// **Label: client-red.** Found by CodeRabbit at `b7a7a1a`. Before this, the read published four
+/// empty families.
+#[tokio::test]
+async fn a_lost_volume_range_reply_does_not_publish_the_cache_its_reconnect_emptied() {
+    // Element-scoped and one-shot: the daemon applies the request, then vanishes without replying,
+    // once. Scoping it to `VolumeRange` keeps it clear of connection setup and of the list fill, so
+    // the only thing it can disturb is the lazy volume-range fetch itself.
+    let h = Harness::start(
+        VERIFIED_PROFILE,
+        WirePolicy {
+            apply_then_drop_reply_for_element: Some("VolumeRange".to_string()),
+            ..WirePolicy::default()
+        },
+        fast_timeouts(),
+    )
+    .await;
+    h.adapter.connect().await.expect("connect");
+
+    // The first read after connect: nothing is cached, so this read both fills the lists and fetches
+    // the volume range.
+    let outcome = h.adapter.get_pipeline_status().await;
+
+    assert!(
+        h.server.element_drop_fired(),
+        "precondition: the read must actually have lost a `VolumeRange` reply, otherwise this test \
+         proves nothing about what follows one"
+    );
+
+    match outcome {
+        Err(e) => assert!(
+            e.to_string().contains("lists") || e.to_string().contains("chain"),
+            "refusing is a legitimate answer, but it must name what could not be established. Got: \
+             {e}"
+        ),
+        Ok(published) => {
+            let families = published_families(&published);
+            assert_eq!(
+                families.len(),
+                4,
+                "a read may recover and publish a complete set, but a proof of coherence taken \
+                 before a reconnect says nothing about the cache that reconnect emptied. Published \
+                 {families:?}, with filter1x selected as {:?} out of {} options",
+                published.settings.filter1x.selected.value,
+                published.settings.filter1x.options.len()
+            );
+        }
+    }
+    h.stop();
+}

--- a/tests/hqplayer_conformance.rs
+++ b/tests/hqplayer_conformance.rs
@@ -35,15 +35,17 @@ use std::sync::Arc;
 use std::sync::Once;
 use std::time::Duration;
 
-use unified_hifi_control::adapters::hqplayer::{framing, HqpAdapter, HqpTimeouts};
+use unified_hifi_control::adapters::hqplayer::{
+    framing, HqpAdapter, HqpRejected, HqpTimeouts, SettingOutcome,
+};
 use unified_hifi_control::bus::create_bus;
 
 use mock_servers::hqplayer::corpus::{
     self, LEGACY_PROFILE, SYNTHETIC_HAZARD_PROFILE, VERIFIED_PROFILE,
 };
 use mock_servers::hqplayer::model::{
-    request_attr, ActiveModeReporting, DaemonModel, DocumentStyle, FilterFieldReporting, LoadedChain,
-    Metadata,
+    request_attr, ActiveModeReporting, DaemonModel, DocumentStyle, FilterFieldReporting,
+    LoadedChain, Metadata,
 };
 use mock_servers::hqplayer::tier1;
 use mock_servers::hqplayer::wire::{Chunking, Disruption, Responder, WirePolicy, WireServer};
@@ -71,6 +73,21 @@ fn fast_timeouts() -> HqpTimeouts {
         response: Duration::from_millis(300),
         reconnect_delay: Duration::from_millis(10),
         max_attempts: 2,
+    }
+}
+
+/// `Result<SettingOutcome>` collapsed the way every advertised surface collapses it.
+///
+/// The adapter reports *which* of the five things a write turned out to be; HTTP and MCP both answer
+/// `{ok:true}` or `{error}`, so both call [`SettingOutcome::into_applied_result`]. Tests that only
+/// care whether a write landed use the same collapse, so they assert what a client would see.
+trait Applied {
+    fn applied(self) -> anyhow::Result<()>;
+}
+
+impl Applied for anyhow::Result<SettingOutcome> {
+    fn applied(self) -> anyhow::Result<()> {
+        self.and_then(SettingOutcome::into_applied_result)
     }
 }
 
@@ -300,6 +317,7 @@ async fn enumerations_are_mode_relative_and_are_refetched_after_a_mode_change() 
     h.adapter
         .set_mode("SDM (DSD)")
         .await
+        .applied()
         .expect("SetMode to SDM");
     let after = h.adapter.get_filters().await.expect("SDM filters");
     let expected = corpus::enum_entries(
@@ -632,7 +650,11 @@ async fn a_setter_accepted_but_not_applied_does_not_report_success() {
     h.model
         .arm(|f| f.accept_but_ignore.push("SetFilter".to_string()));
 
-    let result = h.adapter.set_filter_1x("IIR").await;
+    let result = h
+        .adapter
+        .set_filter_1x("IIR")
+        .await
+        .and_then(SettingOutcome::into_applied_result);
 
     assert!(
         result.is_err(),
@@ -654,6 +676,7 @@ async fn a_setter_whose_change_lands_after_a_poll_still_reports_success() {
     h.adapter
         .set_filter_1x("IIR")
         .await
+        .applied()
         .expect("a delayed-but-real change is a success");
 
     let expected = corpus::index_of(
@@ -724,9 +747,11 @@ async fn a_rejected_setter_is_reported_as_an_error_without_dropping_the_connecti
     let h = Harness::verified().await;
     let beyond_the_list = 9_999;
 
-    // Low-level: takes an index, resolves no name, so this cannot depend on name-resolution
-    // fallbacks in either direction.
-    let rejected = h.adapter.set_filter(beyond_the_list, None).await;
+    // Low-level: takes indices, resolves no name, so this cannot depend on name-resolution
+    // fallbacks in either direction. Both sides carry the same out-of-range number because
+    // `SetFilter` writes both sides on the wire and the client can no longer express a one-sided
+    // request (#347).
+    let rejected = h.adapter.set_filter(beyond_the_list, beyond_the_list).await;
     // The connection must still be usable afterwards.
     let state_after = h.adapter.get_state().await;
 
@@ -1016,11 +1041,15 @@ async fn the_junk_filter_is_read_as_a_list_index_not_a_boolean() {
 async fn a_filter_name_is_sent_as_the_index_the_observed_list_gives_it() {
     let h = Harness::verified().await;
     let filters = corpus::document(VERIFIED_PROFILE, "filters_pcm");
-    let index = corpus::index_of(&filters, "FiltersItem", "poly-sinc-lp").expect("observed index");
+    // Deliberately a filter the daemon is NOT already on. Since #347 a setter whose authoritative
+    // field already reads the requested value is `AlreadySet` and nothing goes on the wire, so
+    // requesting the current selection would assert about a request that was never sent.
+    let index = corpus::index_of(&filters, "FiltersItem", "poly-sinc-xtr").expect("observed index");
 
     h.adapter
-        .set_filter_1x("poly-sinc-lp")
+        .set_filter_1x("poly-sinc-xtr")
         .await
+        .applied()
         .expect("SetFilter");
 
     let sent = h
@@ -1045,6 +1074,7 @@ async fn a_filter_name_is_not_sent_as_its_enum_id() {
     h.adapter
         .set_filter_1x("poly-sinc-lp")
         .await
+        .applied()
         .expect("SetFilter");
 
     let sent = h
@@ -1077,6 +1107,7 @@ async fn the_same_filter_name_resolves_to_a_different_index_on_a_differently_ord
     h.adapter
         .set_filter_1x("poly-sinc-lp")
         .await
+        .applied()
         .expect("SetFilter");
 
     let sent = h
@@ -1140,7 +1171,9 @@ async fn feeding_a_persistent_enum_id_to_the_live_lane_is_rejected() {
         .parse()
         .expect("numeric");
 
-    let result = h.adapter.set_filter(stored, None).await;
+    // Both sides carry the number: `SetFilter` writes both on the wire, and since #347 the client
+    // cannot express a one-sided call at all.
+    let result = h.adapter.set_filter(stored, stored).await;
     assert!(
         result.is_err(),
         "enum ID {stored} is not a valid list index for this daemon's 12-entry list; sending a \
@@ -1459,6 +1492,7 @@ async fn a_setter_overridden_by_another_controller_fails_and_names_the_observed_
         .adapter
         .set_shaper("NS5")
         .await
+        .and_then(SettingOutcome::into_applied_result)
         .expect_err("a setting we cannot confirm is not a success, however it came to differ");
 
     assert!(
@@ -3392,32 +3426,39 @@ async fn the_fake_does_not_settle_the_independent_state_and_status_active_mode_s
 /// `SetMode` clears the single rate pin **even when the mode does not change**. Measured upstream
 /// 2026-07-28.
 ///
-/// **Label: model-fidelity.** Deliberately so: no client code reads the pin after a mode write, so
-/// there is nothing here that could fail for a client reason. #347 owns the consequence — skipping a
-/// mode write that is already running, rather than destroying the user's pin.
+/// **Label: model-fidelity**, and asserted straight through [`Responder`] with **no adapter in the
+/// path**. It drove the real client until #347, which is the issue this expectation named as the
+/// owner of the consequence — the client now refuses to send a mode it is already in, so a test that
+/// reached this daemon behaviour through `set_mode` could no longer reach it at all. The daemon-side
+/// fact is unchanged and is what this pins; the client-side consequence is
+/// `a_no_op_mode_write_is_not_sent_so_the_rate_pin_survives`.
 ///
 /// Provenance: **derived-upstream**, pending #332.
-#[tokio::test]
-async fn a_same_mode_set_mode_still_clears_the_rate_pin() {
-    let h = Harness::verified().await;
-    h.adapter.set_rate(44100).await.expect("pin a PCM rate");
-    let pinned = h.model.state();
+#[test]
+fn a_same_mode_set_mode_still_clears_the_rate_pin() {
+    let model = DaemonModel::verified();
+    // Pin a rate. Index 1 is 44100 Hz in the observed PCM list.
+    model
+        .respond("<SetRate value=\"1\"/>")
+        .expect("the fake answers SetRate");
+    let pinned = model.state();
     assert_ne!(
         pinned.rate_index, 0,
         "precondition: the pin must actually be set before a mode write can clear it"
     );
 
-    // The mode is already PCM. This write changes nothing about the mode.
-    h.adapter.set_mode("PCM").await.expect("same-mode SetMode");
+    // The mode is already PCM (index 1). This write changes nothing about the mode.
+    model
+        .respond("<SetMode value=\"1\"/>")
+        .expect("the fake answers SetMode");
 
-    let after = h.model.state();
+    let after = model.state();
     assert_eq!(
         (after.mode_index, after.rate_index, after.active_rate_hz),
         (1, 0, 0),
         "a no-op mode write still clears the pin, so a reconciliation loop that writes the mode \
          unconditionally destroys user state; got {after:?}"
     );
-    h.stop();
 }
 
 /// Records the removal of unevidenced fake behaviour.
@@ -3444,10 +3485,15 @@ async fn set_mode_does_not_reset_the_filter_and_shaper_selections() {
     h.adapter
         .set_filter_nx("poly-sinc-gauss-long")
         .await
+        .applied()
         .expect("SetFilter");
     assert_eq!(h.model.state().filter_nx_index, chosen, "precondition");
 
-    h.adapter.set_mode("PCM").await.expect("same-mode SetMode");
+    h.adapter
+        .set_mode("PCM")
+        .await
+        .applied()
+        .expect("same-mode SetMode");
 
     assert_eq!(
         h.model.state().filter_nx_index,
@@ -3808,7 +3854,7 @@ async fn feeding_the_persistent_oversampling_id_to_the_live_lane_is_rejected() {
          index range for this to be a rejection rather than a misselection"
     );
 
-    let result = h.adapter.set_filter(stored, None).await;
+    let result = h.adapter.set_filter(stored, stored).await;
     assert!(
         result.is_err(),
         "the persistent SDM domain's stored ID {stored} is not a live list index; sending it on the \
@@ -3827,27 +3873,33 @@ async fn feeding_the_persistent_oversampling_id_to_the_live_lane_is_rejected() {
 /// the rate there is a persistent config limit for which **no wire command exists**, so retrying on
 /// the live lane can never succeed.
 ///
-/// The nonzero case is caught today by accident of arithmetic: readback compares the requested index
-/// against 0 and they differ, so the client errors. That is a truthful *outcome* reached without any
-/// understanding of the cause, and it is why the message says nothing useful. #347 owns suppressing
-/// the write with an explicit reason.
-///
 /// **Provenance: derived-upstream, tier-2-only, pending #332.**
 ///
-/// **Label: client-conformance** — the client half holds today and is pinned as a regression;
-/// the mode-conditional refusal it runs against is new fake capability.
-#[tokio::test]
-async fn a_nonzero_rate_pin_under_source_is_accepted_and_ignored() {
-    let h = Harness::verified().await;
-    h.model.external_change(|s| {
+/// **Label: model-fidelity**, asserted straight through [`Responder`] with **no adapter in the path**.
+/// It drove the real client until #347 — the issue it named as the owner — which now *suppresses* the
+/// write under `[source]` rather than sending it and failing on readback arithmetic. A client that
+/// does not send the pin cannot demonstrate a daemon that ignores it, so the daemon-side fact is
+/// pinned here directly. The client-side consequence is
+/// `a_rate_pin_under_source_is_suppressed_before_it_reaches_the_daemon`.
+#[test]
+fn a_nonzero_rate_pin_under_source_is_accepted_and_ignored() {
+    let model = DaemonModel::verified();
+    model.external_change(|s| {
         s.mode_index = 0; // configured `[source]`
         s.playback = 2;
     });
-    h.model.arm(|f| f.source_refuses_rate_pin = true);
+    model.arm(|f| f.source_refuses_rate_pin = true);
 
-    let outcome = h.adapter.set_rate(705600).await;
+    // Index 9 is 705600 Hz in the observed PCM list.
+    let reply = model
+        .respond("<SetRate value=\"9\"/>")
+        .expect("the fake answers SetRate");
+    assert!(
+        reply.contains("result=\"OK\""),
+        "the daemon answers OK, which is exactly why OK is not proof; got {reply}"
+    );
 
-    let after = h.model.state();
+    let after = model.state();
     assert_eq!(
         (after.rate_index, after.active_rate_hz),
         (0, 0),
@@ -3855,24 +3907,6 @@ async fn a_nonzero_rate_pin_under_source_is_accepted_and_ignored() {
          upstream probes checked and why checking only `State.rate` produced a plausible wrong \
          answer; got {after:?}"
     );
-    assert!(
-        h.model.request_count("SetRate") > 0,
-        "the client must actually have sent the pin: this is a daemon-side refusal, not a \
-         client-side suppression. Suppression is #347's"
-    );
-    // Assert the *mechanism*, not merely that the call failed. `is_err()` alone would be satisfied
-    // by any error at all — including one for an unrelated reason — so it would pass while telling
-    // us nothing about why. The message must show readback observing the unmoved rate.
-    let err = outcome
-        .expect_err("an unapplied pin must not report success")
-        .to_string();
-    assert!(
-        err.contains("rate") && err.contains("still reads 0"),
-        "the failure must come from readback observing the rate still at 0, which is the only reason \
-         the floor holds here — it holds by arithmetic rather than by any understanding of \
-         `[source]`, and #347 owns replacing that with a stated reason. Got: {err}"
-    );
-    h.stop();
 }
 
 /// The narrower form of the same defect, and the one readback **cannot** catch.
@@ -3881,41 +3915,43 @@ async fn a_nonzero_rate_pin_under_source_is_accepted_and_ignored() {
 /// compares expected 0 against observed 0 and therefore reports **success** for a command that had no
 /// effect. Equality with pre-existing state is not proof that a setter applied.
 ///
-/// Recorded on #347 in comment 5125915480. This test asserts **only** the daemon-side facts and
-/// deliberately does not assert the client's return value: asserting success would encode a known
-/// defect as expected behaviour, and asserting failure would fail until #347 lands. #322's job is to
-/// make the case reachable, which it now is.
+/// Recorded on #347 in comment 5125915480. Asserted straight through [`Responder`] with **no adapter
+/// in the path**: the daemon answers `OK` and moves nothing, so a readback comparing 0 against 0
+/// would call it applied. That is the reason #347's client suppresses the write instead of verifying
+/// it — the client-side consequence is
+/// `an_auto_rate_request_under_source_is_never_reported_as_applied`.
 ///
 /// **Label: model-fidelity.**
-#[tokio::test]
-async fn an_auto_rate_request_under_source_is_ignored_and_readback_cannot_tell() {
-    let h = Harness::verified().await;
-    h.model.external_change(|s| {
+#[test]
+fn an_auto_rate_request_under_source_is_ignored_and_readback_cannot_tell() {
+    let model = DaemonModel::verified();
+    model.external_change(|s| {
         s.mode_index = 0;
         s.playback = 2;
     });
-    h.model.arm(|f| f.source_refuses_rate_pin = true);
-    let before = h.model.state();
+    model.arm(|f| f.source_refuses_rate_pin = true);
+    let before = model.state();
     assert_eq!(
         before.rate_index, 0,
         "precondition: the rate must already be unpinned, which is what makes the readback blind"
     );
 
     // Auto is rate 0, which the observed list carries at index 0.
-    let _ = h.adapter.set_rate(0).await;
+    let reply = model
+        .respond("<SetRate value=\"0\"/>")
+        .expect("the fake answers SetRate");
+    assert!(
+        reply.contains("result=\"OK\""),
+        "the daemon acknowledges it, got {reply}"
+    );
 
-    let after = h.model.state();
+    let after = model.state();
     assert_eq!(
         (after.rate_index, after.active_rate_hz),
         (before.rate_index, before.active_rate_hz),
         "nothing moved, which is the point: a readback comparing 0 to 0 sees a match and calls an \
          ignored command applied"
     );
-    assert!(
-        h.model.request_count("SetRate") > 0,
-        "the request reached the daemon, so this is an ignored write and not an absent one"
-    );
-    h.stop();
 }
 
 /// A DAC that cannot do DSD yields a modes list with **no SDM entry**, and the remaining entries keep
@@ -4232,7 +4268,7 @@ async fn a_delayed_set_mode_still_clamps_indices_into_the_loaded_chain() {
     // The mode change is accepted now and applies two polls later.
     h.model
         .arm(|f| f.apply_after_polls.push(("SetMode".to_string(), 2)));
-    let _ = h.adapter.set_mode("SDM (DSD)").await;
+    let _ = h.adapter.set_mode("SDM (DSD)").await.applied();
 
     // Poll until the deferred change has landed. Each State read ticks the pending queue.
     for _ in 0..4 {
@@ -4334,21 +4370,29 @@ async fn a_rate_valid_in_one_chain_is_refused_in_the_other() {
     h.adapter
         .set_rate(pcm_only_hz)
         .await
-        .expect("a PCM rate resolves while the PCM chain is loaded");
+        .applied()
+        .expect("a PCM rate resolves and applies while the PCM chain is loaded");
 
-    // Configured `[source]` first. Only in `[source]` does the *source* decide the loaded chain, which
-    // is what this scenario needs; asking for an SDM chain while PCM is the configured mode describes a
-    // daemon that cannot exist, and a test resting on it would prove nothing about the client. The model
-    // refuses it at the setter, so the mode is set here rather than the invariant relaxed.
-    h.model.external_change(|s| s.mode_index = 0);
-    // The SDM chain is now in force, and the same Hz value has no index in it.
-    h.model.source_loads_chain(LoadedChain::Sdm);
-    let refused = h.adapter.set_rate(pcm_only_hz).await;
+    // Configure SDM through the client, which pins the loaded chain to SDM. This used to move the
+    // chain under a configured `[source]`, which since #347 short-circuits before the rate list is
+    // ever consulted — the write is suppressed for the mode, so the test would have passed without
+    // exercising rate resolution at all. A configured SDM mode reaches the same loaded chain and
+    // leaves the resolution path the thing under test.
+    h.adapter
+        .set_mode("SDM (DSD)")
+        .await
+        .applied()
+        .expect("configure SDM");
+    let refused = h.adapter.set_rate(pcm_only_hz).await.applied();
 
     assert!(
         refused.is_err(),
         "a rate absent from the loaded chain's enumeration must not resolve to some other chain's \
          index; rate resolution is relative to the list in force"
+    );
+    assert!(
+        h.model.state().rate_index == 0,
+        "and nothing may have been pinned on the way to that refusal"
     );
     h.stop();
 }
@@ -4730,9 +4774,13 @@ async fn a_reply_split_inside_a_multi_byte_character_arrives_intact() {
     // An earlier draft put it mid-string and the premise assertion below caught the arithmetic.
     let profile_name = format!("{SNOWMAN} Rock Roll");
 
+    // The vehicle is `State.matrix_profile`. It was `MatrixGetProfile` until #347 stopped treating
+    // that command as the current-profile authority, at which point the client no longer sent it on
+    // this path — and a split-read claim is only worth anything on a document the client reads. The
+    // claim itself is unchanged: a reply cut inside a multi-byte code point must reassemble exactly.
     // Premise check, before any wire is involved: one byte into the character is not a char boundary.
-    let marker = "value=\"";
-    let doc = format!("<MatrixGetProfile index=\"0\" value=\"{profile_name}\"/>");
+    let marker = "matrix_profile=\"";
+    let doc = format!("<State mode=\"1\" matrix_profile=\"{profile_name}\"/>");
     let cut = doc.find(marker).expect("marker present") + marker.len() + 1;
     assert!(
         std::str::from_utf8(&doc.as_bytes()[..cut]).is_err(),
@@ -4758,13 +4806,13 @@ async fn a_reply_split_inside_a_multi_byte_character_arrives_intact() {
 
     let current = h
         .adapter
-        .get_matrix_profile()
+        .get_state()
         .await
-        .expect("a reply split mid-character must still parse");
+        .expect("a reply split mid-character must still parse")
+        .matrix_profile;
 
     assert_eq!(
-        current.as_ref().map(|p| p.name.as_str()),
-        Some(profile_name.as_str()),
+        current, profile_name,
         "the character split across two reads must be reassembled exactly; a lossy read would show \
          replacement characters here. Got {current:?}"
     );
@@ -5912,7 +5960,7 @@ async fn a_rate_pin_under_source_is_suppressed_before_it_reaches_the_daemon() {
          sending it and failing on readback is a true outcome reached for no stated reason"
     );
     let err = outcome
-        .map(|_| ())
+        .and_then(SettingOutcome::into_applied_result)
         .expect_err("an unsent write must never be reported as applied");
     let message = err.to_string();
     assert!(
@@ -5950,7 +5998,9 @@ async fn an_auto_rate_request_under_source_is_never_reported_as_applied() {
         "Auto is suppressed under `[source]` exactly like any other pin"
     );
     assert!(
-        outcome.map(|_| ()).is_err(),
+        outcome
+            .and_then(SettingOutcome::into_applied_result)
+            .is_err(),
         "equality with pre-existing state is not proof that a setter applied; before #347 this \
          reported success because it compared 0 against 0"
     );
@@ -5964,7 +6014,11 @@ async fn an_auto_rate_request_under_source_is_never_reported_as_applied() {
 #[tokio::test]
 async fn a_rate_pin_outside_source_is_still_sent_and_verified() {
     let h = Harness::verified().await;
-    h.adapter.set_rate(44100).await.expect("a PCM rate pin");
+    h.adapter
+        .set_rate(44100)
+        .await
+        .applied()
+        .expect("a PCM rate pin");
     assert_eq!(
         h.model.state().rate_index,
         1,
@@ -5984,7 +6038,11 @@ async fn a_rate_pin_outside_source_is_still_sent_and_verified() {
 #[tokio::test]
 async fn a_no_op_mode_write_is_not_sent_so_the_rate_pin_survives() {
     let h = Harness::verified().await;
-    h.adapter.set_rate(44100).await.expect("pin a PCM rate");
+    h.adapter
+        .set_rate(44100)
+        .await
+        .applied()
+        .expect("pin a PCM rate");
     let pinned = h.model.state();
     assert_ne!(pinned.rate_index, 0, "precondition: the pin must be set");
 
@@ -5992,6 +6050,7 @@ async fn a_no_op_mode_write_is_not_sent_so_the_rate_pin_survives() {
     h.adapter
         .set_mode("PCM")
         .await
+        .applied()
         .expect("a mode that is already running is trivially satisfied");
 
     assert_eq!(
@@ -6016,11 +6075,16 @@ async fn a_no_op_mode_write_is_not_sent_so_the_rate_pin_survives() {
 #[tokio::test]
 async fn a_performed_mode_write_reports_the_cleared_rate_pin_honestly() {
     let h = Harness::verified().await;
-    h.adapter.set_rate(44100).await.expect("pin a PCM rate");
+    h.adapter
+        .set_rate(44100)
+        .await
+        .applied()
+        .expect("pin a PCM rate");
 
     h.adapter
         .set_mode("SDM (DSD)")
         .await
+        .applied()
         .expect("a real mode change");
 
     assert_eq!(
@@ -6072,7 +6136,10 @@ async fn a_mode_alias_resolves_through_the_daemons_own_name() {
         h.adapter
             .set_mode(requested)
             .await
-            .unwrap_or_else(|e| panic!("`{requested}` must resolve to the daemon's SDM entry: {e}"));
+            .applied()
+            .unwrap_or_else(|e| {
+                panic!("`{requested}` must resolve to the daemon's SDM entry: {e}")
+            });
         assert_eq!(
             h.model.state().mode_index,
             2,
@@ -6125,7 +6192,9 @@ async fn a_source_driven_chain_change_invalidates_the_cached_filter_list() {
     let outcome = h.adapter.set_filter_nx("SYN-pcm-7").await;
 
     assert!(
-        outcome.map(|_| ()).is_err(),
+        outcome
+            .and_then(SettingOutcome::into_applied_result)
+            .is_err(),
         "a filter name that exists only in the chain that is no longer loaded must not resolve; \
          before #347 it resolved from the stale cache to index 7 and selected `SYN-sdm-7`"
     );
@@ -6163,6 +6232,7 @@ async fn after_a_chain_change_a_filter_resolves_against_the_newly_loaded_list() 
     h.adapter
         .set_filter_nx("SYN-sdm-3")
         .await
+        .applied()
         .expect("a name in the loaded chain must resolve");
 
     assert_eq!(
@@ -6204,6 +6274,7 @@ async fn a_name_present_in_both_chains_is_sent_with_the_loaded_chains_index() {
     h.adapter
         .set_filter_nx("poly-sinc-gauss-long")
         .await
+        .applied()
         .expect("the name is in both chains");
 
     assert_eq!(
@@ -6341,7 +6412,9 @@ async fn a_filter_write_is_refused_without_mutation_when_the_sibling_is_unknowab
     let outcome = h.adapter.set_filter_1x("poly-sinc-lp").await;
 
     assert!(
-        outcome.map(|_| ()).is_err(),
+        outcome
+            .and_then(SettingOutcome::into_applied_result)
+            .is_err(),
         "with the Nx sibling unknowable the write must be refused, not guessed"
     );
     assert_eq!(
@@ -6372,6 +6445,7 @@ async fn a_one_sided_filter_write_carries_both_authoritative_arguments() {
     h.adapter
         .set_filter_1x("poly-sinc-xtr")
         .await
+        .applied()
         .expect("SetFilter");
 
     let sent = h.model.last_request("SetFilter").expect("SetFilter sent");
@@ -6380,7 +6454,10 @@ async fn a_one_sided_filter_write_carries_both_authoritative_arguments() {
             request_attr(&sent, "value").as_deref(),
             request_attr(&sent, "value1x").as_deref()
         ),
-        (Some(before.filter_nx_index.to_string().as_str()), Some("11")),
+        (
+            Some(before.filter_nx_index.to_string().as_str()),
+            Some("11")
+        ),
         "both sides go on the wire together: the requested 1x index, and the Nx index the daemon \
          itself reports. Sent: {sent}"
     );
@@ -6401,15 +6478,27 @@ async fn a_numeric_string_is_never_accepted_as_a_setting_name() {
     let h = Harness::verified().await;
 
     assert!(
-        h.adapter.set_mode("1").await.map(|_| ()).is_err(),
+        h.adapter
+            .set_mode("1")
+            .await
+            .and_then(SettingOutcome::into_applied_result)
+            .is_err(),
         "`1` is not a mode name"
     );
     assert!(
-        h.adapter.set_filter_nx("7").await.map(|_| ()).is_err(),
+        h.adapter
+            .set_filter_nx("7")
+            .await
+            .and_then(SettingOutcome::into_applied_result)
+            .is_err(),
         "`7` is not a filter name"
     );
     assert!(
-        h.adapter.set_shaper("4").await.map(|_| ()).is_err(),
+        h.adapter
+            .set_shaper("4")
+            .await
+            .and_then(SettingOutcome::into_applied_result)
+            .is_err(),
         "`4` is not a shaper name"
     );
     assert_eq!(
@@ -6479,7 +6568,9 @@ async fn a_matrix_profile_accepted_but_unchanged_is_not_reported_as_applied() {
         "precondition: the daemon really did not move"
     );
     assert!(
-        outcome.map(|_| ()).is_err(),
+        outcome
+            .and_then(SettingOutcome::into_applied_result)
+            .is_err(),
         "`result=\"OK\"` is not proof of application for the matrix family either"
     );
     h.stop();
@@ -6519,6 +6610,7 @@ async fn a_matrix_profile_write_sends_the_semantic_name_and_verifies_the_readbac
     h.adapter
         .set_matrix_profile(2)
         .await
+        .applied()
         .expect("a profile in the fresh list");
 
     assert_eq!(
@@ -6557,7 +6649,8 @@ async fn an_external_matrix_switch_is_visible_and_an_empty_profile_is_no_selecti
         .expect("selected");
     assert_eq!((current.index, current.name.as_str()), (1, "Speakers"));
 
-    h.model.external_change(|s| s.matrix_profile = String::new());
+    h.model
+        .external_change(|s| s.matrix_profile = String::new());
     assert!(
         h.adapter
             .get_matrix_profile()
@@ -6576,17 +6669,15 @@ async fn an_external_matrix_switch_is_visible_and_an_empty_profile_is_no_selecti
 async fn a_rejected_matrix_profile_write_reports_the_daemon_reason() {
     let h = Harness::verified().await;
     h.model.arm(|f| {
-        f.reject_next.push((
-            "MatrixSetProfile".to_string(),
-            "profile in use".to_string(),
-        ))
+        f.reject_next
+            .push(("MatrixSetProfile".to_string(), "profile in use".to_string()))
     });
 
     let err = h
         .adapter
         .set_matrix_profile(1)
         .await
-        .map(|_| ())
+        .and_then(SettingOutcome::into_applied_result)
         .expect_err("an explicit rejection is a failure");
     assert!(
         err.to_string().contains("profile in use"),
@@ -6625,6 +6716,144 @@ async fn a_malformed_reply_does_not_wedge_later_polling() {
     assert_eq!(
         info.product, "Signalyst HQPlayer Embedded",
         "and it must read the daemon's real reply rather than leftovers"
+    );
+    h.stop();
+}
+
+// -----------------------------------------------------------------------------
+// Ambiguous delivery — a lost reply is not proof the daemon did nothing
+// -----------------------------------------------------------------------------
+
+/// On HQPlayer Embedded 6.0.4 a `SetMode` was **accepted, logged and acted on** while the daemon sent
+/// no response and later dropped the connection (HQP-C-029). Reporting that as a failure is as wrong
+/// as reporting `OK` as success: the setting is there, and a client that says otherwise sends a user
+/// chasing a change that already happened.
+///
+/// The drop is element-scoped because a setter is several commands now — it reads the enumeration and
+/// `State` before it writes — so an unscoped "drop the next reply" would vanish during the read and
+/// the write would never happen.
+///
+/// **Label: client-red.** Before #347 the send's error propagated and the state was never read back.
+#[tokio::test]
+async fn a_write_whose_reply_is_lost_after_the_daemon_applied_it_is_reported_as_applied() {
+    let h = Harness::start(
+        VERIFIED_PROFILE,
+        WirePolicy {
+            apply_then_drop_reply_for_element: Some("SetShaping".to_string()),
+            ..WirePolicy::default()
+        },
+        HqpTimeouts {
+            // One attempt, so the recovery under test is the readback rather than a resend.
+            max_attempts: 1,
+            ..fast_timeouts()
+        },
+    )
+    .await;
+    h.adapter.connect().await.expect("connect");
+
+    let outcome = h
+        .adapter
+        .set_shaper("NS5")
+        .await
+        .expect("a lost reply is not a protocol error");
+
+    assert!(
+        h.server.element_drop_fired(),
+        "precondition: the reply must actually have been dropped after the daemon applied it"
+    );
+    assert_eq!(
+        h.model.state().shaper_index,
+        3,
+        "precondition: the daemon did apply it — NS5 is index 3 in the observed PCM list"
+    );
+    assert_eq!(
+        outcome,
+        SettingOutcome::Applied,
+        "the readback finds the setting in place, so the write landed however its reply was lost"
+    );
+    h.stop();
+}
+
+/// The other side of the same coin. When the write draws no usable reply **and** the state does not
+/// show it, the honest answer is neither success nor "it failed" — it is that delivery could not be
+/// established. A caller that treats that as a clean failure will retry, and a retry of a write the
+/// daemon may already hold is a different risk from a retry of one it certainly does not.
+///
+/// **Label: client-red.**
+#[tokio::test]
+async fn a_write_whose_delivery_cannot_be_established_is_reported_as_ambiguous() {
+    let h = Harness::start(
+        VERIFIED_PROFILE,
+        WirePolicy {
+            silent_for_element: Some("SetShaping".to_string()),
+            ..WirePolicy::default()
+        },
+        HqpTimeouts {
+            max_attempts: 1,
+            ..fast_timeouts()
+        },
+    )
+    .await;
+    h.adapter.connect().await.expect("connect");
+    let before = h.model.state().shaper_index;
+
+    let outcome = h
+        .adapter
+        .set_shaper("NS5")
+        .await
+        .expect("ambiguity is an outcome, not a protocol error");
+
+    assert_eq!(
+        h.model.state().shaper_index,
+        before,
+        "precondition: the daemon never applied it"
+    );
+    match &outcome {
+        SettingOutcome::Ambiguous { what, reason } => {
+            assert_eq!(what, "shaper");
+            assert!(
+                reason.contains("may or may not"),
+                "the reason must say what is unknown rather than assert a failure, got: {reason}"
+            );
+        }
+        other => panic!(
+            "a write whose delivery cannot be established is neither applied nor a plain failure; \
+             got {other:?}"
+        ),
+    }
+    assert!(
+        outcome.into_applied_result().is_err(),
+        "and no advertised surface may report it as success"
+    );
+    h.stop();
+}
+
+/// An explicit rejection is **not** ambiguous delivery, and the two must not be conflated: the daemon
+/// saw the request and refused it, so there is nothing to read back and nothing to retry.
+///
+/// **Label: client-pin**, and the control for the type that separates them.
+#[tokio::test]
+async fn an_explicit_rejection_is_not_treated_as_ambiguous_delivery() {
+    let h = Harness::verified().await;
+    h.model.arm(|f| {
+        f.reject_next
+            .push(("SetShaping".to_string(), "invalid shaper".to_string()))
+    });
+
+    let err = h
+        .adapter
+        .set_shaper("NS5")
+        .await
+        .expect_err("an explicit result=Error stays an error, never an outcome");
+
+    assert!(
+        err.downcast_ref::<HqpRejected>().is_some(),
+        "the rejection must keep its type, or telling it apart from a lost reply goes back to \
+         matching on message text; got: {err}"
+    );
+    assert!(
+        err.to_string().contains("invalid shaper"),
+        "and the daemon's own reason must still reach the caller, got: {err}"
     );
     h.stop();
 }

--- a/tests/hqplayer_conformance.rs
+++ b/tests/hqplayer_conformance.rs
@@ -1496,8 +1496,8 @@ async fn a_setter_overridden_by_another_controller_fails_and_names_the_observed_
         .expect_err("a setting we cannot confirm is not a success, however it came to differ");
 
     assert!(
-        err.to_string().contains('7'),
-        "the error must name the value the daemon actually reports, so an override is \
+        err.to_string().contains("Gauss1"),
+        "the error must name the semantic value the daemon actually reports, so an override is \
          distinguishable from a dropped command; got: {err}"
     );
     h.stop();
@@ -7113,7 +7113,8 @@ async fn a_both_sides_filter_write_that_is_ignored_reports_both_sides() {
 
     let message = err.to_string();
     assert!(
-        message.contains("1x=11,Nx=11") && message.contains("1x=6,Nx=6"),
+        message.contains("1x=poly-sinc-xtr,Nx=poly-sinc-xtr")
+            && message.contains("1x=poly-sinc-lp,Nx=poly-sinc-lp"),
         "the error must name the pair asked for and the pair observed, so a half-applied write and \
          an ignored one are distinguishable. Got: {message}"
     );
@@ -7708,6 +7709,904 @@ async fn a_lost_volume_range_reply_does_not_publish_the_cache_its_reconnect_empt
                 published.settings.filter1x.options.len()
             );
         }
+    }
+    h.stop();
+}
+
+// -----------------------------------------------------------------------------
+// A semantic setter reports the *name* it was asked for, not the index it sent
+// -----------------------------------------------------------------------------
+
+/// The name the daemon's **currently loaded** enumeration gives an index.
+///
+/// Read straight off the model rather than through the adapter, because the whole hazard is that the
+/// adapter's own idea of what an index means can be the previous chain's.
+fn daemon_name_at(model: &DaemonModel, family: &str, item_tag: &str, index: u32) -> String {
+    corpus::enum_entries(&model.current_enumeration(family), item_tag)
+        .into_iter()
+        .find(|e| e.index == index)
+        .map(|e| e.name)
+        .unwrap_or_else(|| format!("<no entry at index {index}>"))
+}
+
+/// A semantic setter's outcome, asserted to be anything other than "the requested value is set".
+///
+/// `Err` is a legitimate answer and so is `Ignored`/`Ambiguous`/`Suppressed`; what is forbidden is
+/// [`SettingOutcome::is_applied`], which is what the HTTP and MCP surfaces collapse to `{"ok":true}`.
+#[track_caller]
+fn assert_not_reported_as_set(
+    outcome: &anyhow::Result<SettingOutcome>,
+    requested: &str,
+    daemon_holds: &str,
+    context: &str,
+) {
+    eprintln!("PROBE {context}: {outcome:?}");
+    if let Ok(o) = outcome {
+        assert!(
+            !o.is_applied(),
+            "{context}: `{requested}` was reported as set ({o:?}) while the daemon is on \
+             `{daemon_holds}`. A setter that resolves a name to an index and then compares only the \
+             index cannot tell those apart, and a caller reading {{\"ok\":true}} has been told its \
+             filter is loaded when a different one is"
+        );
+    }
+}
+
+#[track_caller]
+fn assert_ambiguous_after_wire(outcome: &anyhow::Result<SettingOutcome>, what: &str) {
+    match outcome {
+        Ok(SettingOutcome::Ambiguous {
+            what: actual,
+            reason,
+        }) => {
+            assert_eq!(actual, what);
+            assert!(
+                reason.contains("wire"),
+                "an ambiguity after a write must disclose that a wire attempt already happened; \
+                 got: {reason}"
+            );
+        }
+        other => panic!(
+            "a later lookup failure may not erase an earlier {what} write; expected a wire-aware \
+             Ambiguous outcome, got: {other:?}"
+        ),
+    }
+}
+
+/// **The headline gap: a no-op decision taken in the previous chain's list.**
+///
+/// `set_filter_pair` fetches `GetFilters`, resolves the requested name to a position in it, then
+/// reads `State` and compares **numbers**. Under configured `[source]` the loaded chain can move
+/// between those two requests, and on the synthetic hazard profile every position exists in both
+/// chains and names a different filter there — so the comparison succeeds, `AlreadySet` comes back,
+/// and the daemon is sitting on a filter nobody asked for.
+///
+/// Nothing is written on this path, so no cache writer competes and no generation moves: the fence
+/// added at `412f20c` cannot see this at all.
+///
+/// **Label: client-red.** Found by CodeRabbit at `412f20c`.
+#[tokio::test]
+async fn a_stale_cross_chain_filter_index_is_never_reported_as_already_set() {
+    let h = Harness::start(
+        SYNTHETIC_HAZARD_PROFILE,
+        WirePolicy::default(),
+        fast_timeouts(),
+    )
+    .await;
+    h.adapter.connect().await.expect("connect");
+    h.model.external_change(|s| {
+        s.mode_index = 0; // configured `[source]`: the source decides which chain is loaded
+        s.playback = 2;
+        s.filter_1x_index = 7;
+        s.filter_nx_index = 7;
+    });
+    assert_eq!(
+        daemon_name_at(&h.model, "GetFilters", "FiltersItem", 7),
+        "SYN-pcm-7",
+        "precondition: the PCM chain is loaded and position 7 is the filter being asked for"
+    );
+
+    // The source moves the chain the instant the filter list has been served. From here on position
+    // 7 is `SYN-sdm-7`, and the client's freshly fetched list already says `SYN-pcm-7`.
+    h.model
+        .switch_chain_after_request("GetFilters", LoadedChain::Sdm);
+
+    let outcome = h.adapter.set_filter_pair("SYN-pcm-7").await;
+
+    let daemon_holds = daemon_name_at(
+        &h.model,
+        "GetFilters",
+        "FiltersItem",
+        h.model.state().filter_1x_index,
+    );
+    assert_ne!(
+        daemon_holds, "SYN-pcm-7",
+        "precondition: the daemon must have ended on a different filter, or there is no hazard to \
+         report"
+    );
+    assert_eq!(
+        h.model.request_count("SetFilter"),
+        0,
+        "precondition: this is the no-op path, so nothing was written"
+    );
+    assert_not_reported_as_set(
+        &outcome,
+        "SYN-pcm-7",
+        &daemon_holds,
+        "a chain change after GetFilters, on the AlreadySet path",
+    );
+    h.stop();
+}
+
+/// The same gap on the **post-write** path: the index is sent, the daemon applies it in the chain it
+/// has now, and the readback compares that same number against `State` and agrees with itself.
+///
+/// **Label: client-red.** Found by CodeRabbit at `412f20c`.
+#[tokio::test]
+async fn a_cross_chain_filter_write_is_never_reported_as_applied() {
+    let h = Harness::start(
+        SYNTHETIC_HAZARD_PROFILE,
+        WirePolicy::default(),
+        fast_timeouts(),
+    )
+    .await;
+    h.adapter.connect().await.expect("connect");
+    h.model.external_change(|s| {
+        s.mode_index = 0;
+        s.playback = 2;
+        // Not the requested position, so a write actually happens.
+        s.filter_1x_index = 3;
+        s.filter_nx_index = 3;
+    });
+    h.model
+        .switch_chain_after_request("GetFilters", LoadedChain::Sdm);
+
+    let outcome = h.adapter.set_filter_pair("SYN-pcm-7").await;
+
+    let daemon_holds = daemon_name_at(
+        &h.model,
+        "GetFilters",
+        "FiltersItem",
+        h.model.state().filter_1x_index,
+    );
+    assert_ne!(
+        daemon_holds, "SYN-pcm-7",
+        "precondition: the position went to the daemon and selected a different filter in the chain \
+         it had loaded by then"
+    );
+    assert_not_reported_as_set(
+        &outcome,
+        "SYN-pcm-7",
+        &daemon_holds,
+        "a chain change after GetFilters, on the Applied path",
+    );
+    assert_ambiguous_after_wire(&outcome, "filter");
+    h.stop();
+}
+
+/// And on the one-sided path, which carries the sibling read out of `State` alongside it.
+///
+/// **Label: client-red.** Found by CodeRabbit at `412f20c`.
+#[tokio::test]
+async fn a_one_sided_cross_chain_filter_write_is_never_reported_as_applied() {
+    let h = Harness::start(
+        SYNTHETIC_HAZARD_PROFILE,
+        WirePolicy::default(),
+        fast_timeouts(),
+    )
+    .await;
+    h.adapter.connect().await.expect("connect");
+    h.model.external_change(|s| {
+        s.mode_index = 0;
+        s.playback = 2;
+        s.filter_1x_index = 3;
+        s.filter_nx_index = 3;
+    });
+    h.model
+        .switch_chain_after_request("GetFilters", LoadedChain::Sdm);
+
+    let outcome = h.adapter.set_filter_1x("SYN-pcm-7").await;
+
+    let daemon_holds = daemon_name_at(
+        &h.model,
+        "GetFilters",
+        "FiltersItem",
+        h.model.state().filter_1x_index,
+    );
+    assert_ne!(
+        daemon_holds, "SYN-pcm-7",
+        "precondition: the 1x side ended on a different filter"
+    );
+    assert_not_reported_as_set(
+        &outcome,
+        "SYN-pcm-7",
+        &daemon_holds,
+        "a chain change after GetFilters, on the one-sided Applied path",
+    );
+    assert_ambiguous_after_wire(&outcome, "filter1x");
+    h.stop();
+}
+
+/// The shaper family has the same gap, and it needs **no synthetic profile**: the verified corpus's
+/// two shaper lists are the same length and every position but `none` names a different modulator in
+/// the other chain — `NS9` and `ASDM5` are both position 4.
+///
+/// The no-op path, where the daemon's shaper already reads 4 because it is on `NS9` in PCM.
+///
+/// **Label: client-red.** Found by CodeRabbit at `412f20c`.
+#[tokio::test]
+async fn a_stale_cross_chain_shaper_index_is_never_reported_as_already_set() {
+    let h = Harness::verified().await;
+    h.model.external_change(|s| {
+        s.mode_index = 0; // configured `[source]`
+        s.playback = 2;
+        s.shaper_index = 4;
+    });
+    assert_eq!(
+        daemon_name_at(&h.model, "GetShapers", "ShapersItem", 4),
+        "NS9",
+        "precondition: the PCM chain is loaded and position 4 is the shaper being asked for"
+    );
+
+    h.model
+        .switch_chain_after_request("GetShapers", LoadedChain::Sdm);
+
+    let outcome = h.adapter.set_shaper("NS9").await;
+
+    let daemon_holds = daemon_name_at(
+        &h.model,
+        "GetShapers",
+        "ShapersItem",
+        h.model.state().shaper_index,
+    );
+    assert_ne!(
+        daemon_holds, "NS9",
+        "precondition: position 4 must name a different modulator in the SDM chain"
+    );
+    assert_eq!(
+        h.model.request_count("SetShaping"),
+        0,
+        "precondition: this is the no-op path, so nothing was written"
+    );
+    assert_not_reported_as_set(
+        &outcome,
+        "NS9",
+        &daemon_holds,
+        "a chain change after GetShapers, on the AlreadySet path",
+    );
+    h.stop();
+}
+
+/// The shaper family's post-write path.
+///
+/// **Label: client-red.** Found by CodeRabbit at `412f20c`.
+#[tokio::test]
+async fn a_cross_chain_shaper_write_is_never_reported_as_applied() {
+    let h = Harness::verified().await;
+    h.model.external_change(|s| {
+        s.mode_index = 0;
+        s.playback = 2;
+        s.shaper_index = 1; // not the requested position, so a write happens
+    });
+    h.model
+        .switch_chain_after_request("GetShapers", LoadedChain::Sdm);
+
+    let outcome = h.adapter.set_shaper("NS9").await;
+
+    let daemon_holds = daemon_name_at(
+        &h.model,
+        "GetShapers",
+        "ShapersItem",
+        h.model.state().shaper_index,
+    );
+    assert_ne!(
+        daemon_holds, "NS9",
+        "precondition: the position went to the daemon and selected a different modulator"
+    );
+    assert_not_reported_as_set(
+        &outcome,
+        "NS9",
+        &daemon_holds,
+        "a chain change after GetShapers, on the Applied path",
+    );
+    assert_ambiguous_after_wire(&outcome, "shaper");
+    h.stop();
+}
+
+/// **The rate family, whose mapping shape is Hz to position rather than name to position.**
+///
+/// The source-driven transition cannot reach this setter: a source change only happens under a
+/// configured `[source]` mode, and under `[source]` a rate pin is *suppressed and never sent*
+/// (HQP-C-018/019). So there is no cross-chain rate write to catch, and the only reachable claim is
+/// the structural one — that the pin's semantic value is established against the enumeration the
+/// daemon serves **after** the write rather than against the one it served before it.
+///
+/// Asserted on the wire, in order, because that is the difference between a setter that proves its
+/// value and one that trusts a number it resolved earlier.
+///
+/// **Label: client-red.** Before the proof there was exactly one `GetRates`, and it came before the
+/// write.
+#[tokio::test]
+async fn a_rate_pin_is_proved_against_the_enumeration_served_after_the_write() {
+    let h = Harness::verified().await;
+    // Configured SDM, which is a mode a rate pin is actually sent in.
+    h.model.external_change(|s| {
+        s.mode_index = 2;
+        s.loaded_chain = LoadedChain::Sdm;
+        s.playback = 2;
+    });
+    assert!(
+        h.model.armed_upstream_claims().is_empty(),
+        "a configured SDM mode with the SDM chain loaded is the ordinary consistent case and must \
+         claim nothing unqualified: {:?}",
+        h.model.armed_upstream_claims()
+    );
+
+    h.adapter
+        .set_rate(2_822_400)
+        .await
+        .applied()
+        .expect("a rate the loaded SDM chain offers");
+
+    let requests = h.model.requests();
+    let wrote_at = requests
+        .iter()
+        .rposition(|r| r.contains("<SetRate"))
+        .expect("precondition: the pin reached the wire");
+    assert!(
+        requests[wrote_at + 1..]
+            .iter()
+            .any(|r| r.contains("<GetRates")),
+        "a rate reported as applied must have had its Hz value re-established against the rate list \
+         the daemon serves after the write; the index alone cannot say which rate it names. \
+         Requests: {requests:#?}"
+    );
+    h.stop();
+}
+
+/// **Mode, for the same structural reason and not for the chain one.**
+///
+/// `GetModes` is device-scoped: the fake serves the same modes document whichever chain is loaded,
+/// which is the daemon's own behaviour — the offered modes follow the DAC's capabilities, not the
+/// material. So a source-driven transition cannot move this mapping and the CodeRabbit hazard is
+/// unreachable here.
+///
+/// What is reachable is the general one: the modes list is not immutable. A PCM-only DAC's list has
+/// **no** SDM entry and the survivors keep their own positions (HQP-C-013), so a profile or device
+/// change reshapes it — and an *external* one moves no UHC cache and bumps no generation, which is
+/// exactly the hole the fence cannot cover. An exemption argued from "this family does not move" is
+/// the shape of reasoning this issue exists to remove, so mode is proved like the rest.
+///
+/// **Label: client-red.** Before the proof there was exactly one `GetModes`, and it came before the
+/// write.
+#[tokio::test]
+async fn a_mode_write_is_proved_against_the_enumeration_served_after_it() {
+    let h = Harness::verified().await;
+
+    h.adapter
+        .set_mode("DSD")
+        .await
+        .applied()
+        .expect("the daemon offers SDM (DSD)");
+
+    let requests = h.model.requests();
+    let wrote_at = requests
+        .iter()
+        .rposition(|r| r.contains("<SetMode"))
+        .expect("precondition: the mode write reached the wire");
+    assert!(
+        requests[wrote_at + 1..]
+            .iter()
+            .any(|r| r.contains("<GetModes")),
+        "a mode reported as applied must have had its name re-established against the modes list the \
+         daemon serves after the write. Requests: {requests:#?}"
+    );
+    h.stop();
+}
+
+/// **The retry is a correction, not just a second way to fail.**
+///
+/// `poly-sinc-short-lp` exists in both of the verified corpus's filter chains and at *different*
+/// positions — 3 in PCM, 0 in SDM. So a chain change after `GetFilters` sends position 3 into the SDM
+/// chain, where it is in range and names `sinc-Lh`; the bracket sees the enumeration move, resolves
+/// the same name against the list the daemon serves now, and writes position 0.
+///
+/// Both halves are asserted: the outcome is a success *and* the daemon is on the filter that was
+/// asked for. A test that only checked the outcome would pass for a client that refused, and one that
+/// only checked the daemon would pass for a client that lied about it.
+///
+/// **Label: client-red.** Before the bracket this returned `Applied` with the daemon on `sinc-Lh`.
+#[tokio::test]
+async fn a_chain_change_after_the_filter_list_is_corrected_by_the_retry() {
+    let h = Harness::verified().await;
+    h.model.external_change(|s| {
+        s.mode_index = 0; // configured `[source]`
+        s.playback = 2;
+        s.filter_1x_index = 1;
+        s.filter_nx_index = 1;
+    });
+    assert_eq!(
+        daemon_name_at(&h.model, "GetFilters", "FiltersItem", 3),
+        "poly-sinc-short-lp",
+        "precondition: position 3 is the requested filter in the loaded PCM chain"
+    );
+
+    h.model
+        .switch_chain_after_request("GetFilters", LoadedChain::Sdm);
+
+    h.adapter
+        .set_filter_pair("poly-sinc-short-lp")
+        .await
+        .applied()
+        .expect(
+            "the filter is offered by the chain the daemon settles on, so the retry can land it",
+        );
+
+    let daemon = h.model.state();
+    assert_eq!(
+        daemon_name_at(
+            &h.model,
+            "GetFilters",
+            "FiltersItem",
+            daemon.filter_1x_index
+        ),
+        "poly-sinc-short-lp",
+        "reporting success means the daemon is on the requested filter, not on whatever the \
+         previous chain's position named"
+    );
+    assert_eq!(
+        daemon.filter_1x_index, daemon.filter_nx_index,
+        "and both sides of the pair, which is what was requested"
+    );
+    assert_eq!(
+        h.model.request_count("SetFilter"),
+        2,
+        "bounded at one retry: the first write went to the position the previous chain gave the \
+         name, the second to the position the loaded one does. A third would mean the bound is not a \
+         bound"
+    );
+    h.stop();
+}
+
+/// A retry that discovers the requested semantic value already selected must not erase the fact
+/// that the first attempt sent a write. `AlreadySet` is a promise that nothing was sent; returning it
+/// here would make the bounded correction semantically dishonest even though the final value is
+/// right.
+///
+/// `none` is position 0 in both shaper chains. The first attempt writes it in PCM and the daemon then
+/// moves to SDM, so the bracket retries because the *enumeration* changed. The retry correctly sends
+/// nothing because SDM also reports `none` at 0. The operation as a whole is nevertheless `Applied`,
+/// not `AlreadySet`, because one `SetShaping` reached the wire.
+///
+/// **Label: client-pin.** Found by independent review of the CodeRabbit correction; it is a RED
+/// against the first `SemanticFamily` implementation, not against the pre-#347 client.
+#[tokio::test]
+async fn a_retry_no_op_does_not_hide_the_write_sent_by_the_first_attempt() {
+    let h = Harness::verified().await;
+    h.model.external_change(|s| {
+        s.mode_index = 0;
+        s.playback = 2;
+        s.shaper_index = 1;
+    });
+    h.model
+        .switch_chain_after_request("SetShaping", LoadedChain::Sdm);
+
+    let outcome = h
+        .adapter
+        .set_shaper("none")
+        .await
+        .expect("the requested semantic value is established after the bounded retry");
+
+    assert_eq!(
+        h.model.request_count("SetShaping"),
+        1,
+        "the first attempt wrote and the retry was a semantic no-op"
+    );
+    assert_eq!(
+        outcome,
+        SettingOutcome::Applied,
+        "the operation sent a write, so it may not claim AlreadySet even though the retry found the \
+         final semantic value already selected"
+    );
+    assert_eq!(
+        daemon_name_at(
+            &h.model,
+            "GetShapers",
+            "ShapersItem",
+            h.model.state().shaper_index,
+        ),
+        "none",
+        "the semantic proof still establishes the requested value in the settled chain"
+    );
+    h.stop();
+}
+
+/// A chain that moves during the resolve **and** during the retry.
+///
+/// The bracket is one retry, not a loop, so a source flapping faster than the client can read has to
+/// end somewhere — and it ends on [`SettingOutcome::Ambiguous`], which is what "the write may or may
+/// not have landed on the requested value" honestly is. Not `Applied`, and not `Ignored` either:
+/// nothing was observed contradicting the request, only nothing establishing it.
+///
+/// **Label: client-red.** Before the bracket the first straddle was invisible and `Applied` came
+/// back.
+#[tokio::test]
+async fn a_chain_that_moves_on_the_setter_and_on_its_retry_is_reported_as_ambiguous() {
+    let h = Harness::verified().await;
+    h.model.external_change(|s| {
+        s.mode_index = 0;
+        s.playback = 2;
+        s.filter_1x_index = 1;
+        s.filter_nx_index = 1;
+    });
+
+    // One switch per filter-list read: the resolve and the proof of each of the two attempts.
+    h.model
+        .switch_chain_after_request("GetFilters", LoadedChain::Sdm);
+    h.model
+        .switch_chain_after_request("GetFilters", LoadedChain::Pcm);
+    h.model
+        .switch_chain_after_request("GetFilters", LoadedChain::Sdm);
+
+    let outcome = h
+        .adapter
+        .set_filter_pair("poly-sinc-short-lp")
+        .await
+        .expect("a flapping chain is not a protocol error");
+
+    match &outcome {
+        SettingOutcome::Ambiguous { what, reason } => {
+            assert_eq!(what, "filter");
+            assert!(
+                reason.contains("enumeration")
+                    && reason.contains("retry")
+                    && reason.contains("wire"),
+                "the reason must say what could not be settled and that the bound was reached, got: \
+                 {reason}"
+            );
+        }
+        other => panic!(
+            "a value the client could not establish must be reported as ambiguous rather than as \
+             set or as refused, got: {other:?}"
+        ),
+    }
+    assert!(
+        !outcome.is_applied(),
+        "and it must not collapse to {{\"ok\":true}} at the HTTP or MCP boundary"
+    );
+    h.stop();
+}
+
+/// **The value check, on its own.** The bracket answers "did the enumeration move"; this answers "does
+/// the position the daemon holds resolve to what was asked for", and they are not the same question.
+///
+/// A `SetMode` clears the exact-rate pin even when the mode does not change (HQP-C-017), and the
+/// daemon can apply an acknowledged write a poll later than the acknowledgement (HQP-C-028's sibling
+/// behaviour, modelled by `apply_after_polls`). Put together: another controller's mode write lands
+/// between this client's rate readback and its proof, the rate pin it just set is cleared, and the
+/// rate enumeration never moves — so nothing about the *lists* is wrong and only comparing the
+/// semantic value catches it.
+///
+/// The mode is written straight through [`Responder`] rather than through the adapter, so the deferred
+/// change is armed without consuming any of the polls it is counted in. `requested` is the
+/// discriminator that keeps this from passing for the wrong reason: the readback inside
+/// `write_setting` reports the **position** it wrote, and only the proof reports the **Hz** that was
+/// asked for.
+///
+/// **Label: client-red.** Before the proof this returned `Applied` for a pin the daemon no longer
+/// held.
+#[tokio::test]
+async fn a_rate_pin_cleared_after_the_readback_is_not_reported_as_applied() {
+    let h = Harness::verified().await;
+    // Configured PCM, PCM chain loaded: the ordinary consistent case, and one a rate pin is sent in.
+    assert_eq!(
+        h.model.state().mode_index,
+        1,
+        "precondition: configured PCM"
+    );
+    assert_eq!(
+        h.model.state().rate_index,
+        0,
+        "precondition: no pin yet, so the pin below is a real write"
+    );
+
+    // Three `State`/`Status` renders from now, which is this client's proof read: the mode write lands
+    // and takes the rate pin with it. `[source]` is chosen because it leaves the loaded chain alone —
+    // so the rate enumeration is untouched and the bracket has nothing to notice.
+    h.model
+        .arm(|f| f.apply_after_polls.push(("SetMode".to_string(), 3)));
+    h.model
+        .respond("<SetMode value=\"0\"/>")
+        .expect("the fake answers SetMode");
+
+    let outcome = h
+        .adapter
+        .set_rate(44_100)
+        .await
+        .expect("a rate the loaded PCM chain offers is not a protocol error");
+
+    let daemon = h.model.state();
+    assert_eq!(
+        (daemon.mode_index, daemon.rate_index),
+        (0, 0),
+        "precondition: the other controller's mode write landed and cleared the pin. If this fails \
+         the poll budget has drifted and the test is no longer about what it says"
+    );
+    match &outcome {
+        SettingOutcome::Ignored {
+            what,
+            requested,
+            observed,
+        } => {
+            assert_eq!(
+                (what.as_str(), requested.as_str(), observed.as_str()),
+                ("rate", "44100", "Auto"),
+                "the proof must report the Hz that was asked for against the Hz the daemon now \
+                 holds. A `requested` of \"1\" would be the position, which means this came from the \
+                 readback inside the write rather than from the proof"
+            );
+        }
+        other => panic!(
+            "a pin the daemon stopped holding must be reported as ignored rather than applied, got: \
+             {other:?}"
+        ),
+    }
+    h.stop();
+}
+
+/// A stable split pair is evidence that an acknowledged pair write did not establish the request;
+/// it is not the same as an absent field. The report stays in the semantic name domain.
+///
+/// **Label: client-red.** The first semantic proof collapsed split and missing pairs to `None` and
+/// reported both as ambiguous.
+#[tokio::test]
+async fn an_acknowledged_filter_pair_that_remains_split_is_semantically_ignored() {
+    let h = Harness::verified().await;
+    h.model.external_change(|s| {
+        s.filter_1x_index = 6;
+        s.filter_nx_index = 5;
+    });
+    h.model
+        .arm(|f| f.accept_but_ignore.push("SetFilter".to_string()));
+
+    let expected_observed = format!(
+        "1x={},Nx={}",
+        daemon_name_at(&h.model, "GetFilters", "FiltersItem", 6),
+        daemon_name_at(&h.model, "GetFilters", "FiltersItem", 5)
+    );
+    let outcome = h
+        .adapter
+        .set_filter_pair("poly-sinc-xtr")
+        .await
+        .expect("an acknowledged refusal is an outcome");
+
+    assert_eq!(
+        outcome,
+        SettingOutcome::Ignored {
+            what: "filter".to_string(),
+            requested: "1x=poly-sinc-xtr,Nx=poly-sinc-xtr".to_string(),
+            observed: expected_observed,
+        },
+        "both reported sides disprove application and must be named semantically"
+    );
+    h.stop();
+}
+
+/// Missing pair fields prove neither application nor refusal, even after an acknowledgement.
+///
+/// **Label: client-pin.** The parser already admits this client-contract shape.
+#[tokio::test]
+async fn a_filter_pair_with_missing_authoritative_fields_is_ambiguous() {
+    let h = Harness::verified().await;
+    h.model
+        .set_filter_field_reporting(FilterFieldReporting::CombinedOnly);
+
+    let outcome = h
+        .adapter
+        .set_filter_pair("poly-sinc-xtr")
+        .await
+        .expect("missing evidence is an outcome");
+
+    match outcome {
+        SettingOutcome::Ambiguous { what, reason } => {
+            assert_eq!(what, "filter");
+            assert!(
+                reason.contains("does not report") && reason.contains("State"),
+                "absence must be reported as missing evidence, got: {reason}"
+            );
+        }
+        other => panic!("an absent pair is not an observed split or a success: {other:?}"),
+    }
+    h.stop();
+}
+
+/// A no-op decision is never evidence that a write was ignored. If another controller changes the
+/// stable semantic value before the closing observation, the outcome must say no write was sent.
+///
+/// **Label: client-red.** The first semantic proof returned `Ignored`, whose contract promises an
+/// acknowledged wire write.
+#[tokio::test]
+async fn a_stale_no_op_that_sent_nothing_is_not_reported_as_ignored() {
+    let h = Harness::verified().await;
+    assert_eq!(
+        daemon_name_at(
+            &h.model,
+            "GetShapers",
+            "ShapersItem",
+            h.model.state().shaper_index,
+        ),
+        "NS9",
+        "precondition: the adapter will initially choose the no-op path"
+    );
+    h.model
+        .arm(|f| f.apply_after_polls.push(("SetShaping".to_string(), 2)));
+    h.model
+        .respond("<SetShaping value=\"3\"/>")
+        .expect("the other controller's delayed write is accepted");
+    let external_writes = h.model.request_count("SetShaping");
+
+    let outcome = h
+        .adapter
+        .set_shaper("NS9")
+        .await
+        .expect("a raced no-op is an outcome");
+
+    assert_eq!(
+        h.model.request_count("SetShaping"),
+        external_writes,
+        "the adapter itself must not have sent a write"
+    );
+    match outcome {
+        SettingOutcome::Suppressed { what, reason } => {
+            assert_eq!(what, "shaper");
+            assert!(
+                reason.contains("nothing was sent") && reason.contains("NS5"),
+                "the report must disclose the never-sent decision and the semantic value observed; \
+                 got: {reason}"
+            );
+        }
+        other => panic!("a never-sent operation cannot be Ignored or Applied: {other:?}"),
+    }
+    h.stop();
+}
+
+/// Numeric readback outcomes from the inner write are normalized through the semantic list before
+/// they leave a name-based one-sided setter.
+///
+/// **Label: client-red.** The first proof returned the inner numeric `Ignored` unchanged.
+#[tokio::test]
+async fn an_ignored_one_sided_filter_write_reports_filter_names() {
+    let h = Harness::verified().await;
+    let observed = daemon_name_at(
+        &h.model,
+        "GetFilters",
+        "FiltersItem",
+        h.model.state().filter_1x_index,
+    );
+    h.model
+        .arm(|f| f.accept_but_ignore.push("SetFilter".to_string()));
+
+    let outcome = h
+        .adapter
+        .set_filter_1x("poly-sinc-xtr")
+        .await
+        .expect("an acknowledged refusal is an outcome");
+
+    assert_eq!(
+        outcome,
+        SettingOutcome::Ignored {
+            what: "filter1x".to_string(),
+            requested: "poly-sinc-xtr".to_string(),
+            observed,
+        }
+    );
+    h.stop();
+}
+
+/// Mode and rate use the same semantic descriptor path as filters. In particular rate position zero
+/// is `Auto`, not the ambiguous numeric string `0`.
+///
+/// **Label: client-red.** The first proof returned numeric inner outcomes and rendered rate zero as
+/// `0`.
+#[tokio::test]
+async fn ignored_mode_and_rate_writes_report_names_and_hertz() {
+    let h = Harness::verified().await;
+    h.model.arm(|f| {
+        f.accept_but_ignore.push("SetMode".to_string());
+        f.accept_but_ignore.push("SetRate".to_string());
+    });
+
+    let mode = h
+        .adapter
+        .set_mode("DSD")
+        .await
+        .expect("an ignored mode is an outcome");
+    assert_eq!(
+        mode,
+        SettingOutcome::Ignored {
+            what: "mode".to_string(),
+            requested: "DSD".to_string(),
+            observed: "PCM".to_string(),
+        }
+    );
+
+    let rate = h
+        .adapter
+        .set_rate(44_100)
+        .await
+        .expect("an ignored rate is an outcome");
+    assert_eq!(
+        rate,
+        SettingOutcome::Ignored {
+            what: "rate".to_string(),
+            requested: "44100".to_string(),
+            observed: "Auto".to_string(),
+        }
+    );
+    h.stop();
+}
+
+/// Source-mode refusal is re-evaluated by the retry. The first rate write happens while PCM is
+/// configured; an external delayed mode change and source-driven chain move make the bracket retry
+/// under `[source]`, where no second `SetRate` may be sent.
+///
+/// **Label: client-red.** Suppression outside the bracket was checked only once.
+#[tokio::test]
+async fn a_rate_retry_that_enters_source_never_sends_a_second_pin() {
+    let h = Harness::verified().await;
+    h.model.external_change(|s| {
+        s.mode_index = 0;
+    });
+    h.model
+        .arm(|f| f.apply_after_polls.push(("SetMode".to_string(), 1)));
+    h.model
+        .respond("<SetMode value=\"1\"/>")
+        .expect("the delayed PCM transition is accepted");
+    h.model.arm(|f| {
+        f.apply_after_polls.clear();
+        f.apply_after_polls.push(("SetRate".to_string(), 1));
+    });
+    h.model
+        .respond("<SetRate value=\"1\"/>")
+        .expect("the external PCM pin is accepted for the same poll");
+    h.model.arm(|f| {
+        f.apply_after_polls.clear();
+        f.apply_after_polls.push(("SetMode".to_string(), 3));
+    });
+    h.model
+        .respond("<SetMode value=\"0\"/>")
+        .expect("the delayed source transition is accepted");
+    h.model.arm(|f| f.source_refuses_rate_pin = true);
+    // The first decision's State keeps PCM loaded; the write readback then moves the loaded chain,
+    // and the proof State applies the pending source configuration before rendering it.
+    h.model
+        .switch_chain_after_request("State", LoadedChain::Pcm);
+    h.model
+        .switch_chain_after_request("State", LoadedChain::Sdm);
+    let external_rate_writes = h.model.request_count("SetRate");
+
+    let outcome = h
+        .adapter
+        .set_rate(0)
+        .await
+        .expect("a bounded transition is an outcome");
+
+    assert_eq!(
+        h.model.request_count("SetRate"),
+        external_rate_writes + 1,
+        "the first PCM attempt may write, but the retry must re-check `[source]` and suppress a \
+         second pin"
+    );
+    match outcome {
+        SettingOutcome::Ambiguous { what, reason } => {
+            assert_eq!(what, "rate");
+            assert!(
+                reason.contains("earlier attempt") && reason.contains("suppressed"),
+                "the operation must disclose both the prior wire attempt and retry refusal; got: \
+                 {reason}"
+            );
+        }
+        other => panic!("a write followed by a suppressed retry is ambiguous: {other:?}"),
     }
     h.stop();
 }

--- a/tests/hqplayer_conformance.rs
+++ b/tests/hqplayer_conformance.rs
@@ -7183,3 +7183,59 @@ async fn a_raw_filter_write_the_daemon_acknowledges_and_drops_is_not_reported_as
     );
     h.stop();
 }
+
+/// A bounded retry has to be allowed to **fail**. When the chain moves during the state read on the
+/// retry as well, the client has nothing coherent to publish: the lists it holds are from the chain
+/// before that second move, and noticing the move drops them. Answering `Ok` there hands back a
+/// `PipelineStatus` whose option lists are empty and whose selections resolve to nothing, presented
+/// as this daemon's settings.
+///
+/// "I could not read this coherently" is a truthful answer and the route already renders it — the
+/// pipeline handler has always had an error arm. "Here are no filters at all" is not.
+///
+/// **Label: client-red.** Before this, the second mismatch set the state and published anyway.
+#[tokio::test]
+async fn a_chain_that_moves_on_both_the_read_and_the_retry_is_reported_rather_than_published() {
+    let h = Harness::verified().await;
+    h.model.external_change(|s| {
+        s.mode_index = 0; // configured `[source]`
+        s.playback = 2;
+        s.filter_1x_index = 7;
+        s.filter_nx_index = 7;
+    });
+    h.adapter
+        .get_pipeline_status()
+        .await
+        .expect("precondition: a settled daemon reads fine");
+
+    // Two transitions, each landing on a `State` read: the first catches the initial read, the
+    // second catches the retry. A daemon whose source is flapping does exactly this.
+    h.model
+        .switch_chain_after_request("State", LoadedChain::Sdm);
+    h.model
+        .switch_chain_after_request("State", LoadedChain::Pcm);
+
+    let outcome = h.adapter.get_pipeline_status().await;
+
+    match outcome {
+        Err(e) => {
+            let message = e.to_string();
+            assert!(
+                message.contains("chain"),
+                "the failure must say what could not be established — that the loaded chain kept \
+                 moving — rather than surfacing as some unrelated read error. Got: {message}"
+            );
+        }
+        Ok(published) => {
+            let families = published_families(&published);
+            panic!(
+                "a read that could not settle must not be reported as a successful one. It \
+                 published {families:?}, with filter1x selected as {:?} out of {} options — a \
+                 caller cannot tell that from a daemon that genuinely offers nothing",
+                published.settings.filter1x.selected.value,
+                published.settings.filter1x.options.len()
+            );
+        }
+    }
+    h.stop();
+}

--- a/tests/hqplayer_ledger_lint.rs
+++ b/tests/hqplayer_ledger_lint.rs
@@ -2002,25 +2002,33 @@ fn no_production_comment_settles_the_active_mode_question_by_fiat() {
 /// honoured — but the number is resolved to a name at the boundary
 /// (`HqpAdapter::legacy_index_to_name`) and what travels inward is the name.
 ///
-/// Scoped to the resolver and setter bodies rather than to the whole file, because the adapter parses
-/// numbers legitimately everywhere else: every `State` attribute arrives as one. The scoping is a
-/// brace walk over the source rather than a syntax visit, so that what is searched is exactly the text
-/// a reviewer would read.
+/// Decided by **parsing** the adapter, not by scanning its text. An earlier revision of this check
+/// hand-rolled a brace matcher to carve function bodies out of the source, which is the helper shape
+/// this file has been burned by before: comments, raw strings and — fatally — the apostrophe in a
+/// lifetime such as `&'a str` all desynchronise a character walk, and every one of those failures is
+/// silent and in the *permissive* direction. `syn` already parses this file for two other checks, and
+/// a visitor that finds `.parse()` calls inside a named function has none of those failure modes,
+/// because comments and literals are not expressions.
+///
+/// Scoped to the resolvers and setters rather than the whole file, because the adapter parses numbers
+/// legitimately everywhere else: every `State` attribute arrives as one.
 #[test]
 fn no_production_control_path_parses_a_setting_name_as_an_index() {
     let src = read(&repo_root().join("src/adapters/hqplayer.rs"));
-    let mut offenders = Vec::new();
-    for (name, body) in fn_bodies(&src) {
-        if !(name.starts_with("resolve_") || name.starts_with("set_")) {
-            continue;
-        }
-        if body.contains("parse::<u32>")
-            || body.contains("parse::<usize>")
-            || body.contains(".parse()")
-        {
-            offenders.push(name);
-        }
-    }
+    let file = syn::parse_file(&src).expect("the adapter parses");
+    let scanned = control_fn_names(&file);
+    assert!(
+        scanned.len() >= 5,
+        "the scope collapsed to {} function(s), which would make this check pass by looking at \
+         almost nothing — the adapter has a resolver per family and a setter per setting: {scanned:?}",
+        scanned.len()
+    );
+
+    let offenders: Vec<String> = control_fn_names(&file)
+        .into_iter()
+        .filter(|name| !parse_calls_in(&file, name).is_empty())
+        .collect();
+
     assert!(
         offenders.is_empty(),
         "a resolver or setter that parses a semantic name into a list index has reinstated \
@@ -2031,112 +2039,141 @@ fn no_production_control_path_parses_a_setting_name_as_an_index() {
     );
 }
 
-/// `(name, body)` for every `fn` in a source file, bodies delimited by brace matching.
-///
-/// Deliberately textual. A syntax visit would need a token renderer this crate does not depend on,
-/// and the thing being guarded is a line a reviewer reads, not a shape only a parser can see.
-/// Braces inside string literals and char literals would confuse it, so both are skipped.
-fn fn_bodies(src: &str) -> Vec<(String, String)> {
-    let bytes: Vec<char> = src.chars().collect();
-    let mut out = Vec::new();
-    let mut i = 0;
-    while let Some(rel) = src[i..].find("fn ") {
-        let at = i + rel;
-        // Must be a token boundary, so `async fn` counts and `my_fn ` does not.
-        let preceded_ok = at == 0
-            || !src[..at]
-                .chars()
-                .next_back()
-                .is_some_and(|c| c.is_alphanumeric() || c == '_');
-        i = at + 3;
-        if !preceded_ok {
-            continue;
-        }
-        let name: String = src[i..]
-            .chars()
-            .take_while(|c| c.is_alphanumeric() || *c == '_')
-            .collect();
-        if name.is_empty() {
-            continue;
-        }
-        let Some(open_rel) = src[i..].find('{') else {
-            continue;
-        };
-        let mut j = i + open_rel;
-        // Character indices, so multi-byte source cannot desynchronise the walk.
-        let mut k = src[..j].chars().count();
-        let mut depth = 0i32;
-        let mut in_str = false;
-        let mut in_char = false;
-        let start = k;
-        while k < bytes.len() {
-            let c = bytes[k];
-            let escaped = k > 0 && bytes[k - 1] == '\\';
-            match c {
-                '"' if !in_char && !escaped => in_str = !in_str,
-                '\'' if !in_str && !escaped => in_char = !in_char,
-                '{' if !in_str && !in_char => depth += 1,
-                '}' if !in_str && !in_char => {
-                    depth -= 1;
-                    if depth == 0 {
-                        break;
-                    }
-                }
-                _ => {}
+/// Names of every function that resolves or writes a setting.
+fn control_fn_names(file: &syn::File) -> Vec<String> {
+    struct Names(Vec<String>);
+    impl<'ast> syn::visit::Visit<'ast> for Names {
+        fn visit_impl_item_fn(&mut self, f: &'ast syn::ImplItemFn) {
+            let name = f.sig.ident.to_string();
+            if name.starts_with("resolve_") || name.starts_with("set_") {
+                self.0.push(name);
             }
-            k += 1;
+            syn::visit::visit_impl_item_fn(self, f);
         }
-        let body: String = bytes[start..k.min(bytes.len())].iter().collect();
-        j += body.len();
-        let _ = j;
-        out.push((name, body));
+        fn visit_item_fn(&mut self, f: &'ast syn::ItemFn) {
+            let name = f.sig.ident.to_string();
+            if name.starts_with("resolve_") || name.starts_with("set_") {
+                self.0.push(name);
+            }
+            syn::visit::visit_item_fn(self, f);
+        }
     }
-    out
+    let mut names = Names(Vec::new());
+    syn::visit::Visit::visit_file(&mut names, file);
+    names.0
 }
 
-/// Controls for [`fn_bodies`], written as the false passes it must not produce.
+/// Every `.parse(...)` **call expression** inside the named function, reported as its receiver text
+/// where one can be named.
 ///
-/// Every false pass this file has shipped was in a helper rather than in a check, so the helper is
-/// exercised directly with the shapes that would defeat it: a brace inside a string literal, a
-/// nested block, and a name that merely ends in `fn`.
+/// A call expression, deliberately: a `parse` inside a comment or a string literal is not one, so the
+/// whole class of false positives a text scan has to defend against does not arise. `visit_expr_call`
+/// covers the free-function form (`str::parse(x)`) and `visit_expr_method_call` the method form.
+fn parse_calls_in(file: &syn::File, target: &str) -> Vec<String> {
+    struct Finder<'a> {
+        target: &'a str,
+        in_target: bool,
+        hits: Vec<String>,
+    }
+    impl<'a> Finder<'a> {
+        fn scan_body(&mut self, name: &str, block: &syn::Block) {
+            if name != self.target {
+                return;
+            }
+            let was = self.in_target;
+            self.in_target = true;
+            syn::visit::visit_block(self, block);
+            self.in_target = was;
+        }
+    }
+    impl<'ast, 'a> syn::visit::Visit<'ast> for Finder<'a> {
+        fn visit_impl_item_fn(&mut self, f: &'ast syn::ImplItemFn) {
+            let name = f.sig.ident.to_string();
+            self.scan_body(&name, &f.block);
+            syn::visit::visit_impl_item_fn(self, f);
+        }
+        fn visit_item_fn(&mut self, f: &'ast syn::ItemFn) {
+            let name = f.sig.ident.to_string();
+            self.scan_body(&name, &f.block);
+            syn::visit::visit_item_fn(self, f);
+        }
+        fn visit_expr_method_call(&mut self, call: &'ast syn::ExprMethodCall) {
+            if self.in_target && call.method == "parse" {
+                self.hits.push(format!("{}.parse(..)", "<receiver>"));
+            }
+            syn::visit::visit_expr_method_call(self, call);
+        }
+        fn visit_expr_call(&mut self, call: &'ast syn::ExprCall) {
+            if self.in_target {
+                if let syn::Expr::Path(p) = &*call.func {
+                    if p.path
+                        .segments
+                        .last()
+                        .is_some_and(|s| s.ident == "parse" || s.ident == "from_str")
+                    {
+                        self.hits.push("parse(..)".to_string());
+                    }
+                }
+            }
+            syn::visit::visit_expr_call(self, call);
+        }
+    }
+    let mut finder = Finder {
+        target,
+        in_target: false,
+        hits: Vec::new(),
+    };
+    syn::visit::Visit::visit_file(&mut finder, file);
+    finder.hits
+}
+
+/// Controls for the two helpers above, written as the false passes they must not produce.
+///
+/// Every false pass this file has shipped was in a helper rather than in a check, so both are driven
+/// directly with the shapes that defeat a text scan: a `parse` inside a comment, inside a plain string
+/// literal, inside a **raw** string literal, and a lifetime apostrophe in the signature — which is
+/// what broke the brace-matching predecessor this replaced.
 #[test]
-fn fn_bodies_finds_a_parse_in_a_resolver_and_is_not_fooled_by_braces_in_strings() {
-    let src = r#"
+fn the_parse_finder_reads_expressions_and_not_comments_literals_or_lifetimes() {
+    let file = syn::parse_file(
+        r##"
         impl A {
-            fn resolve_filter_index(&self, name: &str) -> u32 {
+            fn resolve_filter_index<'a>(&self, name: &'a str) -> u32 {
                 if let Ok(i) = name.parse::<u32>() { return i; }
-                { let _nested = 1; }
                 0
             }
-            fn innocent(&self) -> String {
-                // A brace inside a literal must not close the body early, or the parse above would
-                // leak into this body and the check would report the wrong function.
-                format!("{{ not a block }}")
+            fn resolve_mode_index<'a>(&self, name: &'a str) -> u32 {
+                // name.parse::<u32>() would be wrong here, and a comment is not code
+                let _doc = "call name.parse::<u32>() to get an index";
+                let _raw = r#"name.parse::<u32>()"#;
+                let _lifetime_bearing: &'a str = name;
+                0
             }
+            fn unrelated_helper(&self, s: &str) -> u32 { s.parse().unwrap_or(0) }
         }
-    "#;
-    let bodies: HashMap<String, String> = fn_bodies(src).into_iter().collect();
+    "##,
+    )
+    .expect("the control source parses");
 
     assert!(
-        bodies
-            .get("resolve_filter_index")
-            .is_some_and(|b| b.contains("parse::<u32>")),
-        "the resolver's own body must be found, or the check passes because it looked at nothing. \
-         Got keys {:?}",
-        bodies.keys().collect::<Vec<_>>()
+        !parse_calls_in(&file, "resolve_filter_index").is_empty(),
+        "a real `.parse()` call inside the target must be found, or the check looks at nothing"
     );
     assert!(
-        bodies
-            .get("innocent")
-            .is_some_and(|b| !b.contains("parse::<u32>")),
-        "a body must end at its own closing brace: a brace inside a string literal is not a block, \
-         and mistaking one merges two functions and misattributes what is in them"
+        parse_calls_in(&file, "resolve_mode_index").is_empty(),
+        "a `parse` in a comment, a string literal or a raw string literal is not a call — and the \
+         lifetime apostrophes here are exactly what desynchronised the character walk this replaced"
     );
-    // And the exploit that motivates the token-boundary check.
+
+    let names = control_fn_names(&file);
     assert!(
-        !fn_bodies("let my_fn = 1;")
-            .iter()
-            .any(|(n, _)| n == "my_fn"),
-        "`fn` must be matched as a token, not as the tail of an identifier"
+        names.contains(&"resolve_filter_index".to_string())
+            && names.contains(&"resolve_mode_index".to_string()),
+        "both resolvers must be in scope, got {names:?}"
+    );
+    assert!(
+        !names.contains(&"unrelated_helper".to_string()),
+        "a helper that is neither a resolver nor a setter is out of scope; it may parse numbers \
+         legitimately, and widening the scope to it would make the check noise"
     );
 }

--- a/tests/hqplayer_ledger_lint.rs
+++ b/tests/hqplayer_ledger_lint.rs
@@ -1942,3 +1942,201 @@ fn a_missing_proof_file_is_reported_rather_than_panicking() {
         "the real conformance suite is readable"
     );
 }
+
+// ===========================================================================================
+// Issue #347 — tripwires for the two rows it retired
+//
+// Both fire on a *regression*, which is the shape HQP-C-063's anchor argued a proof must have: a
+// check that asserts a defect still exists fails on the happy path and is worthless as a guard.
+// ===========================================================================================
+
+/// The mirror of [`the_reference_document_no_longer_settles_the_active_mode_question_by_fiat`], aimed
+/// at production source rather than prose — HQP-C-026, retired by #347.
+///
+/// `src/adapters/hqplayer.rs` told the reader that `Status.active_mode` is "unreliable" and to use
+/// `State`'s. `Status.active_mode` echoing the configured mode under `[source]` is measured
+/// (HQP-C-023); what `State.active_mode` reports there is unmeasured by anyone (HQP-C-024). Asserting
+/// the second as fact is settling an open question by comment, and a comment is where such a rule
+/// survives longest, because nothing executes it.
+///
+/// A line may still *name* the fields — the adapter has to read one of them — as long as it does not
+/// call the other unreliable without citing the open row.
+#[test]
+fn no_production_comment_settles_the_active_mode_question_by_fiat() {
+    let mut found = Vec::new();
+    for entry in walkdir::WalkDir::new(repo_root().join("src"))
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("rs"))
+    {
+        let Ok(body) = fs::read_to_string(entry.path()) else {
+            continue;
+        };
+        for (i, line) in body.lines().enumerate() {
+            let lower = line.to_ascii_lowercase();
+            let calls_it_unreliable = lower.contains("active_mode") && lower.contains("unreliable");
+            if calls_it_unreliable && !line.contains("HQP-C-024") {
+                found.push(format!(
+                    "{}:{}: {}",
+                    entry.path().display(),
+                    i + 1,
+                    line.trim()
+                ));
+            }
+        }
+    }
+    assert!(
+        found.is_empty(),
+        "production source states HQP-C-024's unmeasured half as fact. `Status.active_mode` echoing \
+         under `[source]` is measured; what `State.active_mode` reports there is not, and #332 owns \
+         settling it. Cite HQP-C-024 on the line or drop the claim: {found:#?}"
+    );
+}
+
+/// No production control path may turn a setting **name** back into a list index by parsing it —
+/// HQP-C-063, retired by #347.
+///
+/// The removed fallback tried `parse::<u32>()` in `resolve_mode_index`, `resolve_filter_index` and
+/// `resolve_shaper_index` and used the result as a direct list position, so a stale or guessed number
+/// selected whatever now sat there. The legacy numeric HTTP contracts still exist and are still
+/// honoured — but the number is resolved to a name at the boundary
+/// (`HqpAdapter::legacy_index_to_name`) and what travels inward is the name.
+///
+/// Scoped to the resolver and setter bodies rather than to the whole file, because the adapter parses
+/// numbers legitimately everywhere else: every `State` attribute arrives as one. The scoping is a
+/// brace walk over the source rather than a syntax visit, so that what is searched is exactly the text
+/// a reviewer would read.
+#[test]
+fn no_production_control_path_parses_a_setting_name_as_an_index() {
+    let src = read(&repo_root().join("src/adapters/hqplayer.rs"));
+    let mut offenders = Vec::new();
+    for (name, body) in fn_bodies(&src) {
+        if !(name.starts_with("resolve_") || name.starts_with("set_")) {
+            continue;
+        }
+        if body.contains("parse::<u32>")
+            || body.contains("parse::<usize>")
+            || body.contains(".parse()")
+        {
+            offenders.push(name);
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "a resolver or setter that parses a semantic name into a list index has reinstated \
+         HQP-C-063: a number arriving where a name belongs comes from another chain, another daemon, \
+         or a guess, and using it as a position silently selects a different setting. The legacy \
+         numeric contracts are served by `legacy_index_to_name` at the HTTP boundary instead. \
+         Offenders: {offenders:#?}"
+    );
+}
+
+/// `(name, body)` for every `fn` in a source file, bodies delimited by brace matching.
+///
+/// Deliberately textual. A syntax visit would need a token renderer this crate does not depend on,
+/// and the thing being guarded is a line a reviewer reads, not a shape only a parser can see.
+/// Braces inside string literals and char literals would confuse it, so both are skipped.
+fn fn_bodies(src: &str) -> Vec<(String, String)> {
+    let bytes: Vec<char> = src.chars().collect();
+    let mut out = Vec::new();
+    let mut i = 0;
+    while let Some(rel) = src[i..].find("fn ") {
+        let at = i + rel;
+        // Must be a token boundary, so `async fn` counts and `my_fn ` does not.
+        let preceded_ok = at == 0
+            || !src[..at]
+                .chars()
+                .next_back()
+                .is_some_and(|c| c.is_alphanumeric() || c == '_');
+        i = at + 3;
+        if !preceded_ok {
+            continue;
+        }
+        let name: String = src[i..]
+            .chars()
+            .take_while(|c| c.is_alphanumeric() || *c == '_')
+            .collect();
+        if name.is_empty() {
+            continue;
+        }
+        let Some(open_rel) = src[i..].find('{') else {
+            continue;
+        };
+        let mut j = i + open_rel;
+        // Character indices, so multi-byte source cannot desynchronise the walk.
+        let mut k = src[..j].chars().count();
+        let mut depth = 0i32;
+        let mut in_str = false;
+        let mut in_char = false;
+        let start = k;
+        while k < bytes.len() {
+            let c = bytes[k];
+            let escaped = k > 0 && bytes[k - 1] == '\\';
+            match c {
+                '"' if !in_char && !escaped => in_str = !in_str,
+                '\'' if !in_str && !escaped => in_char = !in_char,
+                '{' if !in_str && !in_char => depth += 1,
+                '}' if !in_str && !in_char => {
+                    depth -= 1;
+                    if depth == 0 {
+                        break;
+                    }
+                }
+                _ => {}
+            }
+            k += 1;
+        }
+        let body: String = bytes[start..k.min(bytes.len())].iter().collect();
+        j += body.len();
+        let _ = j;
+        out.push((name, body));
+    }
+    out
+}
+
+/// Controls for [`fn_bodies`], written as the false passes it must not produce.
+///
+/// Every false pass this file has shipped was in a helper rather than in a check, so the helper is
+/// exercised directly with the shapes that would defeat it: a brace inside a string literal, a
+/// nested block, and a name that merely ends in `fn`.
+#[test]
+fn fn_bodies_finds_a_parse_in_a_resolver_and_is_not_fooled_by_braces_in_strings() {
+    let src = r#"
+        impl A {
+            fn resolve_filter_index(&self, name: &str) -> u32 {
+                if let Ok(i) = name.parse::<u32>() { return i; }
+                { let _nested = 1; }
+                0
+            }
+            fn innocent(&self) -> String {
+                // A brace inside a literal must not close the body early, or the parse above would
+                // leak into this body and the check would report the wrong function.
+                format!("{{ not a block }}")
+            }
+        }
+    "#;
+    let bodies: HashMap<String, String> = fn_bodies(src).into_iter().collect();
+
+    assert!(
+        bodies
+            .get("resolve_filter_index")
+            .is_some_and(|b| b.contains("parse::<u32>")),
+        "the resolver's own body must be found, or the check passes because it looked at nothing. \
+         Got keys {:?}",
+        bodies.keys().collect::<Vec<_>>()
+    );
+    assert!(
+        bodies
+            .get("innocent")
+            .is_some_and(|b| !b.contains("parse::<u32>")),
+        "a body must end at its own closing brace: a brace inside a string literal is not a block, \
+         and mistaking one merges two functions and misattributes what is in them"
+    );
+    // And the exploit that motivates the token-boundary check.
+    assert!(
+        !fn_bodies("let my_fn = 1;")
+            .iter()
+            .any(|(n, _)| n == "my_fn"),
+        "`fn` must be matched as a token, not as the tail of an identifier"
+    );
+}

--- a/tests/hqplayer_pipeline_projection_lint.rs
+++ b/tests/hqplayer_pipeline_projection_lint.rs
@@ -1,0 +1,137 @@
+//! AST-level test: the HQPlayer pipeline projection may not read the cache it is projecting.
+//!
+//! `get_pipeline_status` joins `State`'s **list indices** to cached chain-scoped enumerations. That
+//! join is only meaningful if the lists it resolves through are the ones the verification step
+//! proved coherent with that `State`, and the only way to guarantee it is for the verification step
+//! to *hand back the snapshot it verified*. A proof that returns a `bool` and leaves the caller to
+//! fetch the data again is a check-then-re-read: between the two there is a window, and a profile
+//! load, a reconnect, a `fresh_*` publication or a refresh landing inside it replaces the cache with
+//! one that is perfectly coherent in itself and has nothing to do with the `State` being projected.
+//!
+//! A presence re-check cannot close that. "The lists are still there" and "the lists are still the
+//! ones I verified" are different questions, and a *complete* replacement answers the first while
+//! failing the second.
+//!
+//! So the structural rule this pins is narrow and mechanical:
+//!
+//! ```ignore
+//! // BAD: proof returns a verdict, projection re-reads the cache
+//! if !self.chain_still_matches_cache().await { /* ... */ }
+//! let (modes, filters, ..) = {
+//!     let cached = self.state.read().await;      // <-- a different moment
+//!     (cached.modes.clone(), cached.filters.clone(), ..)
+//! };
+//!
+//! // GOOD: proof returns the exact snapshot it verified, under one lock
+//! let snapshot = self.verified_chain_snapshot(identity, &probe).await?;
+//! // ... project from `snapshot`, and from nothing else
+//! ```
+//!
+//! Expressed as: **`get_pipeline_status` acquires no lock of its own.** Every value it projects is
+//! either something it read from the daemon in this call or something a helper returned to it
+//! already verified. A future edit that reaches back into `self.state` inside the projection is
+//! re-opening the window whatever else it does, and this test fails on the shape rather than waiting
+//! for a race to be observed.
+//!
+//! **Label: client-red.** Red at `b7a7a1a`, where the function took the state lock three times after
+//! its chain check had already passed.
+
+use std::fs;
+use std::path::Path;
+use syn::visit::Visit;
+use syn::{Expr, ExprMethodCall, File, ImplItemFn};
+
+/// The function whose shape is pinned, and the file it lives in.
+const SUBJECT_FILE: &str = "src/adapters/hqplayer.rs";
+const SUBJECT_FN: &str = "get_pipeline_status";
+
+/// Lock-acquisition method names, matching the ones `await_in_lock_lint` already recognises.
+fn is_lock_acquisition(method: &str) -> bool {
+    matches!(
+        method,
+        "lock" | "read" | "write" | "try_lock" | "try_read" | "try_write"
+    )
+}
+
+/// Whether the receiver is one of the adapter's own shared fields (`self.state`, `self.connection`).
+///
+/// Deliberately receiver-shaped rather than name-shaped: `snapshot.modes` and a local `Vec::read`
+/// are not what this forbids, and a lock taken on something reached through `self` is.
+fn is_own_field(receiver: &Expr) -> Option<String> {
+    match receiver {
+        Expr::Field(field) => match &*field.base {
+            Expr::Path(path) if path.path.is_ident("self") => match &field.member {
+                syn::Member::Named(name) => Some(name.to_string()),
+                syn::Member::Unnamed(_) => None,
+            },
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+#[derive(Default)]
+struct LockVisitor {
+    violations: Vec<String>,
+}
+
+impl<'ast> Visit<'ast> for LockVisitor {
+    fn visit_expr_method_call(&mut self, call: &'ast ExprMethodCall) {
+        let method = call.method.to_string();
+        if is_lock_acquisition(&method) {
+            if let Some(field) = is_own_field(&call.receiver) {
+                self.violations
+                    .push(format!("self.{field}.{method}()", field = field));
+            }
+        }
+        syn::visit::visit_expr_method_call(self, call);
+    }
+}
+
+struct FnFinder<'ast> {
+    wanted: &'static str,
+    found: Option<&'ast ImplItemFn>,
+}
+
+impl<'ast> Visit<'ast> for FnFinder<'ast> {
+    fn visit_impl_item_fn(&mut self, item: &'ast ImplItemFn) {
+        if item.sig.ident == self.wanted {
+            self.found = Some(item);
+        }
+        syn::visit::visit_impl_item_fn(self, item);
+    }
+}
+
+#[test]
+fn the_pipeline_projection_never_re_reads_the_cache_it_projects() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(SUBJECT_FILE);
+    let source = fs::read_to_string(&path).expect("read the HQPlayer adapter");
+    let syntax: File = syn::parse_file(&source).expect("parse the HQPlayer adapter");
+
+    let mut finder = FnFinder {
+        wanted: SUBJECT_FN,
+        found: None,
+    };
+    finder.visit_file(&syntax);
+    let subject = finder.found.unwrap_or_else(|| {
+        panic!(
+            "{SUBJECT_FILE} must still define `{SUBJECT_FN}`; if it was renamed, this lint has to \
+             follow it rather than silently pass"
+        )
+    });
+
+    let mut visitor = LockVisitor::default();
+    visitor.visit_block(&subject.block);
+
+    assert!(
+        visitor.violations.is_empty(),
+        "`{SUBJECT_FN}` takes {} lock(s) of its own: {:?}.\n\nIt must project only what the \
+         verification step returned to it. A lock taken inside the projection is a second moment, \
+         and the cache it reads at that moment is not provably the cache the `State` being \
+         projected was verified against — a concurrent profile load, reconnect, `fresh_*` \
+         publication or refresh can have replaced it with a complete, coherent, *different* one. \
+         Move the access into a helper that verifies and returns its snapshot atomically.",
+        visitor.violations.len(),
+        visitor.violations
+    );
+}

--- a/tests/hqplayer_pipeline_projection_lint.rs
+++ b/tests/hqplayer_pipeline_projection_lint.rs
@@ -39,7 +39,7 @@
 use std::fs;
 use std::path::Path;
 use syn::visit::Visit;
-use syn::{Expr, ExprMethodCall, File, ImplItemFn};
+use syn::{Expr, ExprIf, ExprMethodCall, File, ImplItemFn};
 
 /// The function whose shape is pinned, and the file it lives in.
 const SUBJECT_FILE: &str = "src/adapters/hqplayer.rs";
@@ -132,6 +132,141 @@ fn the_pipeline_projection_never_re_reads_the_cache_it_projects() {
          publication or refresh can have replaced it with a complete, coherent, *different* one. \
          Move the access into a helper that verifies and returns its snapshot atomically.",
         visitor.violations.len(),
+        visitor.violations
+    );
+}
+
+/// The refresh whose result must not gate the re-read, and the re-read it must not gate.
+const REFRESH_CALL: &str = "refresh_lists";
+const IDENTITY_CALL: &str = "chain_identity";
+
+/// Whether a call to `wanted` appears anywhere inside this expression.
+fn calls(expr: &Expr, wanted: &str) -> bool {
+    struct Finder<'a> {
+        wanted: &'a str,
+        found: bool,
+    }
+    impl<'ast> Visit<'ast> for Finder<'_> {
+        fn visit_expr_method_call(&mut self, call: &'ast ExprMethodCall) {
+            if call.method == self.wanted {
+                self.found = true;
+            }
+            syn::visit::visit_expr_method_call(self, call);
+        }
+    }
+    let mut finder = Finder {
+        wanted,
+        found: false,
+    };
+    finder.visit_expr(expr);
+    finder.found
+}
+
+/// Every `if` in the subject whose **condition** calls `refresh_lists` and whose **branches** call
+/// `chain_identity` — the shape that makes the re-read conditional on the refresh having published.
+#[derive(Default)]
+struct GatedRereadVisitor {
+    violations: Vec<String>,
+    saw_refresh: bool,
+    saw_identity: bool,
+}
+
+impl<'ast> Visit<'ast> for GatedRereadVisitor {
+    fn visit_expr_method_call(&mut self, call: &'ast ExprMethodCall) {
+        if call.method == REFRESH_CALL {
+            self.saw_refresh = true;
+        }
+        if call.method == IDENTITY_CALL {
+            self.saw_identity = true;
+        }
+        syn::visit::visit_expr_method_call(self, call);
+    }
+
+    fn visit_expr_if(&mut self, node: &'ast ExprIf) {
+        if calls(&node.cond, REFRESH_CALL) {
+            let then_rereads = node.then_branch.stmts.iter().any(|stmt| match stmt {
+                syn::Stmt::Expr(expr, _) => calls(expr, IDENTITY_CALL),
+                syn::Stmt::Local(local) => local
+                    .init
+                    .as_ref()
+                    .is_some_and(|init| calls(&init.expr, IDENTITY_CALL)),
+                _ => false,
+            });
+            let else_rereads = node
+                .else_branch
+                .as_ref()
+                .is_some_and(|(_, expr)| calls(expr, IDENTITY_CALL));
+            if then_rereads || else_rereads {
+                self.violations.push(format!(
+                    "an `if` whose condition calls `{REFRESH_CALL}` guards a `{IDENTITY_CALL}` \
+                     re-read"
+                ));
+            }
+        }
+        syn::visit::visit_expr_if(self, node);
+    }
+}
+
+/// **The winner is re-read after *any* refresh attempt, never only after a successful one.**
+///
+/// `refresh_lists` returns `false` in two situations that look nothing alike. It failed — a family
+/// would not answer, or the bracket disagreed — and the cache is as empty as it found it. Or it was
+/// **overtaken**: a profile load, a reconnect's refill or another poll's refresh published a
+/// complete, coherent set while this one was gathering, and the loser declined to overwrite it. That
+/// is the asymmetry `publish_chain_snapshot` deliberately implements, and its whole point is that
+/// the cache ends up *filled* — by the winner.
+///
+/// So a caller that reads the cache only when the refresh returned `true` throws the winner away. It
+/// then finds no identity, spends its one retry, and on an unlucky second pass returns
+/// "HQPlayer's setting lists could not be read as one coherent set" about a daemon whose lists were
+/// sitting complete and current in the cache the whole time. The bug is not in the refresh; it is in
+/// reading the refresh's `bool` as "is there a cache" when it means "did *I* fill it".
+///
+/// Pinned structurally rather than behaviourally: the losing branch requires a second publisher
+/// inside `refresh_lists`' gather window, which no sequence of public calls can arrange without a
+/// production hook. What can be pinned honestly is that the re-read is not gated on the refresh's
+/// verdict.
+///
+/// **Label: client-red.** Red against the short-circuit
+/// `if captured.is_none() && self.refresh_lists().await { captured = self.chain_identity().await; }`.
+#[test]
+fn the_pipeline_read_re_reads_the_cache_after_any_refresh_attempt() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(SUBJECT_FILE);
+    let source = fs::read_to_string(&path).expect("read the HQPlayer adapter");
+    let syntax: File = syn::parse_file(&source).expect("parse the HQPlayer adapter");
+
+    let mut finder = FnFinder {
+        wanted: SUBJECT_FN,
+        found: None,
+    };
+    finder.visit_file(&syntax);
+    let subject = finder.found.unwrap_or_else(|| {
+        panic!(
+            "{SUBJECT_FILE} must still define `{SUBJECT_FN}`; if it was renamed, this lint has to \
+             follow it rather than silently pass"
+        )
+    });
+
+    let mut visitor = GatedRereadVisitor::default();
+    visitor.visit_block(&subject.block);
+
+    assert!(
+        visitor.saw_refresh && visitor.saw_identity,
+        "`{SUBJECT_FN}` no longer calls both `{REFRESH_CALL}` and `{IDENTITY_CALL}` (refresh: {}, \
+         identity: {}). This lint is about how those two relate, so it must not pass by their \
+         absence — follow the rename or delete the lint deliberately.",
+        visitor.saw_refresh,
+        visitor.saw_identity
+    );
+
+    assert!(
+        visitor.violations.is_empty(),
+        "`{SUBJECT_FN}` gates its cache re-read on the refresh's verdict: {:?}.\n\n\
+         `{REFRESH_CALL}` returning `false` does not mean the cache is empty. An overtaken refresh \
+         returns `false` precisely because a *newer, complete* set won the race and it declined to \
+         overwrite it — the cache is filled, by someone else. Re-read `{IDENTITY_CALL}` after every \
+         refresh attempt and use whatever is there, rather than discarding a winner and failing the \
+         read with \"could not be read as one coherent set\".",
         visitor.violations
     );
 }

--- a/tests/mock_servers/hqplayer/model.rs
+++ b/tests/mock_servers/hqplayer/model.rs
@@ -341,6 +341,8 @@ struct Inner {
     status_active_mode: ActiveModeReporting,
     /// Which filter fields `State` carries. See [`FilterFieldReporting`].
     filter_fields: FilterFieldReporting,
+    /// `(element, chain)` — move the loaded chain once, right after that element is answered.
+    chain_switch_after: Option<(String, LoadedChain)>,
     enums: Enumerations,
     /// Every request line received, in order, so a test can assert on the value the client actually
     /// put on the wire (AC5) instead of on timing.
@@ -372,6 +374,7 @@ impl DaemonModel {
             state_active_mode: ActiveModeReporting::EchoesConfiguredMode,
             status_active_mode: ActiveModeReporting::EchoesConfiguredMode,
             filter_fields: FilterFieldReporting::default(),
+            chain_switch_after: None,
             enums: Enumerations::load(profile),
             requests: Vec::new(),
         };
@@ -437,6 +440,28 @@ impl DaemonModel {
         );
         inner.state.loaded_chain = chain;
         inner.clamp_to_loaded_chain();
+    }
+
+    /// Move the loaded chain **while the client is mid-conversation**: once, immediately after the
+    /// named element has been answered.
+    ///
+    /// [`Self::source_loads_chain`] moves the chain between client calls, which is enough for a
+    /// client that reads one list. It is not enough for one that reads several and publishes them as
+    /// a set: four replies read one after another are four moments, and a source change landing
+    /// between two of them yields a set that mixes the chains. Only a change *inside* the window can
+    /// express that, so the trigger is the request rather than the test's own timeline.
+    ///
+    /// **Provenance: derived-upstream, tier-2-only** — the same source-following observation as
+    /// [`LoadedChain`]. That a change can land between two requests needs no separate evidence: it
+    /// follows from the chain being able to move at all while the client is connected.
+    pub fn switch_chain_after_request(&self, element: &str, chain: LoadedChain) {
+        let mut inner = self.lock();
+        assert_eq!(
+            inner.state.mode_index, 0,
+            "switch_chain_after_request requires configured [source] mode, for the same reason \
+             source_loads_chain does: in PCM or SDM the configured mode *is* the chain"
+        );
+        inner.chain_switch_after = Some((element.to_string(), chain));
     }
 
     fn lock(&self) -> std::sync::MutexGuard<'_, Inner> {
@@ -1137,6 +1162,17 @@ impl Responder for DaemonModel {
             // Verified: even an unknown element gets an echoed error, connection intact.
             other => inner.error(other, "Unknown command"),
         };
+
+        // A source-driven chain change landing *inside* a client's multi-request conversation. Applied
+        // after the reply is built, so this request still sees the chain it asked about and every
+        // later one sees the new chain — which is exactly how a change between two requests looks.
+        let due = matches!(inner.chain_switch_after, Some((ref el, _)) if *el == element);
+        if due {
+            if let Some((_, chain)) = inner.chain_switch_after.take() {
+                inner.state.loaded_chain = chain;
+                inner.clamp_to_loaded_chain();
+            }
+        }
 
         Some(reply)
     }

--- a/tests/mock_servers/hqplayer/model.rs
+++ b/tests/mock_servers/hqplayer/model.rs
@@ -348,6 +348,9 @@ struct Inner {
     /// be caught in, and "the chain moved during the retry as well" is the case a bounded retry must
     /// answer for. One slot could only ever express the first.
     chain_switch_after: Vec<(String, LoadedChain)>,
+    /// `(element, mode index)` queue — an external controller changes configured mode immediately
+    /// after the named reply, before the client's next command.
+    mode_switch_after: Vec<(String, u32)>,
     enums: Enumerations,
     /// Every request line received, in order, so a test can assert on the value the client actually
     /// put on the wire (AC5) instead of on timing.
@@ -380,6 +383,7 @@ impl DaemonModel {
             status_active_mode: ActiveModeReporting::EchoesConfiguredMode,
             filter_fields: FilterFieldReporting::default(),
             chain_switch_after: Vec::new(),
+            mode_switch_after: Vec::new(),
             enums: Enumerations::load(profile),
             requests: Vec::new(),
         };
@@ -470,6 +474,18 @@ impl DaemonModel {
              source_loads_chain does: in PCM or SDM the configured mode *is* the chain"
         );
         inner.chain_switch_after.push((element.to_string(), chain));
+    }
+
+    /// Change configured mode between two client commands, as another controller can.
+    pub fn switch_mode_after_request(&self, element: &str, mode_index: u32) {
+        let mut inner = self.lock();
+        assert!(
+            mode_index < inner.entry_count("GetModes", "ModesItem"),
+            "switch_mode_after_request requires a mode the daemon offers"
+        );
+        inner
+            .mode_switch_after
+            .push((element.to_string(), mode_index));
     }
 
     fn lock(&self) -> std::sync::MutexGuard<'_, Inner> {
@@ -1181,6 +1197,24 @@ impl Responder for DaemonModel {
         if due {
             let (_, chain) = inner.chain_switch_after.remove(0);
             inner.state.loaded_chain = chain;
+            inner.clamp_to_loaded_chain();
+        }
+
+        let mode_due = inner
+            .mode_switch_after
+            .first()
+            .is_some_and(|(el, _)| *el == element);
+        if mode_due {
+            let (_, mode_index) = inner.mode_switch_after.remove(0);
+            inner.state.mode_index = mode_index;
+            // Match the measured SetMode side effect: every configured-mode change clears the pin.
+            inner.state.rate_index = 0;
+            inner.state.active_rate_hz = 0;
+            match mode_index {
+                1 => inner.state.loaded_chain = LoadedChain::Pcm,
+                2 => inner.state.loaded_chain = LoadedChain::Sdm,
+                _ => {}
+            }
             inner.clamp_to_loaded_chain();
         }
 

--- a/tests/mock_servers/hqplayer/model.rs
+++ b/tests/mock_servers/hqplayer/model.rs
@@ -152,6 +152,28 @@ pub enum ActiveModeReporting {
     ResolvesLoadedChain,
 }
 
+/// Which filter fields a `State` document carries.
+///
+/// **This is a client-contract shape, not a daemon claim.** Every capture in the corpus carries both
+/// `filter1x` and `filterNx`, and nothing here asserts that a daemon omits them. What *is* true, and
+/// what this exists to make reachable, is that UHC's own parser admits their absence —
+/// `HqpState::filter1x` and `HqpState::filter_nx` are `Option<u32>` — so the client has a branch for
+/// it and that branch decides whether a one-sided `SetFilter` **guesses** the sibling from the legacy
+/// combined `filter` field or **refuses**. #322's own audit recorded the guess as defect C5.
+///
+/// Constructed shapes and observed evidence are kept apart in this suite (see the
+/// `synthetic-chain-hazard` profile), so this is deliberately *not* reported by
+/// [`DaemonModel::armed_upstream_claims`]: that list names unqualified claims about **daemons**, and
+/// this makes no claim about any daemon at all.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum FilterFieldReporting {
+    /// `filter`, `filter1x` and `filterNx` — what every corpus capture shows.
+    #[default]
+    Split,
+    /// The legacy combined `filter` only, so both siblings read as absent to the client.
+    CombinedOnly,
+}
+
 /// The daemon's observable state.
 #[derive(Debug, Clone, PartialEq)]
 pub struct DaemonState {
@@ -317,6 +339,8 @@ struct Inner {
     state_active_mode: ActiveModeReporting,
     /// How `Status.active_mode` reports.
     status_active_mode: ActiveModeReporting,
+    /// Which filter fields `State` carries. See [`FilterFieldReporting`].
+    filter_fields: FilterFieldReporting,
     enums: Enumerations,
     /// Every request line received, in order, so a test can assert on the value the client actually
     /// put on the wire (AC5) instead of on timing.
@@ -347,6 +371,7 @@ impl DaemonModel {
             // wants either behaviour must now say so.
             state_active_mode: ActiveModeReporting::EchoesConfiguredMode,
             status_active_mode: ActiveModeReporting::EchoesConfiguredMode,
+            filter_fields: FilterFieldReporting::default(),
             enums: Enumerations::load(profile),
             requests: Vec::new(),
         };
@@ -372,6 +397,12 @@ impl DaemonModel {
 
     pub fn set_style(&self, style: DocumentStyle) {
         self.lock().style = style;
+    }
+
+    /// Declare which filter fields `State` carries. See [`FilterFieldReporting`] — a client-contract
+    /// shape, never a claim about a daemon.
+    pub fn set_filter_field_reporting(&self, reporting: FilterFieldReporting) {
+        self.lock().filter_fields = reporting;
     }
 
     /// Declare how each renderer reports `active_mode`.
@@ -588,11 +619,21 @@ impl Inner {
             ActiveModeReporting::EchoesConfiguredMode => self.state.mode_index,
             ActiveModeReporting::ResolvesLoadedChain => self.loaded_chain_mode_index(),
         };
+        // Absent siblings are rendered by *omitting the attributes*, not by emitting empty ones: the
+        // client reads them with `parse_attr(...).and_then(parse)`, and an empty value would be an
+        // unparseable present attribute rather than an absent one. Only absence exercises the branch.
+        let siblings = match self.filter_fields {
+            FilterFieldReporting::Split => format!(
+                " filter1x=\"{}\" filterNx=\"{}\"",
+                self.state.filter_1x_index, self.state.filter_nx_index
+            ),
+            FilterFieldReporting::CombinedOnly => String::new(),
+        };
         let s = &self.state;
         let doc = format!(
             concat!(
-                "<State state=\"{state}\" mode=\"{mode}\" filter=\"{filter}\" ",
-                "filter1x=\"{f1x}\" filterNx=\"{fnx}\" shaper=\"{shaper}\" rate=\"{rate}\" ",
+                "<State state=\"{state}\" mode=\"{mode}\" filter=\"{filter}\"",
+                "{siblings} shaper=\"{shaper}\" rate=\"{rate}\" ",
                 "volume=\"{volume}\" active_mode=\"{active_mode}\" active_rate=\"{active_rate}\" ",
                 "convolution=\"{conv}\" invert=\"{invert}\" repeat=\"{repeat}\" ",
                 "random=\"{random}\" adaptive=\"{adaptive}\" filter_junk=\"{junk}\" ",
@@ -602,8 +643,7 @@ impl Inner {
             mode = s.mode_index,
             // Legacy single-filter field; observed tracking the most recently set of 1x/Nx.
             filter = s.filter_nx_index,
-            f1x = s.filter_1x_index,
-            fnx = s.filter_nx_index,
+            siblings = siblings,
             shaper = s.shaper_index,
             rate = s.rate_index,
             volume = format_db(s.volume_db),

--- a/tests/mock_servers/hqplayer/model.rs
+++ b/tests/mock_servers/hqplayer/model.rs
@@ -341,8 +341,13 @@ struct Inner {
     status_active_mode: ActiveModeReporting,
     /// Which filter fields `State` carries. See [`FilterFieldReporting`].
     filter_fields: FilterFieldReporting,
-    /// `(element, chain)` — move the loaded chain once, right after that element is answered.
-    chain_switch_after: Option<(String, LoadedChain)>,
+    /// `(element, chain)` queue — each entry moves the loaded chain once, right after that element
+    /// is answered, in the order they were armed.
+    ///
+    /// A queue rather than a single slot because a client that retries has more than one window to
+    /// be caught in, and "the chain moved during the retry as well" is the case a bounded retry must
+    /// answer for. One slot could only ever express the first.
+    chain_switch_after: Vec<(String, LoadedChain)>,
     enums: Enumerations,
     /// Every request line received, in order, so a test can assert on the value the client actually
     /// put on the wire (AC5) instead of on timing.
@@ -374,7 +379,7 @@ impl DaemonModel {
             state_active_mode: ActiveModeReporting::EchoesConfiguredMode,
             status_active_mode: ActiveModeReporting::EchoesConfiguredMode,
             filter_fields: FilterFieldReporting::default(),
-            chain_switch_after: None,
+            chain_switch_after: Vec::new(),
             enums: Enumerations::load(profile),
             requests: Vec::new(),
         };
@@ -454,6 +459,9 @@ impl DaemonModel {
     /// **Provenance: derived-upstream, tier-2-only** — the same source-following observation as
     /// [`LoadedChain`]. That a change can land between two requests needs no separate evidence: it
     /// follows from the chain being able to move at all while the client is connected.
+    ///
+    /// Calls queue: arming twice moves the chain on the next two matching requests, in order, which
+    /// is how a client's *retry* window is reached as well as its first.
     pub fn switch_chain_after_request(&self, element: &str, chain: LoadedChain) {
         let mut inner = self.lock();
         assert_eq!(
@@ -461,7 +469,7 @@ impl DaemonModel {
             "switch_chain_after_request requires configured [source] mode, for the same reason \
              source_loads_chain does: in PCM or SDM the configured mode *is* the chain"
         );
-        inner.chain_switch_after = Some((element.to_string(), chain));
+        inner.chain_switch_after.push((element.to_string(), chain));
     }
 
     fn lock(&self) -> std::sync::MutexGuard<'_, Inner> {
@@ -1166,12 +1174,14 @@ impl Responder for DaemonModel {
         // A source-driven chain change landing *inside* a client's multi-request conversation. Applied
         // after the reply is built, so this request still sees the chain it asked about and every
         // later one sees the new chain — which is exactly how a change between two requests looks.
-        let due = matches!(inner.chain_switch_after, Some((ref el, _)) if *el == element);
+        let due = inner
+            .chain_switch_after
+            .first()
+            .is_some_and(|(el, _)| *el == element);
         if due {
-            if let Some((_, chain)) = inner.chain_switch_after.take() {
-                inner.state.loaded_chain = chain;
-                inner.clamp_to_loaded_chain();
-            }
+            let (_, chain) = inner.chain_switch_after.remove(0);
+            inner.state.loaded_chain = chain;
+            inner.clamp_to_loaded_chain();
         }
 
         Some(reply)

--- a/tests/mock_servers/hqplayer/tier1.rs
+++ b/tests/mock_servers/hqplayer/tier1.rs
@@ -838,9 +838,12 @@ pub async fn capture(adapter: &HqpAdapter) -> anyhow::Result<Capture> {
             .collect(),
     );
 
-    // Read-only: MatrixGetProfile reports the current selection without changing it.
+    // Read-only: what `MatrixGetProfile` reports, captured as an observation. Deliberately the raw
+    // command rather than `get_matrix_profile()`, which since #347 answers from
+    // `State.matrix_profile` — diffing that field against itself would prove nothing, and settling
+    // whether the command agrees with `State` is exactly what this lane is for.
     let t = Instant::now();
-    match adapter.get_matrix_profile().await {
+    match adapter.read_matrix_get_profile().await {
         Ok(Some(p)) => {
             timed("matrix_current", t.elapsed(), &mut c);
             c.current_matrix_profile = Some((p.index, p.name));

--- a/tests/mock_servers/hqplayer/wire.rs
+++ b/tests/mock_servers/hqplayer/wire.rs
@@ -80,6 +80,12 @@ pub struct WirePolicy {
     pub disruption: Disruption,
     /// Requests for this element draw no reply at all, so the client must hit its response timeout.
     pub silent_for_element: Option<String>,
+    /// Like [`Self::silent_for_element`], but only once [`WireServer::arm_element_silence`] is called.
+    ///
+    /// Some faults must arrive *after* a client has already succeeded at something — a cache filled,
+    /// a profile loaded — and a policy that holds from the first byte cannot express that. Declaring
+    /// it does not arm it, so setup is never the thing under test.
+    pub silent_for_element_when_armed: Option<String>,
     /// Apply this element to the model, then close the connection without replying — **once**.
     ///
     /// The element-scoped mirror of [`Disruption::ApplyThenDropReplyOnce`], which fires on whichever
@@ -143,6 +149,7 @@ impl Default for WirePolicy {
             chunk_delay: Duration::from_millis(20),
             disruption: Disruption::None,
             silent_for_element: None,
+            silent_for_element_when_armed: None,
             apply_then_drop_reply_for_element: None,
             malformed_for_element: None,
             oversized_for_element: None,
@@ -220,6 +227,9 @@ pub struct WireServer {
     /// One-shot budget for `apply_then_drop_reply_for_element`. Element-scoped, so like the oversized
     /// fault it is armed by being declared and cannot disturb connection setup.
     element_drops_left: Arc<AtomicU32>,
+    /// Whether `silent_for_element_when_armed` is live. Shared across connections, because a client
+    /// that reconnects must still meet the fault.
+    element_silence_armed: Arc<AtomicU32>,
     accept_task: JoinHandle<()>,
 }
 
@@ -248,7 +258,9 @@ impl WireServer {
         let accept_stats = stats.clone();
         let accept_budget = disruptions_left.clone();
         let accept_oversized = oversized_left.clone();
+        let element_silence_armed = Arc::new(AtomicU32::new(0));
         let accept_element_drops = element_drops_left.clone();
+        let accept_element_silence = element_silence_armed.clone();
         let accept_task = tokio::spawn(async move {
             while let Ok((stream, _)) = listener.accept().await {
                 accept_stats.connections.fetch_add(1, Ordering::SeqCst);
@@ -258,6 +270,7 @@ impl WireServer {
                 let budget = accept_budget.clone();
                 let oversized = accept_oversized.clone();
                 let element_drops = accept_element_drops.clone();
+                let element_silence = accept_element_silence.clone();
                 tokio::spawn(async move {
                     serve_connection(
                         stream,
@@ -267,6 +280,7 @@ impl WireServer {
                         budget,
                         oversized,
                         element_drops,
+                        element_silence,
                     )
                     .await;
                 });
@@ -279,8 +293,15 @@ impl WireServer {
             disruptions_left,
             oversized_left,
             element_drops_left,
+            element_silence_armed,
             accept_task,
         }
+    }
+
+    /// Make `silent_for_element_when_armed` live. Call once the client has got as far as the fault is
+    /// meant to interrupt.
+    pub fn arm_element_silence(&self) {
+        self.element_silence_armed.store(1, Ordering::SeqCst);
     }
 
     /// Whether the one-shot element-scoped apply-then-drop has fired.
@@ -379,6 +400,7 @@ async fn serve_connection(
     disruptions_left: Arc<AtomicU32>,
     oversized_left: Arc<AtomicU32>,
     element_drops_left: Arc<AtomicU32>,
+    element_silence_armed: Arc<AtomicU32>,
 ) {
     let (reader, mut writer) = stream.into_split();
     let mut reader = BufReader::new(reader);
@@ -410,6 +432,12 @@ async fn serve_connection(
 
         if let Some(ref element) = policy.silent_for_element {
             if mentions(&line, element) {
+                continue;
+            }
+        }
+
+        if let Some(ref element) = policy.silent_for_element_when_armed {
+            if element_silence_armed.load(Ordering::SeqCst) == 1 && mentions(&line, element) {
                 continue;
             }
         }

--- a/tests/mock_servers/hqplayer/wire.rs
+++ b/tests/mock_servers/hqplayer/wire.rs
@@ -80,6 +80,14 @@ pub struct WirePolicy {
     pub disruption: Disruption,
     /// Requests for this element draw no reply at all, so the client must hit its response timeout.
     pub silent_for_element: Option<String>,
+    /// Apply this element to the model, then close the connection without replying — **once**.
+    ///
+    /// The element-scoped mirror of [`Disruption::ApplyThenDropReplyOnce`], which fires on whichever
+    /// request comes next. That is enough when a client operation is one command, and not enough when
+    /// it is several: since #347 a setter reads an enumeration and `State` before it writes, so the
+    /// unscoped form vanishes during the *read* and the write never happens. Naming the element puts
+    /// the drop where the claim is — after the daemon applied the write, before the reply.
+    pub apply_then_drop_reply_for_element: Option<String>,
     /// Append these raw bytes instead of a reply for this element, to model a malformed document.
     pub malformed_for_element: Option<(String, String)>,
     /// `(element, document, interval)` — on a request for that element, stream `document`
@@ -135,6 +143,7 @@ impl Default for WirePolicy {
             chunk_delay: Duration::from_millis(20),
             disruption: Disruption::None,
             silent_for_element: None,
+            apply_then_drop_reply_for_element: None,
             malformed_for_element: None,
             oversized_for_element: None,
             oversized_newline_free_for_element: None,
@@ -208,6 +217,9 @@ pub struct WireServer {
     /// One-shot budget for `oversized_for_element`, shared across connections for the same reason:
     /// a test proves the *next* command recovers, which needs the fault to stop after firing.
     oversized_left: Arc<AtomicU32>,
+    /// One-shot budget for `apply_then_drop_reply_for_element`. Element-scoped, so like the oversized
+    /// fault it is armed by being declared and cannot disturb connection setup.
+    element_drops_left: Arc<AtomicU32>,
     accept_task: JoinHandle<()>,
 }
 
@@ -229,9 +241,14 @@ impl WireServer {
                 || policy.oversized_newline_free_for_element.is_some(),
         )));
 
+        let element_drops_left = Arc::new(AtomicU32::new(u32::from(
+            policy.apply_then_drop_reply_for_element.is_some(),
+        )));
+
         let accept_stats = stats.clone();
         let accept_budget = disruptions_left.clone();
         let accept_oversized = oversized_left.clone();
+        let accept_element_drops = element_drops_left.clone();
         let accept_task = tokio::spawn(async move {
             while let Ok((stream, _)) = listener.accept().await {
                 accept_stats.connections.fetch_add(1, Ordering::SeqCst);
@@ -240,8 +257,18 @@ impl WireServer {
                 let stats = accept_stats.clone();
                 let budget = accept_budget.clone();
                 let oversized = accept_oversized.clone();
+                let element_drops = accept_element_drops.clone();
                 tokio::spawn(async move {
-                    serve_connection(stream, responder, policy, stats, budget, oversized).await;
+                    serve_connection(
+                        stream,
+                        responder,
+                        policy,
+                        stats,
+                        budget,
+                        oversized,
+                        element_drops,
+                    )
+                    .await;
                 });
             }
         });
@@ -251,8 +278,14 @@ impl WireServer {
             stats,
             disruptions_left,
             oversized_left,
+            element_drops_left,
             accept_task,
         }
+    }
+
+    /// Whether the one-shot element-scoped apply-then-drop has fired.
+    pub fn element_drop_fired(&self) -> bool {
+        self.element_drops_left.load(Ordering::SeqCst) == 0
     }
 
     /// Whether the one-shot oversized reply has been served.
@@ -345,6 +378,7 @@ async fn serve_connection(
     stats: Arc<WireStats>,
     disruptions_left: Arc<AtomicU32>,
     oversized_left: Arc<AtomicU32>,
+    element_drops_left: Arc<AtomicU32>,
 ) {
     let (reader, mut writer) = stream.into_split();
     let mut reader = BufReader::new(reader);
@@ -493,6 +527,16 @@ async fn serve_connection(
         // The command has now been applied. Vanishing here is the ambiguous case the client cannot
         // resolve: it wrote a request and got nothing back, exactly as in `DropNextReplyOnce`, but the
         // side effect has already happened.
+        if let Some(ref element) = policy.apply_then_drop_reply_for_element {
+            if mentions(&line, element)
+                && element_drops_left
+                    .compare_exchange(1, 0, Ordering::SeqCst, Ordering::SeqCst)
+                    .is_ok()
+            {
+                return;
+            }
+        }
+
         if policy.disruption == Disruption::ApplyThenDropReplyOnce
             && disruptions_left
                 .compare_exchange(1, 0, Ordering::SeqCst, Ordering::SeqCst)

--- a/tests/mock_servers/hqplayer/wire.rs
+++ b/tests/mock_servers/hqplayer/wire.rs
@@ -80,12 +80,6 @@ pub struct WirePolicy {
     pub disruption: Disruption,
     /// Requests for this element draw no reply at all, so the client must hit its response timeout.
     pub silent_for_element: Option<String>,
-    /// Like [`Self::silent_for_element`], but only once [`WireServer::arm_element_silence`] is called.
-    ///
-    /// Some faults must arrive *after* a client has already succeeded at something — a cache filled,
-    /// a profile loaded — and a policy that holds from the first byte cannot express that. Declaring
-    /// it does not arm it, so setup is never the thing under test.
-    pub silent_for_element_when_armed: Option<String>,
     /// Apply this element to the model, then close the connection without replying — **once**.
     ///
     /// The element-scoped mirror of [`Disruption::ApplyThenDropReplyOnce`], which fires on whichever
@@ -149,7 +143,6 @@ impl Default for WirePolicy {
             chunk_delay: Duration::from_millis(20),
             disruption: Disruption::None,
             silent_for_element: None,
-            silent_for_element_when_armed: None,
             apply_then_drop_reply_for_element: None,
             malformed_for_element: None,
             oversized_for_element: None,
@@ -227,9 +220,6 @@ pub struct WireServer {
     /// One-shot budget for `apply_then_drop_reply_for_element`. Element-scoped, so like the oversized
     /// fault it is armed by being declared and cannot disturb connection setup.
     element_drops_left: Arc<AtomicU32>,
-    /// Whether `silent_for_element_when_armed` is live. Shared across connections, because a client
-    /// that reconnects must still meet the fault.
-    element_silence_armed: Arc<AtomicU32>,
     accept_task: JoinHandle<()>,
 }
 
@@ -258,9 +248,7 @@ impl WireServer {
         let accept_stats = stats.clone();
         let accept_budget = disruptions_left.clone();
         let accept_oversized = oversized_left.clone();
-        let element_silence_armed = Arc::new(AtomicU32::new(0));
         let accept_element_drops = element_drops_left.clone();
-        let accept_element_silence = element_silence_armed.clone();
         let accept_task = tokio::spawn(async move {
             while let Ok((stream, _)) = listener.accept().await {
                 accept_stats.connections.fetch_add(1, Ordering::SeqCst);
@@ -270,7 +258,6 @@ impl WireServer {
                 let budget = accept_budget.clone();
                 let oversized = accept_oversized.clone();
                 let element_drops = accept_element_drops.clone();
-                let element_silence = accept_element_silence.clone();
                 tokio::spawn(async move {
                     serve_connection(
                         stream,
@@ -280,7 +267,6 @@ impl WireServer {
                         budget,
                         oversized,
                         element_drops,
-                        element_silence,
                     )
                     .await;
                 });
@@ -293,15 +279,8 @@ impl WireServer {
             disruptions_left,
             oversized_left,
             element_drops_left,
-            element_silence_armed,
             accept_task,
         }
-    }
-
-    /// Make `silent_for_element_when_armed` live. Call once the client has got as far as the fault is
-    /// meant to interrupt.
-    pub fn arm_element_silence(&self) {
-        self.element_silence_armed.store(1, Ordering::SeqCst);
     }
 
     /// Whether the one-shot element-scoped apply-then-drop has fired.
@@ -400,7 +379,6 @@ async fn serve_connection(
     disruptions_left: Arc<AtomicU32>,
     oversized_left: Arc<AtomicU32>,
     element_drops_left: Arc<AtomicU32>,
-    element_silence_armed: Arc<AtomicU32>,
 ) {
     let (reader, mut writer) = stream.into_split();
     let mut reader = BufReader::new(reader);
@@ -432,12 +410,6 @@ async fn serve_connection(
 
         if let Some(ref element) = policy.silent_for_element {
             if mentions(&line, element) {
-                continue;
-            }
-        }
-
-        if let Some(ref element) = policy.silent_for_element_when_armed {
-            if element_silence_armed.load(Ordering::SeqCst) == 1 && mentions(&line, element) {
                 continue;
             }
         }


### PR DESCRIPTION
Fixes #347

OH: 80222d6d · epic #311 · **stacked on #341**

| | |
|---|---|
| **Base** | `feat/issue-341-hqplayer-evidence-ledger` @ `6d688bdbcb3fa607ca87a1593dd692e7ba00133a` |
| **Head** | `8970fd9cb93d537b6e7e234aef55c6e289a323bb` |
| **Merge order** | #322 → #341 → **#347**. Do not merge before #341 |

---

## Problem

Three things were treated as proof that were not.

1. **`result="OK"` was treated as application.** The daemon can acknowledge a setter and apply
   nothing (HQP-C-028). Worse, the readback #322 added cannot catch the narrow case: requesting Auto
   under `[source]`, where the rate is already Auto and the daemon ignores the pin, compares 0 against
   0 and reports success for a command that did nothing (HQP-C-019).
2. **A mode-keyed list cache was treated as the loaded chain.** Under configured `[source]` the source
   decides which PCM/SDM chain is loaded and `State.mode` never moves (HQP-C-007), so nothing prompted
   a re-read. Observed pre-fix, hermetically, on #347 comment 5125934210: `ok=true` returned while the
   daemon ended on `poly-sinc-lp` — a filter nobody asked for.
3. **A number arriving where a name belongs was treated as a list position.** `resolve_mode_index`,
   `resolve_filter_index` and `resolve_shaper_index` each fell back to `parse::<u32>()` (HQP-C-063).

Plus: one-sided `SetFilter` guessed the absent sibling from the legacy combined `filter` field, which
silently overwrites the setting the caller did not touch (#322 audit, defect C5).

## Solution

**1 · A setter reports what it did.** `SettingOutcome` — `Applied` / `AlreadySet` / `Ignored` /
`Suppressed` / `Ambiguous`, `#[must_use]` — replaces `Result<()>` on the enumerated live setters.
`into_applied_result()` collapses it to today's `{"ok":true}` / `{"error":…}` at the HTTP and MCP
boundaries, so **no response contract moves** and the *compiler*, not a reviewer, is what forces both
surfaces to handle it. `HqpRejected` makes an explicit `result="Error"` a type rather than a message,
because a rejection is terminal while a lost reply is **ambiguous delivery** (HQP-C-029) — a `SetMode`
was once accepted, logged and acted on while the daemon answered nothing — and telling those apart by
matching error text is how the distinction quietly stops holding. A write whose reply is lost is now
read back: if the daemon has it, it applied.

**2 · The loaded chain is the enumeration the daemon serves.** Not the configured mode, and not
`State.active_mode`, whose semantics under `[source]` are *unmeasured* (HQP-C-024) — reading it as an
answer would settle by fiat exactly what #341 refuses to settle. Per-family fingerprints: a freshly
fetched list whose fingerprint differs from the cached one **is** a chain transition, and every
chain-scoped family dies with it. Control paths resolve names against a list fetched now; the read
path probes with `GetRates`, the smallest chain-scoped enumeration, whose two chains were observed
disjoint (HQP-C-020). Connect, disconnect and `mark_disconnected` all invalidate.

**3 · Numbers stop at the boundary.** `legacy_index_to_name` resolves the frozen numeric request
contracts against the current enumeration and passes the **name** inward. A position the current list
does not have is an error there rather than an index forwarded to the wire.

And the consequences the issue names: `SetRate` **suppressed** under `[source]` with the mode quoted
rather than sent and failed on readback arithmetic — the only thing that fixes the Auto case;
`SetMode` **skipped** when the daemon is already in that mode, because it clears the rate pin even
when the mode does not change (HQP-C-017); `SetFilter` carrying **both** sides or refusing without
mutating; modes resolved by semantic family so `"DSD"` reaches the daemon's `"SDM (DSD)"` with no
positional assumption (HQP-C-013).

## RED → GREEN evidence

Every expectation was written first and run against the pre-fix adapter. Thirteen behavioural reds,
commit `4fc93b5`, before any production change:

| Expectation | Failure at `6d688bd` |
|---|---|
| `a_rate_pin_under_source_is_suppressed_before_it_reaches_the_daemon` | `SetRate` count `1`, want `0` |
| `an_auto_rate_request_under_source_is_never_reported_as_applied` | sent, and `Ok` returned |
| `a_no_op_mode_write_is_not_sent_so_the_rate_pin_survives` | `SetMode` count `1`, want `0` |
| `a_mode_alias_resolves_through_the_daemons_own_name` | `Mode 'DSD' not found. Available: [source], PCM, SDM (DSD)` |
| `a_source_driven_chain_change_invalidates_the_cached_filter_list` | stale index 7 accepted, daemon on `SYN-sdm-7` |
| `after_a_chain_change_a_filter_resolves_against_the_newly_loaded_list` | `HQPlayer rejected SetFilter: invalid filter` |
| `a_name_present_in_both_chains_is_sent_with_the_loaded_chains_index` | same |
| `a_chain_change_invalidates_the_shaper_and_rate_lists_the_pipeline_publishes` | PCM shapers still served over a loaded SDM chain |
| `a_reconnect_invalidates_the_cached_enumerations` | `SYN-pcm-*` after reconnect |
| `a_filter_write_is_refused_without_mutation_when_the_sibling_is_unknowable` | sibling guessed and sent |
| `a_numeric_string_is_never_accepted_as_a_setting_name` | `"1"` taken as index 1 |
| `the_current_matrix_profile_is_read_from_state_not_matrix_get_profile` | `MatrixGetProfile` believed over `State` |
| `a_matrix_profile_accepted_but_unchanged_is_not_reported_as_applied` | `OK` reported as applied |
| `a_current_matrix_profile_absent_from_the_fresh_list_...` | published as `MatrixProfile { index: 0, name: "Ghost" }` — index 0 is `Default` |

Further reds were demonstrated by restoring the pre-fix behaviour in place and re-running:

| Expectation | Failure with the pre-fix mechanism restored |
|---|---|
| `a_write_whose_reply_is_lost_after_the_daemon_applied_it_is_reported_as_applied` | `Connection closed mid-document after 1 bytes` |
| `a_write_whose_delivery_cannot_be_established_is_reported_as_ambiguous` | `Response timeout` |
| `a_chain_change_during_a_list_refresh_publishes_nothing_rather_than_a_mixed_set` | `filters=[… "sinc-Lh" …] shapers=[… "NS9" …]` — SDM filters offered beside PCM shapers |
| `a_single_failed_family_publishes_no_part_of_the_refresh` | `Published anyway: ["samplerate"]` |
| `the_legacy_both_sides_filter_write_is_a_single_command` | 2 requests, want 1 |
| `a_both_sides_filter_write_that_is_ignored_reports_both_sides` | `accepted filter1x but filter1x still reads 6` — naming half the write |
| `the_legacy_setting_route_still_refuses_a_name_it_never_accepted` | `{"error":"Connection timeout"}` — `dither` was accepted and reached the adapter |
| `a_chain_change_between_the_state_read_and_the_list_read_is_not_published` | published `""` while the daemon held `poly-sinc-xtr` |
| `a_raw_filter_write_the_daemon_acknowledges_and_drops_is_not_reported_as_success` | `Ok(())` for a write the daemon acknowledged and dropped |
| `a_chain_that_moves_on_both_the_read_and_the_retry_is_reported_rather_than_published` | published `[]` families, `filter1x` selected as `""` out of 0 options, as a successful read |
| `a_single_failed_family_fails_the_read_rather_than_publishing_an_empty_one` | `Ok` with four empty lists, reported as a successful read |
| `a_first_read_whose_required_fill_never_settles_is_not_reported_as_success` | same, reached through the first read after connect |

The static lint's bite was verified the same way: reinstating the fallback in `resolve_shaper` yields
`Offenders: ["resolve_shaper"]`.

### Exact-head review corrections

Four later exact-head CodeRabbit findings plus two independent dissent rounds produced seventeen
additional RED expectations before this head. Each behavioral or structural regression was run
against the prior production shape and failed before its correction:

| Expectation | Failure before the correction |
|---|---|
| `a_profile_load_whose_refresh_fails_never_reuses_pre_profile_enumerations` | after a successful profile POST followed by protocol-level `Error` replies for `GetShapers`, the next read confidently returned the old list containing `NS9` |
| `a_reconnect_during_the_reads_never_publishes_empty_enumerations_as_current` | a reconnect between list and state reads returned all four option families empty and selected `filter1x` as `""` in a successful response |
| `a_final_chain_check_that_cannot_run_twice_is_reported_rather_than_published` | two rejected final `GetRates` checks still published all four families through an unverified cache |
| `a_final_chain_check_that_runs_on_the_retry_publishes_the_verified_read` | one rejected final check was swallowed and the read published without any successful verification |
| `a_lost_volume_range_reply_does_not_publish_the_cache_its_reconnect_emptied` | a post-proof reconnect emptied the cache and the read still returned `Ok` with 0/4 option families |
| `the_pipeline_projection_never_re_reads_the_cache_it_projects` | the AST lint found three direct state-lock acquisitions after/beside proof, leaving a check-then-re-read replacement window |
| `an_old_probe_never_clears_a_newer_complete_cache_with_different_rates` | an old probe erased a newer complete cache instead of yielding as `Replaced` |
| `a_gather_overtaken_by_a_newer_profile_publishes_nothing_and_leaves_the_winner` | a stale off-lock full gather overwrote a newer complete profile cache |
| `an_invalidation_with_no_refill_stops_an_overtaken_gather_as_well` | a gather issued before a reconnect could refill the cache after the reconnect event |
| `a_byte_identical_refill_is_still_a_replacement_for_a_read_that_captured_the_old_cache` | four equal fingerprints made a clear/refill look untouched and joined pre-event lists to post-event `State` |
| `the_generation_counter_never_stalls_at_the_integer_ceiling` | a saturating counter stayed at `u64::MAX`, making every later cache event invisible |
| `a_stale_filter_fetch_overtaken_by_a_complete_winner_is_refused_and_leaves_it_alone` | a stale single-family writer produced a complete mixed cache: three families from the winner and old filters |
| `every_family_refuses_a_fetch_the_cache_has_outrun` | each `fresh_*` path could publish a reply from a session/cache generation that had ended |
| `a_fresh_family_identical_to_the_cached_one_is_not_a_new_filling_of_the_cache` | ordinary identical setter refetches advanced the generation and manufactured retry/failure races |
| `the_pipeline_read_re_reads_the_cache_after_any_refresh_attempt` | `refresh_lists=false` discarded a newer complete winner when this refresh lost the publication race |
| `an_overtaken_fresh_family_that_resolves_like_the_winner_is_still_usable` | the first generation guard returned a 500 after an empty-cache full refresh won with the exact same semantic mapping |
| `a_full_snapshot_fill_fences_an_older_fresh_family_with_a_different_mapping` / `changed_family_metadata_is_published_even_when_the_mapping_fingerprint_is_unchanged` | mutation checks showed the full-snapshot bump and whole-family no-op comparison were not independently pinned |

CodeRabbit then found a separate setter race at exact head `412f20c`: a semantic name was resolved
against one chain, but `AlreadySet`/write/readback compared only the numeric position after the chain
moved. Eleven additional semantic-bracket expectations plus six dissent corrections pin the result:

| Setter proof | Failure before the correction |
|---|---|
| stale filter/shaper no-op | returned `AlreadySet` for a different semantic value at the same position |
| cross-chain filter/shaper write | returned `Applied` after the position selected a different name |
| retry after an earlier write | a later resolve/fetch/decision error erased the wire attempt, or a retry no-op returned `AlreadySet` |
| paired filter readback | split and missing fields both collapsed to ambiguity instead of observed `Ignored` vs unknown `Ambiguous` |
| acknowledged negative readback | leaked numeric positions instead of filter/mode/shaper names or rate Hz (`0` is now `Auto`) |
| rate retry entering `[source]` | source suppression was checked only once, outside the retry decision |
| transition to `[source]` between decision and `SetRate` | Auto was acknowledged/ignored, numeric zero and an unchanged rate list falsely yielded `Applied`; final proof now resolves configured mode and returns wire-aware `Ambiguous` |
| transition after proof `State` before modes fetch | `GetModes` is capability-only; stale `State` still yielded `Applied`; `State` is now re-read after modes and used for source/value proof |
| exhausted bracket | ambiguity did not disclose whether any write reached or may have reached the wire |

`SemanticFamily` now brackets each semantic setter with opening and closing enumerations, resolves and
compares in the semantic domain, and permits one bounded correction. Operation-level bookkeeping
preserves the truth of `Applied`/`Ignored` (sent), `Ambiguous` (attempted), and
`AlreadySet`/`Suppressed` (not sent) across both attempts. Pair selection distinguishes equal, split,
and missing state. The bracket is explicitly not compare-and-set: an out-and-back ABA transition or
another controller between resolution and write remains possible without daemon-side atomic support.

The final read architecture is a value proof rather than a boolean verdict. Reconnect-capable lazy
`VolumeRange` discovery happens first. The read captures a four-family fingerprint plus cache
generation identity, reads `State`/`Status`, takes the live rates probe, and under one state lock
verifies the identity and returns the exact `ChainSnapshot` it proved. Projection consumes only that
snapshot. A partial cache retries; a cache replaced by a newer complete identity retries without
erasing the winner; only a live probe contradicting the same captured identity invalidates it as
moved. The single retry is shared across the whole read.

Writers use the same epoch rule. Full gathers capture `chain_generation` before their first request
and publish all four families only if it is unchanged. Every `fresh_*` captures the generation before
the request and performs transition detection plus publication under one write lock. An overtaken
mapping is refused without disturbing the winner; if the anchored winner has exactly the same
`(index, semantic value)` mapping, the setter may safely resolve through the reply without rewriting
or re-dating the winner. Identical cached contents are a no-op; clear/refill and changed publications
advance the wrapping generation.

The profile test uses ordinary protocol `Error` replies without disconnecting the fake daemon. The
volume regression uses the existing element-scoped one-shot dropped reply; no production sleep,
yield, or test-only hook was introduced. Twenty-one internal identity/publication tests cover all
four family identities, partial/unanchored sets, exact snapshot return, replacement preservation,
stale-probe ordering, full and single-family writer races, equal-winner acceptance, movement,
metadata-only change, byte-identical refill, overflow, and unchanged reads. Two AST tests pin exact
snapshot projection and unconditional winner re-read. Mutation checks killed the prior mechanisms,
including removal of either writer guard, each required generation bump, generation identity,
wrapping overflow, and whole-family equality.

Final exact head: `8970fd9cb93d537b6e7e234aef55c6e289a323bb`. Three consecutive
`hqplayer_conformance` runs passed 271/271. The complete workspace gate passed 675 tests with 12
explicit live tests ignored; CI.s exact `cargo clippy -- -D warnings`, fmt, diff, API contract,
protocol schema/integration, projection lint, and 21 cache-identity tests passed. The final `sg review`
found no blocker; its suggestions were non-blocking helper/readability deduplication and the explicitly
documented request amplification. A final Opus dissent process returned no report and made no edits;
the prior Opus P2/P3 findings were closed by the semantic-bracket tests above and a manual exact-diff
dissent found no remaining P1-P3.

Eight further expectations are **pins**, not reds — they already held and now cannot regress. Each is
labelled `client-red`, `client-pin` or `model-fidelity` in its own doc comment.

## Commands and results

```
cargo fmt --check                                   FMT_EXIT=0
cargo clippy -- -D warnings                         CLIPPY_EXIT=0   (CI's exact invocation, unpiped)
cargo test --workspace --no-fail-fast               TESTS_EXIT=0, 675 passed (12 live tests ignored)
```

| Target | Result |
|---|---|
| `hqplayer_conformance` | 271 passed |
| `hqplayer_pipeline_projection_lint` | 2 passed |
| `hqplayer_ledger_lint` | 40 passed |
| `api_contract` | 2 passed |
| `protocol_schema` | 41 passed |
| `adapter_integration` | 52 passed |
| `client_harness` | 46 passed |
| `protocol_integration` | 33 passed |
| `zones_sha_integration` | 30 passed |
| `architecture_lint` · `aggregator_lint` · `await_in_lock_lint` · `arbitrary_find_lint` · `ignored_send_lint` · `oneshot_leak_lint` · `spawn_cancellation_lint` · `unbounded_channel_lint` · `volume_safety` · `volume_step` | 47 passed |

`cargo check --features web` and `cargo build --bins` both succeed. **`dx build` was not run: `dx` is
not installed in this environment** — `command -v dx` exits 1, and `/Users/muness/.cargo/bin` (which
is on `PATH`) holds `ba`, `cargo-audit`, `repo-native-alignment`, `sg` and `wm` and no `dx`. So the
WASM half of the Dioxus build is unverified here. Nothing
under `src/app/` is touched and no UI file calls the adapter — the pages reach HQPlayer over HTTP —
so the exposure is a build-tooling gap rather than an untested code path, but it is a gap and CI is
what closes it.

## API and appliance boundaries

- **No API change.** No route added, removed or renamed. `tests/fixtures/api_routes.txt` is
  untouched — `git diff` against it is empty — and `cargo test --test api_contract` passes.
- Request schemas unchanged: `HqpSettingRequest { name, value: u32 }` and
  `HqpPipelineRequest { setting, value }` are as they were, numbers included.
- Response schemas unchanged: `{"ok":true}` / `{"error":…}` / `PipelineStatus` /
  `{profiles, current}`. `protocol_schema` pins them.
- **MCP unchanged.** Ten tools, same names, same descriptions, same arguments. No tool was added and
  none was made to do something its description does not promise.
- **No appliance was contacted.** Every test is hermetic against the #322 fake over loopback TCP. No
  credentials were used and `192.168.1.61` was never addressed.

## Dependency and merge order

Blocked by #322 (executable protocol foundation) and #341 (evidence ledger). This PR targets
`feat/issue-341-hqplayer-evidence-ledger` and must merge after it. It unblocks #325 and #329, which
own the producer and the verified live-setting surfaces.

**Ledger changes** (this PR's own rows): HQP-C-019 `open → settled`; HQP-C-026 and HQP-C-063
`open → retired`, both with the anchor rewritten to say what changed; HQP-C-064 `open → settled` (it
went stale the moment a conformance expectation drove `set_shaper`); HQP-C-004 restored to its
stronger wording, which #341 had scoped back because the two paths in HQP-C-063 made it false;
HQP-C-017 gains the client-side proof. Two tripwires added that fail on **regression** rather than on
the happy path — the asymmetry HQP-C-063's own anchor argued a proof must have.

## Residual risks

1. **The refresh bracket detects a chain that *ended* elsewhere than it started.** A change out and
   back inside one gather window would leave both probes agreeing. Nothing observed suggests that is
   reachable — a chain follows source material, not a poll cycle — and the guard is described as
   "did not straddle a visible transition", never as a same-instant snapshot.
2. **`GetRates` as the chain probe rests on HQP-C-020's disjointness.** The rate list also varies with
   the selected filter (HQP-C-021), so a filter change can move the fingerprint without a chain
   change: harmless, costing a refetch. The missed direction — a chain move leaving the rate list
   byte-identical — has no observation behind it, and is stated rather than assumed away.
3. **A numeric index sent as a JSON *string* to `/hqp/pipeline` now fails.** As a JSON *number* it
   still works, resolved at the boundary. The shipped clients send names (the pipeline GET's options
   carry names) or numbers, so no known caller regresses — but a caller sending `"3"` for `filter1x`
   gets an error naming the available filters instead of silently selecting position 3. That is the
   acceptance criterion, not an accident.
4. **`shaper_label` still derives from the configured mode.** Under `[source]` it can read "Shaper"
   over a loaded DSD chain. Changing a response *value* has no acceptance criterion here and was left
   alone deliberately; the loaded chain is now known, so #325/#329 can fix it cheaply.
5. **One extra command per pipeline poll** (the chain probe), and five on a detected transition. The
   alternative is a cache that can name a different filter than the user picked.
6. **The chain check confirms "same chain now as when the lists were published", not "one instant".**
   `get_pipeline_status` settles the lists, reads `State`, then re-checks — but a move out and back
   inside that window leaves the check agreeing. One retry bounds it; only a daemon-side atomic
   snapshot would close it, and the protocol offers none. When the retry is caught by a second
   transition the read **fails** rather than publishing: `GET /hqplayer/pipeline` answers its
   existing 500 error arm, which a flapping-source daemon can therefore reach. That is deliberate —
   the alternative was returning empty option lists as a successful read.
7. **`FilterFieldReporting` is a constructed shape, not evidence.** Every corpus capture carries both
   `filter1x` and `filterNx`; what it models is that UHC's *own parser* admits their absence. It is
   deliberately absent from `armed_upstream_claims`, which names unqualified claims about **daemons**.
8. **Tier-2 provenance is unchanged.** Source-following and the `[source]` rate refusal remain
   `derived-upstream, tier-2-only, pending #332`. This PR builds client behaviour on them; it does not
   promote them.
9. **Semantic proof is bracketed, not daemon-atomic.** Opening/closing enumeration fingerprints now
   catch a visible mapping move, re-resolve once, and prevent numeric-position false success. Another
   controller can still move the daemon between resolution and the wire, or move the mapping out and
   back (ABA) before the closing read. The protocol offers no compare-and-set; #162 retains the broader
   session/provenance boundary rather than this PR claiming atomicity against external controllers.
10. **`VolumeRange` is not yet host/session-versioned.** An old-host fetch can land after `configure`,
    and reconnect does not currently clear the cached range. #162 now owns provenance and invalidation
    for that non-chain cache; the current correction deliberately does not present it as solved.

## How to test

```bash
# The whole thing, hermetic, no daemon:
cargo test --test hqplayer_conformance --test hqplayer_ledger_lint --test api_contract

# The headline hazard on its own — the stale cross-chain filter selection:
cargo test --test hqplayer_conformance a_source_driven_chain_change_invalidates_the_cached_filter_list

# The contract that must not move:
cargo test --test api_contract && cargo test --test protocol_schema

# CI's own gates:
cargo fmt --check && cargo clippy -- -D warnings
```

To see a red rather than take one on trust, restore any pre-fix mechanism in
`src/adapters/hqplayer.rs` and re-run the target — the commit messages name which mechanism each red
depends on.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * HQPlayer setting changes now verify whether values were applied, already set, ignored, or rejected.
  * Invalid, unsupported, ambiguous, and unapplied settings now return clear errors instead of appearing successful.
  * Legacy numeric settings are resolved against the currently loaded HQPlayer options.
  * Filter updates, matrix profiles, samplerates, modes, and shapers now handle setting changes more reliably across reconnects and profile or chain changes.
  * Improved handling of fragmented, unsolicited, malformed, and oversized HQPlayer responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


