### PR TITLE
ci: update sccache action and fix Windows argfile builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -389,7 +389,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.11
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
@@ -832,7 +832,7 @@ jobs:
           targets: x86_64-apple-darwin
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.11
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
@@ -888,7 +888,7 @@ jobs:
           targets: aarch64-apple-darwin
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.11
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
@@ -980,7 +980,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.11
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -981,6 +981,11 @@ jobs:
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.11
+        with:
+          # v0.17 expands Cargo's Rust argfiles before spawning rustc, which
+          # exceeds Windows' command-line limit for crates such as web-sys.
+          # Remove this pin once https://github.com/mozilla/sccache/issues/2787 is fixed.
+          version: v0.16.0
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2

--- a/docs/gh-release.md
+++ b/docs/gh-release.md
@@ -188,7 +188,7 @@ WASM is built once and shared across all platform builds. The cache uses content
 **sccache** caches individual compilation units (`.o` files). Used with rust-cache for native builds:
 
 ```yaml
-- uses: mozilla-actions/sccache-action@v0.0.9
+- uses: mozilla-actions/sccache-action@v0.0.11
 - run: cargo build --release
   env:
     SCCACHE_GHA_ENABLED: "true"


### PR DESCRIPTION
## Outcome

Removes the deprecated Node 20 runtime warning from every sccache-enabled job and restores Windows release builds without removing compiler caching.

## Changes

- update all four `mozilla-actions/sccache-action` references from `v0.0.9` to Node-24-based `v0.0.11`
- pin the Windows sccache binary to `v0.16.0` to avoid the new `v0.17.0` Rust argfile expansion regression
- retain current sccache on test and macOS jobs
- integrate the current `v3`, including `actions/download-artifact@v8` from #293

## Root cause

Cargo passes the 43 KB `web-sys` command through a Rust argfile. sccache v0.17.0 expands that file before spawning `rustc`, exceeding Windows’ command-line limit (`os error 206`). This is tracked upstream as mozilla/sccache#2787.

## Verification

- workflow YAML parses successfully
- `git diff --check` passes
- confirmed upstream action `v0.0.11` declares `runs.using: node24`
- dedicated Windows workflow validation required before merge
- Superego review attempted, but this repository has no `.superego` configuration

Fixes #377

@coderabbit review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure across Test, macOS, and Windows workflows to improve build reliability and performance.
  * Improved Windows build reliability for projects with large dependency trees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->