### PR TITLE
feat: make HQPlayer workers restart-aware and self-healing

### DIFF
--- a/.oh/issue-369-hqplayer-worker-backoff.md
+++ b/.oh/issue-369-hqplayer-worker-backoff.md
@@ -1,0 +1,137 @@
+# Issue #369 — HQPlayer restart-aware recovery and worker self-healing
+
+**OH:** 80222d6d
+**Issue:** #369
+**Parent:** #311
+**Program:** #310
+**Branch:** `feat/issue-369-hqplayer-worker-backoff`
+
+## Aim
+**Updated:** 2026-07-31
+
+Keep every configured HQPlayer producer observable and recoverable: fast through a qualified daemon
+restart, quiet during a prolonged outage, stable before retry debt is forgiven, and replaced exactly
+once after an unexpected worker exit.
+
+## Problem Statement
+**Updated:** 2026-07-31
+
+A fixed reconnect delay and retained task-map membership are not lifecycle management. HQPlayer
+recovery has a short expected restart phase and a prolonged-outage phase, while a completed task
+handle is no longer a live producer. Retry state and worker liveness must therefore be explicit
+supervisor state.
+
+## Constraints
+
+- Preserve all existing HTTP, SSE, client, and MCP route/payload schemas.
+- The aggregator remains the authority for reachable zone state.
+- Runtime add/remove/start/stop operations remain serialized and return only after affected workers
+  are joined.
+- Restart timing is injectable until measured against a supported HQPlayer build.
+- Retry debt resets only after coherent observations remain stable for a threshold.
+- Every delay and observation is cancellation-aware.
+- The release profile currently uses `panic = "abort"`; in-process panic replacement is impossible
+  there. Unexpected exits remain self-healing, unwind-build panics are covered, and release panic
+  policy is tracked explicitly rather than overclaimed.
+
+## Solution Space
+**Updated:** 2026-07-31
+
+| Option | Level | Approach | Trade-off |
+|---|---|---|---|
+| A | Band-Aid | Check `JoinHandle::is_finished` opportunistically | A dead worker remains dead until another API call and races multiply |
+| B | Local optimum | Reuse `AdapterHandle::run_with_retry` unchanged | Wrong lifecycle unit; no restart window, per-instance health, or retained-handle repair |
+| C | Reframe | One per-instance supervisor around the existing observer, sharing a pure recovery tracker across replacements | Moderate local refactor |
+| D | Redesign | Replace the manager with a command-channel actor and `JoinSet` | Strong global ownership, but disproportionate rewrite for this slice |
+
+### Recommendation
+
+Select **C**. Keep the manager's existing lifecycle transaction as the single ordering boundary.
+Each map entry becomes a long-lived supervisor handle/token/status. The supervisor owns and joins one
+child observer, clears adapter reachability after an unexpected exit, preserves the recovery tracker
+across replacements, waits cancellation-safely, and starts exactly one replacement.
+
+Use a pure recovery state machine:
+
+- fixed short delay while elapsed outage time is inside the measured restart window;
+- saturating exponential progression after that window, capped at a documented maximum;
+- a coherent success marks the child healthy, but retry debt resets only after coherent health spans
+  the configured stability threshold.
+
+Expose only an internal Rust lifecycle snapshot with supervisor-enabled plus
+`Recovering`/`Healthy`/`Failed`/`Stopped`. Existing serialized status shapes remain frozen.
+
+### Why not the alternatives
+
+- A cannot notice failure autonomously and does not own completion.
+- B solves adapter-loop retries but not per-instance supervisor liveness.
+- D is a valid later redesign if lifecycle mutations outgrow the existing transaction lock, but
+  rewriting every manager command now adds more race surface than it removes.
+
+### Dissent adjustments accepted
+
+- Retry state outlives replaceable children.
+- Unexpected exit cleanup invalidates stale reachability before replacement.
+- Stop/remove cancel and join the supervisor inside the existing lifecycle transaction.
+- Same-name remove/re-add cannot observe an old completion because removal joins before the
+  transaction releases.
+- Panic recovery is not claimed for release builds while `panic = "abort"` remains.
+
+## Execute
+**Updated:** 2026-07-31
+**Status:** in-progress
+
+- [x] Aim is clear.
+- [x] Frozen external contracts and manager transaction boundaries are known.
+- [x] Scope is limited to recovery policy, supervisor ownership, internal status, tests, and measured
+  supported-version evidence.
+- [x] No UI or MCP payload changes are in this issue.
+- [x] RED tests demonstrated policy progression/reset, zero-delay storm prevention, internal status,
+  shared retry debt, supervisor exit/panic/cancellation behavior, and the shutdown-vs-panic stale
+  cleanup race before their implementations.
+- [x] Focused lifecycle (37), lifecycle policy/supervisor unit tests (8), native conformance (271),
+  API contract, await-in-lock lint, and workspace/all-features clippy gates pass.
+- [x] Full-workspace all-features test passes; the opt-in live qualification remains ignored.
+- [x] Final exact-diff review and dissent gates pass with no code findings.
+- [ ] Supported HQPlayer restart recovery is measured only after explicit live-test notice.
+
+### Live qualification attempt
+
+The explicit read-only probe was compiled and run from the development host against HQPlayer
+Embedded 6.0.2 at the configured native endpoint. A coherent baseline could not be established:
+both remote and loopback requests were accepted at TCP and reset by the daemon. HTTP remained
+available, redirected the main surface to `/about`, and reported a Trial license. The process had
+been running since the prior day.
+
+No restart occurred. `systemctl restart hqplayerd` requested the root credential; the supplied
+operator account is not authorized to manage the unit, and no privilege or service configuration
+was changed. The supported-version restart-window gate therefore remains pending an
+operator-authorized restart while the read-only probe is waiting.
+
+The ignored, opt-in probe now emits `uhc-hqp-lifecycle/v1` JSON containing product, version, engine,
+probe interval, connect/response timeouts, last-coherent-to-first-failed-observation time, and
+first-failed-observation-to-coherent-recovery time. It also emits explicit recovery-window lower
+and upper bounds; policy qualification uses the conservative last-coherent-to-recovery upper bound.
+
+## Review and Dissent
+**Updated:** 2026-07-31
+
+- Review: PASS for a draft PR. The shutdown/panic cleanup race, shared replacement debt, probe
+  identity, and timing-bound semantics are verified.
+- Dissent: PASS with no P1–P4 code findings. No stale reachability, duplicate supervisor, orphan
+  worker, reconnect storm, or public-contract drift was found.
+- Known gate: keep the PR draft until the live HQPlayer Embedded 6.0.2 measurement qualifies or
+  replaces the provisional 12-second restart window.
+- Explicit dependency: #372 owns release-mode in-process panic recovery while release builds use
+  `panic = "abort"`.
+
+## Ship
+**Updated:** 2026-07-31
+**Status:** in-progress
+
+- [x] Implementation, hermetic tests, exact-diff review, and dissent are complete.
+- [x] Issue #369 states the release panic constraint and dependency on #372.
+- [ ] Commit and push the focused stacked branch.
+- [ ] Open a draft PR stacked on #371 and post the six exact-head workflow reports.
+- [ ] Request CodeRabbit and validate report output contracts.
+- [ ] Live qualification remains a pre-merge gate; no merge is authorized.

