### PR TITLE
feat(162): manage the HQPlayer producer lifecycle

### DIFF
--- a/src/adapters/hqplayer.rs
+++ b/src/adapters/hqplayer.rs
@@ -30,13 +30,16 @@ use std::collections::HashMap;
 use std::io::Cursor;
 use std::net::{Ipv4Addr, SocketAddrV4};
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{TcpStream, UdpSocket};
 use tokio::sync::{Mutex, RwLock};
 use tokio::time::timeout;
+use tokio_util::sync::CancellationToken;
 
+use crate::adapters::Startable;
 use crate::bus::{
     BusEvent, NowPlaying as BusNowPlaying, PlaybackState, PrefixedZoneId, SharedBus, TrackMetadata,
     VolumeControl as BusVolumeControl, VolumeScale, Zone as BusZone,
@@ -854,6 +857,18 @@ pub struct HqpStatus {
     pub active_channels: u32,
     pub samplerate: u32,
     pub bitrate: u32,
+    /// Track title from the optional `Status/metadata` child.
+    ///
+    /// Kept internal until the public HQPlayer payload contract is explicitly revised; the unified
+    /// zone projection can still publish it through the existing now-playing shape.
+    #[serde(skip)]
+    pub title: Option<String>,
+    /// Track artist from the optional `Status/metadata` child.
+    #[serde(skip)]
+    pub artist: Option<String>,
+    /// Track album from the optional `Status/metadata` child.
+    #[serde(skip)]
+    pub album: Option<String>,
 }
 
 /// Volume range info
@@ -1269,6 +1284,12 @@ struct HqpAdapterState {
     web_username: Option<String>,
     web_password: Option<String>,
     connected: bool,
+    /// Monotonic identity of the last connection that completed a coherent handshake.
+    ///
+    /// A fast reconnect may pass through `connected=false` between two consumer observations, so
+    /// correctness cannot depend on sampling that transient edge. This advances only when the new
+    /// socket has produced the complete initial direct-zone snapshot.
+    producer_epoch: u64,
     info: Option<HqpInfo>,
     last_state: Option<HqpState>,
     modes: Vec<ListItem>,
@@ -1329,6 +1350,7 @@ impl Default for HqpAdapterState {
             web_username: None,
             web_password: None,
             connected: false,
+            producer_epoch: 0,
             info: None,
             last_state: None,
             modes: Vec::new(),
@@ -1355,6 +1377,15 @@ impl Default for HqpAdapterState {
 pub struct HqpAdapter {
     state: Arc<RwLock<HqpAdapterState>>,
     connection: Arc<Mutex<Option<HqpConnection>>>,
+    /// Serializes socket establishment. The command mutex serializes an existing connection, but
+    /// without this two concurrent first requests can both observe `None` and install two sessions.
+    connect_lock: Arc<Mutex<()>>,
+    /// Linearizes one instance's native conversations with connection, disconnect and configure.
+    ///
+    /// The socket mutex protects request/reply framing, but not the identity surrounding it: without
+    /// this lease `configure` can publish a new host while an old-host response is still in flight,
+    /// and a poll can combine State/Status/VolumeRange around a local command.
+    conversation_lock: Arc<Mutex<()>>,
     http_client: Client,
     bus: SharedBus,
     /// Unsolicited documents skipped while awaiting command replies. Diagnostics for tier-1 live
@@ -1373,6 +1404,8 @@ impl HqpAdapter {
         let adapter = Self {
             state: Arc::new(RwLock::new(HqpAdapterState::default())),
             connection: Arc::new(Mutex::new(None)),
+            connect_lock: Arc::new(Mutex::new(())),
+            conversation_lock: Arc::new(Mutex::new(())),
             http_client,
             bus,
             unsolicited_skipped: Arc::new(std::sync::atomic::AtomicU32::new(0)),
@@ -1446,11 +1479,19 @@ impl HqpAdapter {
         web_username: Option<String>,
         web_password: Option<String>,
     ) {
-        let changed = {
+        let _conversation_guard = self.conversation_lock.lock().await;
+        let (changed, old_reachable) = {
             let mut state = self.state.write().await;
             let port = port.unwrap_or(DEFAULT_PORT);
 
             let changed = state.host.as_ref() != Some(&host) || state.port != port;
+            let old_reachable = changed.then(|| {
+                (
+                    state.connected,
+                    state.host.clone(),
+                    state.instance_name.clone(),
+                )
+            });
             state.host = Some(host);
             state.port = port;
             state.web_port = web_port.unwrap_or(DEFAULT_WEB_PORT);
@@ -1483,12 +1524,19 @@ impl HqpAdapter {
                 state.hidden_fields.clear();
                 state.config_title = None;
             }
-            changed
+            (changed, old_reachable)
         };
 
         if changed {
             let mut conn = self.connection.lock().await;
             *conn = None;
+        }
+
+        if let Some((true, Some(old_host), instance_name)) = old_reachable {
+            let zone_id = PrefixedZoneId::hqplayer(instance_name.as_deref().unwrap_or(&old_host));
+            self.bus.publish(BusEvent::ZoneRemoved { zone_id });
+            self.bus
+                .publish(BusEvent::HqpDisconnected { host: old_host });
         }
 
         // Persist to disk
@@ -1548,8 +1596,25 @@ impl HqpAdapter {
         }
     }
 
-    /// Connect to HQPlayer
-    pub async fn connect(&self) -> Result<()> {
+    /// Identity of the most recent session that completed the coherent handshake.
+    ///
+    /// Internal lifecycle provenance seam for producer snapshots and conformance tests. It is not
+    /// serialized by any existing HTTP, SSE or MCP payload.
+    pub async fn producer_epoch(&self) -> u64 {
+        self.state.read().await.producer_epoch
+    }
+
+    /// Establish only the serialized native transport.
+    ///
+    /// The managed producer's reachability contract is deliberately stronger than this: it becomes
+    /// connected only after [`Self::connect`] has assembled a coherent zone snapshot. Command retry
+    /// must nevertheless be able to rebuild a socket without making an unrelated query depend on
+    /// every projection field being readable. The caller holds `connect_lock`.
+    async fn establish_transport_locked(&self) -> Result<()> {
+        if self.connection.lock().await.is_some() {
+            return Ok(());
+        }
+
         let (host, port) = {
             let state = self.state.read().await;
             let host = state
@@ -1566,35 +1631,81 @@ impl HqpAdapter {
             .map_err(|_| anyhow!("Connection timeout"))?
             .map_err(|e| anyhow!("Connection failed: {}", e))?;
 
-        // A new session inherits nothing. The daemon may have restarted onto another profile, been
-        // reconfigured, or simply followed the source onto the other chain while UHC was away, and a
-        // list index cached before the drop names a different setting in every one of those cases.
+        // A new native session inherits nothing. It is transport-usable immediately, but it is not
+        // yet a publishable producer session and therefore does not advance `producer_epoch` or set
+        // `connected`.
         self.invalidate_chain_cache().await;
-
         let (read_half, write_half) = stream.into_split();
         let reader = BufReader::new(read_half);
+        *self.connection.lock().await = Some(HqpConnection {
+            stream: reader,
+            write_half,
+            carry: Vec::new(),
+        });
+        Ok(())
+    }
 
-        {
-            let mut conn = self.connection.lock().await;
-            *conn = Some(HqpConnection {
-                stream: reader,
-                write_half,
-                carry: Vec::new(),
-            });
+    /// Connect to HQPlayer
+    pub async fn connect(&self) -> Result<()> {
+        let _conversation_guard = self.conversation_lock.lock().await;
+        let _connect_guard = self.connect_lock.lock().await;
+
+        // A second caller may have completed the session while this caller waited for the guard.
+        let has_connection = self.connection.lock().await.is_some();
+        if has_connection && self.state.read().await.connected {
+            return Ok(());
         }
 
-        {
-            let mut state = self.state.write().await;
-            state.connected = true;
-        }
+        self.establish_transport_locked().await?;
+        let host = self
+            .state
+            .read()
+            .await
+            .host
+            .clone()
+            .ok_or_else(|| anyhow!("HQPlayer host not configured"))?;
 
-        // Minimal on-connect: just GetInfo + Status to verify connection
-        let info = self.get_info_inner().await?;
-        let status = self.get_playback_status_inner().await.unwrap_or_default();
+        // Reachability starts only after every field required to build a truthful direct-zone
+        // snapshot has been read on this session. In particular, Status failure cannot be replaced
+        // with Default: doing so publishes a stopped, empty, fixed-volume zone that the daemon never
+        // reported and leaves `connected=true` after a partial handshake.
+        let handshake = async {
+            let info = self.get_info_inner().await?;
+            let state = self.get_state_inner().await?;
+            let status = self.get_playback_status_inner().await?;
+            let volume_range = self.get_volume_range_inner().await?;
+            Ok::<_, anyhow::Error>((info, state, status, volume_range))
+        }
+        .await;
+
+        let (info, observed_state, status, volume_range) = match handshake {
+            Ok(snapshot) => snapshot,
+            Err(error) => {
+                {
+                    let mut conn = self.connection.lock().await;
+                    *conn = None;
+                }
+                {
+                    let mut state = self.state.write().await;
+                    state.connected = false;
+                    state.info = None;
+                    state.last_state = None;
+                    state.volume_range = None;
+                    Self::clear_chain_cache(&mut state);
+                }
+                return Err(error.context("HQPlayer coherent initial snapshot failed"));
+            }
+        };
 
         {
             let mut state = self.state.write().await;
             state.info = Some(info.clone());
+            state.last_state = Some(observed_state);
+            state.volume_range = Some(volume_range.clone());
+            state.producer_epoch = state.producer_epoch.wrapping_add(1);
+            // This is deliberately last: no observer may see reachable until the session has a
+            // coherent initial snapshot ready to publish.
+            state.connected = true;
         }
 
         tracing::info!("HQPlayer connected: {} v{}", info.name, info.version);
@@ -1613,7 +1724,7 @@ impl HqpAdapter {
             instance_name.as_deref(),
             &info,
             &status,
-            &VolumeRange::default(),
+            &volume_range,
         );
         self.bus.publish(BusEvent::ZoneDiscovered { zone });
 
@@ -1626,20 +1737,30 @@ impl HqpAdapter {
 
     /// Disconnect
     pub async fn disconnect(&self) {
-        let (host, instance_name) = {
+        let _conversation_guard = self.conversation_lock.lock().await;
+        let (was_connected, host, instance_name) = {
             let mut state = self.state.write().await;
+            let was_connected = state.connected;
             state.connected = false;
-            (state.host.clone(), state.instance_name.clone())
+            state.info = None;
+            state.last_state = None;
+            state.volume_range = None;
+            Self::clear_chain_cache(&mut state);
+            (
+                was_connected,
+                state.host.clone(),
+                state.instance_name.clone(),
+            )
         };
-        // Nothing observed through the old session may outlive it.
-        self.invalidate_chain_cache().await;
-
         {
             let mut conn = self.connection.lock().await;
             *conn = None;
         }
 
-        if let Some(ref h) = host {
+        if was_connected {
+            let Some(ref h) = host else {
+                return;
+            };
             // Emit ZoneRemoved for this HQPlayer instance
             let zone_id = PrefixedZoneId::hqplayer(instance_name.as_deref().unwrap_or(h));
             self.bus.publish(BusEvent::ZoneRemoved { zone_id });
@@ -1647,6 +1768,111 @@ impl HqpAdapter {
             self.bus
                 .publish(BusEvent::HqpDisconnected { host: h.clone() });
         }
+    }
+
+    /// Observe and publish one complete direct-zone snapshot.
+    ///
+    /// `ZoneDiscovered` is intentionally an upsert in the aggregator. Publishing the whole zone is
+    /// what lets a definitive server clear remove now-playing metadata or volume capability; the
+    /// narrower delta events cannot express either transition.
+    async fn observe_and_publish_zone(&self) -> Result<()> {
+        if !self.get_status().await.connected {
+            self.connect().await?;
+            return Ok(());
+        }
+
+        let _conversation_guard = self.conversation_lock.lock().await;
+        let epoch = self.producer_epoch().await;
+        let observed_state = self.get_state_inner().await?;
+        let status = self.get_playback_status_inner().await?;
+        // Re-read the range rather than treating it as process-lifetime configuration. A restarted
+        // daemon or an external configuration change can alter fixed/adaptive/range policy.
+        let volume_range = self.get_volume_range_inner().await?;
+
+        let (host, instance_name, info) = {
+            let mut state = self.state.write().await;
+            if state.producer_epoch != epoch {
+                // One of the reconnect-capable reads established a new session and `connect()`
+                // already published that session's coherent initial zone. Never combine a State
+                // from before that edge with Status/VolumeRange from after it.
+                return Ok(());
+            }
+            state.last_state = Some(observed_state);
+            state.volume_range = Some(volume_range.clone());
+            (
+                state
+                    .host
+                    .clone()
+                    .ok_or_else(|| anyhow!("HQPlayer host not configured"))?,
+                state.instance_name.clone(),
+                state
+                    .info
+                    .clone()
+                    .ok_or_else(|| anyhow!("HQPlayer session has no coherent identity"))?,
+            )
+        };
+
+        let zone = Self::hqp_status_to_zone(
+            &host,
+            instance_name.as_deref(),
+            &info,
+            &status,
+            &volume_range,
+        );
+        self.bus.publish(BusEvent::ZoneDiscovered { zone });
+        self.bus.publish(BusEvent::HqpStateChanged {
+            host: host.clone(),
+            state: match status.state {
+                0 => "stopped",
+                1 => "paused",
+                2 => "playing",
+                _ => "unknown",
+            }
+            .to_string(),
+        });
+        self.bus.publish(BusEvent::HqpPipelineChanged {
+            host,
+            filter: (!status.active_filter.is_empty()).then_some(status.active_filter),
+            shaper: (!status.active_shaper.is_empty()).then_some(status.active_shaper),
+            rate: (status.active_rate != 0).then_some(status.active_rate.to_string()),
+        });
+        Ok(())
+    }
+
+    /// Run this configured instance until cancelled.
+    ///
+    /// Each instance owns its retry timing independently, while the manager remains the single
+    /// adapter-wide lifecycle/ACK visible to the coordinator. Poll futures are cancellation-safe:
+    /// cancellation drops the in-flight request and immediately closes the session before return.
+    async fn run_managed(&self, shutdown: CancellationToken) {
+        const POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+        loop {
+            let observation = tokio::select! {
+                _ = shutdown.cancelled() => break,
+                result = self.observe_and_publish_zone() => result,
+            };
+
+            let delay = match observation {
+                Ok(()) => POLL_INTERVAL,
+                Err(error) => {
+                    tracing::warn!("HQPlayer managed observation failed: {error}");
+                    // A handshake failure already leaves a clean disconnected session. A failure
+                    // after reachability normally passes through send_command/mark_disconnected;
+                    // this closes any remaining partially-used socket without publishing a false
+                    // disconnect edge for a session that never became reachable.
+                    self.disconnect().await;
+                    self.timeouts().await.reconnect_delay
+                }
+            };
+
+            tokio::select! {
+                _ = shutdown.cancelled() => break,
+                _ = tokio::time::sleep(delay) => {}
+            }
+        }
+
+        self.disconnect().await;
     }
 
     /// Drop every cached chain-scoped enumeration.
@@ -2171,6 +2397,12 @@ impl HqpAdapter {
 
     /// Ensure connection is established, reconnecting if needed
     pub async fn ensure_connected(&self) -> Result<()> {
+        let _conversation_guard = self.conversation_lock.lock().await;
+        self.ensure_transport().await
+    }
+
+    /// Ensure a native socket exists. The caller owns the conversation lease.
+    async fn ensure_transport(&self) -> Result<()> {
         // Check if already connected
         {
             let conn = self.connection.lock().await;
@@ -2179,29 +2411,43 @@ impl HqpAdapter {
             }
         }
 
-        // Not connected, try to connect
-        self.connect().await
+        // Command recovery needs only a serialized transport. Managed reachability remains false
+        // until `connect()` completes and publishes its coherent initial snapshot.
+        let _connect_guard = self.connect_lock.lock().await;
+        self.establish_transport_locked().await
     }
 
     /// Mark connection as broken (called on communication errors)
     async fn mark_disconnected(&self) {
-        let (host, instance_name) = {
+        let (was_connected, host, instance_name) = {
             let mut state = self.state.write().await;
+            let was_connected = state.connected;
             state.connected = false;
-            (state.host.clone(), state.instance_name.clone())
+            state.info = None;
+            state.last_state = None;
+            state.volume_range = None;
+            Self::clear_chain_cache(&mut state);
+            (
+                was_connected,
+                state.host.clone(),
+                state.instance_name.clone(),
+            )
         };
-        self.invalidate_chain_cache().await;
-
         {
             let mut conn = self.connection.lock().await;
             *conn = None;
         }
 
-        if let Some(ref h) = host {
+        if was_connected {
+            let Some(ref h) = host else {
+                return;
+            };
             tracing::warn!("HQPlayer connection lost to {}", h);
             // Emit ZoneRemoved for this HQPlayer instance
             let zone_id = PrefixedZoneId::hqplayer(instance_name.as_deref().unwrap_or(h));
             self.bus.publish(BusEvent::ZoneRemoved { zone_id });
+            self.bus
+                .publish(BusEvent::HqpDisconnected { host: h.clone() });
         }
     }
 
@@ -2229,6 +2475,12 @@ impl HqpAdapter {
 
     /// Send command and get response with auto-reconnection
     async fn send_command(&self, xml: &str) -> Result<String> {
+        let _conversation_guard = self.conversation_lock.lock().await;
+        self.send_command_serialized(xml).await
+    }
+
+    /// Retry one command while the caller owns the instance conversation lease.
+    async fn send_command_serialized(&self, xml: &str) -> Result<String> {
         let timeouts = self.timeouts().await;
         let mut last_error = None;
         // Relative and toggling commands carry a side effect that is not the same applied twice.
@@ -2238,7 +2490,7 @@ impl HqpAdapter {
 
         for attempt in 0..timeouts.max_attempts {
             // Ensure we're connected
-            if let Err(e) = self.ensure_connected().await {
+            if let Err(e) = self.ensure_transport().await {
                 last_error = Some(e);
                 if attempt + 1 < timeouts.max_attempts {
                     tracing::debug!(
@@ -2592,10 +2844,62 @@ impl HqpAdapter {
     // Inner methods (used during connect, no auto-reconnect to avoid recursion)
     // =========================================================================
 
+    /// Require the minimum authoritative root shape needed for a publishable session snapshot.
+    ///
+    /// The normal parsers remain tolerant for version-specific optional fields. The handshake is a
+    /// different boundary: silently defaulting a missing required field would turn `<Status/>` into
+    /// a fabricated stopped, zero-volume zone and call it reachable.
+    fn require_root_attrs(response: &str, element: &str, attrs: &[&str]) -> Result<()> {
+        let actual = framing::root_element(response);
+        if actual.as_deref() != Some(element) {
+            return Err(anyhow!(
+                "Expected {element} handshake document, received {:?}",
+                actual
+            ));
+        }
+        let missing: Vec<&str> = attrs
+            .iter()
+            .copied()
+            .filter(|attr| Self::parse_attr(response, attr).is_none())
+            .collect();
+        if !missing.is_empty() {
+            return Err(anyhow!(
+                "Incomplete {element} handshake document; missing root attribute(s): {}",
+                missing.join(", ")
+            ));
+        }
+        Ok(())
+    }
+
+    fn require_numeric_root_attrs(response: &str, element: &str, attrs: &[&str]) -> Result<()> {
+        Self::require_root_attrs(response, element, attrs)?;
+        let invalid: Vec<&str> = attrs
+            .iter()
+            .copied()
+            .filter(|attr| {
+                Self::parse_attr(response, attr)
+                    .and_then(|value| value.parse::<f64>().ok())
+                    .is_none()
+            })
+            .collect();
+        if !invalid.is_empty() {
+            return Err(anyhow!(
+                "Invalid {element} handshake numeric attribute(s): {}",
+                invalid.join(", ")
+            ));
+        }
+        Ok(())
+    }
+
     /// Get HQPlayer info (no reconnection)
     async fn get_info_inner(&self) -> Result<HqpInfo> {
         let xml = Self::build_request("GetInfo", &[]);
         let response = self.send_command_inner(&xml).await?;
+        Self::require_root_attrs(
+            &response,
+            "GetInfo",
+            &["name", "product", "version", "platform", "engine"],
+        )?;
 
         Ok(HqpInfo {
             name: Self::parse_attr(&response, "name").unwrap_or_default(),
@@ -2606,28 +2910,90 @@ impl HqpAdapter {
         })
     }
 
+    /// Parse the authoritative `State` document.
+    fn parse_state_response(response: &str) -> HqpState {
+        HqpState {
+            state: Self::parse_attr_u32(response, "state") as u8,
+            mode: Self::parse_attr_u32(response, "mode") as u8,
+            filter: Self::parse_attr_u32(response, "filter"),
+            filter1x: Self::parse_attr(response, "filter1x").and_then(|s| s.parse().ok()),
+            filter_nx: Self::parse_attr(response, "filterNx").and_then(|s| s.parse().ok()),
+            shaper: Self::parse_attr_u32(response, "shaper"),
+            rate: Self::parse_attr_u32(response, "rate"),
+            volume: Self::parse_attr_i32(response, "volume"),
+            volume_db: Self::parse_attr_f64(response, "volume").unwrap_or_default(),
+            filter_junk: Self::parse_attr_u32(response, "filter_junk"),
+            active_mode: Self::parse_attr_u32(response, "active_mode") as u8,
+            active_rate: Self::parse_attr_u32(response, "active_rate"),
+            invert: Self::parse_attr_bool(response, "invert"),
+            convolution: Self::parse_attr_bool(response, "convolution"),
+            repeat: Self::parse_attr_u32(response, "repeat") as u8,
+            random: Self::parse_attr_bool(response, "random"),
+            adaptive: Self::parse_attr_bool(response, "adaptive"),
+            filter_20k: Self::parse_attr_bool(response, "filter_20k"),
+            matrix_profile: Self::parse_attr(response, "matrix_profile").unwrap_or_default(),
+        }
+    }
+
+    /// Get current state without reconnecting. Used only while establishing a new session.
+    async fn get_state_inner(&self) -> Result<HqpState> {
+        let xml = Self::build_request("State", &[]);
+        let response = self.send_command_inner(&xml).await?;
+        Self::require_numeric_root_attrs(&response, "State", &["state", "mode", "volume"])?;
+        Ok(Self::parse_state_response(&response))
+    }
+
+    /// Read an attribute from a child element without letting child attributes override the root.
+    fn parse_child_attr(response: &str, child: &str, attr: &str) -> Option<String> {
+        let marker = format!("<{child}");
+        let start = response.find(&marker)?;
+        Self::parse_attr(&response[start..], attr)
+    }
+
+    /// Parse the complete playback status, including its optional metadata child.
+    fn parse_status_response(response: &str) -> HqpStatus {
+        HqpStatus {
+            state: Self::parse_attr_u32(response, "state") as u8,
+            track: Self::parse_attr_u32(response, "track"),
+            track_id: Self::parse_attr(response, "track_id").unwrap_or_default(),
+            position: Self::parse_attr_u32(response, "position"),
+            length: Self::parse_attr_u32(response, "length"),
+            volume: Self::parse_attr_i32(response, "volume"),
+            volume_db: Self::parse_attr_f64(response, "volume").unwrap_or_default(),
+            active_mode: Self::parse_attr(response, "active_mode").unwrap_or_default(),
+            active_filter: Self::parse_attr(response, "active_filter").unwrap_or_default(),
+            active_shaper: Self::parse_attr(response, "active_shaper").unwrap_or_default(),
+            active_rate: Self::parse_attr_u32(response, "active_rate"),
+            active_bits: Self::parse_attr_u32(response, "active_bits"),
+            active_channels: Self::parse_attr_u32(response, "active_channels"),
+            samplerate: Self::parse_attr_u32(response, "samplerate"),
+            bitrate: Self::parse_attr_u32(response, "bitrate"),
+            title: Self::parse_child_attr(response, "metadata", "song"),
+            artist: Self::parse_child_attr(response, "metadata", "artist"),
+            album: Self::parse_child_attr(response, "metadata", "album"),
+        }
+    }
+
     /// Get playback status (no reconnection)
     async fn get_playback_status_inner(&self) -> Result<HqpStatus> {
         let xml = Self::build_request("Status", &[("subscribe", "0")]);
         let response = self.send_command_inner(&xml).await?;
+        Self::require_numeric_root_attrs(&response, "Status", &["state", "volume"])?;
 
-        Ok(HqpStatus {
-            state: Self::parse_attr_u32(&response, "state") as u8,
-            track: Self::parse_attr_u32(&response, "track"),
-            track_id: Self::parse_attr(&response, "track_id").unwrap_or_default(),
-            position: Self::parse_attr_u32(&response, "position"),
-            length: Self::parse_attr_u32(&response, "length"),
-            volume: Self::parse_attr_i32(&response, "volume"),
-            volume_db: Self::parse_attr_f64(&response, "volume").unwrap_or_default(),
-            active_mode: Self::parse_attr(&response, "active_mode").unwrap_or_default(),
-            active_filter: Self::parse_attr(&response, "active_filter").unwrap_or_default(),
-            active_shaper: Self::parse_attr(&response, "active_shaper").unwrap_or_default(),
-            active_rate: Self::parse_attr_u32(&response, "active_rate"),
-            active_bits: Self::parse_attr_u32(&response, "active_bits"),
-            active_channels: Self::parse_attr_u32(&response, "active_channels"),
-            samplerate: Self::parse_attr_u32(&response, "samplerate"),
-            bitrate: Self::parse_attr_u32(&response, "bitrate"),
-        })
+        Ok(Self::parse_status_response(&response))
+    }
+
+    /// Get the volume capability without reconnecting. Used only during the coherent handshake.
+    async fn get_volume_range_inner(&self) -> Result<VolumeRange> {
+        let xml = Self::build_request("VolumeRange", &[]);
+        let response = self.send_command_inner(&xml).await?;
+        Self::require_root_attrs(
+            &response,
+            "VolumeRange",
+            &["min", "max", "enabled", "adaptive"],
+        )?;
+        Self::require_numeric_root_attrs(&response, "VolumeRange", &["min", "max"])?;
+        Ok(Self::parse_volume_range_response(&response))
     }
 
     /// Build XML request
@@ -2734,69 +3100,34 @@ impl HqpAdapter {
     pub async fn get_state(&self) -> Result<HqpState> {
         let xml = Self::build_request("State", &[]);
         let response = self.send_command(&xml).await?;
-
-        Ok(HqpState {
-            state: Self::parse_attr_u32(&response, "state") as u8,
-            mode: Self::parse_attr_u32(&response, "mode") as u8,
-            filter: Self::parse_attr_u32(&response, "filter"),
-            filter1x: Self::parse_attr(&response, "filter1x").and_then(|s| s.parse().ok()),
-            filter_nx: Self::parse_attr(&response, "filterNx").and_then(|s| s.parse().ok()),
-            shaper: Self::parse_attr_u32(&response, "shaper"),
-            rate: Self::parse_attr_u32(&response, "rate"),
-            volume: Self::parse_attr_i32(&response, "volume"),
-            volume_db: Self::parse_attr_f64(&response, "volume").unwrap_or_default(),
-            filter_junk: Self::parse_attr_u32(&response, "filter_junk"),
-            active_mode: Self::parse_attr_u32(&response, "active_mode") as u8,
-            active_rate: Self::parse_attr_u32(&response, "active_rate"),
-            invert: Self::parse_attr_bool(&response, "invert"),
-            convolution: Self::parse_attr_bool(&response, "convolution"),
-            repeat: Self::parse_attr_u32(&response, "repeat") as u8,
-            random: Self::parse_attr_bool(&response, "random"),
-            adaptive: Self::parse_attr_bool(&response, "adaptive"),
-            filter_20k: Self::parse_attr_bool(&response, "filter_20k"),
-            matrix_profile: Self::parse_attr(&response, "matrix_profile").unwrap_or_default(),
-        })
+        Ok(Self::parse_state_response(&response))
     }
 
     /// Get playback status
     pub async fn get_playback_status(&self) -> Result<HqpStatus> {
         let xml = Self::build_request("Status", &[("subscribe", "0")]);
         let response = self.send_command(&xml).await?;
+        Ok(Self::parse_status_response(&response))
+    }
 
-        Ok(HqpStatus {
-            state: Self::parse_attr_u32(&response, "state") as u8,
-            track: Self::parse_attr_u32(&response, "track"),
-            track_id: Self::parse_attr(&response, "track_id").unwrap_or_default(),
-            position: Self::parse_attr_u32(&response, "position"),
-            length: Self::parse_attr_u32(&response, "length"),
-            volume: Self::parse_attr_i32(&response, "volume"),
-            volume_db: Self::parse_attr_f64(&response, "volume").unwrap_or_default(),
-            active_mode: Self::parse_attr(&response, "active_mode").unwrap_or_default(),
-            active_filter: Self::parse_attr(&response, "active_filter").unwrap_or_default(),
-            active_shaper: Self::parse_attr(&response, "active_shaper").unwrap_or_default(),
-            active_rate: Self::parse_attr_u32(&response, "active_rate"),
-            active_bits: Self::parse_attr_u32(&response, "active_bits"),
-            active_channels: Self::parse_attr_u32(&response, "active_channels"),
-            samplerate: Self::parse_attr_u32(&response, "samplerate"),
-            bitrate: Self::parse_attr_u32(&response, "bitrate"),
-        })
+    fn parse_volume_range_response(response: &str) -> VolumeRange {
+        VolumeRange {
+            min: Self::parse_attr_i32(response, "min"),
+            max: Self::parse_attr_i32(response, "max"),
+            step: Self::parse_attr_i32(response, "step").max(1),
+            enabled: Self::parse_attr_bool(response, "enabled"),
+            adaptive: Self::parse_attr_bool(response, "adaptive"),
+            min_db: Self::parse_attr_f64(response, "min").unwrap_or_default(),
+            max_db: Self::parse_attr_f64(response, "max").unwrap_or_default(),
+            step_db: Self::parse_attr_f64(response, "step"),
+        }
     }
 
     /// Get volume range
     pub async fn get_volume_range(&self) -> Result<VolumeRange> {
         let xml = Self::build_request("VolumeRange", &[]);
         let response = self.send_command(&xml).await?;
-
-        Ok(VolumeRange {
-            min: Self::parse_attr_i32(&response, "min"),
-            max: Self::parse_attr_i32(&response, "max"),
-            step: Self::parse_attr_i32(&response, "step").max(1),
-            enabled: Self::parse_attr_bool(&response, "enabled"),
-            adaptive: Self::parse_attr_bool(&response, "adaptive"),
-            min_db: Self::parse_attr_f64(&response, "min").unwrap_or_default(),
-            max_db: Self::parse_attr_f64(&response, "max").unwrap_or_default(),
-            step_db: Self::parse_attr_f64(&response, "step"),
-        })
+        Ok(Self::parse_volume_range_response(&response))
     }
 
     /// Parse multi-item response
@@ -4928,11 +5259,13 @@ impl HqpAdapter {
         };
 
         // Build now_playing if we have track info
-        let now_playing = if !status.track_id.is_empty() || status.length > 0 {
+        let has_metadata =
+            status.title.is_some() || status.artist.is_some() || status.album.is_some();
+        let now_playing = if !status.track_id.is_empty() || status.length > 0 || has_metadata {
             Some(BusNowPlaying {
-                title: String::new(), // HQPlayer status doesn't include title
-                artist: String::new(),
-                album: String::new(),
+                title: status.title.clone().unwrap_or_default(),
+                artist: status.artist.clone().unwrap_or_default(),
+                album: status.album.clone().unwrap_or_default(),
                 image_key: None,
                 seek_position: Some(status.position as f64),
                 duration: Some(status.length as f64),
@@ -4989,9 +5322,18 @@ pub struct HqpInstanceInfo {
 }
 
 /// Manager for multiple HQPlayer instances
+struct HqpManagedWorker {
+    shutdown: CancellationToken,
+    join: tokio::task::JoinHandle<()>,
+}
+
 pub struct HqpInstanceManager {
     instances: Arc<RwLock<HashMap<String, Arc<HqpAdapter>>>>,
     bus: SharedBus,
+    running: Arc<AtomicBool>,
+    workers: Arc<Mutex<HashMap<String, HqpManagedWorker>>>,
+    /// Serializes lifecycle and runtime instance mutations as one manager transaction.
+    lifecycle_lock: Arc<Mutex<()>>,
 }
 
 impl HqpInstanceManager {
@@ -5000,6 +5342,9 @@ impl HqpInstanceManager {
         Self {
             instances: Arc::new(RwLock::new(HashMap::new())),
             bus,
+            running: Arc::new(AtomicBool::new(false)),
+            workers: Arc::new(Mutex::new(HashMap::new())),
+            lifecycle_lock: Arc::new(Mutex::new(())),
         }
     }
 
@@ -5056,20 +5401,13 @@ impl HqpInstanceManager {
 
     /// Get or create an instance by name
     pub async fn get_or_create(&self, name: &str) -> Arc<HqpAdapter> {
-        {
-            let instances = self.instances.read().await;
-            if let Some(adapter) = instances.get(name) {
-                return adapter.clone();
-            }
-        }
-
-        // Create new instance
+        // Prepare outside the map lock, then use the entry as the atomic winner. Two callers may
+        // prepare candidates, but they can no longer return different adapters for the same name.
         let adapter = Arc::new(HqpAdapter::new(self.bus.clone()));
         adapter.set_instance_name(name.to_string()).await;
 
         let mut instances = self.instances.write().await;
-        instances.insert(name.to_string(), adapter.clone());
-        adapter
+        instances.entry(name.to_string()).or_insert(adapter).clone()
     }
 
     /// Get an instance by name (if it exists)
@@ -5120,23 +5458,33 @@ impl HqpInstanceManager {
         username: Option<String>,
         password: Option<String>,
     ) -> Arc<HqpAdapter> {
+        let _lifecycle_guard = self.lifecycle_lock.lock().await;
         let adapter = self.get_or_create(&name).await;
         adapter
             .configure(host, port, web_port, username, password)
             .await;
         self.save_to_config().await;
+        if self.running.load(Ordering::SeqCst) {
+            self.start_worker(name, adapter.clone()).await;
+        }
         adapter
     }
 
     /// Remove an instance by name
     pub async fn remove_instance(&self, name: &str) -> bool {
+        let _lifecycle_guard = self.lifecycle_lock.lock().await;
         let mut instances = self.instances.write().await;
-        let removed = instances.remove(name).is_some();
-        if removed {
-            drop(instances);
-            self.save_to_config().await;
-        }
-        removed
+        let removed = instances.remove(name);
+        drop(instances);
+        let Some(adapter) = removed else {
+            return false;
+        };
+
+        self.stop_worker(name).await;
+        // Removal is definitive even if the manager was not running and therefore had no worker.
+        adapter.disconnect().await;
+        self.save_to_config().await;
+        true
     }
 
     /// Check if any instance is configured
@@ -5145,10 +5493,141 @@ impl HqpInstanceManager {
         !instances.is_empty()
     }
 
+    /// Whether at least one child has a native endpoint and can enter the managed lifecycle.
+    async fn has_configured_instances(&self) -> bool {
+        let adapters: Vec<Arc<HqpAdapter>> =
+            self.instances.read().await.values().cloned().collect();
+        for adapter in adapters {
+            if adapter.is_configured().await {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Start exactly one child observer for a configured runtime instance.
+    async fn start_worker(&self, name: String, adapter: Arc<HqpAdapter>) {
+        if !adapter.is_configured().await {
+            return;
+        }
+
+        // Build the child future before taking the worker-map lock. The future is inert until
+        // spawned; keeping its await expression outside the map-guard scope also makes the actual
+        // invariant obvious to the AST lock lint.
+        let shutdown = CancellationToken::new();
+        let child_shutdown = shutdown.clone();
+        let child = async move {
+            adapter.run_managed(child_shutdown).await;
+        };
+
+        let mut workers = self.workers.lock().await;
+        // Recheck while holding the worker-set lock. A concurrent stop may have flipped `running`
+        // after `add_instance` decided this call was needed; spawning after stop drained the map
+        // would otherwise create an orphan observer.
+        if !self.running.load(Ordering::SeqCst) {
+            return;
+        }
+        if workers.contains_key(&name) {
+            return;
+        }
+
+        let join = tokio::spawn(child);
+        workers.insert(name, HqpManagedWorker { shutdown, join });
+    }
+
+    /// Cancel and join one child before returning so it cannot republish after removal.
+    async fn stop_worker(&self, name: &str) {
+        let worker = self.workers.lock().await.remove(name);
+        if let Some(worker) = worker {
+            worker.shutdown.cancel();
+            if let Err(error) = worker.join.await {
+                tracing::warn!("HQPlayer child lifecycle failed to join: {error}");
+            }
+        }
+    }
+
+    async fn start_internal(&self) -> Result<()> {
+        let _lifecycle_guard = self.lifecycle_lock.lock().await;
+        if self.running.load(Ordering::SeqCst) {
+            return Ok(());
+        }
+
+        let candidates: Vec<(String, Arc<HqpAdapter>)> = self
+            .instances
+            .read()
+            .await
+            .iter()
+            .map(|(name, adapter)| (name.clone(), adapter.clone()))
+            .collect();
+        let mut adapters = Vec::new();
+        for (name, adapter) in candidates {
+            if adapter.is_configured().await {
+                adapters.push((name, adapter));
+            }
+        }
+
+        if adapters.is_empty() {
+            return Err(anyhow!("No configured HQPlayer instances"));
+        }
+
+        self.running.store(true, Ordering::SeqCst);
+        for (name, adapter) in adapters {
+            self.start_worker(name, adapter).await;
+        }
+
+        Ok(())
+    }
+
+    async fn stop_internal(&self) {
+        let _lifecycle_guard = self.lifecycle_lock.lock().await;
+        if !self.running.swap(false, Ordering::SeqCst) {
+            return;
+        }
+        self.bus.publish(BusEvent::AdapterStopping {
+            adapter: "hqplayer".to_string(),
+            reason: Some("HQPlayer lifecycle stopped".to_string()),
+        });
+
+        let workers = {
+            let mut workers = self.workers.lock().await;
+            std::mem::take(&mut *workers)
+        };
+        for worker in workers.values() {
+            worker.shutdown.cancel();
+        }
+        for (_, worker) in workers {
+            if let Err(error) = worker.join.await {
+                tracing::warn!("HQPlayer child lifecycle failed to join: {error}");
+            }
+        }
+        self.bus.publish(BusEvent::AdapterStopped {
+            adapter: "hqplayer".to_string(),
+        });
+    }
+
     /// Get instance count
     pub async fn instance_count(&self) -> usize {
         let instances = self.instances.read().await;
         instances.len()
+    }
+}
+
+#[async_trait::async_trait]
+impl Startable for HqpInstanceManager {
+    fn name(&self) -> &'static str {
+        "hqplayer"
+    }
+
+    async fn start(&self) -> Result<()> {
+        self.start_internal().await
+    }
+
+    async fn stop(&self) {
+        self.stop_internal().await;
+    }
+
+    async fn can_start(&self) -> bool {
+        self.has_configured_instances().await
     }
 }
 

--- a/src/aggregator.rs
+++ b/src/aggregator.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use tokio::sync::RwLock;
+use tokio::sync::{oneshot, RwLock};
 use tracing::{debug, info};
 
 use crate::bus::{BusEvent, NowPlaying, SharedBus, Zone};
@@ -28,7 +28,24 @@ impl ZoneAggregator {
     /// Start the aggregator's event processing loop
     /// Should be spawned as a task
     pub async fn run(&self) {
+        self.run_inner(None).await;
+    }
+
+    /// Start the event loop and acknowledge after the broadcast subscription exists.
+    ///
+    /// The bus does not replay. Merely spawning `run()` before producers is insufficient because the
+    /// spawned future may not be polled until after an adapter publishes its initial snapshot.
+    pub async fn run_with_ready(&self, ready: oneshot::Sender<()>) {
+        self.run_inner(Some(ready)).await;
+    }
+
+    async fn run_inner(&self, ready: Option<oneshot::Sender<()>>) {
         let mut rx = self.bus.subscribe();
+        if let Some(ready) = ready {
+            if ready.send(()).is_err() {
+                debug!("ZoneAggregator readiness receiver was dropped before startup completed");
+            }
+        }
 
         info!("ZoneAggregator started");
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1540,6 +1540,20 @@ pub async fn hqp_configure_handler(
     // Save to instance manager for persistence
     state.hqp_instances.save_to_config().await;
 
+    // An enabled fresh installation may have skipped the HQPlayer lifecycle at process startup
+    // because no endpoint existed yet. Start the idempotent manager after configuration rather than
+    // requiring a process restart, while still honoring the adapter's explicit enabled setting.
+    if state.coordinator.is_enabled("hqplayer").await {
+        match state.hqp_instances.start().await {
+            Ok(()) => state.coordinator.set_running("hqplayer", true).await,
+            Err(error) => {
+                tracing::warn!(
+                    "HQPlayer managed lifecycle could not start after configuration: {error}"
+                )
+            }
+        }
+    }
+
     // Test connection by attempting to get pipeline status (this establishes connection)
     let connected = match state.hqplayer.get_pipeline_status().await {
         Ok(_) => true,
@@ -1750,6 +1764,15 @@ pub async fn hqp_add_instance_handler(
             req.password,
         )
         .await;
+
+    if state.coordinator.is_enabled("hqplayer").await {
+        match state.hqp_instances.start().await {
+            Ok(()) => state.coordinator.set_running("hqplayer", true).await,
+            Err(error) => tracing::warn!(
+                "HQPlayer managed lifecycle could not start after adding an instance: {error}"
+            ),
+        }
+    }
 
     (
         StatusCode::OK,
@@ -2257,11 +2280,14 @@ pub async fn api_settings_post_handler(
                 if adapter.can_start().await {
                     if let Err(e) = adapter.start().await {
                         tracing::warn!("Failed to start adapter {}: {}", name, e);
+                    } else {
+                        coord.set_running(name, true).await;
                     }
                 }
             } else {
                 tracing::info!("Dynamically disabling adapter: {}", name);
                 adapter.stop().await;
+                coord.set_running(name, false).await;
             }
         }
     }

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 /// All available adapters in the system.
 /// This is the single source of truth for what adapters exist.
 /// Note: "lms-cli" is a companion to "lms" and shares its enabled state.
-pub const AVAILABLE_ADAPTERS: &[&str] = &["roon", "lms", "lms-cli", "openhome", "upnp"];
+pub const AVAILABLE_ADAPTERS: &[&str] = &["roon", "lms", "lms-cli", "openhome", "upnp", "hqplayer"];
 
 /// Registered adapter with its spawn function
 struct RegisteredAdapter {
@@ -31,6 +31,8 @@ struct RegisteredAdapter {
     enabled: bool,
     /// Running task handle (if started)
     handle: Option<JoinHandle<()>>,
+    /// Startable adapters own their child tasks internally rather than exposing a JoinHandle here.
+    direct_running: bool,
     /// Cancellation token for this adapter
     cancel: CancellationToken,
 }
@@ -79,6 +81,7 @@ impl AdapterCoordinator {
                 "lms-cli" => settings.lms,
                 "openhome" => settings.openhome,
                 "upnp" => settings.upnp,
+                "hqplayer" => settings.hqplayer,
                 _ => false,
             };
             self.register(name, enabled).await;
@@ -104,7 +107,12 @@ impl AdapterCoordinator {
                 continue;
             }
             match adapter.start().await {
-                Ok(()) => info!("Started adapter: {}", name),
+                Ok(()) => {
+                    if let Some(registered) = self.adapters.write().await.get_mut(name) {
+                        registered.direct_running = true;
+                    }
+                    info!("Started adapter: {}", name);
+                }
                 Err(e) => warn!("Failed to start adapter {}: {}", name, e),
             }
         }
@@ -114,6 +122,9 @@ impl AdapterCoordinator {
     pub async fn stop_all(&self, adapters: &[Arc<dyn Startable>]) {
         for adapter in adapters {
             adapter.stop().await;
+            if let Some(registered) = self.adapters.write().await.get_mut(adapter.name()) {
+                registered.direct_running = false;
+            }
             debug!("Stopped adapter: {}", adapter.name());
         }
     }
@@ -127,6 +138,7 @@ impl AdapterCoordinator {
                 prefix: prefix.to_string(),
                 enabled,
                 handle: None,
+                direct_running: false,
                 cancel: self.shutdown.child_token(),
             },
         );
@@ -175,6 +187,13 @@ impl AdapterCoordinator {
         }
     }
 
+    /// Record lifecycle state for Startable adapters that own their worker tasks internally.
+    pub async fn set_running(&self, prefix: &str, running: bool) {
+        if let Some(adapter) = self.adapters.write().await.get_mut(prefix) {
+            adapter.direct_running = running;
+        }
+    }
+
     /// Check if an adapter is enabled
     pub async fn is_enabled(&self, prefix: &str) -> bool {
         let adapters = self.adapters.read().await;
@@ -186,7 +205,7 @@ impl AdapterCoordinator {
         let adapters = self.adapters.read().await;
         adapters
             .get(prefix)
-            .map(|a| a.handle.is_some())
+            .map(|a| a.handle.is_some() || a.direct_running)
             .unwrap_or(false)
     }
 
@@ -353,7 +372,7 @@ impl AdapterCoordinator {
                     AdapterStatus {
                         prefix: prefix.clone(),
                         enabled: adapter.enabled,
-                        running: adapter.handle.is_some(),
+                        running: adapter.handle.is_some() || adapter.direct_running,
                     },
                 )
             })
@@ -376,6 +395,26 @@ mod tests {
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
 
+    struct DirectStartable {
+        started: AtomicBool,
+    }
+
+    #[async_trait::async_trait]
+    impl Startable for DirectStartable {
+        fn name(&self) -> &'static str {
+            "direct"
+        }
+
+        async fn start(&self) -> Result<()> {
+            self.started.store(true, Ordering::SeqCst);
+            Ok(())
+        }
+
+        async fn stop(&self) {
+            self.started.store(false, Ordering::SeqCst);
+        }
+    }
+
     #[tokio::test]
     async fn test_register_and_check_enabled() {
         let bus = create_bus();
@@ -386,6 +425,55 @@ mod tests {
 
         coord.register("disabled", false).await;
         assert!(!coord.is_enabled("disabled").await);
+    }
+
+    /// Issue #162: the public settings model has carried an `hqplayer` enable switch while the
+    /// lifecycle registry silently omitted it. A configured producer therefore could not enter the
+    /// coordinator-owned start/stop path at all.
+    ///
+    /// **Label: client-red.** The settings surface already promises this toggle controls the adapter.
+    #[tokio::test]
+    async fn hqplayer_setting_registers_the_managed_adapter() {
+        let bus = create_bus();
+        let coord = AdapterCoordinator::new(bus);
+        let settings = AdapterSettings {
+            hqplayer: true,
+            ..Default::default()
+        };
+
+        coord.register_from_settings(&settings).await;
+
+        assert!(
+            coord
+                .registered_adapters()
+                .await
+                .iter()
+                .any(|a| a == "hqplayer"),
+            "HQPlayer must be a coordinator-owned lifecycle, not an opportunistic page read"
+        );
+        assert!(coord.is_enabled("hqplayer").await);
+    }
+
+    #[tokio::test]
+    async fn direct_startable_lifecycle_is_reported_as_running() {
+        let bus = create_bus();
+        let coord = AdapterCoordinator::new(bus);
+        coord.register("direct", true).await;
+
+        let adapter = Arc::new(DirectStartable {
+            started: AtomicBool::new(false),
+        });
+        let adapters: Vec<Arc<dyn Startable>> = vec![adapter.clone()];
+
+        coord.start_all_enabled(&adapters).await;
+        assert!(adapter.started.load(Ordering::SeqCst));
+        assert!(coord.is_running("direct").await);
+        assert!(coord.adapter_status().await["direct"].running);
+
+        coord.stop_all(&adapters).await;
+        assert!(!adapter.started.load(Ordering::SeqCst));
+        assert!(!coord.is_running("direct").await);
+        assert!(!coord.adapter_status().await["direct"].running);
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,9 +10,6 @@ mod server {
         mdns,
     };
 
-    // Import Startable trait for adapter lifecycle methods
-    use adapters::Startable;
-
     // Import load_app_settings for checking adapter enabled state
     use api::load_app_settings;
 
@@ -252,17 +249,6 @@ mod server {
             }
         }
 
-        // Auto-connect HQPlayer if configured (establishes TCP connection at startup)
-        if hqplayer.is_configured().await {
-            match hqplayer.get_pipeline_status().await {
-                Ok(_) => tracing::info!("HQPlayer auto-connected at startup"),
-                Err(e) => tracing::warn!(
-                    "HQPlayer auto-connect failed (will retry on page access): {}",
-                    e
-                ),
-            }
-        }
-
         // HQP zone link service
         let hqp_zone_links = Arc::new(adapters::hqplayer::HqpZoneLinkService::new(
             hqp_instances.clone(),
@@ -296,10 +282,27 @@ mod server {
         // Start enabled adapters (single codepath using coordinator)
         // =========================================================================
 
+        // Subscribe the authoritative aggregator before any producer can publish its initial
+        // discovery snapshot. The bus is broadcast-only and does not replay messages to subscribers
+        // created after adapter startup.
+        let zone_aggregator = Arc::new(aggregator::ZoneAggregator::new(bus.clone()));
+        let (aggregator_ready_tx, aggregator_ready_rx) = tokio::sync::oneshot::channel();
+        let aggregator_for_spawn = zone_aggregator.clone();
+        tokio::spawn(async move {
+            aggregator_for_spawn
+                .run_with_ready(aggregator_ready_tx)
+                .await;
+        });
+        aggregator_ready_rx
+            .await
+            .map_err(|_| anyhow::anyhow!("ZoneAggregator stopped before subscribing to the bus"))?;
+        tracing::info!("ZoneAggregator started");
+
         // Build list of startable adapters
         // Note: lms_cli shares config with lms - both start when LMS is configured
         let startable_adapters: Vec<Arc<dyn adapters::Startable>> = vec![
             roon.clone(),
+            hqp_instances.clone(),
             lms.clone(),
             lms_cli.clone(),
             openhome.clone(),
@@ -309,17 +312,6 @@ mod server {
         // Single loop to start all enabled adapters
         coord.start_all_enabled(&startable_adapters).await;
 
-        // Initialize ZoneAggregator for unified zone state
-        let zone_aggregator = Arc::new(aggregator::ZoneAggregator::new(bus.clone()));
-        let aggregator_for_spawn = zone_aggregator.clone();
-        tokio::spawn(async move {
-            aggregator_for_spawn.run().await;
-        });
-        tracing::info!("ZoneAggregator started");
-
-        // Clone Roon adapter for shutdown access (cheap - just Arc clones)
-        let roon_for_shutdown = roon.clone();
-
         // Create shutdown token for graceful SSE termination (fixes #73)
         let shutdown_token = CancellationToken::new();
 
@@ -327,7 +319,7 @@ mod server {
         let state = api::AppState::new(
             roon,
             hqplayer,
-            hqp_instances,
+            hqp_instances.clone(),
             hqp_zone_links,
             lms.clone(),
             openhome.clone(),
@@ -634,14 +626,14 @@ mod server {
         // Give listeners a moment to react to ShuttingDown
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
-        // Stop adapters
-        roon_for_shutdown.stop().await;
+        // Stop every coordinator-owned Startable and wait for its children. Individual stop methods
+        // are idempotent, so adapters that already reacted to ShuttingDown remain safe here.
+        coord
+            .stop_all(state_for_shutdown.startable_adapters.as_ref())
+            .await;
         if let Some(ref fw) = firmware_service {
             fw.stop();
         }
-        lms.stop().await;
-        openhome.stop().await;
-        upnp.stop().await;
         tracing::info!("Shutdown complete");
 
         Ok(())

--- a/tests/await_in_lock_lint.rs
+++ b/tests/await_in_lock_lint.rs
@@ -237,6 +237,29 @@ const ALLOWLIST: &[(&str, &str, &str)] = &[
         "conn_guard",
         "Protocol requires exclusive connection access",
     ),
+    // One native instance is a serialized conversation. This lease deliberately spans connect,
+    // command/retry, multi-document observation and configure so host/session identity cannot
+    // change around an in-flight response and local commands cannot split a published snapshot.
+    (
+        "adapters/hqplayer.rs",
+        "_conversation_guard",
+        "HQPlayer instance conversations must be linearized",
+    ),
+    // Socket establishment is itself one operation. Releasing this lease during TcpStream::connect
+    // lets concurrent first callers install different sessions; every call acquires it only after
+    // the conversation lease, giving the pair one documented lock order.
+    (
+        "adapters/hqplayer.rs",
+        "_connect_guard",
+        "HQPlayer socket establishment must be single-flight",
+    ),
+    // The manager changes its instance and worker maps together and joins removed children before
+    // releasing the transaction. This prevents same-name add/remove and start/stop races.
+    (
+        "adapters/hqplayer.rs",
+        "_lifecycle_guard",
+        "HQPlayer manager lifecycle mutations must be serialized",
+    ),
 ];
 
 fn is_allowed(file: &str, guard: &str) -> bool {

--- a/tests/hqplayer_conformance.rs
+++ b/tests/hqplayer_conformance.rs
@@ -130,8 +130,14 @@ impl Harness {
 
     /// Connected, with a wire policy of the test's choosing.
     async fn with_policy(policy: WirePolicy) -> Self {
-        let h = Self::start(VERIFIED_PROFILE, policy, fast_timeouts()).await;
+        Self::connected_then_policy(policy, fast_timeouts()).await
+    }
+
+    /// Complete the coherent initial snapshot before arming a command-level wire fault.
+    async fn connected_then_policy(policy: WirePolicy, timeouts: HqpTimeouts) -> Self {
+        let h = Self::start(VERIFIED_PROFILE, WirePolicy::default(), timeouts).await;
         h.adapter.connect().await.expect("connect to fake daemon");
+        h.server.set_policy(policy);
         h
     }
 
@@ -474,11 +480,13 @@ async fn a_silent_daemon_is_retried_exactly_the_configured_number_of_times() {
         ..WirePolicy::default()
     })
     .await;
+    let state_requests_before_command = h.server.stats().element_count("State");
     let _ = h.adapter.get_state().await;
     assert_eq!(
-        h.server.stats().element_count("State"),
+        h.server.stats().element_count("State") - state_requests_before_command,
         fast_timeouts().max_attempts,
-        "the retry budget is asserted by counting the State requests the daemon saw, never by timing"
+        "the retry budget is asserted by counting only the command's State requests, excluding the \
+         coherent initial snapshot and never relying on timing"
     );
     h.stop();
 }
@@ -4569,8 +4577,7 @@ async fn a_burst_larger_than_the_skip_ceiling_is_reported_rather_than_drained_fo
     // Comfortably past the 256 ceiling, delivered ahead of the reply in one write so the whole burst
     // lands in the buffer and the drain loop has to deal with all of it without reading again.
     let burst = vec![PUSH_STATUS_FRAME; 400].join("\n");
-    let h = Harness::start(
-        VERIFIED_PROFILE,
+    let h = Harness::connected_then_policy(
         WirePolicy {
             coalesce_leading_for_element: Some(("State".to_string(), burst)),
             ..WirePolicy::default()
@@ -4582,7 +4589,6 @@ async fn a_burst_larger_than_the_skip_ceiling_is_reported_rather_than_drained_fo
         },
     )
     .await;
-    h.adapter.connect().await.expect("connect");
 
     let err = h
         .adapter
@@ -5160,8 +5166,7 @@ async fn a_follower_burst_past_the_ceiling_is_refused_like_a_leading_burst() {
          it; {} bytes",
         follower.len()
     );
-    let h = Harness::start(
-        VERIFIED_PROFILE,
+    let h = Harness::connected_then_policy(
         WirePolicy {
             coalesce_extra_for_element: Some(("State".to_string(), follower)),
             ..WirePolicy::default()
@@ -5169,7 +5174,6 @@ async fn a_follower_burst_past_the_ceiling_is_refused_like_a_leading_burst() {
         fast_timeouts(),
     )
     .await;
-    h.adapter.connect().await.expect("connect");
 
     let outcome = h.adapter.get_state().await;
 
@@ -7670,8 +7674,7 @@ async fn a_lost_volume_range_reply_does_not_publish_the_cache_its_reconnect_empt
     // Element-scoped and one-shot: the daemon applies the request, then vanishes without replying,
     // once. Scoping it to `VolumeRange` keeps it clear of connection setup and of the list fill, so
     // the only thing it can disturb is the lazy volume-range fetch itself.
-    let h = Harness::start(
-        VERIFIED_PROFILE,
+    let h = Harness::connected_then_policy(
         WirePolicy {
             apply_then_drop_reply_for_element: Some("VolumeRange".to_string()),
             ..WirePolicy::default()
@@ -7679,10 +7682,11 @@ async fn a_lost_volume_range_reply_does_not_publish_the_cache_its_reconnect_empt
         fast_timeouts(),
     )
     .await;
-    h.adapter.connect().await.expect("connect");
 
-    // The first read after connect: nothing is cached, so this read both fills the lists and fetches
-    // the volume range.
+    // The lifecycle handshake now establishes the initial range. Exercise the same lost-reply
+    // recovery boundary explicitly, then ask the projection to prove that any cache invalidated by
+    // the reconnect is either refilled coherently or refused.
+    let _ = h.adapter.get_volume_range().await;
     let outcome = h.adapter.get_pipeline_status().await;
 
     assert!(

--- a/tests/hqplayer_lifecycle.rs
+++ b/tests/hqplayer_lifecycle.rs
@@ -1,0 +1,691 @@
+//! Managed HQPlayer producer lifecycle conformance (issue #162).
+//!
+//! These tests use the same stateful wire daemon as the native-protocol suite. The lifecycle is the
+//! client under test: no live HQPlayer is contacted, and no route handler is allowed to stand in for
+//! continuous observation or recovery.
+
+#[allow(dead_code, unused_imports, unused_variables)]
+mod mock_servers;
+
+use std::sync::{Arc, Once};
+use std::time::Duration;
+
+use mock_servers::hqplayer::corpus::VERIFIED_PROFILE;
+use mock_servers::hqplayer::model::{DaemonModel, Metadata};
+use mock_servers::hqplayer::wire::{Chunking, WirePolicy, WireServer};
+use unified_hifi_control::adapters::hqplayer::{HqpAdapter, HqpInstanceManager, HqpTimeouts};
+use unified_hifi_control::adapters::Startable;
+use unified_hifi_control::aggregator::ZoneAggregator;
+use unified_hifi_control::bus::{create_bus, BusEvent, PlaybackState, Zone};
+
+fn isolate_config_dir() {
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        let dir = std::env::temp_dir().join(format!("uhc-hqp-lifecycle-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create isolated lifecycle config dir");
+        std::env::set_var("UHC_CONFIG_DIR", dir);
+    });
+}
+
+fn fast_timeouts() -> HqpTimeouts {
+    HqpTimeouts {
+        connect: Duration::from_millis(100),
+        response: Duration::from_millis(500),
+        reconnect_delay: Duration::from_millis(10),
+        max_attempts: 1,
+    }
+}
+
+async fn advance_until_zone(
+    aggregator: &ZoneAggregator,
+    mut condition: impl FnMut(&Zone) -> bool,
+) -> Zone {
+    for _ in 0..100 {
+        if let Some(zone) = aggregator.get_zone("hqplayer:rig").await {
+            if condition(&zone) {
+                return zone;
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!(
+        "zone did not settle inside the bounded polling budget; zones={:?}",
+        aggregator.get_zones().await
+    );
+}
+
+/// The coordinator owns one logical HQPlayer lifecycle. Individual configured instances are child
+/// workers of that supervisor, so shutdown has one adapter-wide acknowledgment and one place that
+/// reconciles runtime additions/removals.
+///
+/// **Label: client-red.** Issue #162 rejects a default-instance-only lifecycle.
+#[test]
+fn the_instance_manager_is_the_managed_hqplayer_adapter() {
+    fn assert_startable<T: Startable>() {}
+    assert_startable::<HqpInstanceManager>();
+}
+
+/// Reachability starts after a coherent handshake, not after TCP accept. A malformed required
+/// `Status` response must never publish a placeholder zone or leave the adapter connected.
+///
+/// **Label: client-red.** The pre-lifecycle `connect()` swallowed Status failure with `default()`.
+#[tokio::test]
+async fn a_failed_initial_status_never_becomes_a_connected_partial_zone() {
+    isolate_config_dir();
+    let model = DaemonModel::with_profile(VERIFIED_PROFILE);
+    let server = WireServer::start(
+        Arc::new(model.clone()),
+        WirePolicy {
+            // Syntactically valid but semantically empty. Framing alone must not turn absent
+            // authoritative fields into a stopped/fixed-volume zone through parser defaults.
+            malformed_for_element: Some((
+                "Status".to_string(),
+                "<?xml version=\"1.0\"?><Status/>".to_string(),
+            )),
+            ..WirePolicy::default()
+        },
+    )
+    .await;
+    let bus = create_bus();
+    let aggregator = Arc::new(ZoneAggregator::new(bus.clone()));
+    let aggregator_task = {
+        let aggregator = aggregator.clone();
+        tokio::spawn(async move { aggregator.run().await })
+    };
+    tokio::task::yield_now().await;
+
+    let manager = HqpInstanceManager::new(bus.clone());
+    let adapter = manager
+        .add_instance(
+            "rig".to_string(),
+            "127.0.0.1".to_string(),
+            Some(server.port()),
+            None,
+            None,
+            None,
+        )
+        .await;
+    adapter.set_timeouts(fast_timeouts()).await;
+
+    manager.start().await.expect("start managed lifecycle");
+    for _ in 0..4 {
+        tokio::task::yield_now().await;
+    }
+    for _ in 0..100 {
+        if server.stats().element_count("Status") > 0 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    assert!(
+        server.stats().element_count("Status") > 0,
+        "the RED must exercise the failed handshake"
+    );
+    assert!(!adapter.get_status().await.connected);
+    assert!(aggregator.get_zone("hqplayer:rig").await.is_none());
+
+    manager.stop().await;
+    bus.publish(BusEvent::ShuttingDown { reason: None });
+    aggregator_task.await.expect("aggregator stops");
+    server.stop();
+}
+
+/// A full observed snapshot is the convergence primitive. An external controller changing playback,
+/// decimal volume and metadata must replace the aggregator-owned zone without any page/API read.
+///
+/// **Label: client-red.** Before #162 no HQPlayer task polls after startup.
+#[tokio::test]
+async fn external_changes_converge_into_the_aggregator_without_a_surface_read() {
+    isolate_config_dir();
+    let model = DaemonModel::with_profile(VERIFIED_PROFILE);
+    model.external_change(|s| {
+        s.playback = 2;
+        s.track = 1;
+        s.track_id = "first".to_string();
+        s.position = 10;
+        s.length = 300;
+        s.metadata = Some(Metadata::sample());
+    });
+    let server = WireServer::start(Arc::new(model.clone()), WirePolicy::default()).await;
+    let bus = create_bus();
+    let aggregator = Arc::new(ZoneAggregator::new(bus.clone()));
+    let aggregator_task = {
+        let aggregator = aggregator.clone();
+        tokio::spawn(async move { aggregator.run().await })
+    };
+    tokio::task::yield_now().await;
+
+    let manager = HqpInstanceManager::new(bus.clone());
+    let adapter = manager
+        .add_instance(
+            "rig".to_string(),
+            "127.0.0.1".to_string(),
+            Some(server.port()),
+            None,
+            None,
+            None,
+        )
+        .await;
+    adapter.set_timeouts(fast_timeouts()).await;
+    manager.start().await.expect("start managed lifecycle");
+
+    let first = advance_until_zone(&aggregator, |_| true).await;
+    assert_eq!(first.state, PlaybackState::Playing);
+    assert_eq!(
+        first.now_playing.as_ref().map(|n| n.title.as_str()),
+        Some("Alice in Wonderland")
+    );
+    assert_eq!(first.volume_control.as_ref().map(|v| v.value), Some(-23.5));
+
+    model.external_change(|s| {
+        s.playback = 1;
+        s.track = 2;
+        s.track_id = "second".to_string();
+        s.position = 77;
+        s.volume_db = -31.5;
+        s.metadata = Some(Metadata {
+            artist: "Nina Simone".to_string(),
+            album: "Pastel Blues".to_string(),
+            song: "Sinnerman".to_string(),
+            samplerate: 96_000,
+            bits: 24,
+            channels: 2,
+            bitrate: 4_608,
+        });
+    });
+
+    let changed = advance_until_zone(&aggregator, |z| {
+        z.now_playing
+            .as_ref()
+            .map(|n| n.title == "Sinnerman")
+            .unwrap_or(false)
+    })
+    .await;
+    assert_eq!(changed.state, PlaybackState::Paused);
+    assert_eq!(
+        changed.now_playing.as_ref().map(|n| n.artist.as_str()),
+        Some("Nina Simone")
+    );
+    assert_eq!(
+        changed.now_playing.as_ref().and_then(|n| n.seek_position),
+        Some(77.0)
+    );
+    assert_eq!(
+        changed.volume_control.as_ref().map(|v| v.value),
+        Some(-31.5)
+    );
+
+    // A definitive server-side clear replaces the whole snapshot. Delta-only publication cannot
+    // express either of these transitions: NowPlayingChanged(None, ..) currently constructs an
+    // empty Some(NowPlaying), and VolumeChanged cannot remove a volume control.
+    model.external_change(|s| {
+        s.playback = 0;
+        s.track = 0;
+        s.track_id.clear();
+        s.position = 0;
+        s.length = 0;
+        s.metadata = None;
+        s.volume_range.enabled = false;
+    });
+
+    let cleared = advance_until_zone(&aggregator, |z| {
+        z.now_playing.is_none() && z.volume_control.is_none()
+    })
+    .await;
+    assert_eq!(cleared.state, PlaybackState::Stopped);
+
+    manager.stop().await;
+    for _ in 0..100 {
+        if aggregator.get_zone("hqplayer:rig").await.is_none() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(aggregator.get_zone("hqplayer:rig").await.is_none());
+    bus.publish(BusEvent::ShuttingDown { reason: None });
+    aggregator_task.await.expect("aggregator stops");
+    server.stop();
+}
+
+/// A reconnect has durable provenance even when a consumer never samples the short disconnected
+/// edge. Session identity, rather than a transient boolean, is what makes later snapshot ordering
+/// unambiguous.
+///
+/// **Label: client-red.** Issue #162 requires a monotonic producer epoch after each fresh handshake.
+#[tokio::test]
+async fn a_reconnected_session_advances_the_producer_epoch() {
+    isolate_config_dir();
+    let model = DaemonModel::with_profile(VERIFIED_PROFILE);
+    let server = WireServer::start(Arc::new(model), WirePolicy::default()).await;
+    let bus = create_bus();
+    let aggregator = Arc::new(ZoneAggregator::new(bus.clone()));
+    let aggregator_task = {
+        let aggregator = aggregator.clone();
+        tokio::spawn(async move { aggregator.run().await })
+    };
+    tokio::task::yield_now().await;
+
+    let manager = HqpInstanceManager::new(bus.clone());
+    let adapter = manager
+        .add_instance(
+            "rig".to_string(),
+            "127.0.0.1".to_string(),
+            Some(server.port()),
+            None,
+            None,
+            None,
+        )
+        .await;
+    adapter.set_timeouts(fast_timeouts()).await;
+    manager.start().await.expect("start managed lifecycle");
+    advance_until_zone(&aggregator, |_| true).await;
+
+    let first_epoch = adapter.producer_epoch().await;
+    assert!(first_epoch > 0, "the initial coherent session has an epoch");
+
+    // Deliberately do not observe `connected=false` or the temporary ZoneRemoved event here. The
+    // next coherent snapshot must still carry a distinguishable session identity.
+    adapter.disconnect().await;
+    for _ in 0..100 {
+        if adapter.producer_epoch().await > first_epoch
+            && aggregator.get_zone("hqplayer:rig").await.is_some()
+        {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    assert_eq!(
+        adapter.producer_epoch().await,
+        first_epoch.wrapping_add(1),
+        "one fresh coherent handshake advances the epoch exactly once"
+    );
+    assert!(aggregator.get_zone("hqplayer:rig").await.is_some());
+
+    manager.stop().await;
+    bus.publish(BusEvent::ShuttingDown { reason: None });
+    aggregator_task.await.expect("aggregator stops");
+    server.stop();
+}
+
+/// Runtime instance changes reconcile with the managed worker set. Adding a configured instance
+/// starts observation without restarting UHC; removing one stops and joins its worker while leaving
+/// unrelated instances healthy.
+///
+/// **Label: client-red.** The pre-reconciliation manager snapshots instances only in `start()`.
+#[tokio::test]
+async fn runtime_instance_add_and_remove_reconcile_managed_workers() {
+    isolate_config_dir();
+    let first_server = WireServer::start(
+        Arc::new(DaemonModel::with_profile(VERIFIED_PROFILE)),
+        WirePolicy::default(),
+    )
+    .await;
+    let second_server = WireServer::start(
+        Arc::new(DaemonModel::with_profile(VERIFIED_PROFILE)),
+        WirePolicy::default(),
+    )
+    .await;
+    let bus = create_bus();
+    let aggregator = Arc::new(ZoneAggregator::new(bus.clone()));
+    let aggregator_task = {
+        let aggregator = aggregator.clone();
+        tokio::spawn(async move { aggregator.run().await })
+    };
+    tokio::task::yield_now().await;
+
+    let manager = HqpInstanceManager::new(bus.clone());
+    let first = manager
+        .add_instance(
+            "first".to_string(),
+            "127.0.0.1".to_string(),
+            Some(first_server.port()),
+            None,
+            None,
+            None,
+        )
+        .await;
+    first.set_timeouts(fast_timeouts()).await;
+    manager.start().await.expect("start managed lifecycle");
+    for _ in 0..100 {
+        if aggregator.get_zone("hqplayer:first").await.is_some() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(aggregator.get_zone("hqplayer:first").await.is_some());
+
+    let second = manager
+        .add_instance(
+            "second".to_string(),
+            "127.0.0.1".to_string(),
+            Some(second_server.port()),
+            None,
+            None,
+            None,
+        )
+        .await;
+    second.set_timeouts(fast_timeouts()).await;
+    for _ in 0..50 {
+        if aggregator.get_zone("hqplayer:second").await.is_some() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(
+        aggregator.get_zone("hqplayer:second").await.is_some(),
+        "a runtime addition must get a managed observer without process restart"
+    );
+
+    assert!(manager.remove_instance("first").await);
+    for _ in 0..50 {
+        if aggregator.get_zone("hqplayer:first").await.is_none() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(aggregator.get_zone("hqplayer:first").await.is_none());
+    assert!(
+        aggregator.get_zone("hqplayer:second").await.is_some(),
+        "removing one instance must not tear down another instance's lane"
+    );
+
+    let unavailable = std::net::TcpListener::bind(("127.0.0.1", 0))
+        .expect("reserve unavailable replacement address");
+    let unavailable_port = unavailable
+        .local_addr()
+        .expect("unavailable replacement address")
+        .port();
+    drop(unavailable);
+    second
+        .configure(
+            "127.0.0.1".to_string(),
+            Some(unavailable_port),
+            None,
+            None,
+            None,
+        )
+        .await;
+    for _ in 0..50 {
+        if aggregator.get_zone("hqplayer:second").await.is_none() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(
+        aggregator.get_zone("hqplayer:second").await.is_none(),
+        "reconfiguration removes the old reachable projection before replacement recovery"
+    );
+    assert!(second.get_status().await.info.is_none());
+
+    manager.stop().await;
+    bus.publish(BusEvent::ShuttingDown { reason: None });
+    aggregator_task.await.expect("aggregator stops");
+    first_server.stop();
+    second_server.stop();
+}
+
+/// An unavailable daemon does not become a partial zone, then converges when it appears. A later
+/// daemon restart on the same endpoint removes the old zone, advances session provenance and
+/// republishes the replacement daemon's authoritative metadata.
+///
+/// **Label: client-pin.** This covers unavailable startup, mid-poll EOF, delayed recovery and restart.
+#[tokio::test]
+async fn unavailable_startup_and_daemon_restart_recover_without_stale_state() {
+    isolate_config_dir();
+    let reservation =
+        std::net::TcpListener::bind(("127.0.0.1", 0)).expect("reserve restart test address");
+    let restart_addr = reservation.local_addr().expect("reserved local address");
+    drop(reservation);
+
+    let bus = create_bus();
+    let aggregator = Arc::new(ZoneAggregator::new(bus.clone()));
+    let aggregator_task = {
+        let aggregator = aggregator.clone();
+        tokio::spawn(async move { aggregator.run().await })
+    };
+    tokio::task::yield_now().await;
+
+    let manager = HqpInstanceManager::new(bus.clone());
+    let adapter = manager
+        .add_instance(
+            "rig".to_string(),
+            restart_addr.ip().to_string(),
+            Some(restart_addr.port()),
+            None,
+            None,
+            None,
+        )
+        .await;
+    adapter.set_timeouts(fast_timeouts()).await;
+    manager
+        .start()
+        .await
+        .expect("an unavailable child does not prevent lifecycle startup");
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    assert!(!adapter.get_status().await.connected);
+    assert!(aggregator.get_zone("hqplayer:rig").await.is_none());
+
+    let first_model = DaemonModel::with_profile(VERIFIED_PROFILE);
+    first_model.external_change(|s| {
+        s.playback = 2;
+        s.track = 1;
+        s.track_id = "before-restart".to_string();
+        s.metadata = Some(Metadata::sample());
+    });
+    let first_server =
+        WireServer::start_on(restart_addr, Arc::new(first_model), WirePolicy::default()).await;
+    let first_zone = advance_until_zone(&aggregator, |z| {
+        z.now_playing
+            .as_ref()
+            .map(|n| n.title == "Alice in Wonderland")
+            .unwrap_or(false)
+    })
+    .await;
+    assert_eq!(first_zone.state, PlaybackState::Playing);
+    let first_epoch = adapter.producer_epoch().await;
+
+    first_server.shutdown().await;
+    for _ in 0..100 {
+        if aggregator.get_zone("hqplayer:rig").await.is_none() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert!(
+        aggregator.get_zone("hqplayer:rig").await.is_none(),
+        "the pre-restart snapshot must not remain presented as reachable"
+    );
+
+    let second_model = DaemonModel::with_profile(VERIFIED_PROFILE);
+    second_model.external_change(|s| {
+        s.playback = 1;
+        s.track = 2;
+        s.track_id = "after-restart".to_string();
+        s.metadata = Some(Metadata {
+            artist: "Restarted Artist".to_string(),
+            album: "Restarted Album".to_string(),
+            song: "After Restart".to_string(),
+            samplerate: 192_000,
+            bits: 24,
+            channels: 2,
+            bitrate: 9_216,
+        });
+    });
+    let second_server =
+        WireServer::start_on(restart_addr, Arc::new(second_model), WirePolicy::default()).await;
+    let recovered = advance_until_zone(&aggregator, |z| {
+        z.now_playing
+            .as_ref()
+            .map(|n| n.title == "After Restart")
+            .unwrap_or(false)
+    })
+    .await;
+    assert_eq!(recovered.state, PlaybackState::Paused);
+    assert_eq!(
+        recovered.now_playing.as_ref().map(|n| n.artist.as_str()),
+        Some("Restarted Artist")
+    );
+    assert_eq!(
+        adapter.producer_epoch().await,
+        first_epoch.wrapping_add(1),
+        "the replacement daemon is a new coherent producer session"
+    );
+
+    manager.stop().await;
+    bus.publish(BusEvent::ShuttingDown { reason: None });
+    aggregator_task.await.expect("aggregator stops");
+    second_server.stop();
+}
+
+/// Lifecycle start is idempotent, stop returns only after the child has disconnected, and the same
+/// manager can start one fresh worker afterwards. This pins both clean shutdown and the absence of
+/// duplicate producers.
+///
+/// **Label: client-pin.** Cancellation safety is observable through connection/session counts.
+#[tokio::test]
+async fn clean_shutdown_joins_children_and_restart_creates_one_fresh_producer() {
+    isolate_config_dir();
+    let server = WireServer::start(
+        Arc::new(DaemonModel::with_profile(VERIFIED_PROFILE)),
+        WirePolicy::default(),
+    )
+    .await;
+    let bus = create_bus();
+    let aggregator = Arc::new(ZoneAggregator::new(bus.clone()));
+    let aggregator_task = {
+        let aggregator = aggregator.clone();
+        tokio::spawn(async move { aggregator.run().await })
+    };
+    tokio::task::yield_now().await;
+
+    let manager = HqpInstanceManager::new(bus.clone());
+    let adapter = manager
+        .add_instance(
+            "rig".to_string(),
+            "127.0.0.1".to_string(),
+            Some(server.port()),
+            None,
+            None,
+            None,
+        )
+        .await;
+    adapter.set_timeouts(fast_timeouts()).await;
+
+    manager.start().await.expect("initial lifecycle start");
+    advance_until_zone(&aggregator, |_| true).await;
+    let first_epoch = adapter.producer_epoch().await;
+    let first_connections = server.stats().connections();
+
+    manager
+        .start()
+        .await
+        .expect("duplicate start is idempotent");
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert_eq!(adapter.producer_epoch().await, first_epoch);
+    assert_eq!(server.stats().connections(), first_connections);
+
+    manager.stop().await;
+    let stopped = adapter.get_status().await;
+    assert!(
+        !stopped.connected,
+        "stop returns after the child has disconnected"
+    );
+    assert!(
+        stopped.info.is_none(),
+        "disconnected status cannot present old daemon identity without stale provenance"
+    );
+    assert!(aggregator.get_zone("hqplayer:rig").await.is_none());
+
+    manager.start().await.expect("restart managed lifecycle");
+    for _ in 0..100 {
+        if adapter.producer_epoch().await > first_epoch
+            && aggregator.get_zone("hqplayer:rig").await.is_some()
+        {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert_eq!(adapter.producer_epoch().await, first_epoch.wrapping_add(1));
+    assert_eq!(
+        server.stats().connections(),
+        first_connections + 1,
+        "restart creates exactly one replacement producer"
+    );
+
+    manager.stop().await;
+    bus.publish(BusEvent::ShuttingDown { reason: None });
+    aggregator_task.await.expect("aggregator stops");
+    server.stop();
+}
+
+/// Reconfiguration is ordered after an in-flight native conversation. The adapter must not present
+/// the new host identity while a response from the old host can still complete and be interpreted.
+///
+/// **Label: client-red.** Before the conversation lease, `configure` changed state before it waited
+/// for the old connection mutex.
+#[tokio::test]
+async fn reconfiguration_cannot_overtake_an_old_host_response() {
+    isolate_config_dir();
+    let server = WireServer::start(
+        Arc::new(DaemonModel::with_profile(VERIFIED_PROFILE)),
+        WirePolicy::default(),
+    )
+    .await;
+    let adapter = Arc::new(HqpAdapter::new(create_bus()));
+    adapter
+        .configure(
+            "127.0.0.1".to_string(),
+            Some(server.port()),
+            None,
+            None,
+            None,
+        )
+        .await;
+    adapter.set_timeouts(fast_timeouts()).await;
+    adapter.connect().await.expect("coherent initial session");
+
+    server.set_policy(WirePolicy {
+        chunking: Chunking::AfterMarker("state=\"".to_string()),
+        chunk_delay: Duration::from_millis(200),
+        ..WirePolicy::default()
+    });
+    let state_requests = server.stats().element_count("State");
+    let state_task = {
+        let adapter = adapter.clone();
+        tokio::spawn(async move { adapter.get_state().await })
+    };
+    for _ in 0..100 {
+        if server.stats().element_count("State") > state_requests {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(2)).await;
+    }
+
+    let configure_task = {
+        let adapter = adapter.clone();
+        tokio::spawn(async move {
+            adapter
+                .configure("192.0.2.1".to_string(), Some(4321), None, None, None)
+                .await;
+        })
+    };
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert_eq!(
+        adapter.get_status().await.host.as_deref(),
+        Some("127.0.0.1"),
+        "host identity changes only after the old-host conversation completes"
+    );
+
+    state_task
+        .await
+        .expect("state task joins")
+        .expect("old-host state response completes");
+    configure_task.await.expect("configure task joins");
+    assert_eq!(
+        adapter.get_status().await.host.as_deref(),
+        Some("192.0.2.1")
+    );
+    server.stop();
+}

--- a/tests/mock_servers/hqplayer/wire.rs
+++ b/tests/mock_servers/hqplayer/wire.rs
@@ -18,12 +18,13 @@
 
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicU32, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 
 /// How one reply document is split across TCP writes.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -211,6 +212,7 @@ where
 pub struct WireServer {
     addr: SocketAddr,
     stats: Arc<WireStats>,
+    policy: Arc<RwLock<WirePolicy>>,
     /// One-shot disruption budget shared across connections, so `DropNextReplyOnce` fires once for
     /// the whole server rather than once per connection.
     disruptions_left: Arc<AtomicU32>,
@@ -220,15 +222,23 @@ pub struct WireServer {
     /// One-shot budget for `apply_then_drop_reply_for_element`. Element-scoped, so like the oversized
     /// fault it is armed by being declared and cannot disturb connection setup.
     element_drops_left: Arc<AtomicU32>,
+    shutdown: CancellationToken,
     accept_task: JoinHandle<()>,
 }
 
 impl WireServer {
     /// Bind an ephemeral loopback port and start serving.
     pub async fn start(responder: Arc<dyn Responder>, policy: WirePolicy) -> Self {
-        let listener = TcpListener::bind("127.0.0.1:0")
-            .await
-            .expect("bind loopback");
+        Self::start_on(SocketAddr::from(([127, 0, 0, 1], 0)), responder, policy).await
+    }
+
+    /// Bind a specific loopback address so lifecycle tests can restart the daemon in place.
+    pub async fn start_on(
+        bind_addr: SocketAddr,
+        responder: Arc<dyn Responder>,
+        policy: WirePolicy,
+    ) -> Self {
+        let listener = TcpListener::bind(bind_addr).await.expect("bind loopback");
         let addr = listener.local_addr().expect("local_addr");
         let stats = Arc::new(WireStats::default());
         // Disruptions start unarmed so connection setup is never the thing under test; a test
@@ -244,41 +254,61 @@ impl WireServer {
         let element_drops_left = Arc::new(AtomicU32::new(u32::from(
             policy.apply_then_drop_reply_for_element.is_some(),
         )));
+        let policy = Arc::new(RwLock::new(policy));
 
         let accept_stats = stats.clone();
+        let accept_policy = policy.clone();
         let accept_budget = disruptions_left.clone();
         let accept_oversized = oversized_left.clone();
         let accept_element_drops = element_drops_left.clone();
+        let shutdown = CancellationToken::new();
+        let accept_shutdown = shutdown.clone();
         let accept_task = tokio::spawn(async move {
-            while let Ok((stream, _)) = listener.accept().await {
+            let mut connections = tokio::task::JoinSet::new();
+            loop {
+                let accepted = tokio::select! {
+                    _ = accept_shutdown.cancelled() => break,
+                    accepted = listener.accept() => accepted,
+                };
+                let Ok((stream, _)) = accepted else {
+                    break;
+                };
                 accept_stats.connections.fetch_add(1, Ordering::SeqCst);
                 let responder = responder.clone();
-                let policy = policy.clone();
+                let policy = accept_policy.clone();
                 let stats = accept_stats.clone();
                 let budget = accept_budget.clone();
                 let oversized = accept_oversized.clone();
                 let element_drops = accept_element_drops.clone();
-                tokio::spawn(async move {
-                    serve_connection(
-                        stream,
-                        responder,
-                        policy,
-                        stats,
-                        budget,
-                        oversized,
-                        element_drops,
-                    )
-                    .await;
+                let connection_shutdown = accept_shutdown.clone();
+                connections.spawn(async move {
+                    tokio::select! {
+                        _ = connection_shutdown.cancelled() => {}
+                        _ = serve_connection(
+                            stream,
+                            responder,
+                            policy,
+                            stats,
+                            budget,
+                            oversized,
+                            element_drops,
+                        ) => {}
+                    }
                 });
             }
+
+            accept_shutdown.cancel();
+            while connections.join_next().await.is_some() {}
         });
 
         Self {
             addr,
             stats,
+            policy,
             disruptions_left,
             oversized_left,
             element_drops_left,
+            shutdown,
             accept_task,
         }
     }
@@ -306,6 +336,25 @@ impl WireServer {
         self.stats.clone()
     }
 
+    /// Replace the active wire policy without replacing the TCP session.
+    ///
+    /// This lets a conformance test establish the adapter's required coherent initial snapshot and
+    /// then arm the fault whose recovery behavior it actually intends to exercise.
+    pub fn set_policy(&self, policy: WirePolicy) {
+        self.oversized_left.store(
+            u32::from(
+                policy.oversized_for_element.is_some()
+                    || policy.oversized_newline_free_for_element.is_some(),
+            ),
+            Ordering::SeqCst,
+        );
+        self.element_drops_left.store(
+            u32::from(policy.apply_then_drop_reply_for_element.is_some()),
+            Ordering::SeqCst,
+        );
+        *self.policy.write().expect("wire policy lock poisoned") = policy;
+    }
+
     /// Arm the policy's one-shot disruption. Call after connecting, so setup is never disrupted.
     pub fn arm_disruption(&self) {
         self.disruptions_left.store(1, Ordering::SeqCst);
@@ -317,7 +366,14 @@ impl WireServer {
     }
 
     pub fn stop(self) {
+        self.shutdown.cancel();
         self.accept_task.abort();
+    }
+
+    /// Stop accepting, close every accepted connection and wait until the address is reusable.
+    pub async fn shutdown(self) {
+        self.shutdown.cancel();
+        let _ = self.accept_task.await;
     }
 }
 
@@ -374,7 +430,7 @@ fn mentions(line: &str, element: &str) -> bool {
 async fn serve_connection(
     stream: TcpStream,
     responder: Arc<dyn Responder>,
-    policy: WirePolicy,
+    policy: Arc<RwLock<WirePolicy>>,
     stats: Arc<WireStats>,
     disruptions_left: Arc<AtomicU32>,
     oversized_left: Arc<AtomicU32>,
@@ -398,6 +454,7 @@ async fn serve_connection(
         }
         stats.requests.fetch_add(1, Ordering::SeqCst);
         stats.record(&line);
+        let policy = policy.read().expect("wire policy lock poisoned").clone();
 
         if policy.disruption == Disruption::DropNextReplyOnce
             && disruptions_left


### PR DESCRIPTION
## Problem

HQPlayer was still an on-demand client: TCP accept could be mistaken for a coherent producer, initial discovery could be lost before the aggregator subscribed, external changes did not continuously converge, and configured instances were outside coordinator-owned startup/shutdown.

That made direct HQPlayer zones stale or partial after daemon restarts, runtime reconfiguration, metadata clears, and process lifecycle changes.

## Solution

- make the multi-instance manager the coordinator-owned Startable
- require Info + State + Status + VolumeRange before publishing reachability
- continuously observe complete direct-zone snapshots and upsert them through the bus/aggregator
- carry metadata, decimal volume, transport state, seek state, and active pipeline deltas
- clear stale session caches and remove the old zone on disconnect or endpoint change
- reconcile runtime instance additions/removals and join child workers on shutdown
- serialize lifecycle mutations, connection establishment, and native conversations
- start an enabled manager when its first endpoint is configured after process startup
- acknowledge aggregator subscription readiness before any producer starts
- extend the stateful wire fake to support mutable faults and real same-port daemon restart tests

## RED to GREEN

Client-first lifecycle cases demonstrated the previous failures before implementation:

- syntactically valid but incomplete Status became a partial connected zone
- external metadata/volume/playback changes never converged without a surface read
- reconnect had no durable producer-session provenance
- runtime additions/removals did not reconcile worker ownership
- unavailable startup and same-port daemon restart did not recover coherently
- duplicate start/stop could leave duplicate or orphan producers
- endpoint reconfiguration could overtake an old-host response
- coordinator status did not report internally-owned Startable workers

## Evidence

Exact head: bac21131a9bc5ab67b6e6c2a5f1e3ef4f300180c

- cargo test --workspace --all-features --quiet: 714 passed; 12 live-device tests intentionally ignored
- HQPlayer conformance: 271/271
- managed lifecycle suite: 37/37 including nested stateful-wire coverage
- API contract: 2/2
- architecture lint: 8/8
- await-in-lock lint: 4/4
- protocol schema: 41/41
- cargo clippy --all-features -- -D warnings
- cargo fmt --check
- git diff --check
- independent final review: PASS for draft
- independent final dissent: PASS for draft

The required Dioxus dx build could not run because dx is not installed in this environment. No UI source changed, and the server/all-feature Rust build compiled in the workspace suite.

No live appliance was contacted for this slice.

## Stack and dependencies

This is a stacked draft based on PR #366 at 8970fd9cb93d537b6e7e234aef55c6e289a323bb.

Advances #162. It does **not** close #162.

Explicit blockers before #162 can close:

- #368 — keep endpoint identity stable across an entire multi-request semantic operation
- #369 — measured restart-window backoff, completed-worker reaping, and self-healing
- #325 — declarative pipeline/options/control-document publication
- #328 — complete aggregator-owned direct HQPlayer surface control/read paths

## Residual boundaries

- API/MCP routes and payload schemas are unchanged.
- Existing HQPlayer API/MCP reads are not yet fully aggregator-only.
- Complete pipeline enumerations and adaptive control documents remain later program work.
- AdapterCoordinator::shutdown() still reasons about handle-backed tasks; production shutdown uses stop_all() over every Startable.
- Hermetic recovery evidence is not a substitute for the later authorized live/version-matrix and beta-build qualification.

## Authorization

Draft review only. Do not merge, mark ready, deploy, contact the appliance, or alter public API/MCP contracts without the separately required approvals.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HQPlayer support to adapter management and settings.
  * HQPlayer status now includes title, artist, and album metadata.
  * Added reliable instance startup, shutdown, reconnection, and runtime configuration handling.
  * Adapter status now accurately reflects running state.
* **Bug Fixes**
  * Improved connection validation and recovery when HQPlayer is unavailable or returns incomplete data.
  * Prevented unsolicited responses and stale state from affecting displayed information.
* **Reliability**
  * Improved startup ordering and graceful shutdown across adapters and zone aggregation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->