--- a/.oh/issue-369-hqplayer-worker-backoff.md
+++ b/.oh/issue-369-hqplayer-worker-backoff.md
@@ -5,6 +5,7 @@
 **Parent:** #311
 **Program:** #310
 **Branch:** `feat/issue-369-hqplayer-worker-backoff`
+**Draft PR:** #373 (stacked on #371)
 
 ## Aim
 **Updated:** 2026-07-31
@@ -131,7 +132,8 @@ and upper bounds; policy qualification uses the conservative last-coherent-to-re
 
 - [x] Implementation, hermetic tests, exact-diff review, and dissent are complete.
 - [x] Issue #369 states the release panic constraint and dependency on #372.
-- [ ] Commit and push the focused stacked branch.
-- [ ] Open a draft PR stacked on #371 and post the six exact-head workflow reports.
-- [ ] Request CodeRabbit and validate report output contracts.
+- [x] Commit and push the focused stacked branch.
+- [x] Open draft PR #373 stacked on #371.
+- [x] Request CodeRabbit.
+- [ ] Post the six exact-head workflow reports and validate their output contracts.
 - [ ] Live qualification remains a pre-merge gate; no merge is authorized.

--- a/src/adapters/hqplayer.rs
+++ b/src/adapters/hqplayer.rs
@@ -20,6 +20,9 @@
 //! - Enumerations are mode-relative: a mode change swaps the filter/shaper/rate lists wholesale.
 //! - `result="OK"` is not proof a setting applied. See `verify_applied`.
 
+mod lifecycle;
+pub use lifecycle::{HqpRecoveryConfig, HqpWorkerPhase, HqpWorkerStatus};
+
 use anyhow::{anyhow, Result};
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Writer;
@@ -45,6 +48,7 @@ use crate::bus::{
     VolumeControl as BusVolumeControl, VolumeScale, Zone as BusZone,
 };
 use crate::config::{get_config_file_path, read_config_file};
+use lifecycle::{supervise_worker, RecoveryState, SharedRecoveryState, SharedWorkerPhase};
 
 const HQP_CONFIG_FILE: &str = "hqp-config.json";
 
@@ -1432,6 +1436,8 @@ struct HqpAdapterState {
     cookies: HashMap<String, String>,
     /// Injectable timeout/retry policy. Defaults to the shipped constants.
     timeouts: HqpTimeouts,
+    /// Long-lived producer recovery policy. Separate from per-command retry semantics.
+    recovery_config: HqpRecoveryConfig,
 }
 
 /// Digest authentication state
@@ -1475,6 +1481,7 @@ impl Default for HqpAdapterState {
             digest_auth: None,
             cookies: HashMap::new(),
             timeouts: HqpTimeouts::default(),
+            recovery_config: HqpRecoveryConfig::default(),
         }
     }
 }
@@ -1713,6 +1720,18 @@ impl HqpAdapter {
     /// serialized payload.
     pub async fn set_timeouts(&self, timeouts: HqpTimeouts) {
         self.state.write().await.timeouts = timeouts;
+    }
+
+    async fn recovery_config(&self) -> HqpRecoveryConfig {
+        self.state.read().await.recovery_config
+    }
+
+    /// Override the managed producer recovery policy.
+    ///
+    /// This is an internal conformance seam, not a serialized setting or public control-plane
+    /// contract. Production uses the supported-version-qualified default.
+    pub async fn set_recovery_config(&self, config: HqpRecoveryConfig) {
+        self.state.write().await.recovery_config = config;
     }
 
     /// Check if configured
@@ -2005,9 +2024,12 @@ impl HqpAdapter {
     /// Each instance owns its retry timing independently, while the manager remains the single
     /// adapter-wide lifecycle/ACK visible to the coordinator. Poll futures are cancellation-safe:
     /// cancellation drops the in-flight request and immediately closes the session before return.
-    async fn run_managed(&self, shutdown: CancellationToken) {
-        const POLL_INTERVAL: Duration = Duration::from_secs(2);
-
+    async fn run_managed(
+        &self,
+        shutdown: CancellationToken,
+        phase: SharedWorkerPhase,
+        recovery: SharedRecoveryState,
+    ) {
         loop {
             let observation = tokio::select! {
                 _ = shutdown.cancelled() => break,
@@ -2015,15 +2037,31 @@ impl HqpAdapter {
             };
 
             let delay = match observation {
-                Ok(()) => POLL_INTERVAL,
+                Ok(()) => {
+                    *phase.write().await = HqpWorkerPhase::Healthy;
+                    let mut recovery = recovery.lock().await;
+                    if recovery.on_coherent_success(tokio::time::Instant::now()) {
+                        tracing::info!(
+                            "HQPlayer managed observation remained coherent for {:?}; \
+                             retry debt reset",
+                            recovery.config().stable_threshold
+                        );
+                    }
+                    recovery.config().poll_interval
+                }
                 Err(error) => {
                     tracing::warn!("HQPlayer managed observation failed: {error}");
+                    *phase.write().await = HqpWorkerPhase::Recovering;
+                    let delay = recovery
+                        .lock()
+                        .await
+                        .on_failure(tokio::time::Instant::now());
                     // A handshake failure already leaves a clean disconnected session. A failure
                     // after reachability normally passes through send_command/mark_disconnected;
                     // this closes any remaining partially-used socket without publishing a false
                     // disconnect edge for a session that never became reachable.
                     self.disconnect().await;
-                    self.timeouts().await.reconnect_delay
+                    delay
                 }
             };
 
@@ -5953,6 +5991,7 @@ pub struct HqpInstanceInfo {
 struct HqpManagedWorker {
     shutdown: CancellationToken,
     join: tokio::task::JoinHandle<()>,
+    phase: SharedWorkerPhase,
 }
 
 pub struct HqpInstanceManager {
@@ -6139,13 +6178,42 @@ impl HqpInstanceManager {
             return;
         }
 
-        // Build the child future before taking the worker-map lock. The future is inert until
-        // spawned; keeping its await expression outside the map-guard scope also makes the actual
-        // invariant obvious to the AST lock lint.
+        // Build the supervisor before taking the worker-map lock. The future is inert until
+        // spawned; keeping its await expressions outside the map-guard scope also makes the actual
+        // invariant obvious to the AST lock lint. Retry debt belongs to the supervisor and is
+        // therefore preserved across replaceable observer children.
         let shutdown = CancellationToken::new();
-        let child_shutdown = shutdown.clone();
-        let child = async move {
-            adapter.run_managed(child_shutdown).await;
+        let supervisor_shutdown = shutdown.clone();
+        let phase = Arc::new(RwLock::new(HqpWorkerPhase::Recovering));
+        let recovery = Arc::new(Mutex::new(RecoveryState::new(
+            adapter.recovery_config().await,
+        )));
+        let supervisor_name = name.clone();
+        let run_adapter = adapter.clone();
+        let cleanup_adapter = adapter;
+        let supervisor_phase = phase.clone();
+        let supervisor = async move {
+            supervise_worker(
+                supervisor_name,
+                supervisor_shutdown,
+                supervisor_phase,
+                recovery,
+                move |child_shutdown, child_phase, child_recovery| {
+                    let adapter = run_adapter.clone();
+                    async move {
+                        adapter
+                            .run_managed(child_shutdown, child_phase, child_recovery)
+                            .await;
+                    }
+                },
+                move || {
+                    let adapter = cleanup_adapter.clone();
+                    async move {
+                        adapter.disconnect().await;
+                    }
+                },
+            )
+            .await;
         };
 
         let mut workers = self.workers.lock().await;
@@ -6159,8 +6227,15 @@ impl HqpInstanceManager {
             return;
         }
 
-        let join = tokio::spawn(child);
-        workers.insert(name, HqpManagedWorker { shutdown, join });
+        let join = tokio::spawn(supervisor);
+        workers.insert(
+            name,
+            HqpManagedWorker {
+                shutdown,
+                join,
+                phase,
+            },
+        );
     }
 
     /// Cancel and join one child before returning so it cannot republish after removal.
@@ -6237,6 +6312,25 @@ impl HqpInstanceManager {
     pub async fn instance_count(&self) -> usize {
         let instances = self.instances.read().await;
         instances.len()
+    }
+
+    /// Internal supervisor/child status without changing any serialized status payload.
+    pub async fn worker_status(&self, name: &str) -> HqpWorkerStatus {
+        let phase = self
+            .workers
+            .lock()
+            .await
+            .get(name)
+            .map(|worker| worker.phase.clone());
+        let supervisor_enabled = self.running.load(Ordering::SeqCst) && phase.is_some();
+        let phase = match phase {
+            Some(phase) => *phase.read().await,
+            None => HqpWorkerPhase::Stopped,
+        };
+        HqpWorkerStatus {
+            supervisor_enabled,
+            phase,
+        }
     }
 }
 

--- a/src/adapters/hqplayer/lifecycle.rs
+++ b/src/adapters/hqplayer/lifecycle.rs
@@ -1,0 +1,606 @@
+use std::future::Future;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::{Mutex, RwLock};
+use tokio::time::Instant;
+use tokio_util::sync::CancellationToken;
+
+/// Retry and stability policy for one managed HQPlayer producer.
+///
+/// This is deliberately independent from command timeouts. A command retry proves whether one
+/// request can finish; this policy controls how a long-lived producer behaves while the daemon is
+/// restarting or unavailable. It is not serialized by any HTTP, SSE or MCP payload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HqpRecoveryConfig {
+    /// Delay between coherent observations while the producer is healthy.
+    pub poll_interval: Duration,
+    /// Fixed retry delay during the qualified daemon-restart window.
+    pub short_retry_delay: Duration,
+    /// Elapsed outage time for which the fixed short delay remains appropriate.
+    pub restart_window: Duration,
+    /// First delay after the restart window has elapsed.
+    pub backoff_initial: Duration,
+    /// Maximum prolonged-outage delay.
+    pub backoff_cap: Duration,
+    /// Coherent-health duration required before retry debt is forgiven.
+    pub stable_threshold: Duration,
+}
+
+impl Default for HqpRecoveryConfig {
+    fn default() -> Self {
+        Self {
+            poll_interval: Duration::from_secs(2),
+            short_retry_delay: Duration::from_secs(1),
+            // This remains an injectable qualification value. Issue #369 records the supported
+            // HQPlayer Embedded measurement before this branch is handed off as release-ready.
+            restart_window: Duration::from_secs(12),
+            backoff_initial: Duration::from_secs(2),
+            backoff_cap: Duration::from_secs(60),
+            stable_threshold: Duration::from_secs(10),
+        }
+    }
+}
+
+/// Internally observable child state. Existing public wire payloads deliberately remain unchanged.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HqpWorkerPhase {
+    Recovering,
+    Healthy,
+    Failed,
+    Stopped,
+}
+
+/// Internal lifecycle snapshot for diagnostics and conformance tests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HqpWorkerStatus {
+    pub supervisor_enabled: bool,
+    pub phase: HqpWorkerPhase,
+}
+
+pub(crate) type SharedWorkerPhase = Arc<RwLock<HqpWorkerPhase>>;
+pub(crate) type SharedRecoveryState = Arc<Mutex<RecoveryState>>;
+
+/// Pure outage/stability state. Callers provide the observation instant, making every transition
+/// deterministic without sleeping or measuring scheduler wall time in tests.
+#[derive(Debug)]
+pub(crate) struct RecoveryState {
+    config: HqpRecoveryConfig,
+    outage_started: Option<Instant>,
+    healthy_since: Option<Instant>,
+    next_backoff: Duration,
+}
+
+impl RecoveryState {
+    pub(crate) fn new(mut config: HqpRecoveryConfig) -> Self {
+        const MIN_DELAY: Duration = Duration::from_millis(1);
+        config.poll_interval = config.poll_interval.max(MIN_DELAY);
+        config.backoff_cap = config.backoff_cap.max(MIN_DELAY);
+        config.short_retry_delay = config
+            .short_retry_delay
+            .max(MIN_DELAY)
+            .min(config.backoff_cap);
+        config.backoff_initial = config
+            .backoff_initial
+            .max(MIN_DELAY)
+            .max(config.short_retry_delay)
+            .min(config.backoff_cap);
+        Self {
+            next_backoff: config.backoff_initial,
+            config,
+            outage_started: None,
+            healthy_since: None,
+        }
+    }
+
+    pub(crate) fn config(&self) -> HqpRecoveryConfig {
+        self.config
+    }
+
+    /// Record a failed coherent observation and return the next cancellation-aware wait.
+    pub(crate) fn on_failure(&mut self, now: Instant) -> Duration {
+        self.healthy_since = None;
+        let outage_started = *self.outage_started.get_or_insert(now);
+        if now.saturating_duration_since(outage_started) <= self.config.restart_window {
+            return self.config.short_retry_delay;
+        }
+
+        let delay = self.next_backoff;
+        self.next_backoff = self
+            .next_backoff
+            .checked_mul(2)
+            .unwrap_or(self.config.backoff_cap)
+            .min(self.config.backoff_cap);
+        delay
+    }
+
+    /// Record a complete coherent observation. Returns true only when the prior outage debt was
+    /// reset after continuous coherent health reached the configured stability threshold.
+    pub(crate) fn on_coherent_success(&mut self, now: Instant) -> bool {
+        if self.outage_started.is_none() {
+            return false;
+        }
+
+        let healthy_since = *self.healthy_since.get_or_insert(now);
+        if now.saturating_duration_since(healthy_since) < self.config.stable_threshold {
+            return false;
+        }
+
+        self.outage_started = None;
+        self.healthy_since = None;
+        self.next_backoff = self.config.backoff_initial;
+        true
+    }
+}
+
+/// Own one replaceable observer child for the lifetime of a configured instance.
+///
+/// Manager map membership now means this supervisor is live, not merely that a historical child
+/// handle was retained. Retry state is shared across replacement children so a crashing observer
+/// cannot manufacture a fresh fast-retry budget. With the current release `panic = "abort"` policy,
+/// panic replacement is available only in unwind builds; issue #372 owns that production choice.
+pub(crate) async fn supervise_worker<Run, RunFuture, Cleanup, CleanupFuture>(
+    name: String,
+    shutdown: CancellationToken,
+    phase: SharedWorkerPhase,
+    recovery: SharedRecoveryState,
+    mut run: Run,
+    mut cleanup: Cleanup,
+) where
+    Run: FnMut(CancellationToken, SharedWorkerPhase, SharedRecoveryState) -> RunFuture,
+    RunFuture: Future<Output = ()> + Send + 'static,
+    Cleanup: FnMut() -> CleanupFuture,
+    CleanupFuture: Future<Output = ()> + Send,
+{
+    loop {
+        if shutdown.is_cancelled() {
+            break;
+        }
+
+        *phase.write().await = HqpWorkerPhase::Recovering;
+        let child_shutdown = shutdown.child_token();
+        let mut child = tokio::spawn(run(child_shutdown.clone(), phase.clone(), recovery.clone()));
+
+        let (completion, unexpected) = tokio::select! {
+            _ = shutdown.cancelled() => {
+                child_shutdown.cancel();
+                (child.await, false)
+            }
+            result = &mut child => (result, true),
+        };
+
+        if !unexpected {
+            match completion {
+                Ok(()) => tracing::debug!("HQPlayer worker {name} joined during shutdown"),
+                Err(error) => {
+                    tracing::warn!(
+                        "HQPlayer worker {name} failed while joining during shutdown: {error}"
+                    );
+                    // The observer's normal shutdown path disconnects itself. An abnormal join
+                    // result bypassed that guarantee, so clear any still-reachable state here.
+                    cleanup().await;
+                }
+            }
+            break;
+        }
+
+        if completion.is_ok() && shutdown.is_cancelled() {
+            // A cancellation-aware observer may finish in the same scheduler turn as the parent
+            // token, allowing its join branch to win the select. Its normal exit path already
+            // disconnected; treat this as an ordinary shutdown, not a failed producer epoch.
+            tracing::debug!("HQPlayer worker {name} joined during shutdown");
+            break;
+        }
+
+        match completion {
+            Ok(()) => tracing::warn!("HQPlayer worker {name} exited unexpectedly"),
+            Err(error) if error.is_panic() => {
+                tracing::error!("HQPlayer worker {name} panicked: {error}")
+            }
+            Err(error) => tracing::warn!("HQPlayer worker {name} failed to join: {error}"),
+        }
+        *phase.write().await = HqpWorkerPhase::Failed;
+        let delay = recovery.lock().await.on_failure(Instant::now());
+
+        // A panic can bypass the observer's final disconnect. Clear reachable state before any
+        // replacement is allowed to publish a new producer epoch. Cleanup also remains mandatory
+        // when manager shutdown races this already-observed unexpected completion; cancellation
+        // suppresses only replacement and backoff.
+        cleanup().await;
+        if shutdown.is_cancelled() {
+            break;
+        }
+
+        tracing::warn!("HQPlayer worker {name} will be replaced after {:?}", delay);
+        tokio::select! {
+            _ = shutdown.cancelled() => break,
+            _ = tokio::time::sleep(delay) => {}
+        }
+    }
+
+    *phase.write().await = HqpWorkerPhase::Stopped;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+    use tokio::sync::{Mutex, Notify, RwLock};
+    use tokio::time::Instant;
+    use tokio_util::sync::CancellationToken;
+
+    fn policy() -> HqpRecoveryConfig {
+        HqpRecoveryConfig {
+            poll_interval: Duration::from_secs(2),
+            short_retry_delay: Duration::from_millis(10),
+            restart_window: Duration::from_millis(100),
+            backoff_initial: Duration::from_millis(20),
+            backoff_cap: Duration::from_millis(80),
+            stable_threshold: Duration::from_millis(50),
+        }
+    }
+
+    #[test]
+    fn restart_window_then_exponential_backoff_is_exact_and_capped() {
+        let mut recovery = RecoveryState::new(policy());
+        let start = Instant::now();
+
+        assert_eq!(recovery.on_failure(start), Duration::from_millis(10));
+        assert_eq!(
+            recovery.on_failure(start + Duration::from_millis(100)),
+            Duration::from_millis(10),
+            "the measured restart window includes its boundary"
+        );
+        assert_eq!(
+            recovery.on_failure(start + Duration::from_millis(101)),
+            Duration::from_millis(20)
+        );
+        assert_eq!(
+            recovery.on_failure(start + Duration::from_millis(110)),
+            Duration::from_millis(40)
+        );
+        assert_eq!(
+            recovery.on_failure(start + Duration::from_millis(120)),
+            Duration::from_millis(80)
+        );
+        assert_eq!(
+            recovery.on_failure(start + Duration::from_millis(130)),
+            Duration::from_millis(80),
+            "prolonged outages stay at the cap"
+        );
+    }
+
+    #[test]
+    fn only_stable_coherent_health_resets_retry_debt() {
+        let mut recovery = RecoveryState::new(policy());
+        let start = Instant::now();
+
+        assert_eq!(recovery.on_failure(start), Duration::from_millis(10));
+        assert_eq!(
+            recovery.on_failure(start + Duration::from_millis(101)),
+            Duration::from_millis(20)
+        );
+        assert_eq!(
+            recovery.on_failure(start + Duration::from_millis(110)),
+            Duration::from_millis(40)
+        );
+
+        assert!(
+            !recovery.on_coherent_success(start + Duration::from_millis(120)),
+            "one coherent observation is healthy but not stable"
+        );
+        assert_eq!(
+            recovery.on_failure(start + Duration::from_millis(130)),
+            Duration::from_millis(80),
+            "brief health must preserve the existing outage debt"
+        );
+
+        assert!(!recovery.on_coherent_success(start + Duration::from_millis(140)));
+        assert!(
+            recovery.on_coherent_success(start + Duration::from_millis(190)),
+            "coherent health spanning the threshold resets the outage"
+        );
+        assert_eq!(
+            recovery.on_failure(start + Duration::from_millis(191)),
+            Duration::from_millis(10),
+            "the next outage starts in the short restart window"
+        );
+    }
+
+    #[test]
+    fn zero_duration_configuration_cannot_create_a_busy_retry_loop() {
+        let zero = HqpRecoveryConfig {
+            poll_interval: Duration::ZERO,
+            short_retry_delay: Duration::ZERO,
+            restart_window: Duration::ZERO,
+            backoff_initial: Duration::ZERO,
+            backoff_cap: Duration::ZERO,
+            stable_threshold: Duration::ZERO,
+        };
+        let mut recovery = RecoveryState::new(zero);
+        let config = recovery.config();
+
+        assert!(config.poll_interval >= Duration::from_millis(1));
+        assert!(config.short_retry_delay >= Duration::from_millis(1));
+        assert!(config.backoff_initial >= Duration::from_millis(1));
+        assert!(config.backoff_cap >= Duration::from_millis(1));
+        assert!(recovery.on_failure(Instant::now()) >= Duration::from_millis(1));
+    }
+
+    #[tokio::test]
+    async fn unexpected_normal_exit_is_cleaned_and_replaced_exactly_once() {
+        let shutdown = CancellationToken::new();
+        let phase = Arc::new(RwLock::new(HqpWorkerPhase::Recovering));
+        let recovery = Arc::new(Mutex::new(RecoveryState::new(policy())));
+        let starts = Arc::new(AtomicUsize::new(0));
+        let second_started = Arc::new(Notify::new());
+        let cleanups = Arc::new(AtomicUsize::new(0));
+
+        let task = tokio::spawn(supervise_worker(
+            "rig".to_string(),
+            shutdown.clone(),
+            phase.clone(),
+            recovery,
+            {
+                let starts = starts.clone();
+                let second_started = second_started.clone();
+                move |child_shutdown, _, _| {
+                    let starts = starts.clone();
+                    let second_started = second_started.clone();
+                    async move {
+                        if starts.fetch_add(1, Ordering::SeqCst) == 0 {
+                            return;
+                        }
+                        second_started.notify_one();
+                        child_shutdown.cancelled().await;
+                    }
+                }
+            },
+            {
+                let cleanups = cleanups.clone();
+                move || {
+                    let cleanups = cleanups.clone();
+                    async move {
+                        cleanups.fetch_add(1, Ordering::SeqCst);
+                    }
+                }
+            },
+        ));
+
+        second_started.notified().await;
+        shutdown.cancel();
+        task.await.expect("supervisor joins");
+
+        assert_eq!(starts.load(Ordering::SeqCst), 2);
+        assert_eq!(cleanups.load(Ordering::SeqCst), 1);
+        assert_eq!(*phase.read().await, HqpWorkerPhase::Stopped);
+    }
+
+    #[tokio::test]
+    async fn unwind_panic_is_joined_cleaned_and_replaced_exactly_once() {
+        let shutdown = CancellationToken::new();
+        let phase = Arc::new(RwLock::new(HqpWorkerPhase::Recovering));
+        let recovery = Arc::new(Mutex::new(RecoveryState::new(policy())));
+        let starts = Arc::new(AtomicUsize::new(0));
+        let replacement_started = Arc::new(Notify::new());
+        let cleanups = Arc::new(AtomicUsize::new(0));
+
+        let task = tokio::spawn(supervise_worker(
+            "rig".to_string(),
+            shutdown.clone(),
+            phase,
+            recovery,
+            {
+                let starts = starts.clone();
+                let replacement_started = replacement_started.clone();
+                move |child_shutdown, _, _| {
+                    let starts = starts.clone();
+                    let replacement_started = replacement_started.clone();
+                    async move {
+                        if starts.fetch_add(1, Ordering::SeqCst) == 0 {
+                            panic!("injected observer panic");
+                        }
+                        replacement_started.notify_one();
+                        child_shutdown.cancelled().await;
+                    }
+                }
+            },
+            {
+                let cleanups = cleanups.clone();
+                move || {
+                    let cleanups = cleanups.clone();
+                    async move {
+                        cleanups.fetch_add(1, Ordering::SeqCst);
+                    }
+                }
+            },
+        ));
+
+        replacement_started.notified().await;
+        shutdown.cancel();
+        task.await.expect("supervisor joins");
+
+        assert_eq!(starts.load(Ordering::SeqCst), 2);
+        assert_eq!(cleanups.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn panic_while_shutdown_is_joining_still_clears_reachable_state() {
+        let shutdown = CancellationToken::new();
+        let phase = Arc::new(RwLock::new(HqpWorkerPhase::Recovering));
+        let recovery = Arc::new(Mutex::new(RecoveryState::new(policy())));
+        let starts = Arc::new(AtomicUsize::new(0));
+        let child_started = Arc::new(Notify::new());
+        let release_panic = Arc::new(Notify::new());
+        let cleanups = Arc::new(AtomicUsize::new(0));
+        let state_reachable = Arc::new(AtomicBool::new(true));
+
+        let task = tokio::spawn(supervise_worker(
+            "rig".to_string(),
+            shutdown.clone(),
+            phase.clone(),
+            recovery,
+            {
+                let starts = starts.clone();
+                let child_started = child_started.clone();
+                let release_panic = release_panic.clone();
+                move |_, _, _| {
+                    let starts = starts.clone();
+                    let child_started = child_started.clone();
+                    let release_panic = release_panic.clone();
+                    async move {
+                        starts.fetch_add(1, Ordering::SeqCst);
+                        child_started.notify_one();
+                        release_panic.notified().await;
+                        panic!("injected observer panic concurrent with shutdown");
+                    }
+                }
+            },
+            {
+                let cleanups = cleanups.clone();
+                let state_reachable = state_reachable.clone();
+                move || {
+                    let cleanups = cleanups.clone();
+                    let state_reachable = state_reachable.clone();
+                    async move {
+                        cleanups.fetch_add(1, Ordering::SeqCst);
+                        state_reachable.store(false, Ordering::SeqCst);
+                    }
+                }
+            },
+        ));
+
+        child_started.notified().await;
+        shutdown.cancel();
+        tokio::task::yield_now().await;
+        release_panic.notify_one();
+        task.await.expect("supervisor joins");
+
+        assert_eq!(starts.load(Ordering::SeqCst), 1, "shutdown forbids respawn");
+        assert_eq!(
+            cleanups.load(Ordering::SeqCst),
+            1,
+            "an abnormal child result must be cleaned even after shutdown wins"
+        );
+        assert!(
+            !state_reachable.load(Ordering::SeqCst),
+            "stale adapter and zone state must not remain reachable"
+        );
+        assert_eq!(*phase.read().await, HqpWorkerPhase::Stopped);
+    }
+
+    #[tokio::test]
+    async fn repeated_child_exits_share_and_escalate_one_outage_debt() {
+        let mut escalating_policy = policy();
+        escalating_policy.short_retry_delay = Duration::from_millis(1);
+        escalating_policy.restart_window = Duration::ZERO;
+        escalating_policy.backoff_initial = Duration::from_millis(2);
+        escalating_policy.backoff_cap = Duration::from_millis(4);
+        let shutdown = CancellationToken::new();
+        let phase = Arc::new(RwLock::new(HqpWorkerPhase::Recovering));
+        let recovery = Arc::new(Mutex::new(RecoveryState::new(escalating_policy)));
+        let starts = Arc::new(AtomicUsize::new(0));
+        let fourth_started = Arc::new(Notify::new());
+        let cleanups = Arc::new(AtomicUsize::new(0));
+
+        let task = tokio::spawn(supervise_worker(
+            "rig".to_string(),
+            shutdown.clone(),
+            phase,
+            recovery.clone(),
+            {
+                let starts = starts.clone();
+                let fourth_started = fourth_started.clone();
+                move |child_shutdown, _, _| {
+                    let starts = starts.clone();
+                    let fourth_started = fourth_started.clone();
+                    async move {
+                        if starts.fetch_add(1, Ordering::SeqCst) < 3 {
+                            return;
+                        }
+                        fourth_started.notify_one();
+                        child_shutdown.cancelled().await;
+                    }
+                }
+            },
+            {
+                let cleanups = cleanups.clone();
+                move || {
+                    let cleanups = cleanups.clone();
+                    async move {
+                        cleanups.fetch_add(1, Ordering::SeqCst);
+                    }
+                }
+            },
+        ));
+
+        tokio::time::timeout(Duration::from_millis(100), fourth_started.notified())
+            .await
+            .expect("three bounded replacement delays complete");
+        {
+            let recovery = recovery.lock().await;
+            assert!(
+                recovery.outage_started.is_some(),
+                "replacement children retain the original outage epoch"
+            );
+            assert_eq!(
+                recovery.next_backoff,
+                Duration::from_millis(4),
+                "replacement children share retry debt through the configured cap"
+            );
+        }
+        assert_eq!(starts.load(Ordering::SeqCst), 4);
+        assert_eq!(cleanups.load(Ordering::SeqCst), 3);
+
+        shutdown.cancel();
+        task.await.expect("supervisor joins");
+    }
+
+    #[tokio::test]
+    async fn cancellation_interrupts_replacement_backoff_without_respawn() {
+        let mut long_policy = policy();
+        long_policy.short_retry_delay = Duration::from_secs(60 * 60);
+        let shutdown = CancellationToken::new();
+        let phase = Arc::new(RwLock::new(HqpWorkerPhase::Recovering));
+        let recovery = Arc::new(Mutex::new(RecoveryState::new(long_policy)));
+        let starts = Arc::new(AtomicUsize::new(0));
+        let cleaned = Arc::new(Notify::new());
+
+        let task = tokio::spawn(supervise_worker(
+            "rig".to_string(),
+            shutdown.clone(),
+            phase.clone(),
+            recovery,
+            {
+                let starts = starts.clone();
+                move |_, _, _| {
+                    let starts = starts.clone();
+                    async move {
+                        starts.fetch_add(1, Ordering::SeqCst);
+                    }
+                }
+            },
+            {
+                let cleaned = cleaned.clone();
+                move || {
+                    let cleaned = cleaned.clone();
+                    async move {
+                        cleaned.notify_one();
+                    }
+                }
+            },
+        ));
+
+        cleaned.notified().await;
+        assert_eq!(*phase.read().await, HqpWorkerPhase::Failed);
+        shutdown.cancel();
+        tokio::time::timeout(Duration::from_millis(100), task)
+            .await
+            .expect("cancellation interrupts the one-hour replacement delay")
+            .expect("supervisor joins");
+
+        assert_eq!(starts.load(Ordering::SeqCst), 1);
+        assert_eq!(*phase.read().await, HqpWorkerPhase::Stopped);
+    }
+}

--- a/tests/hqplayer_lifecycle.rs
+++ b/tests/hqplayer_lifecycle.rs
@@ -13,7 +13,9 @@ use std::time::Duration;
 use mock_servers::hqplayer::corpus::VERIFIED_PROFILE;
 use mock_servers::hqplayer::model::{DaemonModel, Metadata};
 use mock_servers::hqplayer::wire::{Chunking, WirePolicy, WireServer};
-use unified_hifi_control::adapters::hqplayer::{HqpAdapter, HqpInstanceManager, HqpTimeouts};
+use unified_hifi_control::adapters::hqplayer::{
+    HqpAdapter, HqpInstanceManager, HqpRecoveryConfig, HqpTimeouts, HqpWorkerPhase, HqpWorkerStatus,
+};
 use unified_hifi_control::adapters::Startable;
 use unified_hifi_control::aggregator::ZoneAggregator;
 use unified_hifi_control::bus::{create_bus, BusEvent, PlaybackState, Zone};
@@ -33,6 +35,17 @@ fn fast_timeouts() -> HqpTimeouts {
         response: Duration::from_millis(500),
         reconnect_delay: Duration::from_millis(10),
         max_attempts: 1,
+    }
+}
+
+fn fast_recovery() -> HqpRecoveryConfig {
+    HqpRecoveryConfig {
+        poll_interval: Duration::from_millis(10),
+        short_retry_delay: Duration::from_millis(10),
+        restart_window: Duration::from_millis(40),
+        backoff_initial: Duration::from_millis(20),
+        backoff_cap: Duration::from_millis(40),
+        stable_threshold: Duration::from_millis(20),
     }
 }
 
@@ -459,6 +472,7 @@ async fn unavailable_startup_and_daemon_restart_recover_without_stale_state() {
         )
         .await;
     adapter.set_timeouts(fast_timeouts()).await;
+    adapter.set_recovery_config(fast_recovery()).await;
     manager
         .start()
         .await
@@ -466,6 +480,14 @@ async fn unavailable_startup_and_daemon_restart_recover_without_stale_state() {
     tokio::time::sleep(Duration::from_millis(100)).await;
     assert!(!adapter.get_status().await.connected);
     assert!(aggregator.get_zone("hqplayer:rig").await.is_none());
+    assert_eq!(
+        manager.worker_status("rig").await,
+        HqpWorkerStatus {
+            supervisor_enabled: true,
+            phase: HqpWorkerPhase::Recovering,
+        },
+        "enabled supervisor and recovering child are distinct from a healthy producer"
+    );
 
     let first_model = DaemonModel::with_profile(VERIFIED_PROFILE);
     first_model.external_change(|s| {
@@ -484,6 +506,10 @@ async fn unavailable_startup_and_daemon_restart_recover_without_stale_state() {
     })
     .await;
     assert_eq!(first_zone.state, PlaybackState::Playing);
+    assert_eq!(
+        manager.worker_status("rig").await.phase,
+        HqpWorkerPhase::Healthy
+    );
     let first_epoch = adapter.producer_epoch().await;
 
     first_server.shutdown().await;
@@ -534,6 +560,13 @@ async fn unavailable_startup_and_daemon_restart_recover_without_stale_state() {
     );
 
     manager.stop().await;
+    assert_eq!(
+        manager.worker_status("rig").await,
+        HqpWorkerStatus {
+            supervisor_enabled: false,
+            phase: HqpWorkerPhase::Stopped,
+        }
+    );
     bus.publish(BusEvent::ShuttingDown { reason: None });
     aggregator_task.await.expect("aggregator stops");
     second_server.stop();

--- a/tests/hqplayer_live_lifecycle.rs
+++ b/tests/hqplayer_live_lifecycle.rs
@@ -1,0 +1,140 @@
+//! Explicitly opted-in HQPlayer lifecycle qualification.
+//!
+//! This probe is read-only. It establishes one coherent native session, waits for an operator to
+//! restart the daemon, observes the first failed poll, and measures until a complete replacement
+//! handshake succeeds. It never invokes a restart itself and never runs in ordinary CI.
+
+use std::io::Write;
+use std::time::Duration;
+
+use unified_hifi_control::adapters::hqplayer::{HqpAdapter, HqpTimeouts};
+use unified_hifi_control::bus::create_bus;
+
+const OPT_IN_ENV: &str = "UHC_HQP_LIFECYCLE_LIVE";
+const HOST_ENV: &str = "UHC_HQP_HOST";
+const PORT_ENV: &str = "UHC_HQP_PORT";
+const PROBE_INTERVAL: Duration = Duration::from_millis(100);
+const CONNECT_TIMEOUT: Duration = Duration::from_millis(250);
+const RESPONSE_TIMEOUT: Duration = Duration::from_millis(750);
+
+#[tokio::test]
+#[ignore = "requires explicit opt-in plus an operator-triggered HQPlayer restart"]
+async fn supported_daemon_restart_window_is_measured_to_a_coherent_snapshot() {
+    assert_eq!(
+        std::env::var(OPT_IN_ENV).as_deref(),
+        Ok("1"),
+        "set {OPT_IN_ENV}=1 explicitly; this lane waits for a live daemon restart"
+    );
+    let host = std::env::var(HOST_ENV).expect("set UHC_HQP_HOST");
+    let port = std::env::var(PORT_ENV)
+        .ok()
+        .map(|value| value.parse::<u16>().expect("UHC_HQP_PORT is a u16"))
+        .unwrap_or(4321);
+
+    let adapter = HqpAdapter::new(create_bus());
+    adapter
+        .configure(host.clone(), Some(port), None, None, None)
+        .await;
+    adapter
+        .set_timeouts(HqpTimeouts {
+            connect: CONNECT_TIMEOUT,
+            response: RESPONSE_TIMEOUT,
+            reconnect_delay: PROBE_INTERVAL,
+            max_attempts: 1,
+        })
+        .await;
+    adapter
+        .connect()
+        .await
+        .expect("baseline coherent HQPlayer handshake");
+    let baseline = adapter
+        .get_status()
+        .await
+        .info
+        .expect("baseline handshake carries daemon identity");
+
+    println!(
+        "HQP_LIFECYCLE_BASELINE_READY={}",
+        serde_json::json!({
+            "schema": "uhc-hqp-lifecycle/v1",
+            "product": baseline.product,
+            "version": baseline.version,
+            "engine": baseline.engine,
+            "host": host,
+            "port": port,
+            "probe_interval_ms": PROBE_INTERVAL.as_millis(),
+            "connect_timeout_ms": CONNECT_TIMEOUT.as_millis(),
+            "response_timeout_ms": RESPONSE_TIMEOUT.as_millis(),
+        })
+    );
+    std::io::stdout()
+        .flush()
+        .expect("flush baseline marker for the operator");
+
+    let wait_deadline = tokio::time::Instant::now() + Duration::from_secs(60);
+    let mut last_coherent_at = tokio::time::Instant::now();
+    let first_failed_observation_at = loop {
+        assert!(
+            tokio::time::Instant::now() < wait_deadline,
+            "no daemon outage was observed within 60 seconds"
+        );
+        tokio::time::sleep(PROBE_INTERVAL).await;
+        match adapter.get_state().await {
+            Ok(_) => last_coherent_at = tokio::time::Instant::now(),
+            Err(_) => break tokio::time::Instant::now(),
+        }
+    };
+
+    let mut failed_attempt_offsets_ms = Vec::new();
+    let recovery_deadline = first_failed_observation_at + Duration::from_secs(60);
+    loop {
+        assert!(
+            tokio::time::Instant::now() < recovery_deadline,
+            "no coherent daemon recovery was observed within 60 seconds"
+        );
+        tokio::time::sleep(PROBE_INTERVAL).await;
+        match adapter.connect().await {
+            Ok(()) => break,
+            Err(_) => failed_attempt_offsets_ms.push(
+                tokio::time::Instant::now()
+                    .saturating_duration_since(first_failed_observation_at)
+                    .as_millis(),
+            ),
+        }
+    }
+
+    let coherent_recovery_at = tokio::time::Instant::now();
+    let outage_onset_uncertainty =
+        first_failed_observation_at.saturating_duration_since(last_coherent_at);
+    let recovery_lower_bound =
+        coherent_recovery_at.saturating_duration_since(first_failed_observation_at);
+    let recovery_upper_bound = coherent_recovery_at.saturating_duration_since(last_coherent_at);
+    let recovered = adapter
+        .get_status()
+        .await
+        .info
+        .expect("replacement coherent handshake carries daemon identity");
+    println!(
+        "HQP_LIFECYCLE_MEASUREMENT={}",
+        serde_json::json!({
+            "schema": "uhc-hqp-lifecycle/v1",
+            "product": recovered.product,
+            "version": recovered.version,
+            "engine": recovered.engine,
+            // The actual outage began between these two completed observations.
+            "last_coherent_to_first_failed_observation_ms":
+                outage_onset_uncertainty.as_millis(),
+            "first_failed_observation_to_coherent_recovery_ms":
+                recovery_lower_bound.as_millis(),
+            // Policy qualification uses this conservative upper bound, not the lower bound above.
+            "last_coherent_to_coherent_recovery_ms":
+                recovery_upper_bound.as_millis(),
+            "recovery_window_lower_bound_ms": recovery_lower_bound.as_millis(),
+            "recovery_window_upper_bound_ms": recovery_upper_bound.as_millis(),
+            "probe_interval_ms": PROBE_INTERVAL.as_millis(),
+            "connect_timeout_ms": CONNECT_TIMEOUT.as_millis(),
+            "response_timeout_ms": RESPONSE_TIMEOUT.as_millis(),
+            "failed_attempt_offsets_ms": failed_attempt_offsets_ms,
+        })
+    );
+}


### PR DESCRIPTION
Refs #369

Stacked on #371 (`fix/issue-368-hqplayer-operation-lease`).

## What changed

- replace retained observer handles with one long-lived per-instance supervisor
- preserve retry debt across replacement children
- use a fixed short retry window followed by capped exponential backoff
- reset retry debt only after a coherent stability threshold
- clean stale adapter and zone reachability before replacing an unexpectedly completed child
- make shutdown interrupt observation and backoff, join children, and prevent respawn
- expose internal supervisor/worker phase without changing HTTP, SSE, client, or MCP schemas
- add an ignored, explicitly opted-in read-only lifecycle probe with daemon identity and conservative timing bounds

## How to test

- `cargo test --workspace --all-features`
- `cargo test --lib --all-features adapters::hqplayer::lifecycle::tests` (8 passed)
- `cargo test --test hqplayer_lifecycle --all-features` (37 passed)
- `cargo test --test hqplayer_conformance --all-features` (271 passed)
- `cargo test --test api_contract --all-features` (2 passed)
- `cargo test --test await_in_lock_lint --all-features` (4 passed)
- `cargo test --test hqplayer_live_lifecycle --all-features --no-run`
- `cargo clippy --workspace --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Review

- exact-diff review: PASS, no remaining code findings
- exact-diff dissent: PASS, no P1–P4 findings
- Superego: PASS, no blocking findings

## Draft-only qualification gates

- The default 12-second restart window is provisional until the opt-in probe records a live HQPlayer Embedded 6.0.2 restart. The probe could not establish a native baseline before the last attempt because the daemon accepted and reset both remote and loopback native connections; no authorized restart occurred.
- Release builds currently use `panic = "abort"`. Unwind-build panic cleanup/replacement is tested here; #372 owns any claim of release-mode in-process panic recovery.
- The stacked base PR #371 has its own unresolved CodeRabbit review and must land first.

Keep this PR draft and `pending-manual-test`. Do not merge or mark ready until the live timing evidence, CI, CodeRabbit, stacked-base review, and explicit user approval are complete.
