### PR TITLE
feat(#329): add revision-fenced HQPlayer immediate commands

### DIFF
--- a/.oh/issue-329-hqplayer-immediate-command.md
+++ b/.oh/issue-329-hqplayer-immediate-command.md
@@ -1,0 +1,188 @@
+# Issue 329 — HQPlayer Immediate Adaptive Command Service
+
+**Updated:** 2026-07-31
+**Status:** solution space
+**Issue:** #329
+**Parent:** #313
+**Blocked by:** #375 / PR #376, #347
+**Blocks:** #331, #209, #222
+
+## Aim
+
+Every UHC surface can request the same semantic HQPlayer control and receive the same truthful, correlated outcome, without knowing native indexes, calling an adapter directly, or inferring success from whether a request returned.
+
+## Problem Statement
+
+**Current framing:** Connect the adaptive control IDs published by #375 to the existing HQPlayer adapter methods.
+
+**Reframed as:** Web, MCP, and control-device users need one mutation path that proves a request was valid against the exact live producer state, records whether a write may have left the process, and converges on authoritative observed state; today each surface either calls an adapter directly or has no adaptive execution path, so validation and ambiguous-delivery semantics would drift.
+
+**The shift:** From a control-ID switch statement to a revision-fenced application service with typed native execution receipts and producer-owned operation history.
+
+### Constraints
+
+- **Hard:** The aggregator remains the only retained producer-state owner; surfaces never reach adapters; the native adapter imports no adaptive contract; one exact producer revision is preflighted and then atomically reserved by the publisher before mutation; native indexes remain private; ambiguous writes are never blindly replayed; operation history is append-only and merged into every observation by the producer publisher; no public route or payload changes in the first PR.
+- **Soft:** Concrete service/module names, whether execution is serialized per instance or per conflict set initially, and how long an indeterminate operation remains eligible for convergence.
+
+### What this framing enables
+
+A single internal command contract can later drive web, MCP, and devices; stale requests fail before mutation; pending/terminal state is visible without replacing observed values; HQPlayer-specific execution stays typed and testable behind the generic preflight boundary.
+
+### What this framing excludes
+
+Surface-specific adapter calls, string-parsing `anyhow` errors into outcomes, optimistic UI values, direct mutation of aggregator snapshots, a public endpoint in the foundation PR, and multi-step persistent/staged plans.
+
+## Solution Space Analysis
+
+**Problem:** Turn a retained adaptive descriptor into one safe, observable HQPlayer immediate command without duplicating validation or outcome semantics across surfaces.
+
+**Key constraint:** Producer documents and `OperationRecord` are retained by the actor-owned aggregator, but a read-only `AdaptiveView` cannot reserve a command. The HQPlayer publisher is the only component that owns both the last admitted document/revision and the run lease needed to publish a Pending reservation before native I/O.
+
+### Candidates Considered
+
+| Option | Level | Approach | Trade-off |
+|---|---|---|---|
+| A | Band-aid | Keep bespoke web/MCP/device switches that call `HqpAdapter` | Fast first demo, guaranteed semantic drift and direct-adapter boundary violations |
+| B | Local optimum | Put HQPlayer dispatch directly in the producer aggregator actor | Atomic store access, but mixes generic retention with backend I/O and lets slow native writes block publication |
+| C | Reframe | Application service performs generic preflight, then the producer publisher atomically reserves Pending, invokes a typed producer executor, and serializes observation/operation publication | More seams, but preserves ownership, lifecycle fencing, backpressure, and one reusable surface contract |
+| D | Redesign | Make every producer a bidirectional actor that owns observation, command execution, and document publication | Strong ownership model, but large #324/#375 redesign before validating the first immediate path |
+
+### Evaluation
+
+**Option A — surface-specific dispatch**
+
+- Solves stated problem: no; it creates three command paths.
+- Implementation cost: low initially.
+- Maintenance burden: high and permanent.
+- Second-order effects: raw identity fallback, inconsistent stale-choice checks, and incompatible outcome language.
+
+**Option B — aggregator executes adapters**
+
+- Solves stated problem: partially.
+- Implementation cost: medium.
+- Maintenance burden: high because the generic actor gains backend registries and async I/O.
+- Second-order effects: native timeouts can stall producer admission; adapter ownership leaks into the state store.
+
+**Option C — advisory generic preflight plus publisher-owned reservation/outcomes**
+
+- Solves stated problem: yes.
+- Implementation cost: medium-high.
+- Maintenance burden: moderate, with one generic preflight path and one typed executor per producer.
+- Second-order effects: the publisher gains a per-instance coordinator/ledger; command and observation commits share that serialization point; operation-only publication advances state revision.
+- Future options: web/MCP/device projections, batching, persistent lanes, and additional producers reuse the same request/receipt model.
+
+**Option D — bidirectional producer actors**
+
+- Solves stated problem: yes.
+- Implementation cost: high.
+- Maintenance burden: potentially low after migration.
+- Second-order effects: invalidates reviewed #324/#375 boundaries and expands the first command slice into a runtime redesign.
+
+### Recommendation
+
+**Selected:** Option C — generic preflight followed by publisher-linearized reservation, typed execution, and producer-owned operation publication.
+
+**Level:** Reframe.
+
+**Rationale:** Reading, reservation, and native execution have different owners. The application service can reject obvious invalid input from one atomic aggregator snapshot without becoming a state store. The publisher must recheck that exact revision and reserve Pending under its per-instance coordinator before the executor may run; that is the command linearization point. The HQPlayer executor preserves native delivery evidence without importing adaptive vocabulary, and the same publisher merges operation history into every later observation. This is the smallest design that produces one truthful path for all later surfaces.
+
+**Why not the others:**
+
+- A violates the explicit #331 architecture and recreates the bug class this program exists to remove.
+- B distributes backend knowledge into the generic aggregator and couples native latency to publication.
+- D may become attractive after several producers, but it is premature before the first typed immediate path validates the need.
+
+**Accepted trade-offs:**
+
+- The foundation PR introduces internal service/executor/outcome seams before any new UI is visible.
+- The first slice covers only the five #329 pipeline settings whose #347 path already performs semantic readback: mode, filter 1x, filter Nx, shaper, and rate.
+- HQPlayer transport and volume remain in #328 because their current `Result<()>` cannot distinguish not-attempted, provisional acknowledgement, and ambiguous delivery truthfully.
+- Operation-only changes become state changes and must advance the producer state revision; volatile health remains revision-neutral.
+
+## Selected execution shape
+
+1. Define an internal immediate command request with explicit producer/instance key, expected epoch/revisions, control ID, Immediate lane, desired semantic value, caller correlation ID, and a deterministic request fingerprint.
+2. Perform advisory generic preflight against one `AdaptiveView` snapshot: exact identity/revision, `Live` presence, non-stale connected Native lane, mutable/available Immediate control, correct kind, and an exact current choice ID whose `engine_name` is the only value forwarded.
+3. Submit the request to the single HQPlayer publisher coordinator actor. That task owns the non-cloneable `AdapterRun` for the whole manager lifecycle and serializes observations, reservations, completions, retirements, and run stop. It rechecks its last admitted epoch/revisions and actionability, deduplicates `(producer, conflict set, correlation, fingerprint)`, allocates a dedicated operation generation, appends an explicit `CommandOutcome::Pending`, advances state revision, and awaits admission before returning an opaque lease.
+4. The application service may enqueue the actor-owned execution job only after reservation succeeds. A private validated command cannot contain a native index or an unvalidated semantic value.
+5. A bounded immediate-command actor owns every accepted job independently of the submitting caller. After reservation it sends the correlation/operation acknowledgement, then continues execution even if the caller disconnects or cancels. Graceful shutdown closes and drains this actor before adapter shutdown, so accepted jobs always terminalize. Immediately before dispatch it asks the publisher coordinator to validate the opaque lease again; stale run/generation is terminalized as not-attempted Superseded.
+6. Route the five pipeline settings through the one #375 `HqpSemanticOperation` registry to a typed HQPlayer executor resolved by exact instance identity. The manager holds its lifecycle transaction across exact-instance resolution and native execution, so concurrent instance removal/reconfiguration cannot race a dispatched command. The registry also declares one conservative pipeline conflict set for this slice; one-sided filters cannot race and mode cannot interleave with dependent settings.
+7. Refactor the #347 setting path to return a contract-free typed native receipt preserving: not attempted, possibly attempted, daemon acknowledged/rejected, same-session readback verified, readback divergent/unavailable. Existing public methods collapse the receipt back to their unchanged `Result<SettingOutcome>` contract; no error-string classification is allowed.
+8. Return the receipt with the opaque lease. The publisher coordinator checks producer epoch, actor-owned adapter-run ID, operation generation, and conflict-set ownership before appending a terminal/indeterminate transition. A stale completion cannot modify the retained document.
+9. Retain the append-only operation ledger separately from each freshly projected observation, merge it before every `RevisionTracker::materialize`, and include canonical operation content in the state view. Pending, terminal, convergence, and supersession advance state revision; volatile health remains revision-neutral.
+10. Store explicit control, desired semantic value, lane, correlation, and observed revision in the operation/plan record. A duplicate correlation plus identical fingerprint returns the existing operation; a reused correlation with different intent is rejected.
+11. Extend the shared command vocabulary with explicit `Pending`: it is non-terminal, not producer-state evidence, and awaits convergence. Legal transitions leave Pending for Applied, Ignored, Rejected, Superseded, Disconnected, TimedOut, Indeterminate, or a recognized future outcome; no terminal outcome can regress to Pending.
+12. If cancellation or shutdown occurs before dispatch, terminalize Pending as Superseded with `WriteAttempt::NotAttempted`. Once native I/O begins, caller cancellation cannot abort the actor-owned job; its typed receipt determines the terminal/indeterminate result. Tests cover cancellation after reservation, during native I/O, and while completion publication is queued.
+
+## First-PR boundaries
+
+In scope:
+
+- internal service, advisory preflight, publisher reservation/ledger, typed HQPlayer setting receipt, and hermetic tests;
+- mode, filter 1x, filter Nx, shaper, and rate through the existing #375 registry;
+- explicit machine-checkable registry evidence/conflict/support policy that returns a structured `DeferredToIssue328`-style refusal for transport and volume until #328 supplies truthful receipts.
+
+Out of scope:
+
+- new or modified HTTP, SSE, MCP, Muse, or device routes/payloads;
+- web rendering, MCP tool schemas, ESP32 manifest composition;
+- staged, held, persistent, restart, batch, preset, matrix, and composite execution;
+- live mutation until the configured Embedded target serves operational native/configuration surfaces.
+
+## Required red tests
+
+- stale epoch or revision refuses before executor invocation;
+- producer state advancing after advisory preflight but before publisher reservation refuses before executor invocation;
+- LastKnown, stale, disconnected, unavailable, read-only, wrong-lane, wrong-kind, out-of-range, off-step, and unknown-choice requests refuse before execution;
+- source-mode rate remains uninvokable while mode remains available as the escape control;
+- every in-scope pipeline descriptor resolves through exactly one executor arm and one declared conflict/evidence policy; transport/volume are explicitly deferred to #328;
+- typed receipts distinguish no-send, provisional, verified/no-op, and possibly-applied delivery without parsing messages;
+- `Pending` is serialized distinctly, is not state evidence, awaits convergence, and cannot be entered from a terminal outcome;
+- pending does not replace observed value; terminal transition appends history and advances state revision only;
+- a native observation after Pending preserves the ledger and advances from the latest state revision rather than erasing or regressing it;
+- an older operation completion cannot clear or overwrite a newer per-control operation;
+- duplicate correlation with an identical fingerprint sends at most once; a different fingerprint is rejected;
+- filter-side commands and mode/dependent settings cannot interleave within the pipeline conflict set;
+- adapter-run replacement prevents stale outcome publication;
+- caller cancellation after reservation cannot strand Pending or retain the conflict set indefinitely;
+- stop/replacement between reservation and dispatch prevents the native call, not merely its later publication.
+
+## Drift stop conditions
+
+- Any proposed public endpoint or payload change pauses for explicit approval.
+- If operation history cannot be published without the command service mutating aggregator state directly, return to solution space rather than adding a debug/release bypass.
+- If an existing adapter method cannot report whether a write may have left, do not advertise that command through this service until the native receipt is made truthful.
+
+## Operation evidence matrix — first slice
+
+| Control | Native operation | Conflict set | Strongest terminal evidence |
+|---|---|---|---|
+| `hqplayer.pipeline.mode` | `set_mode` | pipeline | same-session semantic State readback; same-mode is confirmed no-op |
+| `hqplayer.pipeline.filter_1x` | `set_filter_1x` | pipeline | same-session 1x readback while preserving authoritative Nx sibling |
+| `hqplayer.pipeline.filter_nx` | `set_filter_nx` | pipeline | same-session Nx readback while preserving authoritative 1x sibling |
+| `hqplayer.pipeline.shaper` | `set_shaper` | pipeline | same-session semantic State readback |
+| `hqplayer.pipeline.rate` | `set_rate` | pipeline | same-session exact-rate readback; source-mode suppression is not attempted |
+| transport actions | #328 | transport/library | deferred: at-most-once attempt and observed predicates require explicit policy |
+| decimal-dB volume | #328 | volume | deferred: adaptive volume prevents generic exact readback equivalence |
+
+## Solution review
+
+**Verdict:** ADJUST, then continue.
+
+The selected ownership direction is necessary and aligned, but the original draft incorrectly treated `AdaptiveView` preflight as a reservation, assumed operation publication could be bolted onto an observation-only publisher, reused an unspecified generation token, and overclaimed truthful evidence for all 11 controls. The adjusted design adds publisher-owned reservation/ledger serialization, dedicated operation generation and idempotency, explicit desired-value recording, lifecycle fencing, and the #328/#329 evidence split.
+
+## Solution dissent
+
+**Recommendation:** ADJUST / PROCEED with the revised design.
+
+The strongest failure cases were credible:
+
+- Pending could disappear on the next observation because projection currently starts with an empty operation list.
+- An operation-only update could be refused as `NotAdvanced` because operations were excluded from revision canonicalization.
+- A late completion could publish after a newer command or after manager stop if it retained a clone of the run lease.
+- Transport or volume errors could be falsely classified by parsing `anyhow` text.
+- Per-control locking would still allow two one-sided `SetFilter` calls or mode/rate to conflict.
+
+The revised actor-owned publisher coordinator, operation overlay, dedicated lease generation, typed native setting receipt, conservative pipeline conflict set, and narrowed evidence matrix directly address those cases. This ownership decision is durable enough to record as an ADR before implementation.
+
+Follow-up review found the direction sound after replacing the implied per-call run ownership with a single publisher coordinator actor that owns the non-cloneable run for the manager lifecycle. Follow-up dissent additionally required explicit `Pending`, actor-owned cancellation/drain behavior, and a second lifecycle check immediately before dispatch; all are now part of the selected execution shape and red-test contract.

--- a/docs/adr/004-adaptive-command-causality.md
+++ b/docs/adr/004-adaptive-command-causality.md
@@ -55,7 +55,27 @@ first; global identity eviction can therefore discard only history already made 
 admitted at retirement. Once retirement intent is recorded, coordinator retries are part of the
 committed removal transaction: the observation sink reports success so the instance manager cannot
 restore a worker that the coordinator is still committed to retire. A refusal before retirement
-intent is accepted remains an error and permits manager rollback.
+intent is accepted remains an error and permits manager rollback. Ordinary manager stop retains
+last-known documents and ends its publication run, but a later definitive instance removal still
+creates a coordinator-owned one-command run and awaits aggregator retirement before it can compact
+the producer into private history. A retirement already committed for retry also keeps the ordinary
+run alive until that request clears. Thus successful removal has the same public meaning whether the
+manager is running or stopped.
+
+Producer epoch belongs to the logical instance name for the lifetime of the manager and adaptive
+aggregator, not to a replaceable `HqpAdapter` allocation. The instance manager retains the highest
+removed epoch as long as the aggregator retains its retirement tombstone and seeds a same-name
+replacement at that floor. Its first coherent native session therefore publishes exactly one epoch
+above retirement; it does not manufacture reconnect failures to rediscover the floor. While an old
+lifetime's retirement is pending, observations from a replacement are refused so they cannot
+inherit the retiring tracker, operation ledger, or correlation namespace.
+
+Typed terminal admission and subsequent retirement are two commit points. Once completion is
+admitted, a retryable retirement failure is retained as coordinator-owned retirement debt and the
+completion reply remains successful; callers must never be told an admitted receipt was
+unpublished. Coordinator oneshot replies are likewise handled explicitly: a cancelled receiver is
+observable in tracing, and lint coverage descends into actor macro token streams so reply failures
+cannot regress to silently discarded `send` results.
 
 `CommandOutcome::Pending` is an explicit non-terminal state. It is not evidence of producer state, sets `awaits_convergence`, and may transition to Applied, Ignored, Rejected, Superseded, Disconnected, TimedOut, Indeterminate, or a future recognized terminal outcome. No terminal outcome can regress to Pending.
 
@@ -104,6 +124,8 @@ Deferred. A producer actor owning observation, command execution, and publicatio
 - Operation history survives polls, reconnect handling, and concurrent observations.
 - Stale completions, duplicate gestures, and ended adapter runs cannot send or overwrite newer truth.
 - Caller cancellation and orderly shutdown cannot strand Pending or retain a conflict set forever.
+- Stopped-manager deletion retires public state, and same-name replacement advances on its first
+  coherent session without inheriting prior command history.
 - Native attempt evidence remains typed and testable without adaptive contract leakage into adapters.
 - Coupled HQPlayer controls serialize according to actual wire semantics.
 

--- a/docs/adr/004-adaptive-command-causality.md
+++ b/docs/adr/004-adaptive-command-causality.md
@@ -23,15 +23,18 @@ Adaptive immediate commands use four explicit ownership layers.
 
 1. **Application service — generic advisory preflight and routing.** It reads one `AdaptiveView` snapshot and rejects an unknown producer, non-Live or stale state, mismatched expected revision, unavailable/wrong-lane control, and invalid semantic value. It never mutates a snapshot and never calls an adapter without a producer reservation.
 2. **Producer coordinator — liveness, linearization, and document causality.** One per-instance publisher actor owns the non-cloneable `AdapterRun` for the manager lifecycle and alone performs observation, reservation, completion, retirement, and stop publications. It rechecks the exact expected epoch/revisions, deduplicates correlation plus request fingerprint, allocates a dedicated operation generation, appends explicit `CommandOutcome::Pending`, advances state revision, and awaits admission. Only then may execution be queued. It retains an append-only operation ledger and merges it into every later observed document before revision materialization.
-3. **Immediate-command actor — accepted-job lifetime and dispatch fencing.** A bounded actor owns accepted jobs independently of the submitting caller. Immediately before native dispatch it asks the producer coordinator to validate the opaque lease again. If the producer run, generation, or conflict-set ownership has changed, it terminalizes the operation as not-attempted Superseded and does not call the adapter. Graceful shutdown closes and drains this actor before adapters are stopped. Caller cancellation cannot abandon a reserved operation: cancellation before dispatch becomes Superseded/NotAttempted; after I/O begins, the actor continues through typed completion.
+3. **Immediate-command actor — accepted-job lifetime and dispatch fencing.** A bounded actor owns accepted jobs independently of the submitting caller. Immediately before native dispatch it asks the producer coordinator to atomically validate the opaque lease and record a coordinator-only executor-begun fence. If the producer run, generation, or conflict-set ownership has changed, it terminalizes the operation as not-attempted Superseded and does not call the adapter. The fence is ordering state, not write-attempt evidence, and is never projected into the producer document. Graceful shutdown closes and drains this actor before adapters are stopped. Caller cancellation cannot abandon a reserved operation: cancellation before dispatch becomes Superseded/NotAttempted; after execution begins, the actor continues through typed completion.
 4. **Native executor — typed protocol evidence.** The HQPlayer executor accepts only a validated semantic command and returns a contract-free typed receipt distinguishing no attempt, possible attempt, daemon acknowledgement/rejection, authoritative same-session readback, divergence, and unavailable readback. It never imports adaptive outcome types and never exposes native indexes. The manager holds its lifecycle transaction across exact-instance resolution and native execution so removal or reconfiguration cannot race a dispatched command.
 
 Completion carries an opaque lease containing producer identity, producer epoch, adapter-run ID, conflict set, and operation generation. The publisher accepts a transition only if that lease is still current. A native operation retains the run ID, never the RAII run lease; stop or replacement therefore makes a late completion stale instead of extending producer liveness.
 
-Before the native executor returns a typed receipt, `Pending` is explicitly a no-send state. A
-matching observation in that interval resolves the operation as `Ignored` with
-`NotAttempted`; it must never manufacture `Applied`/`Confirmed`. Receipt evidence is the only
-source of attempted-write truth. Instance removal may arrive after the manager has finished the
+Before the final dispatch fence, `Pending` is explicitly a no-send state. A matching observation in
+that interval resolves the operation as `Ignored` with `NotAttempted`; it must never manufacture
+`Applied`/`Confirmed`. Once the executor-begun fence is installed, `Pending` means the attempt is
+unknown: matching or conflicting observations may update producer state but cannot resolve that
+operation. Receipt evidence is the only source of attempted-write truth, and admitting typed
+completion clears the fence atomically with its operation transition. Manager stop refuses to drop
+the run while a fence remains. Instance removal may arrive after the manager has finished the
 native call but before the command actor publishes that receipt, so it records retirement intent
 and blocks new work while retaining the coordinator. Retirement occurs only after the receipt's
 terminal operation is admitted; the compact retired coordinator then preserves exact correlation
@@ -50,9 +53,12 @@ Every operation records its control, requested semantic value, lane, correlation
 Terminal publications are a serialization frontier: while one is deferred, observations and new
 reservations first flush the immutable terminal candidate rather than publishing a different
 document at the same next revision. Documents retain the newest 32 terminal operations; compacted
-records retain bounded correlation/fingerprint tombstones (256) so an old gesture cannot become a
-fresh write. Unresolved records are never compacted; admission applies backpressure at 32
-unresolved operations instead of silently forgetting uncertainty.
+records retain bounded correlation/fingerprint tombstones (256) so a recent compacted gesture
+cannot become a fresh write. Retired producer identities are globally bounded at 64 as well as
+bounded within each retained ledger. Correlation identity is therefore a finite replay window,
+not perpetual storage; an expired client request must still pass the current epoch/revision
+preflight before it can reserve native I/O. Unresolved records are never compacted; admission
+applies backpressure at 32 unresolved operations instead of silently forgetting uncertainty.
 
 ## Options considered
 
@@ -96,7 +102,7 @@ Deferred. A producer actor owning observation, command execution, and publicatio
 - **Publisher complexity:** require barrier-based tests for observation/pending/completion ordering and stale run replacement.
 - **Cancellation and shutdown races:** make accepted jobs actor-owned, drain before adapter shutdown, and test cancellation after reservation, during I/O, and while completion publication is queued.
 - **False receipt strength:** define and test an evidence policy per semantic operation; defer operations that cannot meet it.
-- **Unbounded ledger growth:** define retention/compaction before public surfaces depend on long histories; never silently discard active or unresolved operations.
+- **Unbounded ledger growth:** bound terminal ledgers, correlation tombstones, and retired instance identities; never silently discard active or unresolved operations.
 - **Future producers need a different model:** keep the command service generic but the coordinator producer-owned; revisit bidirectional actors after a second producer supplies evidence.
 
 ## Notes

--- a/docs/adr/004-adaptive-command-causality.md
+++ b/docs/adr/004-adaptive-command-causality.md
@@ -42,9 +42,15 @@ and manager start is rejected while that stopping run still owns an in-flight or
 start may be retried only after terminal admission releases the prior run. Instance removal may
 arrive after the manager has finished the native call but before the command actor publishes that
 receipt, so it records retirement intent
-and blocks new work while retaining the coordinator. Retirement occurs only after the receipt's
-terminal operation is admitted; the compact retired coordinator then preserves exact correlation
-truth for a late duplicate callback.
+and blocks new work while retaining the coordinator. Retirement begins only after the typed
+receipt transition is admitted and no `Pending` operation or dispatch fence remains. Definitive
+retirement transitions every non-Pending outcome that still awaits convergence to explicit
+`Expired` audit truth with producer-scoped
+`ReasonCode::Expired` and `ReplanRequired`, and admits that terminal document before hiding the
+producer. Publication failure retains the live coordinator and immutable deferred candidate for
+retry, so retirement cannot overtake the audit frontier. The bounded compact retired coordinator
+then preserves exact correlation truth for late duplicate callbacks; global identity eviction can
+discard only history already made terminal at retirement.
 
 `CommandOutcome::Pending` is an explicit non-terminal state. It is not evidence of producer state, sets `awaits_convergence`, and may transition to Applied, Ignored, Rejected, Superseded, Disconnected, TimedOut, Indeterminate, or a future recognized terminal outcome. No terminal outcome can regress to Pending.
 

--- a/docs/adr/004-adaptive-command-causality.md
+++ b/docs/adr/004-adaptive-command-causality.md
@@ -33,9 +33,15 @@ that interval resolves the operation as `Ignored` with `NotAttempted`; it must n
 `Applied`/`Confirmed`. Once the executor-begun fence is installed, `Pending` means the attempt is
 unknown: matching or conflicting observations may update producer state but cannot resolve that
 operation. Receipt evidence is the only source of attempted-write truth, and admitting typed
-completion clears the fence atomically with its operation transition. Manager stop refuses to drop
-the run while a fence remains. Instance removal may arrive after the manager has finished the
-native call but before the command actor publishes that receipt, so it records retirement intent
+completion clears the fence atomically with its operation transition. The exact fenced receipt
+remains admissible as audit evidence if a newer producer epoch is observed after dispatch begins:
+the full opaque lease, correlation, generation, pending operation, and live fence must still match.
+This narrow exception does not restore native authority, and the same stale receipt is rejected
+after its one-shot fence is consumed. Manager stop refuses to drop the run while a fence remains,
+and manager start is rejected while that stopping run still owns an in-flight or deferred receipt;
+start may be retried only after terminal admission releases the prior run. Instance removal may
+arrive after the manager has finished the native call but before the command actor publishes that
+receipt, so it records retirement intent
 and blocks new work while retaining the coordinator. Retirement occurs only after the receipt's
 terminal operation is admitted; the compact retired coordinator then preserves exact correlation
 truth for a late duplicate callback.

--- a/docs/adr/004-adaptive-command-causality.md
+++ b/docs/adr/004-adaptive-command-causality.md
@@ -1,0 +1,88 @@
+# ADR 004: Producer-owned adaptive command causality
+
+## Status
+
+Proposed
+
+## Context
+
+The adaptive producer document describes semantic controls, observed values, apply behavior, revisions, and command outcomes. HQPlayer is the first real producer. Web, MCP, and device surfaces need one execution path, but the existing boundaries are deliberately one-way:
+
+- `AdaptiveView` reads atomic aggregator-owned snapshots but cannot reserve or mutate them;
+- native adapters translate protocol facts and commands but import no adaptive contract;
+- `HqpAdaptivePublisher` owns the producer's revision tracker and active adapter-run lease;
+- the aggregator retains only admitted whole documents and refuses different content at equal revisions.
+
+A command crosses time. State may advance after a surface reads a snapshot and before native I/O begins; observations may arrive while the write is in flight; a newer command or adapter run may supersede an older completion. Delivery evidence also differs from application evidence. An absent reply after bytes left is possibly applied, not rejected, and cannot be safely replayed.
+
+The initial proposal used an application service to preflight `AdaptiveView`, execute the adapter, and ask the publisher to append an outcome. Review and dissent showed that this had no atomic reservation, would let the next observation erase operation history, excluded operation changes from state revisions, and could retain a clone of the run lease across native I/O.
+
+## Decision
+
+Adaptive immediate commands use four explicit ownership layers.
+
+1. **Application service — generic advisory preflight and routing.** It reads one `AdaptiveView` snapshot and rejects an unknown producer, non-Live or stale state, mismatched expected revision, unavailable/wrong-lane control, and invalid semantic value. It never mutates a snapshot and never calls an adapter without a producer reservation.
+2. **Producer coordinator — liveness, linearization, and document causality.** One per-instance publisher actor owns the non-cloneable `AdapterRun` for the manager lifecycle and alone performs observation, reservation, completion, retirement, and stop publications. It rechecks the exact expected epoch/revisions, deduplicates correlation plus request fingerprint, allocates a dedicated operation generation, appends explicit `CommandOutcome::Pending`, advances state revision, and awaits admission. Only then may execution be queued. It retains an append-only operation ledger and merges it into every later observed document before revision materialization.
+3. **Immediate-command actor — accepted-job lifetime and dispatch fencing.** A bounded actor owns accepted jobs independently of the submitting caller. Immediately before native dispatch it asks the producer coordinator to validate the opaque lease again. If the producer run, generation, or conflict-set ownership has changed, it terminalizes the operation as not-attempted Superseded and does not call the adapter. Graceful shutdown closes and drains this actor before adapters are stopped. Caller cancellation cannot abandon a reserved operation: cancellation before dispatch becomes Superseded/NotAttempted; after I/O begins, the actor continues through typed completion.
+4. **Native executor — typed protocol evidence.** The HQPlayer executor accepts only a validated semantic command and returns a contract-free typed receipt distinguishing no attempt, possible attempt, daemon acknowledgement/rejection, authoritative same-session readback, divergence, and unavailable readback. It never imports adaptive outcome types and never exposes native indexes. The manager holds its lifecycle transaction across exact-instance resolution and native execution so removal or reconfiguration cannot race a dispatched command.
+
+Completion carries an opaque lease containing producer identity, producer epoch, adapter-run ID, conflict set, and operation generation. The publisher accepts a transition only if that lease is still current. A native operation retains the run ID, never the RAII run lease; stop or replacement therefore makes a late completion stale instead of extending producer liveness.
+
+`CommandOutcome::Pending` is an explicit non-terminal state. It is not evidence of producer state, sets `awaits_convergence`, and may transition to Applied, Ignored, Rejected, Superseded, Disconnected, TimedOut, Indeterminate, or a future recognized terminal outcome. No terminal outcome can regress to Pending.
+
+Operation content participates in canonical state equivalence. Pending, terminal, convergence, and supersession transitions advance the state revision. Volatile lane timing and health refreshes remain revision-neutral. Observations merge the ledger instead of clearing it, so operation history cannot disappear after a poll.
+
+Immediate commands are serialized by declared conflict set, not merely by control ID. The first #329 slice uses one conservative pipeline conflict set for mode, filter 1x, filter Nx, shaper, and rate. Transport and volume stay in #328 until their native APIs expose truthful attempt/evidence receipts.
+
+The supported-operation policy is machine-checkable. Descriptors that #375 publishes as mutable but whose evidence is owned by #328 receive a structured deferred refusal from this service rather than falling through generic dispatch.
+
+Every operation records its control, requested semantic value, lane, correlation, observed base revision, write attempt, outcome, and transition history. Repeating the same correlation and request fingerprint returns the existing operation without another send; reusing a correlation for different intent is rejected.
+
+## Options considered
+
+### Surface-specific adapter dispatch
+
+Rejected. It duplicates validation/outcomes across web, MCP, and devices, leaks backend identity rules, and recreates direct-adapter architecture violations.
+
+### Aggregator actor executes native commands
+
+Rejected. It would make the generic retained-state owner depend on backend executors and hold publication progress behind native timeouts. The aggregator remains the admission/store authority, not the I/O worker.
+
+### Application preflight followed directly by execution
+
+Rejected. A read-only snapshot is not a reservation. It cannot prevent producer advancement between preflight and send or order completion against observations/newer commands.
+
+### Fully bidirectional producer actors
+
+Deferred. A producer actor owning observation, command execution, and publication may be appropriate after several producers validate the pattern, but redesigning #324/#375 is disproportionate for the first immediate command path.
+
+## Consequences
+
+### Positive
+
+- All later surfaces share one revision-fenced semantic command contract.
+- Pending state is admitted before native I/O and never replaces authoritative observed values.
+- Operation history survives polls, reconnect handling, and concurrent observations.
+- Stale completions, duplicate gestures, and ended adapter runs cannot send or overwrite newer truth.
+- Caller cancellation and orderly shutdown cannot strand Pending or retain a conflict set forever.
+- Native attempt evidence remains typed and testable without adaptive contract leakage into adapters.
+- Coupled HQPlayer controls serialize according to actual wire semantics.
+
+### Costs
+
+- The publisher gains a per-instance command coordinator and operation ledger in addition to observation revision tracking.
+- The existing #347 setter internals need a typed receipt seam while preserving current public method contracts.
+- Operation transitions cause additional producer state revisions and publications.
+- The foundation PR adds no visible user surface; #331/#209/#222 depend on it.
+
+### Risks and mitigations
+
+- **Publisher complexity:** require barrier-based tests for observation/pending/completion ordering and stale run replacement.
+- **Cancellation and shutdown races:** make accepted jobs actor-owned, drain before adapter shutdown, and test cancellation after reservation, during I/O, and while completion publication is queued.
+- **False receipt strength:** define and test an evidence policy per semantic operation; defer operations that cannot meet it.
+- **Unbounded ledger growth:** define retention/compaction before public surfaces depend on long histories; never silently discard active or unresolved operations.
+- **Future producers need a different model:** keep the command service generic but the coordinator producer-owned; revisit bidirectional actors after a second producer supplies evidence.
+
+## Notes
+
+Generated from solution review and structured dissent for #329 on 2026-07-31. The ADR becomes Accepted only when the implementation PR is approved and merged.

--- a/docs/adr/004-adaptive-command-causality.md
+++ b/docs/adr/004-adaptive-command-causality.md
@@ -49,8 +49,13 @@ retirement transitions every non-Pending outcome that still awaits convergence t
 `ReasonCode::Expired` and `ReplanRequired`, and admits that terminal document before hiding the
 producer. Publication failure retains the live coordinator and immutable deferred candidate for
 retry, so retirement cannot overtake the audit frontier. The bounded compact retired coordinator
-then preserves exact correlation truth for late duplicate callbacks; global identity eviction can
-discard only history already made terminal at retirement.
+then preserves exact correlation truth for late duplicate callbacks. Retirement-specific pruning
+protects every operation made `Expired` by this frontier and compacts pre-existing terminal history
+first; global identity eviction can therefore discard only history already made terminal and
+admitted at retirement. Once retirement intent is recorded, coordinator retries are part of the
+committed removal transaction: the observation sink reports success so the instance manager cannot
+restore a worker that the coordinator is still committed to retire. A refusal before retirement
+intent is accepted remains an error and permits manager rollback.
 
 `CommandOutcome::Pending` is an explicit non-terminal state. It is not evidence of producer state, sets `awaits_convergence`, and may transition to Applied, Ignored, Rejected, Superseded, Disconnected, TimedOut, Indeterminate, or a future recognized terminal outcome. No terminal outcome can regress to Pending.
 

--- a/docs/adr/004-adaptive-command-causality.md
+++ b/docs/adr/004-adaptive-command-causality.md
@@ -28,6 +28,15 @@ Adaptive immediate commands use four explicit ownership layers.
 
 Completion carries an opaque lease containing producer identity, producer epoch, adapter-run ID, conflict set, and operation generation. The publisher accepts a transition only if that lease is still current. A native operation retains the run ID, never the RAII run lease; stop or replacement therefore makes a late completion stale instead of extending producer liveness.
 
+Before the native executor returns a typed receipt, `Pending` is explicitly a no-send state. A
+matching observation in that interval resolves the operation as `Ignored` with
+`NotAttempted`; it must never manufacture `Applied`/`Confirmed`. Receipt evidence is the only
+source of attempted-write truth. Instance removal may arrive after the manager has finished the
+native call but before the command actor publishes that receipt, so it records retirement intent
+and blocks new work while retaining the coordinator. Retirement occurs only after the receipt's
+terminal operation is admitted; the compact retired coordinator then preserves exact correlation
+truth for a late duplicate callback.
+
 `CommandOutcome::Pending` is an explicit non-terminal state. It is not evidence of producer state, sets `awaits_convergence`, and may transition to Applied, Ignored, Rejected, Superseded, Disconnected, TimedOut, Indeterminate, or a future recognized terminal outcome. No terminal outcome can regress to Pending.
 
 Operation content participates in canonical state equivalence. Pending, terminal, convergence, and supersession transitions advance the state revision. Volatile lane timing and health refreshes remain revision-neutral. Observations merge the ledger instead of clearing it, so operation history cannot disappear after a poll.
@@ -37,6 +46,13 @@ Immediate commands are serialized by declared conflict set, not merely by contro
 The supported-operation policy is machine-checkable. Descriptors that #375 publishes as mutable but whose evidence is owned by #328 receive a structured deferred refusal from this service rather than falling through generic dispatch.
 
 Every operation records its control, requested semantic value, lane, correlation, observed base revision, write attempt, outcome, and transition history. Repeating the same correlation and request fingerprint returns the existing operation without another send; reusing a correlation for different intent is rejected.
+
+Terminal publications are a serialization frontier: while one is deferred, observations and new
+reservations first flush the immutable terminal candidate rather than publishing a different
+document at the same next revision. Documents retain the newest 32 terminal operations; compacted
+records retain bounded correlation/fingerprint tombstones (256) so an old gesture cannot become a
+fresh write. Unresolved records are never compacted; admission applies backpressure at 32
+unresolved operations instead of silently forgetting uncertainty.
 
 ## Options considered
 

--- a/src/adapters/hqplayer.rs
+++ b/src/adapters/hqplayer.rs
@@ -890,63 +890,72 @@ impl std::fmt::Display for HqpRejected {
 
 impl std::error::Error for HqpRejected {}
 
-/// Authoritative readback evidence for one native setting operation.
-///
-/// This intentionally names protocol facts, not adaptive command outcomes.  The adapter knows
-/// whether its same-session `State` observation matched; the producer layer decides what that
-/// means for a correlated operation later.  Keeping it here means that layer never has to recover
-/// an attempt boundary by inspecting an `anyhow` display string.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum NativeSettingReadback {
-    /// `State` read the requested semantic value after the operation.
-    Verified,
-    /// The preflight/readback proof established that no write was needed.
-    Noop,
-    /// `State` was available but held a different value.
-    Divergent { requested: String, observed: String },
-    /// The native session could not provide an authoritative readback.
-    Unavailable { reason: String },
+// Native execution is intentionally internal.  The debug-profile visibility exists solely for
+// `tests/hqplayer_conformance.rs`, whose socket fake is an integration test and therefore cannot
+// see library `cfg(test)` items.  Release consumers cannot construct a setting, forge a target, or
+// inspect a receipt; they must use the shared command service.
+macro_rules! native_execution_test_seam {
+    ($visibility:vis) => {
+        /// Authoritative readback evidence for one native setting operation.
+        #[doc(hidden)]
+        #[derive(Debug, Clone, PartialEq, Eq)]
+        $visibility enum NativeSettingReadback {
+            Verified,
+            Noop,
+            Divergent { requested: String, observed: String },
+            Unavailable { reason: String },
+        }
+
+        /// Native evidence retained by semantic pipeline setters.
+        #[doc(hidden)]
+        #[derive(Debug, Clone, PartialEq, Eq)]
+        $visibility enum NativeSettingReceipt {
+            NotAttempted { reason: String, readback: NativeSettingReadback },
+            Suppressed { reason: String },
+            DaemonRejected(HqpRejected),
+            DaemonAcknowledged { readback: NativeSettingReadback },
+            PossibleAttempt { reason: String, readback: NativeSettingReadback },
+        }
+
+        /// Semantic names/Hz only; never native list positions.
+        #[doc(hidden)]
+        #[derive(Debug, Clone, PartialEq, Eq)]
+        $visibility enum HqpNativeSetting {
+            Mode(String),
+            Filter1x(String),
+            FilterNx(String),
+            Shaper(String),
+            Rate(u32),
+        }
+
+        /// Exact producer identity retained in an opaque command lease.
+        #[doc(hidden)]
+        #[derive(Debug, Clone, PartialEq, Eq)]
+        $visibility struct HqpNativeExecutionTarget {
+            pub instance_name: String,
+            pub producer_epoch: u64,
+            pub endpoint_generation: u64,
+            pub transport_generation: u64,
+        }
+    };
 }
 
-/// Native evidence retained by the five semantic pipeline setters.
-///
-/// This is deliberately contract-free: it does not mention adaptive controls, operation IDs, or
-/// user-facing status.  It distinguishes the facts the wire can establish: no send, a reply that
-/// explicitly rejected or acknowledged the request, and a request that may have left the process
-/// but never supplied usable acknowledgement.  The accompanying [`NativeSettingReadback`] remains
-/// separate so a caller never mistakes `result="OK"` for proof of application.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum NativeSettingReceipt {
-    /// No request was attempted.  A no-op can still have a verified readback.
-    NotAttempted {
-        reason: String,
-        readback: NativeSettingReadback,
-    },
-    /// The daemon explicitly refused this request.  This is not inferred from a string.
-    DaemonRejected(HqpRejected),
-    /// The daemon explicitly returned `result="OK"`; readback determines whether it applied.
-    DaemonAcknowledged { readback: NativeSettingReadback },
-    /// A request may have been written, but acknowledgement was unavailable or non-explicit.
-    PossibleAttempt {
-        reason: String,
-        readback: NativeSettingReadback,
-    },
-}
-
-/// Semantic setting commands whose native evidence is available to the producer layer.
-///
-/// Values remain semantic names/Hz values; native list positions never cross this adapter boundary.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(dead_code)] // Wired by the producer command service in the next #329 slice.
-pub(crate) enum HqpNativeSetting<'a> {
-    Mode(&'a str),
-    Filter1x(&'a str),
-    FilterNx(&'a str),
-    Shaper(&'a str),
-    Rate(u32),
-}
+#[cfg(debug_assertions)]
+native_execution_test_seam!(pub);
+#[cfg(not(debug_assertions))]
+native_execution_test_seam!(pub(crate));
 
 impl NativeSettingReceipt {
+    fn with_readback(self, readback: NativeSettingReadback) -> Self {
+        match self {
+            Self::NotAttempted { reason, .. } => Self::NotAttempted { reason, readback },
+            Self::Suppressed { reason } => Self::Suppressed { reason },
+            Self::DaemonRejected(rejected) => Self::DaemonRejected(rejected),
+            Self::DaemonAcknowledged { .. } => Self::DaemonAcknowledged { readback },
+            Self::PossibleAttempt { reason, .. } => Self::PossibleAttempt { reason, readback },
+        }
+    }
+
     /// Preserve the pre-existing adapter surface while the immediate-command service is introduced.
     ///
     /// Public setters still return `Result<SettingOutcome>`; this is the one intentional collapse
@@ -964,6 +973,10 @@ impl NativeSettingReceipt {
                 reason: format!(
                     "the write was not attempted ({reason}); native readback was {readback:?}"
                 ),
+            }),
+            Self::Suppressed { reason } => Ok(SettingOutcome::Suppressed {
+                what: what.to_string(),
+                reason,
             }),
             Self::DaemonRejected(rejected) => Err(anyhow!(rejected)),
             Self::DaemonAcknowledged {
@@ -1242,6 +1255,8 @@ struct CoherentPipelineSnapshot {
     host: String,
     instance_name: String,
     producer_epoch: u64,
+    endpoint_generation: u64,
+    transport_generation: u64,
     observed_at: SystemTime,
 }
 
@@ -1251,6 +1266,8 @@ struct CoherentSessionIdentity {
     host: String,
     instance_name: String,
     producer_epoch: u64,
+    endpoint_generation: u64,
+    transport_generation: u64,
 }
 
 /// Contract-free observation exported by the native adapter. Publication policy and adaptive
@@ -1261,6 +1278,9 @@ pub struct HqpNativeObservation {
     pub instance_label: Option<String>,
     pub product_version: Option<String>,
     pub producer_epoch: u64,
+    /// Exact native identity proven by the same coherent observation. The producer coordinator
+    /// retains this out of the declarative document and copies it into the opaque command lease.
+    pub(crate) execution_target: HqpNativeExecutionTarget,
     pub observed_at: SystemTime,
     pub transport: HqpNativeTransportState,
     pub metadata: HqpNativeMetadata,
@@ -1837,6 +1857,27 @@ pub struct HqpAdapter {
 }
 
 impl HqpAdapter {
+    fn store_captured_receipt(
+        captured: &std::sync::Mutex<Option<NativeSettingReceipt>>,
+        receipt: NativeSettingReceipt,
+    ) {
+        let mut guard = match captured.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        *guard = Some(receipt);
+    }
+
+    fn take_captured_receipt(
+        captured: &std::sync::Mutex<Option<NativeSettingReceipt>>,
+    ) -> Option<NativeSettingReceipt> {
+        let mut guard = match captured.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        guard.take()
+    }
+
     pub fn new(bus: SharedBus) -> Self {
         #[allow(clippy::expect_used)] // HTTP client creation only fails if TLS setup fails
         let http_client = Client::builder()
@@ -2095,6 +2136,43 @@ impl HqpAdapter {
         self.state.read().await.transport_generation
     }
 
+    /// Capture the exact producer identity currently eligible for an immediate command.
+    async fn native_execution_target_inner(&self) -> Option<HqpNativeExecutionTarget> {
+        let state = self.state.read().await;
+        let poisoned = self
+            .transport_poisoned
+            .load(std::sync::atomic::Ordering::Acquire);
+        if poisoned || !state.connected || state.host.is_none() {
+            return None;
+        }
+        Some(HqpNativeExecutionTarget {
+            instance_name: state
+                .instance_name
+                .clone()
+                .unwrap_or_else(|| "default".to_string()),
+            producer_epoch: state.producer_epoch,
+            endpoint_generation: state.endpoint_generation,
+            transport_generation: state.transport_generation,
+        })
+    }
+
+    /// Debug-only integration-test seam. Production composition receives this identity only from
+    /// a coherent observation and retains it in the command lease.
+    #[cfg(debug_assertions)]
+    #[doc(hidden)]
+    pub async fn native_execution_target(&self) -> Option<HqpNativeExecutionTarget> {
+        self.native_execution_target_inner().await
+    }
+
+    #[cfg(not(debug_assertions))]
+    pub(crate) async fn native_execution_target(&self) -> Option<HqpNativeExecutionTarget> {
+        self.native_execution_target_inner().await
+    }
+
+    async fn matches_native_execution_target(&self, target: &HqpNativeExecutionTarget) -> bool {
+        self.native_execution_target().await.as_ref() == Some(target)
+    }
+
     /// Capture the envelope fields for a coherent observation under the same native-session
     /// fence as its State, Status, volume range and chain lists. This helper deliberately reads no
     /// chain cache: the verified `ChainSnapshot` remains the only source of list data.
@@ -2117,6 +2195,8 @@ impl HqpAdapter {
                 .clone()
                 .unwrap_or_else(|| "default".to_string()),
             producer_epoch: state.producer_epoch,
+            endpoint_generation: state.endpoint_generation,
+            transport_generation: state.transport_generation,
         })
     }
 
@@ -2539,6 +2619,12 @@ impl HqpAdapter {
             product_version: Some(snapshot.info.version.clone())
                 .filter(|version| !version.is_empty()),
             producer_epoch: snapshot.producer_epoch,
+            execution_target: HqpNativeExecutionTarget {
+                instance_name: snapshot.instance_name.clone(),
+                producer_epoch: snapshot.producer_epoch,
+                endpoint_generation: snapshot.endpoint_generation,
+                transport_generation: snapshot.transport_generation,
+            },
             observed_at: snapshot.observed_at,
             transport: match snapshot.playback_status.state {
                 0 => HqpNativeTransportState::Stopped,
@@ -2852,6 +2938,20 @@ impl HqpAdapter {
         Ok((modes, generation))
     }
 
+    async fn fresh_modes_on_transport(&self, generation: u64) -> Result<(Vec<ListItem>, u64)> {
+        let since = self.chain_generation().await;
+        let xml = Self::build_request("GetModes", &[]);
+        let response = self.send_command_on_transport(&xml, generation).await?;
+        let modes = Self::parse_items(&response, "ModesItem", |item| ListItem {
+            index: Self::parse_attr_u32(item, "index"),
+            name: Self::parse_attr(item, "name").unwrap_or_default(),
+            value: Self::parse_attr_i32(item, "value"),
+        });
+        self.publish_fresh_family(FreshFamily::Modes(modes.clone()), since)
+            .await?;
+        Ok((modes, generation))
+    }
+
     /// Fetch the loaded chain's filter list from the daemon and cache it.
     async fn fresh_filters(&self) -> Result<Vec<FilterItem>> {
         let since = self.chain_generation().await;
@@ -2864,6 +2964,21 @@ impl HqpAdapter {
     async fn fresh_filters_with_generation(&self) -> Result<(Vec<FilterItem>, u64)> {
         let since = self.chain_generation().await;
         let (filters, generation) = self.get_filters_with_generation().await?;
+        self.publish_fresh_family(FreshFamily::Filters(filters.clone()), since)
+            .await?;
+        Ok((filters, generation))
+    }
+
+    async fn fresh_filters_on_transport(&self, generation: u64) -> Result<(Vec<FilterItem>, u64)> {
+        let since = self.chain_generation().await;
+        let xml = Self::build_request("GetFilters", &[]);
+        let response = self.send_command_on_transport(&xml, generation).await?;
+        let filters = Self::parse_items(&response, "FiltersItem", |item| FilterItem {
+            index: Self::parse_attr_u32(item, "index"),
+            name: Self::parse_attr(item, "name").unwrap_or_default(),
+            value: Self::parse_attr_i32(item, "value"),
+            arg: Self::parse_attr_u32(item, "arg"),
+        });
         self.publish_fresh_family(FreshFamily::Filters(filters.clone()), since)
             .await?;
         Ok((filters, generation))
@@ -2886,6 +3001,20 @@ impl HqpAdapter {
         Ok((shapers, generation))
     }
 
+    async fn fresh_shapers_on_transport(&self, generation: u64) -> Result<(Vec<ListItem>, u64)> {
+        let since = self.chain_generation().await;
+        let xml = Self::build_request("GetShapers", &[]);
+        let response = self.send_command_on_transport(&xml, generation).await?;
+        let shapers = Self::parse_items(&response, "ShapersItem", |item| ListItem {
+            index: Self::parse_attr_u32(item, "index"),
+            name: Self::parse_attr(item, "name").unwrap_or_default(),
+            value: Self::parse_attr_i32(item, "value"),
+        });
+        self.publish_fresh_family(FreshFamily::Shapers(shapers.clone()), since)
+            .await?;
+        Ok((shapers, generation))
+    }
+
     /// Fetch the loaded chain's rate list from the daemon and cache it.
     ///
     /// The rate list is also what the read path and [`Self::refresh_lists`] **probe** with — through
@@ -2903,6 +3032,47 @@ impl HqpAdapter {
         self.publish_fresh_family(FreshFamily::Rates(rates.clone()), since)
             .await?;
         Ok((rates, generation))
+    }
+
+    async fn fresh_rates_on_transport(&self, generation: u64) -> Result<(Vec<RateItem>, u64)> {
+        let since = self.chain_generation().await;
+        let xml = Self::build_request("GetRates", &[]);
+        let response = self.send_command_on_transport(&xml, generation).await?;
+        let rates = Self::parse_items(&response, "RatesItem", |item| RateItem {
+            index: Self::parse_attr_u32(item, "index"),
+            rate: Self::parse_attr_u32(item, "rate"),
+        });
+        self.publish_fresh_family(FreshFamily::Rates(rates.clone()), since)
+            .await?;
+        Ok((rates, generation))
+    }
+
+    async fn command_modes(&self, fence: Option<u64>) -> Result<(Vec<ListItem>, u64)> {
+        match fence {
+            Some(generation) => self.fresh_modes_on_transport(generation).await,
+            None => self.fresh_modes_with_generation().await,
+        }
+    }
+
+    async fn command_filters(&self, fence: Option<u64>) -> Result<(Vec<FilterItem>, u64)> {
+        match fence {
+            Some(generation) => self.fresh_filters_on_transport(generation).await,
+            None => self.fresh_filters_with_generation().await,
+        }
+    }
+
+    async fn command_shapers(&self, fence: Option<u64>) -> Result<(Vec<ListItem>, u64)> {
+        match fence {
+            Some(generation) => self.fresh_shapers_on_transport(generation).await,
+            None => self.fresh_shapers_with_generation().await,
+        }
+    }
+
+    async fn command_rates(&self, fence: Option<u64>) -> Result<(Vec<RateItem>, u64)> {
+        match fence {
+            Some(generation) => self.fresh_rates_on_transport(generation).await,
+            None => self.fresh_rates_with_generation().await,
+        }
     }
 
     /// Fingerprint of a name-keyed list — modes and shapers.
@@ -3401,11 +3571,13 @@ impl HqpAdapter {
         let actual_generation = self.transport_generation().await;
         let has_connection = self.connection.lock().await.is_some();
         if !has_connection || actual_generation != expected_generation {
-            return Err(HqpSessionChanged {
-                expected: expected_generation,
-                actual: actual_generation,
-            }
-            .into());
+            return Ok(NativeSettingDelivery::NotAttempted {
+                reason: HqpSessionChanged {
+                    expected: expected_generation,
+                    actual: actual_generation,
+                }
+                .to_string(),
+            });
         }
 
         let mut request_attempted = false;
@@ -4463,26 +4635,7 @@ impl HqpAdapter {
     /// The proof amplifies requests: an ordinary semantic write adds a closing list read, while one
     /// visible pre-write transition can perform a second no-op decision plus its proof. The restart
     /// is deliberately capped at one and never repeats a mutation.
-    async fn proven_setting<T, R, Fetch, FetchFut, Decide, DecideFut>(
-        &self,
-        family: &SemanticFamily<T, R>,
-        requested: &R,
-        fetch: Fetch,
-        decide: Decide,
-    ) -> Result<SettingOutcome>
-    where
-        R: std::fmt::Display + ?Sized,
-        Fetch: Fn() -> FetchFut,
-        FetchFut: std::future::Future<Output = Result<(Vec<T>, u64)>>,
-        Decide: Fn(u32, u64) -> DecideFut,
-        DecideFut: std::future::Future<Output = Result<SettingOutcome>>,
-    {
-        let _operation_guard = self.operation_lock.lock().await;
-        self.proven_setting_under_operation(family, requested, fetch, decide)
-            .await
-    }
-
-    /// [`Self::proven_setting`] while the caller already owns the root operation lease.
+    /// Run the semantic proof while the caller already owns the root operation lease.
     ///
     /// Kept separate because a fair non-reentrant lock plus a public-to-public nested call is a
     /// deadlock as soon as reconfiguration queues between them.
@@ -4490,6 +4643,7 @@ impl HqpAdapter {
         &self,
         family: &SemanticFamily<T, R>,
         requested: &R,
+        fence: Option<u64>,
         fetch: Fetch,
         decide: Decide,
     ) -> Result<SettingOutcome>
@@ -4628,8 +4782,25 @@ impl HqpAdapter {
                 }
             };
             if family.refuses_source_mode {
-                let modes = match self.fresh_modes().await {
-                    Ok(modes) => modes,
+                let modes = match self.command_modes(fence).await {
+                    Ok((modes, modes_generation)) if modes_generation == attempt_generation => {
+                        modes
+                    }
+                    Ok((_, modes_generation)) => {
+                        let error = HqpSessionChanged {
+                            expected: attempt_generation,
+                            actual: modes_generation,
+                        };
+                        if attempted_write {
+                            return Ok(SettingOutcome::Ambiguous {
+                                what: what.to_string(),
+                                reason: format!(
+                                    "a {what} write may have reached the wire, but the configured mode came from another session ({error})"
+                                ),
+                            });
+                        }
+                        return Err(error.into());
+                    }
                     Err(error) if attempted_write => {
                         return Ok(SettingOutcome::Ambiguous {
                             what: what.to_string(),
@@ -5041,41 +5212,9 @@ impl HqpAdapter {
     }
 
     async fn set_mode_under_operation(&self, mode_name: &str) -> Result<SettingOutcome> {
-        self.proven_setting_under_operation(
-            &Self::MODE,
-            mode_name,
-            || self.fresh_modes_with_generation(),
-            |mode_index, generation| async move {
-                let state = self.get_state_on_transport(generation).await?;
-                if u32::from(state.mode) == mode_index {
-                    tracing::debug!(
-                        "HQPlayer is already in mode {mode_index}; not writing it, because SetMode \
-                         clears the rate pin even when the mode does not change"
-                    );
-                    return NativeSettingReceipt::NotAttempted {
-                        reason:
-                            "State already held the requested mode; SetMode was not sent because \
-                                 it clears an exact-rate pin even when unchanged"
-                                .to_string(),
-                        readback: NativeSettingReadback::Noop,
-                    }
-                    .into_setting_outcome("mode");
-                }
-
-                let xml = Self::build_request("SetMode", &[("value", &mode_index.to_string())]);
-                let outcome = self
-                    .write_setting_on_transport(generation, &xml, "mode", mode_index, |s| {
-                        Some(u32::from(s.mode))
-                    })
-                    .await?;
-                // A mode change reloads the chain whatever the readback said, so nothing cached
-                // about it survives. This is also what makes the cleared pin honest: there is no
-                // remembered rate to report, only the one the daemon now holds.
-                self.invalidate_chain_cache().await;
-                Ok(outcome)
-            },
-        )
-        .await
+        self.execute_mode_receipt_under_operation(mode_name, None)
+            .await?
+            .into_setting_outcome("mode")
     }
 
     /// The request both sides of the pair travel in, built in one place so they cannot drift.
@@ -5158,6 +5297,7 @@ impl HqpAdapter {
         self.proven_setting_under_operation(
             &Self::FILTER_PAIR,
             filter_name,
+            None,
             || self.fresh_filters_with_generation(),
             |index, generation| async move {
                 let state = self.get_state_on_transport(generation).await?;
@@ -5206,53 +5346,10 @@ impl HqpAdapter {
         side: FilterSide,
         filter_name: &str,
     ) -> Result<SettingOutcome> {
-        let family = match side {
-            FilterSide::OneX => &Self::FILTER_1X,
-            FilterSide::Nx => &Self::FILTER_NX,
-        };
         let what = side.field();
-        self.proven_setting_under_operation(
-            family,
-            filter_name,
-            || self.fresh_filters_with_generation(),
-            |index, generation| async move {
-                let state = self.get_state_on_transport(generation).await?;
-                let (Some(current_1x), Some(current_nx)) = (state.filter1x, state.filter_nx) else {
-                    return Ok(SettingOutcome::Suppressed {
-                        what: what.to_string(),
-                        reason: "the daemon's State does not report both filter1x and filterNx, and \
-                                 SetFilter writes both sides at once; sending it would overwrite the \
-                                 sibling with a guess"
-                            .to_string(),
-                    });
-                };
-
-                let current = match side {
-                    FilterSide::OneX => current_1x,
-                    FilterSide::Nx => current_nx,
-                };
-                if current == index {
-                    return NativeSettingReceipt::NotAttempted {
-                        reason: format!("State already held the requested {what} filter"),
-                        readback: NativeSettingReadback::Noop,
-                    }
-                    .into_setting_outcome(what);
-                }
-
-                let (send_nx, send_1x) = match side {
-                    FilterSide::OneX => (current_nx, index),
-                    FilterSide::Nx => (index, current_1x),
-                };
-                tracing::debug!("SetFilter: value={send_nx} (Nx), value1x={send_1x} (1x)");
-                let xml = Self::filter_request(send_nx, send_1x);
-                self.write_setting_on_transport(generation, &xml, what, index, |s| match side {
-                    FilterSide::OneX => s.filter1x,
-                    FilterSide::Nx => s.filter_nx,
-                })
-                .await
-            },
-        )
-        .await
+        self.execute_filter_receipt_under_operation(side, filter_name, None)
+            .await?
+            .into_setting_outcome(what)
     }
 
     /// Resolve a filter name against the list the daemon is serving **now**.
@@ -5307,28 +5404,9 @@ impl HqpAdapter {
     }
 
     async fn set_shaper_under_operation(&self, shaper_name: &str) -> Result<SettingOutcome> {
-        self.proven_setting_under_operation(
-            &Self::SHAPER,
-            shaper_name,
-            || self.fresh_shapers_with_generation(),
-            |shaper_index, generation| async move {
-                if self.get_state_on_transport(generation).await?.shaper == shaper_index {
-                    return NativeSettingReceipt::NotAttempted {
-                        reason: "State already held the requested shaper".to_string(),
-                        readback: NativeSettingReadback::Noop,
-                    }
-                    .into_setting_outcome("shaper");
-                }
-
-                let xml =
-                    Self::build_request("SetShaping", &[("value", &shaper_index.to_string())]);
-                self.write_setting_on_transport(generation, &xml, "shaper", shaper_index, |s| {
-                    Some(s.shaper)
-                })
-                .await
-            },
-        )
-        .await
+        self.execute_shaper_receipt_under_operation(shaper_name, None)
+            .await?
+            .into_setting_outcome("shaper")
     }
 
     /// Whether the daemon's **configured** mode is the source-following one.
@@ -5361,131 +5439,361 @@ impl HqpAdapter {
         // Source-mode suppression lives inside the decision so every retry re-evaluates it before a
         // write; checking only once outside the bracket would let a transition to `[source]` during
         // the first attempt send a pin on the retry.
-        self.proven_setting(
-            &Self::RATE,
-            &rate_value,
-            || self.fresh_rates_with_generation(),
-            |index, generation| async move {
-                let modes = self.fresh_modes().await?;
-                let state = self.get_state_on_transport(generation).await?;
-                if let Some(mode_name) = Self::configured_source_mode(&modes, &state) {
-                    return Ok(SettingOutcome::Suppressed {
-                        what: "rate".to_string(),
-                        reason: format!(
-                            "the configured mode is '{mode_name}', in which the daemon acknowledges \
-                             a rate pin and applies nothing — the rate is governed by persistent \
-                             configuration there, so the write was not sent"
-                        ),
-                    });
-                }
-                if state.rate == index {
-                    return NativeSettingReceipt::NotAttempted {
-                        reason: "State already held the requested rate pin".to_string(),
-                        readback: NativeSettingReadback::Noop,
-                    }
-                    .into_setting_outcome("rate");
-                }
-
-                let xml = Self::build_request("SetRate", &[("value", &index.to_string())]);
-                self.write_setting_on_transport(generation, &xml, "rate", index, |s| {
-                    Some(s.rate)
-                })
-                .await
-            },
-        )
-        .await
+        let _operation_guard = self.operation_lock.lock().await;
+        self.execute_rate_receipt_under_operation(rate_value, None)
+            .await?
+            .into_setting_outcome("rate")
     }
 
     /// Execute one semantic pipeline command and retain typed native evidence for its caller.
     ///
-    /// This is the producer-facing seam for the five #329 controls.  It deliberately accepts no
-    /// native index and imports no producer/adaptive vocabulary.  The mature public setters remain
-    /// intact for existing routes; this method converts their already-typed outcome/error boundary
-    /// without classifying `anyhow` display text.  Where that legacy boundary has already collapsed
-    /// an explicit acknowledgement into `Applied`/`Ignored`, this method reports the conservative
-    /// `PossibleAttempt` evidence rather than inventing an acknowledgement.  The lower native write
-    /// seam retains explicit acknowledgement/rejection for the subsequent full receipt migration.
-    #[allow(dead_code)] // Internal producer seam; no public route owns it yet.
+    /// This is the producer-facing seam for the five #329 controls. It deliberately accepts no
+    /// native index and imports no producer/adaptive vocabulary. Unlike the public setters, it
+    /// does **not** collapse a delivery fact into [`SettingOutcome`] and then try to reconstruct it:
+    /// doing so loses the difference between an explicit `OK`, a lost reply after a write, and a
+    /// pre-send failure. The public setters retain their established result contract below.
     pub(crate) async fn execute_native_setting(
         &self,
-        setting: HqpNativeSetting<'_>,
+        target: &HqpNativeExecutionTarget,
+        setting: HqpNativeSetting,
     ) -> Result<NativeSettingReceipt> {
-        let (what, result) = match setting {
-            HqpNativeSetting::Mode(value) => ("mode", self.set_mode(value).await),
-            HqpNativeSetting::Filter1x(value) => ("filter1x", self.set_filter_1x(value).await),
-            HqpNativeSetting::FilterNx(value) => ("filterNx", self.set_filter_nx(value).await),
-            HqpNativeSetting::Shaper(value) => ("shaper", self.set_shaper(value).await),
-            HqpNativeSetting::Rate(value) => ("rate", self.set_rate(value).await),
-        };
-        Self::receipt_from_legacy_setting_result(what, result)
+        let _operation_guard = self.operation_lock.lock().await;
+        if !self.matches_native_execution_target(target).await {
+            return Ok(NativeSettingReceipt::NotAttempted {
+                reason: "reserved native producer identity moved before adapter execution"
+                    .to_string(),
+                readback: NativeSettingReadback::Unavailable {
+                    reason: "the adapter no longer owns the reserved endpoint/session".to_string(),
+                },
+            });
+        }
+        let fence = Some(target.transport_generation);
+        match setting {
+            HqpNativeSetting::Mode(value) => {
+                self.execute_mode_receipt_under_operation(&value, fence)
+                    .await
+            }
+            HqpNativeSetting::Filter1x(value) => {
+                self.execute_filter_receipt_under_operation(FilterSide::OneX, &value, fence)
+                    .await
+            }
+            HqpNativeSetting::FilterNx(value) => {
+                self.execute_filter_receipt_under_operation(FilterSide::Nx, &value, fence)
+                    .await
+            }
+            HqpNativeSetting::Shaper(value) => {
+                self.execute_shaper_receipt_under_operation(&value, fence)
+                    .await
+            }
+            HqpNativeSetting::Rate(value) => {
+                self.execute_rate_receipt_under_operation(value, fence)
+                    .await
+            }
+        }
     }
 
-    /// Convert the frozen `Result<SettingOutcome>` API without trying to recover facts from error
-    /// prose.  The conservative possible-attempt cases are intentional: `SettingOutcome::Applied`
-    /// proves readback but no longer carries whether the reply said `result="OK"`.
-    fn receipt_from_legacy_setting_result(
-        what: &str,
-        result: Result<SettingOutcome>,
+    async fn execute_mode_receipt_under_operation(
+        &self,
+        mode_name: &str,
+        fence: Option<u64>,
     ) -> Result<NativeSettingReceipt> {
-        match result {
-            Ok(SettingOutcome::AlreadySet) => Ok(NativeSettingReceipt::NotAttempted {
-                reason: "the semantic setter proved the requested value was already selected"
-                    .to_string(),
-                readback: NativeSettingReadback::Noop,
-            }),
-            Ok(SettingOutcome::Suppressed { reason, .. }) => {
-                Ok(NativeSettingReceipt::NotAttempted {
-                    reason,
+        let captured = Arc::new(std::sync::Mutex::new(None));
+        let outcome = self
+            .proven_setting_under_operation(
+                &Self::MODE,
+                mode_name,
+                fence,
+                || self.command_modes(fence),
+                |mode_index, generation| {
+                    let captured = captured.clone();
+                    async move {
+                        let state = self.get_state_on_transport(generation).await?;
+                        let receipt = if u32::from(state.mode) == mode_index {
+                            NativeSettingReceipt::NotAttempted {
+                                reason: "State already held the requested mode; SetMode was not sent because it clears an exact-rate pin even when unchanged".to_string(),
+                                readback: NativeSettingReadback::Noop,
+                            }
+                        } else {
+                            let xml = Self::build_request(
+                                "SetMode",
+                                &[("value", &mode_index.to_string())],
+                            );
+                            let receipt = self
+                                .write_setting_receipt_on_transport(
+                                    generation,
+                                    &xml,
+                                    "mode",
+                                    mode_index,
+                                    |s| Some(u32::from(s.mode)),
+                                )
+                                .await?;
+                            if !matches!(receipt, NativeSettingReceipt::NotAttempted { .. }) {
+                                self.invalidate_chain_cache().await;
+                            }
+                            receipt
+                        };
+                        Self::store_captured_receipt(&captured, receipt.clone());
+                        receipt.into_setting_outcome("mode")
+                    }
+                },
+            )
+            .await;
+        let delivery = Self::take_captured_receipt(&captured);
+        Self::semantic_receipt(outcome, delivery, "mode", fence.is_some())
+    }
+
+    async fn execute_filter_receipt_under_operation(
+        &self,
+        side: FilterSide,
+        filter_name: &str,
+        fence: Option<u64>,
+    ) -> Result<NativeSettingReceipt> {
+        let what = side.field();
+        let family = match side {
+            FilterSide::OneX => &Self::FILTER_1X,
+            FilterSide::Nx => &Self::FILTER_NX,
+        };
+        let captured = Arc::new(std::sync::Mutex::new(None));
+        let outcome = self
+            .proven_setting_under_operation(
+                family,
+                filter_name,
+                fence,
+                || self.command_filters(fence),
+                |index, generation| {
+                    let captured = captured.clone();
+                    async move {
+                        let state = self.get_state_on_transport(generation).await?;
+                        let receipt = match (state.filter1x, state.filter_nx) {
+                            (Some(current_1x), Some(current_nx)) => {
+                                let current = match side {
+                                    FilterSide::OneX => current_1x,
+                                    FilterSide::Nx => current_nx,
+                                };
+                                if current == index {
+                                    NativeSettingReceipt::NotAttempted {
+                                        reason: format!(
+                                            "State already held the requested {what} filter"
+                                        ),
+                                        readback: NativeSettingReadback::Noop,
+                                    }
+                                } else {
+                                    let (send_nx, send_1x) = match side {
+                                        FilterSide::OneX => (current_nx, index),
+                                        FilterSide::Nx => (index, current_1x),
+                                    };
+                                    let xml = Self::filter_request(send_nx, send_1x);
+                                    self.write_setting_receipt_on_transport(
+                                        generation,
+                                        &xml,
+                                        what,
+                                        index,
+                                        |s| match side {
+                                            FilterSide::OneX => s.filter1x,
+                                            FilterSide::Nx => s.filter_nx,
+                                        },
+                                    )
+                                    .await?
+                                }
+                            }
+                            _ => NativeSettingReceipt::NotAttempted {
+                                reason: "the daemon's State does not report both filter1x and filterNx, and SetFilter writes both sides at once; sending it would overwrite the sibling with a guess".to_string(),
+                                readback: NativeSettingReadback::Unavailable {
+                                    reason: "the required sibling selection was unavailable during preflight".to_string(),
+                                },
+                            },
+                        };
+                        Self::store_captured_receipt(&captured, receipt.clone());
+                        receipt.into_setting_outcome(what)
+                    }
+                },
+            )
+            .await;
+        let delivery = Self::take_captured_receipt(&captured);
+        Self::semantic_receipt(outcome, delivery, what, fence.is_some())
+    }
+
+    async fn execute_shaper_receipt_under_operation(
+        &self,
+        shaper_name: &str,
+        fence: Option<u64>,
+    ) -> Result<NativeSettingReceipt> {
+        let captured = Arc::new(std::sync::Mutex::new(None));
+        let outcome = self
+            .proven_setting_under_operation(
+                &Self::SHAPER,
+                shaper_name,
+                fence,
+                || self.command_shapers(fence),
+                |shaper_index, generation| {
+                    let captured = captured.clone();
+                    async move {
+                        let state = self.get_state_on_transport(generation).await?;
+                        let receipt = if state.shaper == shaper_index {
+                            NativeSettingReceipt::NotAttempted {
+                                reason: "State already held the requested shaper".to_string(),
+                                readback: NativeSettingReadback::Noop,
+                            }
+                        } else {
+                            let xml = Self::build_request(
+                                "SetShaping",
+                                &[("value", &shaper_index.to_string())],
+                            );
+                            self.write_setting_receipt_on_transport(
+                                generation,
+                                &xml,
+                                "shaper",
+                                shaper_index,
+                                |s| Some(s.shaper),
+                            )
+                            .await?
+                        };
+                        Self::store_captured_receipt(&captured, receipt.clone());
+                        receipt.into_setting_outcome("shaper")
+                    }
+                },
+            )
+            .await;
+        let delivery = Self::take_captured_receipt(&captured);
+        Self::semantic_receipt(outcome, delivery, "shaper", fence.is_some())
+    }
+
+    async fn execute_rate_receipt_under_operation(
+        &self,
+        rate_value: u32,
+        fence: Option<u64>,
+    ) -> Result<NativeSettingReceipt> {
+        let captured = Arc::new(std::sync::Mutex::new(None));
+        let outcome = self
+            .proven_setting_under_operation(
+                &Self::RATE,
+                &rate_value,
+                fence,
+                || self.command_rates(fence),
+                |rate_index, generation| {
+                    let captured = captured.clone();
+                    async move {
+                        let (modes, modes_generation) = self.command_modes(fence).await?;
+                        if modes_generation != generation {
+                            return Err(HqpSessionChanged {
+                                expected: generation,
+                                actual: modes_generation,
+                            }
+                            .into());
+                        }
+                        let state = self.get_state_on_transport(generation).await?;
+                        let receipt = if let Some(mode_name) =
+                            Self::configured_source_mode(&modes, &state)
+                        {
+                            NativeSettingReceipt::NotAttempted {
+                                reason: format!(
+                                    "the configured mode is '{mode_name}', in which the daemon acknowledges a rate pin and applies nothing — the rate is governed by persistent configuration there, so the write was not sent"
+                                ),
+                                readback: NativeSettingReadback::Unavailable {
+                                    reason: "source-mode preflight suppresses rate writes".to_string(),
+                                },
+                            }
+                        } else if state.rate == rate_index {
+                            NativeSettingReceipt::NotAttempted {
+                                reason: "State already held the requested rate pin".to_string(),
+                                readback: NativeSettingReadback::Noop,
+                            }
+                        } else {
+                            let xml = Self::build_request(
+                                "SetRate",
+                                &[("value", &rate_index.to_string())],
+                            );
+                            self.write_setting_receipt_on_transport(
+                                generation,
+                                &xml,
+                                "rate",
+                                rate_index,
+                                |s| Some(s.rate),
+                            )
+                            .await?
+                        };
+                        Self::store_captured_receipt(&captured, receipt.clone());
+                        receipt.into_setting_outcome("rate")
+                    }
+                },
+            )
+            .await;
+        let delivery = Self::take_captured_receipt(&captured);
+        Self::semantic_receipt(outcome, delivery, "rate", fence.is_some())
+    }
+
+    /// Join the mature semantic bracket's verdict back to the delivery fact captured at the exact
+    /// write boundary. The bracket owns meaning; the captured receipt owns whether the daemon
+    /// explicitly acknowledged, rejected, or may have received the request.
+    fn semantic_receipt(
+        outcome: Result<SettingOutcome>,
+        delivery: Option<NativeSettingReceipt>,
+        what: &str,
+        reserved_execution: bool,
+    ) -> Result<NativeSettingReceipt> {
+        if let Some(NativeSettingReceipt::DaemonRejected(rejected)) = delivery.as_ref() {
+            return Ok(NativeSettingReceipt::DaemonRejected(rejected.clone()));
+        }
+        let outcome = match outcome {
+            Ok(outcome) => outcome,
+            // The reserved execution path carries a transport fence. If the semantic proof fails
+            // before its decision closure recorded any delivery evidence, no Set* request entered
+            // the write path. Preserve that fact as typed native evidence rather than making the
+            // producer infer it from an error string. Public setters keep their established error
+            // contract, including invalid semantic names and preflight failures.
+            Err(error) if reserved_execution && delivery.is_none() => {
+                let reason = format!(
+                    "the reserved {what} operation ended before a native write was attempted ({error})"
+                );
+                return Ok(NativeSettingReceipt::NotAttempted {
                     readback: NativeSettingReadback::Unavailable {
-                        reason: "the semantic setter suppressed the write before an authoritative \
-                                 post-write readback"
-                            .to_string(),
+                        reason: reason.clone(),
+                    },
+                    reason,
+                });
+            }
+            Err(error) => return Err(error),
+        };
+        match outcome {
+            SettingOutcome::Applied => Ok(delivery
+                .unwrap_or(NativeSettingReceipt::NotAttempted {
+                    reason: "semantic proof reported application without a captured write"
+                        .to_string(),
+                    readback: NativeSettingReadback::Unavailable {
+                        reason: "native delivery evidence was unavailable".to_string(),
                     },
                 })
-            }
-            Ok(SettingOutcome::Applied) => Ok(NativeSettingReceipt::PossibleAttempt {
-                reason:
-                    "the legacy semantic result proves matching same-session readback but does \
-                         not retain the daemon acknowledgement bit"
-                        .to_string(),
-                readback: NativeSettingReadback::Verified,
+                .with_readback(NativeSettingReadback::Verified)),
+            SettingOutcome::AlreadySet => Ok(NativeSettingReceipt::NotAttempted {
+                reason: format!("State already held the requested {what}"),
+                readback: NativeSettingReadback::Noop,
             }),
-            Ok(SettingOutcome::Ignored {
+            SettingOutcome::Ignored {
                 requested,
                 observed,
                 ..
-            }) => Ok(NativeSettingReceipt::PossibleAttempt {
-                reason: "the legacy semantic result proves a divergent same-session readback but \
-                         does not retain the daemon acknowledgement bit"
-                    .to_string(),
-                readback: NativeSettingReadback::Divergent {
-                    requested,
-                    observed,
-                },
-            }),
-            Ok(SettingOutcome::Ambiguous { reason, .. }) => {
-                Ok(NativeSettingReceipt::PossibleAttempt {
-                    reason,
+            } => Ok(delivery
+                .unwrap_or(NativeSettingReceipt::NotAttempted {
+                    reason: "semantic proof found divergence without a captured write".to_string(),
                     readback: NativeSettingReadback::Unavailable {
-                        reason: format!(
-                            "the legacy {what} setter reported ambiguous delivery without an \
-                             authoritative receipt"
-                        ),
+                        reason: "native delivery evidence was unavailable".to_string(),
                     },
                 })
+                .with_readback(NativeSettingReadback::Divergent {
+                    requested,
+                    observed,
+                })),
+            SettingOutcome::Suppressed { reason, .. } => {
+                Ok(NativeSettingReceipt::Suppressed { reason })
             }
-            Err(error) => match error.downcast::<HqpRejected>() {
-                Ok(rejected) => Ok(NativeSettingReceipt::DaemonRejected(rejected)),
-                Err(error) => Ok(NativeSettingReceipt::NotAttempted {
-                    reason: error.to_string(),
+            SettingOutcome::Ambiguous { reason, .. } => Ok(delivery
+                .unwrap_or(NativeSettingReceipt::NotAttempted {
+                    reason: reason.clone(),
                     readback: NativeSettingReadback::Unavailable {
-                        reason: format!(
-                            "the semantic {what} setter ended before it could return native \
-                             delivery evidence"
-                        ),
+                        reason: reason.clone(),
                     },
-                }),
-            },
+                })
+                .with_readback(NativeSettingReadback::Unavailable { reason })),
         }
     }
 
@@ -6104,6 +6412,8 @@ impl HqpAdapter {
             host: session.host,
             instance_name: session.instance_name,
             producer_epoch: session.producer_epoch,
+            endpoint_generation: session.endpoint_generation,
+            transport_generation: session.transport_generation,
             observed_at: SystemTime::now(),
         })
     }
@@ -6988,6 +7298,70 @@ impl HqpInstanceManager {
     pub async fn get(&self, name: &str) -> Option<Arc<HqpAdapter>> {
         let instances = self.instances.read().await;
         instances.get(name).cloned()
+    }
+
+    /// Execute one semantic native setting against the exact managed instance.
+    ///
+    /// The lifecycle transaction deliberately spans lookup and the complete adapter operation.
+    /// Removal or same-name reconfiguration therefore cannot replace the selected adapter or its
+    /// endpoint while a command is resolving, writing, and reading back native state.
+    async fn execute_reserved_native_setting_inner(
+        &self,
+        target: &HqpNativeExecutionTarget,
+        setting: HqpNativeSetting,
+    ) -> Result<NativeSettingReceipt> {
+        let _lifecycle_guard = self.lifecycle_lock.lock().await;
+        let Some(adapter) = self
+            .instances
+            .read()
+            .await
+            .get(&target.instance_name)
+            .cloned()
+        else {
+            return Ok(NativeSettingReceipt::NotAttempted {
+                reason: format!(
+                    "reserved HQPlayer instance '{}' is no longer configured",
+                    target.instance_name
+                ),
+                readback: NativeSettingReadback::Unavailable {
+                    reason: "the reserved producer no longer exists".to_string(),
+                },
+            });
+        };
+        if !adapter.matches_native_execution_target(target).await {
+            return Ok(NativeSettingReceipt::NotAttempted {
+                reason: format!(
+                    "HQPlayer instance '{}' no longer has the producer epoch, endpoint, and native session against which this command was reserved",
+                    target.instance_name
+                ),
+                readback: NativeSettingReadback::Unavailable {
+                    reason: "reserved native producer identity moved before execution".to_string(),
+                },
+            });
+        }
+        adapter.execute_native_setting(target, setting).await
+    }
+
+    /// Debug-only integration-test seam. Production callers use the actor-owned command service.
+    #[cfg(debug_assertions)]
+    #[doc(hidden)]
+    pub async fn execute_reserved_native_setting(
+        &self,
+        target: &HqpNativeExecutionTarget,
+        setting: HqpNativeSetting,
+    ) -> Result<NativeSettingReceipt> {
+        self.execute_reserved_native_setting_inner(target, setting)
+            .await
+    }
+
+    #[cfg(not(debug_assertions))]
+    pub(crate) async fn execute_reserved_native_setting(
+        &self,
+        target: &HqpNativeExecutionTarget,
+        setting: HqpNativeSetting,
+    ) -> Result<NativeSettingReceipt> {
+        self.execute_reserved_native_setting_inner(target, setting)
+            .await
     }
 
     /// Get the default instance (creates if not exists)

--- a/src/adapters/hqplayer.rs
+++ b/src/adapters/hqplayer.rs
@@ -763,6 +763,104 @@ impl SettingOutcome {
     }
 }
 
+#[cfg(test)]
+mod native_setting_receipt_tests {
+    use super::*;
+
+    #[test]
+    fn receipt_keeps_attempt_acknowledgement_and_readback_as_independent_evidence() {
+        let rejected = HqpRejected {
+            element: "SetRate".to_string(),
+            reason: Some("unsupported".to_string()),
+        };
+
+        let no_attempt = NativeSettingReceipt::NotAttempted {
+            reason: "already selected".to_string(),
+            readback: NativeSettingReadback::Noop,
+        };
+        assert!(matches!(
+            no_attempt,
+            NativeSettingReceipt::NotAttempted { .. }
+        ));
+        assert!(matches!(
+            NativeSettingReceipt::DaemonRejected(rejected),
+            NativeSettingReceipt::DaemonRejected(HqpRejected { .. })
+        ));
+        assert!(matches!(
+            NativeSettingReceipt::DaemonAcknowledged {
+                readback: NativeSettingReadback::Verified
+            },
+            NativeSettingReceipt::DaemonAcknowledged { .. }
+        ));
+        let possible_attempt = NativeSettingReceipt::PossibleAttempt {
+            reason: "reply lost".to_string(),
+            readback: NativeSettingReadback::Unavailable {
+                reason: "State unavailable".to_string(),
+            },
+        };
+        assert!(matches!(
+            possible_attempt,
+            NativeSettingReceipt::PossibleAttempt { .. }
+        ));
+        let divergent = NativeSettingReadback::Divergent {
+            requested: "PCM".to_string(),
+            observed: "SDM (DSD)".to_string(),
+        };
+        assert!(matches!(divergent, NativeSettingReadback::Divergent { .. }));
+    }
+
+    #[test]
+    fn receipt_collapses_only_at_the_legacy_setting_outcome_boundary() {
+        assert_eq!(
+            NativeSettingReceipt::NotAttempted {
+                reason: "already selected".to_string(),
+                readback: NativeSettingReadback::Noop,
+            }
+            .into_setting_outcome("mode")
+            .expect("no-op collapse"),
+            SettingOutcome::AlreadySet
+        );
+
+        assert_eq!(
+            NativeSettingReceipt::DaemonAcknowledged {
+                readback: NativeSettingReadback::Divergent {
+                    requested: "NS5".to_string(),
+                    observed: "NS9".to_string(),
+                },
+            }
+            .into_setting_outcome("shaper")
+            .expect("acknowledged divergence collapse"),
+            SettingOutcome::Ignored {
+                what: "shaper".to_string(),
+                requested: "NS5".to_string(),
+                observed: "NS9".to_string(),
+            }
+        );
+
+        assert!(matches!(
+            NativeSettingReceipt::PossibleAttempt {
+                reason: "reply lost".to_string(),
+                readback: NativeSettingReadback::Unavailable {
+                    reason: "State unavailable".to_string(),
+                },
+            }
+            .into_setting_outcome("rate"),
+            Ok(SettingOutcome::Ambiguous { .. })
+        ));
+
+        let rejection = NativeSettingReceipt::DaemonRejected(HqpRejected {
+            element: "SetFilter".to_string(),
+            reason: Some("unsupported".to_string()),
+        })
+        .into_setting_outcome("filter")
+        .expect_err("explicit daemon rejection must remain an error");
+        assert!(
+            rejection.downcast_ref::<HqpRejected>().is_some(),
+            "the collapse must retain the typed rejection rather than parse its display text"
+        );
+    }
+}
+
 /// The daemon answered `result="Error"`: an **explicit rejection**, carrying its own reason.
 ///
 /// A distinct type rather than a message, because the difference is load-bearing. A rejection is
@@ -791,6 +889,132 @@ impl std::fmt::Display for HqpRejected {
 }
 
 impl std::error::Error for HqpRejected {}
+
+/// Authoritative readback evidence for one native setting operation.
+///
+/// This intentionally names protocol facts, not adaptive command outcomes.  The adapter knows
+/// whether its same-session `State` observation matched; the producer layer decides what that
+/// means for a correlated operation later.  Keeping it here means that layer never has to recover
+/// an attempt boundary by inspecting an `anyhow` display string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum NativeSettingReadback {
+    /// `State` read the requested semantic value after the operation.
+    Verified,
+    /// The preflight/readback proof established that no write was needed.
+    Noop,
+    /// `State` was available but held a different value.
+    Divergent { requested: String, observed: String },
+    /// The native session could not provide an authoritative readback.
+    Unavailable { reason: String },
+}
+
+/// Native evidence retained by the five semantic pipeline setters.
+///
+/// This is deliberately contract-free: it does not mention adaptive controls, operation IDs, or
+/// user-facing status.  It distinguishes the facts the wire can establish: no send, a reply that
+/// explicitly rejected or acknowledged the request, and a request that may have left the process
+/// but never supplied usable acknowledgement.  The accompanying [`NativeSettingReadback`] remains
+/// separate so a caller never mistakes `result="OK"` for proof of application.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum NativeSettingReceipt {
+    /// No request was attempted.  A no-op can still have a verified readback.
+    NotAttempted {
+        reason: String,
+        readback: NativeSettingReadback,
+    },
+    /// The daemon explicitly refused this request.  This is not inferred from a string.
+    DaemonRejected(HqpRejected),
+    /// The daemon explicitly returned `result="OK"`; readback determines whether it applied.
+    DaemonAcknowledged { readback: NativeSettingReadback },
+    /// A request may have been written, but acknowledgement was unavailable or non-explicit.
+    PossibleAttempt {
+        reason: String,
+        readback: NativeSettingReadback,
+    },
+}
+
+/// Semantic setting commands whose native evidence is available to the producer layer.
+///
+/// Values remain semantic names/Hz values; native list positions never cross this adapter boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)] // Wired by the producer command service in the next #329 slice.
+pub(crate) enum HqpNativeSetting<'a> {
+    Mode(&'a str),
+    Filter1x(&'a str),
+    FilterNx(&'a str),
+    Shaper(&'a str),
+    Rate(u32),
+}
+
+impl NativeSettingReceipt {
+    /// Preserve the pre-existing adapter surface while the immediate-command service is introduced.
+    ///
+    /// Public setters still return `Result<SettingOutcome>`; this is the one intentional collapse
+    /// point.  In particular, an explicit daemon rejection stays the existing typed `Err`, while a
+    /// non-acknowledged delivery stays ambiguous even if a later implementation supplies a
+    /// non-matching readback.
+    fn into_setting_outcome(self, what: &str) -> Result<SettingOutcome> {
+        match self {
+            Self::NotAttempted {
+                reason: _,
+                readback: NativeSettingReadback::Noop,
+            } => Ok(SettingOutcome::AlreadySet),
+            Self::NotAttempted { reason, readback } => Ok(SettingOutcome::Ambiguous {
+                what: what.to_string(),
+                reason: format!(
+                    "the write was not attempted ({reason}); native readback was {readback:?}"
+                ),
+            }),
+            Self::DaemonRejected(rejected) => Err(anyhow!(rejected)),
+            Self::DaemonAcknowledged {
+                readback: NativeSettingReadback::Verified,
+            } => Ok(SettingOutcome::Applied),
+            Self::DaemonAcknowledged {
+                readback: NativeSettingReadback::Noop,
+            } => Ok(SettingOutcome::AlreadySet),
+            Self::DaemonAcknowledged {
+                readback:
+                    NativeSettingReadback::Divergent {
+                        requested,
+                        observed,
+                    },
+            } => Ok(SettingOutcome::Ignored {
+                what: what.to_string(),
+                requested,
+                observed,
+            }),
+            Self::DaemonAcknowledged {
+                readback: NativeSettingReadback::Unavailable { reason },
+            } => Ok(SettingOutcome::Ambiguous {
+                what: what.to_string(),
+                reason,
+            }),
+            Self::PossibleAttempt {
+                readback: NativeSettingReadback::Verified,
+                ..
+            } => Ok(SettingOutcome::Applied),
+            Self::PossibleAttempt { reason, readback } => Ok(SettingOutcome::Ambiguous {
+                what: what.to_string(),
+                reason: format!(
+                    "the write may or may not have been applied: {reason}; native readback was \
+                     {readback:?}, so delivery cannot be established"
+                ),
+            }),
+        }
+    }
+}
+
+/// The evidence available immediately after one setter request crosses the native transport.
+///
+/// Kept private because only the adapter can turn a framing/transport event into these facts; the
+/// receipt above is the seam intentionally available to the next internal execution layer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum NativeSettingDelivery {
+    NotAttempted { reason: String },
+    DaemonRejected(HqpRejected),
+    DaemonAcknowledged,
+    PossibleAttempt { reason: String },
+}
 
 /// A semantic operation was about to continue on a different native transport.
 ///
@@ -3161,6 +3385,67 @@ impl HqpAdapter {
         }
     }
 
+    /// Send one semantic-setting request without erasing whether bytes entered the write path.
+    ///
+    /// `send_command_on_transport` predates the receipt seam and must retain its `Result<String>`
+    /// contract for non-setting callers.  This sibling keeps the exact same session fencing and
+    /// serialisation, but returns typed delivery evidence instead of adding prose context to an
+    /// `anyhow::Error` and making a later caller parse it back out.
+    async fn send_setting_on_transport(
+        &self,
+        xml: &str,
+        expected_generation: u64,
+    ) -> Result<NativeSettingDelivery> {
+        let _conversation_guard = self.conversation_lock.lock().await;
+        self.reconcile_cancelled_transport().await;
+        let actual_generation = self.transport_generation().await;
+        let has_connection = self.connection.lock().await.is_some();
+        if !has_connection || actual_generation != expected_generation {
+            return Err(HqpSessionChanged {
+                expected: expected_generation,
+                actual: actual_generation,
+            }
+            .into());
+        }
+
+        let mut request_attempted = false;
+        match self
+            .send_command_inner_tracking(xml, &mut request_attempted)
+            .await
+        {
+            Ok(response) => match Self::parse_attr(&response, "result").as_deref() {
+                Some("Error") => Ok(NativeSettingDelivery::DaemonRejected(HqpRejected {
+                    element: framing::root_element(&response).unwrap_or_else(|| "?".to_string()),
+                    reason: framing::root_text(&response),
+                })),
+                Some("OK") => Ok(NativeSettingDelivery::DaemonAcknowledged),
+                // Existing setters accepted a missing `result` and relied on State verification.
+                // Keep that observable behaviour, but do not call it an acknowledgement the daemon
+                // did not actually make.
+                _ => Ok(NativeSettingDelivery::PossibleAttempt {
+                    reason: "the daemon replied without an explicit result=\"OK\" acknowledgement"
+                        .to_string(),
+                }),
+            },
+            Err(error) => {
+                self.mark_disconnected().await;
+                if request_attempted {
+                    Ok(NativeSettingDelivery::PossibleAttempt {
+                        reason: format!(
+                            "the request entered the native write path but drew no usable reply ({error})"
+                        ),
+                    })
+                } else {
+                    Ok(NativeSettingDelivery::NotAttempted {
+                        reason: format!(
+                            "the native transport failed before the request entered its write path ({error})"
+                        ),
+                    })
+                }
+            }
+        }
+    }
+
     /// Retry one command while the caller owns the instance conversation lease.
     async fn send_command_serialized(&self, xml: &str) -> Result<String> {
         let timeouts = self.timeouts().await;
@@ -4550,7 +4835,7 @@ impl HqpAdapter {
         what: &str,
         expected: T,
         observe: F,
-    ) -> Result<SettingOutcome>
+    ) -> Result<NativeSettingReadback>
     where
         T: PartialEq + std::fmt::Display,
         F: Fn(&HqpState) -> Option<T>,
@@ -4565,7 +4850,7 @@ impl HqpAdapter {
             let state = self.get_state_on_transport(expected_generation).await?;
             let seen = observe(&state);
             if seen.as_ref() == Some(&expected) {
-                return Ok(SettingOutcome::Applied);
+                return Ok(NativeSettingReadback::Verified);
             }
             if seen.is_some() {
                 last_seen = seen;
@@ -4573,22 +4858,82 @@ impl HqpAdapter {
         }
 
         match last_seen {
-            Some(observed) => Ok(SettingOutcome::Ignored {
-                what: what.to_string(),
+            Some(observed) => Ok(NativeSettingReadback::Divergent {
                 requested: expected.to_string(),
                 observed: observed.to_string(),
             }),
-            None => Ok(SettingOutcome::Ambiguous {
-                what: what.to_string(),
+            None => Ok(NativeSettingReadback::Unavailable {
                 reason: format!(
                     "the daemon does not report {what}, so whether it now holds {expected} cannot \
-                     be established from its State"
+                    be established from its State"
                 ),
             }),
         }
     }
 
     /// Write and verify on the exact transport whose enumeration supplied the wire position.
+    ///
+    /// This is the native receipt seam.  It is intentionally private to the adapter until the
+    /// producer executor is ready to accept semantic (never index-bearing) commands, but public
+    /// setter behaviour below is only a collapse of this value.
+    async fn write_setting_receipt_on_transport<T, F>(
+        &self,
+        expected_generation: u64,
+        xml: &str,
+        what: &str,
+        expected: T,
+        observe: F,
+    ) -> Result<NativeSettingReceipt>
+    where
+        T: PartialEq + std::fmt::Display,
+        F: Fn(&HqpState) -> Option<T>,
+    {
+        let receipt = match self
+            .send_setting_on_transport(xml, expected_generation)
+            .await?
+        {
+            NativeSettingDelivery::NotAttempted { reason } => NativeSettingReceipt::NotAttempted {
+                reason,
+                readback: NativeSettingReadback::Unavailable {
+                    reason:
+                        "no authoritative State readback was made because no request entered the \
+                             native write path"
+                            .to_string(),
+                },
+            },
+            NativeSettingDelivery::DaemonRejected(rejected) => {
+                NativeSettingReceipt::DaemonRejected(rejected)
+            }
+            NativeSettingDelivery::DaemonAcknowledged => {
+                let readback = self
+                    .verify_applied_on_transport(expected_generation, what, expected, observe)
+                    .await
+                    .unwrap_or_else(|error| NativeSettingReadback::Unavailable {
+                        reason: format!(
+                            "the write was acknowledged on native session generation \
+                             {expected_generation}, but same-session verification failed ({error})"
+                        ),
+                    });
+                NativeSettingReceipt::DaemonAcknowledged { readback }
+            }
+            NativeSettingDelivery::PossibleAttempt { reason } => {
+                let readback = self
+                    .verify_applied_on_transport(expected_generation, what, expected, observe)
+                    .await
+                    .unwrap_or_else(|error| NativeSettingReadback::Unavailable {
+                        reason: format!(
+                            "a write may have reached native session generation {expected_generation}, \
+                             but same-session verification failed ({error})"
+                        ),
+                    });
+                NativeSettingReceipt::PossibleAttempt { reason, readback }
+            }
+        };
+
+        Ok(receipt)
+    }
+
+    /// Preserve the long-standing public setter contract while callers gain a typed native seam.
     async fn write_setting_on_transport<T, F>(
         &self,
         expected_generation: u64,
@@ -4598,37 +4943,12 @@ impl HqpAdapter {
         observe: F,
     ) -> Result<SettingOutcome>
     where
-        T: PartialEq + std::fmt::Display + Clone,
+        T: PartialEq + std::fmt::Display,
         F: Fn(&HqpState) -> Option<T>,
     {
-        match self
-            .send_command_on_transport(xml, expected_generation)
-            .await
-        {
-            Ok(_) => match self
-                .verify_applied_on_transport(expected_generation, what, expected, observe)
-                .await
-            {
-                Ok(outcome) => Ok(outcome),
-                Err(error) => Ok(SettingOutcome::Ambiguous {
-                    what: what.to_string(),
-                    reason: format!(
-                        "the write was attempted on native session generation \
-                         {expected_generation}, but same-session verification failed ({error})"
-                    ),
-                }),
-            },
-            Err(error) if error.downcast_ref::<HqpRejected>().is_some() => Err(error),
-            Err(error) if error.downcast_ref::<HqpSessionChanged>().is_some() => Err(error),
-            Err(error) => Ok(SettingOutcome::Ambiguous {
-                what: what.to_string(),
-                reason: format!(
-                    "the write was attempted on native session generation {expected_generation} \
-                     but drew no usable reply ({error}); it may or may not have been applied, and \
-                     verification was not moved to a replacement session"
-                ),
-            }),
-        }
+        self.write_setting_receipt_on_transport(expected_generation, xml, what, expected, observe)
+            .await?
+            .into_setting_outcome(what)
     }
 
     /// The semantic family a mode name belongs to, matched by prefix and alias rather than position.
@@ -4732,7 +5052,14 @@ impl HqpAdapter {
                         "HQPlayer is already in mode {mode_index}; not writing it, because SetMode \
                          clears the rate pin even when the mode does not change"
                     );
-                    return Ok(SettingOutcome::AlreadySet);
+                    return NativeSettingReceipt::NotAttempted {
+                        reason:
+                            "State already held the requested mode; SetMode was not sent because \
+                                 it clears an exact-rate pin even when unchanged"
+                                .to_string(),
+                        readback: NativeSettingReadback::Noop,
+                    }
+                    .into_setting_outcome("mode");
                 }
 
                 let xml = Self::build_request("SetMode", &[("value", &mode_index.to_string())]);
@@ -4835,7 +5162,11 @@ impl HqpAdapter {
             |index, generation| async move {
                 let state = self.get_state_on_transport(generation).await?;
                 if state.filter1x == Some(index) && state.filter_nx == Some(index) {
-                    return Ok(SettingOutcome::AlreadySet);
+                    return NativeSettingReceipt::NotAttempted {
+                        reason: "State already held the requested filter pair".to_string(),
+                        readback: NativeSettingReadback::Noop,
+                    }
+                    .into_setting_outcome("filter");
                 }
 
                 // Both sides are the setting here, so both are verified. Rendered as one value
@@ -4901,7 +5232,11 @@ impl HqpAdapter {
                     FilterSide::Nx => current_nx,
                 };
                 if current == index {
-                    return Ok(SettingOutcome::AlreadySet);
+                    return NativeSettingReceipt::NotAttempted {
+                        reason: format!("State already held the requested {what} filter"),
+                        readback: NativeSettingReadback::Noop,
+                    }
+                    .into_setting_outcome(what);
                 }
 
                 let (send_nx, send_1x) = match side {
@@ -4978,7 +5313,11 @@ impl HqpAdapter {
             || self.fresh_shapers_with_generation(),
             |shaper_index, generation| async move {
                 if self.get_state_on_transport(generation).await?.shaper == shaper_index {
-                    return Ok(SettingOutcome::AlreadySet);
+                    return NativeSettingReceipt::NotAttempted {
+                        reason: "State already held the requested shaper".to_string(),
+                        readback: NativeSettingReadback::Noop,
+                    }
+                    .into_setting_outcome("shaper");
                 }
 
                 let xml =
@@ -5040,7 +5379,11 @@ impl HqpAdapter {
                     });
                 }
                 if state.rate == index {
-                    return Ok(SettingOutcome::AlreadySet);
+                    return NativeSettingReceipt::NotAttempted {
+                        reason: "State already held the requested rate pin".to_string(),
+                        readback: NativeSettingReadback::Noop,
+                    }
+                    .into_setting_outcome("rate");
                 }
 
                 let xml = Self::build_request("SetRate", &[("value", &index.to_string())]);
@@ -5051,6 +5394,99 @@ impl HqpAdapter {
             },
         )
         .await
+    }
+
+    /// Execute one semantic pipeline command and retain typed native evidence for its caller.
+    ///
+    /// This is the producer-facing seam for the five #329 controls.  It deliberately accepts no
+    /// native index and imports no producer/adaptive vocabulary.  The mature public setters remain
+    /// intact for existing routes; this method converts their already-typed outcome/error boundary
+    /// without classifying `anyhow` display text.  Where that legacy boundary has already collapsed
+    /// an explicit acknowledgement into `Applied`/`Ignored`, this method reports the conservative
+    /// `PossibleAttempt` evidence rather than inventing an acknowledgement.  The lower native write
+    /// seam retains explicit acknowledgement/rejection for the subsequent full receipt migration.
+    #[allow(dead_code)] // Internal producer seam; no public route owns it yet.
+    pub(crate) async fn execute_native_setting(
+        &self,
+        setting: HqpNativeSetting<'_>,
+    ) -> Result<NativeSettingReceipt> {
+        let (what, result) = match setting {
+            HqpNativeSetting::Mode(value) => ("mode", self.set_mode(value).await),
+            HqpNativeSetting::Filter1x(value) => ("filter1x", self.set_filter_1x(value).await),
+            HqpNativeSetting::FilterNx(value) => ("filterNx", self.set_filter_nx(value).await),
+            HqpNativeSetting::Shaper(value) => ("shaper", self.set_shaper(value).await),
+            HqpNativeSetting::Rate(value) => ("rate", self.set_rate(value).await),
+        };
+        Self::receipt_from_legacy_setting_result(what, result)
+    }
+
+    /// Convert the frozen `Result<SettingOutcome>` API without trying to recover facts from error
+    /// prose.  The conservative possible-attempt cases are intentional: `SettingOutcome::Applied`
+    /// proves readback but no longer carries whether the reply said `result="OK"`.
+    fn receipt_from_legacy_setting_result(
+        what: &str,
+        result: Result<SettingOutcome>,
+    ) -> Result<NativeSettingReceipt> {
+        match result {
+            Ok(SettingOutcome::AlreadySet) => Ok(NativeSettingReceipt::NotAttempted {
+                reason: "the semantic setter proved the requested value was already selected"
+                    .to_string(),
+                readback: NativeSettingReadback::Noop,
+            }),
+            Ok(SettingOutcome::Suppressed { reason, .. }) => {
+                Ok(NativeSettingReceipt::NotAttempted {
+                    reason,
+                    readback: NativeSettingReadback::Unavailable {
+                        reason: "the semantic setter suppressed the write before an authoritative \
+                                 post-write readback"
+                            .to_string(),
+                    },
+                })
+            }
+            Ok(SettingOutcome::Applied) => Ok(NativeSettingReceipt::PossibleAttempt {
+                reason:
+                    "the legacy semantic result proves matching same-session readback but does \
+                         not retain the daemon acknowledgement bit"
+                        .to_string(),
+                readback: NativeSettingReadback::Verified,
+            }),
+            Ok(SettingOutcome::Ignored {
+                requested,
+                observed,
+                ..
+            }) => Ok(NativeSettingReceipt::PossibleAttempt {
+                reason: "the legacy semantic result proves a divergent same-session readback but \
+                         does not retain the daemon acknowledgement bit"
+                    .to_string(),
+                readback: NativeSettingReadback::Divergent {
+                    requested,
+                    observed,
+                },
+            }),
+            Ok(SettingOutcome::Ambiguous { reason, .. }) => {
+                Ok(NativeSettingReceipt::PossibleAttempt {
+                    reason,
+                    readback: NativeSettingReadback::Unavailable {
+                        reason: format!(
+                            "the legacy {what} setter reported ambiguous delivery without an \
+                             authoritative receipt"
+                        ),
+                    },
+                })
+            }
+            Err(error) => match error.downcast::<HqpRejected>() {
+                Ok(rejected) => Ok(NativeSettingReceipt::DaemonRejected(rejected)),
+                Err(error) => Ok(NativeSettingReceipt::NotAttempted {
+                    reason: error.to_string(),
+                    readback: NativeSettingReadback::Unavailable {
+                        reason: format!(
+                            "the semantic {what} setter ended before it could return native \
+                             delivery evidence"
+                        ),
+                    },
+                }),
+            },
+        }
     }
 
     /// Turn a legacy numeric setting value into the semantic name it denotes **right now**.

--- a/src/adapters/hqplayer.rs
+++ b/src/adapters/hqplayer.rs
@@ -2123,6 +2123,16 @@ impl HqpAdapter {
         self.state.read().await.producer_epoch
     }
 
+    /// Carry a retired logical producer's epoch floor into a replacement adapter object.
+    ///
+    /// Instance names are producer identities. Removing and re-adding the same name must therefore
+    /// reconnect at an epoch strictly newer than the adaptive retirement tombstone, even though a
+    /// fresh adapter object's local counter would otherwise restart at zero.
+    async fn seed_producer_epoch_floor(&self, floor: u64) {
+        let mut state = self.state.write().await;
+        state.producer_epoch = state.producer_epoch.max(floor);
+    }
+
     /// Monotonic identity of the configured native + persistent endpoint.
     ///
     /// Internal provenance seam for hermetic operation-lease tests. It is not serialized by an
@@ -7194,6 +7204,11 @@ struct HqpManagedWorker {
 
 pub struct HqpInstanceManager {
     instances: Arc<RwLock<HashMap<String, Arc<HqpAdapter>>>>,
+    /// Highest producer epoch retired for each logical instance name in this process.
+    ///
+    /// The adaptive aggregator retains the corresponding tombstone for the same lifetime, so this
+    /// map deliberately has matching lifetime: a same-name replacement must start above that floor.
+    producer_epoch_floors: Arc<RwLock<HashMap<String, u64>>>,
     bus: SharedBus,
     running: Arc<AtomicBool>,
     workers: Arc<Mutex<HashMap<String, HqpManagedWorker>>>,
@@ -7224,6 +7239,7 @@ impl HqpInstanceManager {
     ) -> Self {
         Self {
             instances: Arc::new(RwLock::new(HashMap::new())),
+            producer_epoch_floors: Arc::new(RwLock::new(HashMap::new())),
             bus,
             running: Arc::new(AtomicBool::new(false)),
             workers: Arc::new(Mutex::new(HashMap::new())),
@@ -7283,15 +7299,29 @@ impl HqpInstanceManager {
         save_hqp_configs(&configs);
     }
 
-    /// Get or create an instance by name
-    pub async fn get_or_create(&self, name: &str) -> Arc<HqpAdapter> {
+    /// Get or create an instance by name while the manager lifecycle transaction is held.
+    async fn get_or_create_locked(&self, name: &str) -> Arc<HqpAdapter> {
         // Prepare outside the map lock, then use the entry as the atomic winner. Two callers may
         // prepare candidates, but they can no longer return different adapters for the same name.
         let adapter = Arc::new(HqpAdapter::new(self.bus.clone()));
         adapter.set_instance_name(name.to_string()).await;
+        let epoch_floor = self
+            .producer_epoch_floors
+            .read()
+            .await
+            .get(name)
+            .copied()
+            .unwrap_or(0);
+        adapter.seed_producer_epoch_floor(epoch_floor).await;
 
         let mut instances = self.instances.write().await;
         instances.entry(name.to_string()).or_insert(adapter).clone()
+    }
+
+    /// Get or create an instance by name.
+    pub async fn get_or_create(&self, name: &str) -> Arc<HqpAdapter> {
+        let _lifecycle_guard = self.lifecycle_lock.lock().await;
+        self.get_or_create_locked(name).await
     }
 
     /// Get an instance by name (if it exists)
@@ -7407,7 +7437,7 @@ impl HqpInstanceManager {
         password: Option<String>,
     ) -> Arc<HqpAdapter> {
         let _lifecycle_guard = self.lifecycle_lock.lock().await;
-        let adapter = self.get_or_create(&name).await;
+        let adapter = self.get_or_create_locked(&name).await;
         adapter
             .configure(host, port, web_port, username, password)
             .await;
@@ -7428,14 +7458,18 @@ impl HqpInstanceManager {
             return false;
         };
 
+        let producer_epoch = adapter.producer_epoch().await;
+        {
+            let mut floors = self.producer_epoch_floors.write().await;
+            let floor = floors.entry(name.to_string()).or_insert(producer_epoch);
+            *floor = (*floor).max(producer_epoch);
+        }
+
         self.stop_worker(name).await;
         // A removed instance is unlike a temporary native outage: its producer identity is gone.
         // Join first so no child can report a same-run observation behind this retirement.
         if let Some(sink) = &self.native_sink {
-            if let Err(error) = sink
-                .instance_removed(name, adapter.producer_epoch().await)
-                .await
-            {
+            if let Err(error) = sink.instance_removed(name, producer_epoch).await {
                 tracing::warn!(%error, instance = %name, "HQPlayer native observation sink could not retire removed instance; rolling removal back");
                 // Retirement and removal are one transaction. Reporting success after the adapter
                 // disappeared but its retained producer survived would leave a document that no

--- a/src/adaptive/command.rs
+++ b/src/adaptive/command.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use super::change_set::ChangeSetId;
 use super::control::{ApplyLane, ControlId, Reason};
 use super::document::{Extensions, RevisionRef};
-use super::value::Timestamp;
+use super::value::{ControlValue, Timestamp};
 use super::vocab::semantic_enum;
 
 /// A stable operation identifier.
@@ -57,6 +57,12 @@ semantic_enum! {
 semantic_enum! {
     /// What became of an operation.
     pub enum CommandOutcome {
+        /// The command was accepted for execution, but no authoritative producer
+        /// convergence has been observed yet.
+        ///
+        /// This is deliberately not evidence that the producer received or applied the
+        /// command. A consumer must await a later outcome or observed revision.
+        Pending => "pending",
         /// The requested effect is observed on the producer.
         Applied => "applied",
         /// The producer accepted the write and nothing changed, because the value was
@@ -111,14 +117,14 @@ impl CommandOutcome {
 
     /// Whether this outcome is evidence about the producer's observed state.
     ///
-    /// False for [`CommandOutcome::Indeterminate`], [`CommandOutcome::TimedOut`] and
-    /// [`CommandOutcome::Compensating`]: those describe what happened to the *operation*,
-    /// not what is true of the producer. A consumer that treats them as state evidence
-    /// will display a value the engine never adopted.
+    /// False for [`CommandOutcome::Pending`], [`CommandOutcome::Indeterminate`],
+    /// [`CommandOutcome::TimedOut`] and [`CommandOutcome::Compensating`]: those describe
+    /// what happened to the *operation*, not what is true of the producer. A consumer
+    /// that treats them as state evidence will display a value the engine never adopted.
     pub fn is_state_evidence(&self) -> bool {
         !matches!(
             self,
-            Self::Indeterminate | Self::TimedOut | Self::Compensating
+            Self::Pending | Self::Indeterminate | Self::TimedOut | Self::Compensating
         )
     }
 
@@ -126,7 +132,8 @@ impl CommandOutcome {
     pub fn awaits_convergence(&self) -> bool {
         matches!(
             self,
-            Self::Indeterminate
+            Self::Pending
+                | Self::Indeterminate
                 | Self::TimedOut
                 | Self::Compensating
                 | Self::PartiallyApplied
@@ -154,8 +161,25 @@ impl CommandOutcome {
             return false;
         }
         // Nothing may regress into an unresolved state.
-        !matches!(next, Self::Indeterminate | Self::TimedOut)
+        !matches!(next, Self::Pending | Self::Indeterminate | Self::TimedOut)
     }
+}
+
+/// The exact semantic request admitted for one operation.
+///
+/// Kept on the operation rather than inferred from later state: once a choice set or revision
+/// advances, the producer still owes consumers an auditable record of what was requested and the
+/// base against which it passed preflight.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct OperationRequest {
+    /// The control addressed by the request.
+    pub control: ControlId,
+    /// The semantic value requested; native indices never cross this boundary.
+    pub requested: ControlValue,
+    /// The lane selected by the admitted control descriptor.
+    pub lane: ApplyLane,
+    /// The exact producer revision against which the request was admitted.
+    pub base: RevisionRef,
 }
 
 /// A rejected attempt to record a transition.
@@ -233,6 +257,9 @@ pub struct OperationRecord {
     /// Correlation id shared with the request that started it, so every surface can
     /// follow the same operation without inventing its own tracking.
     pub correlation_id: String,
+    /// The admitted semantic request, when this record represents a direct control operation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request: Option<OperationRequest>,
     /// The change set this operation executed, if any.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub change_set: Option<ChangeSetId>,

--- a/src/adaptive/command.rs
+++ b/src/adaptive/command.rs
@@ -160,6 +160,13 @@ impl CommandOutcome {
         if self.is_terminal() {
             return false;
         }
+        // Pending is the admitted, pre-execution state. Native execution may establish a
+        // terminal result or may end with an unresolved delivery/readback result that still
+        // awaits convergence. Rejecting those ambiguous transitions would strand the operation
+        // at Pending and erase the most important fact the command path learned.
+        if self == &Self::Pending {
+            return true;
+        }
         // Nothing may regress into an unresolved state.
         !matches!(next, Self::Pending | Self::Indeterminate | Self::TimedOut)
     }

--- a/src/adaptive/mod.rs
+++ b/src/adaptive/mod.rs
@@ -58,8 +58,8 @@ pub use change_set::{
     RetireOutcome, StageOutcome, Staleness, Surface,
 };
 pub use command::{
-    CommandOutcome, OperationId, OperationRecord, OutcomeTransition, PlanStep, RecoveryState,
-    TransitionRejected, WriteAttempt,
+    CommandOutcome, OperationId, OperationRecord, OperationRequest, OutcomeTransition, PlanStep,
+    RecoveryState, TransitionRejected, WriteAttempt,
 };
 pub use constraint::{
     Constraint, ConstraintEffect, Evaluation, Expr, ExprLimit, Permission, ValueLookup, Visibility,

--- a/src/main.rs
+++ b/src/main.rs
@@ -218,7 +218,7 @@ mod server {
         // must not run until the public socket is bound below. This preserves bind-before-startup
         // while allowing HQPlayer's manager to own the handle for its whole lifecycle.
         let producer_shutdown_token = CancellationToken::new();
-        let (adaptive_handle, producer_actor, _adaptive_view) =
+        let (adaptive_handle, producer_actor, adaptive_view) =
             producers::AdaptiveRuntime::build(producer_shutdown_token.clone(), 1024);
         let hqp_adaptive_publisher = Arc::new(producers::hqplayer::HqpAdaptivePublisher::new(
             adaptive_handle,
@@ -228,9 +228,16 @@ mod server {
         let hqp_instances = Arc::new(
             adapters::hqplayer::HqpInstanceManager::new_with_native_sink(
                 bus.clone(),
-                hqp_adaptive_publisher,
+                hqp_adaptive_publisher.clone(),
             ),
         );
+        let (hqp_command_handle, hqp_command_actor) =
+            producers::hqplayer_command_service::HqpImmediateCommandActor::build(
+                adaptive_view,
+                hqp_adaptive_publisher,
+                hqp_instances.clone(),
+                32,
+            );
         hqp_instances.load_from_config().await;
         let instance_count = hqp_instances.instance_count().await;
         if instance_count > 0 {
@@ -340,6 +347,7 @@ mod server {
         let producer_actor_task = tokio::spawn(async move {
             producer_actor.run().await;
         });
+        let hqp_command_actor_task = tokio::spawn(hqp_command_actor.run());
         tracing::info!("ProducerActor started");
 
         // Single loop to start all enabled adapters
@@ -648,6 +656,16 @@ mod server {
 
         // Cleanup: publish ShuttingDown event and stop adapters
         tracing::info!("Shutting down adapters...");
+
+        // Close immediate-command ingress and drain accepted work before broadcasting shutdown.
+        // Some adapters react to that broadcast independently of the coordinator, so publishing it
+        // first would let native lifecycle teardown race an already-admitted command.
+        if let Err(error) = hqp_command_handle.shutdown().await {
+            tracing::warn!(?error, "HQPlayer command actor did not drain cleanly");
+        }
+        if let Err(error) = hqp_command_actor_task.await {
+            tracing::warn!(%error, "HQPlayer command actor exited with a join error");
+        }
 
         // Publish ShuttingDown event for any bus listeners
         bus.publish(bus::BusEvent::ShuttingDown {

--- a/src/producers/hqplayer.rs
+++ b/src/producers/hqplayer.rs
@@ -1479,6 +1479,12 @@ impl HqpPublisherCoordinator {
     }
 
     fn manager_started(&mut self) -> Result<(), HqpCoordinatorRefusal> {
+        if self.run.is_some() && self.stop_requested {
+            // A receipt/deferred terminal publication still owns the old run. Reporting success
+            // here would let the manager launch new workers which that old completion can later
+            // make last-known. The caller may retry once quiescence drops the prior run.
+            return Err(HqpCoordinatorRefusal::LeaseStillCurrent);
+        }
         if self.run.is_none() {
             self.run = Some(self.handle.begin_run("hqplayer"));
             self.stop_requested = false;
@@ -2103,6 +2109,28 @@ impl HqpPublisherCoordinator {
         Ok(())
     }
 
+    /// Validate the narrow exception for a receipt whose exact executor-begun lease crossed a
+    /// producer epoch observation. The correlation's full opaque lease equality prevents a stale
+    /// or fabricated generation from borrowing another operation's fence.
+    fn is_exact_fenced_pending(&self, lease: &HqpCommandLease) -> bool {
+        let Some(instance_name) = lease.producer_id.strip_prefix("hqplayer:") else {
+            return false;
+        };
+        let Some(state) = self.instances.get(instance_name) else {
+            return false;
+        };
+        state.dispatch_in_progress.contains(&lease.generation)
+            && state
+                .correlations
+                .get(&lease.correlation_id)
+                .is_some_and(|correlation| correlation.lease == *lease)
+            && state.ledger.iter().any(|operation| {
+                operation.id == lease.operation_id
+                    && operation.generation == Some(lease.generation)
+                    && operation.outcome == CommandOutcome::Pending
+            })
+    }
+
     /// Return already-published terminal truth for a late actor callback. In particular, instance
     /// retirement removes the document from the public view, but must not make a completion retry
     /// look like a fresh lease or make the accepted operation's audit disappear.
@@ -2131,7 +2159,7 @@ impl HqpPublisherCoordinator {
         lease: &HqpCommandLease,
         completion: HqpCommandCompletion,
     ) -> Result<OperationRecord, HqpCoordinatorRefusal> {
-        if self.validate(lease).is_err() {
+        if self.validate(lease).is_err() && !self.is_exact_fenced_pending(lease) {
             return self
                 .retained_terminal_operation(lease)
                 .ok_or(HqpCoordinatorRefusal::StaleLease);
@@ -3904,8 +3932,15 @@ mod tests {
             .begin_dispatch(reservation.lease())
             .await
             .expect("final lease check fences the begun executor");
+        let mut restarted = sample();
+        restarted.producer_epoch = 8;
+        restarted.execution_target.producer_epoch = 8;
         publisher
-            .instance_removed("main", 7)
+            .observed(restarted)
+            .await
+            .expect("new epoch may be observed while exact old-session receipt is pending");
+        publisher
+            .instance_removed("main", 8)
             .await
             .expect("removal waits for the actor's receipt completion");
         assert!(
@@ -4012,6 +4047,79 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn manager_start_is_rejected_until_stopping_run_admits_deferred_receipt() {
+        let (publisher, view, shutdown, actor_task) = coordinator_fixture().await;
+        let key = crate::producers::ProducerKey {
+            producer_id: "hqplayer:main".to_string(),
+            role: TargetRole::DspEngine,
+            zone_id: None,
+        };
+        let reservation = publisher
+            .reserve(validated_mode_command(
+                &view.snapshot(&key).expect("initial"),
+                "restart-before-old-receipt",
+                "PCM",
+            ))
+            .await
+            .expect("reserve");
+        publisher
+            .begin_dispatch(reservation.lease())
+            .await
+            .expect("executor begun fence");
+        assert!(publisher.manager_stopped().await.is_err());
+        assert!(
+            publisher.manager_started().await.is_err(),
+            "new workers cannot start while the old fenced receipt owns the run"
+        );
+
+        for _ in 0..5 {
+            publisher.refuse_next_publication().await;
+        }
+        assert!(matches!(
+            publisher
+                .complete(
+                    reservation.lease(),
+                    HqpCommandCompletion::new(
+                        CommandOutcome::Indeterminate,
+                        WriteAttempt::Attempted,
+                        Timestamp::new("2026-07-31T00:00:01Z"),
+                        Some(RecoveryState::AwaitingReadback),
+                        None,
+                    ),
+                )
+                .await,
+            Err(HqpCoordinatorRefusal::PublicationFailed(_))
+        ));
+        assert!(
+            publisher.manager_started().await.is_err(),
+            "deferred terminal admission still owns the stopping run"
+        );
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                if publisher.manager_started().await.is_ok() {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("restart succeeds only after old receipt admission ends the prior run");
+        assert_eq!(
+            view.snapshot(&key)
+                .expect("receipt audit")
+                .document
+                .operations[0]
+                .outcome,
+            CommandOutcome::Indeterminate
+        );
+
+        publisher.manager_stopped().await.expect("new run stops");
+        shutdown.cancel();
+        actor_task.await.expect("actor joins");
+    }
+
+    #[tokio::test]
     async fn coordinator_retries_one_terminal_publication_failure_without_stranding_conflict() {
         let (publisher, view, shutdown, actor_task) = coordinator_fixture().await;
         let key = crate::producers::ProducerKey {
@@ -4073,6 +4181,17 @@ mod tests {
             ))
             .await
             .expect("reserve");
+        publisher
+            .begin_dispatch(reservation.lease())
+            .await
+            .expect("executor begun before epoch advance");
+        let mut restarted = sample();
+        restarted.producer_epoch = 8;
+        restarted.execution_target.producer_epoch = 8;
+        publisher
+            .observed(restarted)
+            .await
+            .expect("new epoch observation preserves exact fence");
         for _ in 0..3 {
             publisher.refuse_next_publication().await;
         }
@@ -4469,6 +4588,89 @@ mod tests {
         assert_eq!(operation.history.len(), 1);
         assert_eq!(operation.history[0].from, CommandOutcome::Pending);
         assert_eq!(operation.history[0].to, CommandOutcome::Rejected);
+
+        publisher.manager_stopped().await.expect("manager stops");
+        shutdown.cancel();
+        actor_task.await.expect("actor joins");
+    }
+
+    #[tokio::test]
+    async fn newer_epoch_after_executor_begins_still_admits_exact_old_session_receipt() {
+        let (publisher, view, shutdown, actor_task) = coordinator_fixture().await;
+        let key = crate::producers::ProducerKey {
+            producer_id: "hqplayer:main".to_string(),
+            role: TargetRole::DspEngine,
+            zone_id: None,
+        };
+        let reservation = publisher
+            .reserve(validated_mode_command(
+                &view.snapshot(&key).expect("epoch-7 snapshot"),
+                "epoch-advance-during-executor",
+                "PCM",
+            ))
+            .await
+            .expect("epoch-7 reservation");
+        publisher
+            .begin_dispatch(reservation.lease())
+            .await
+            .expect("epoch-7 executor fence");
+
+        let mut restarted = sample();
+        restarted.producer_epoch = 8;
+        restarted.execution_target.producer_epoch = 8;
+        restarted.mode_is_source = false;
+        restarted.mode.selected = "PCM".to_string();
+        publisher
+            .observed(restarted)
+            .await
+            .expect("new epoch observation is admitted without resolving fenced operation");
+        let advanced = view.snapshot(&key).expect("epoch-8 snapshot");
+        assert_eq!(advanced.document.producer.epoch, ProducerEpoch(8));
+        assert_eq!(
+            advanced.document.operations[0].outcome,
+            CommandOutcome::Pending
+        );
+
+        publisher
+            .complete(
+                reservation.lease(),
+                HqpCommandCompletion::new(
+                    CommandOutcome::Indeterminate,
+                    WriteAttempt::Attempted,
+                    Timestamp::new("2026-07-31T00:00:01Z"),
+                    Some(RecoveryState::AwaitingReadback),
+                    None,
+                ),
+            )
+            .await
+            .expect("exact fenced epoch-7 receipt remains admissible as epoch-8 audit");
+        let audited = view.snapshot(&key).expect("receipt audit");
+        assert_eq!(audited.document.producer.epoch, ProducerEpoch(8));
+        assert_eq!(
+            audited.document.operations[0].outcome,
+            CommandOutcome::Indeterminate
+        );
+        assert_eq!(
+            audited.document.operations[0].write_attempt,
+            WriteAttempt::Attempted
+        );
+
+        assert_eq!(
+            publisher
+                .complete(
+                    reservation.lease(),
+                    HqpCommandCompletion::new(
+                        CommandOutcome::Applied,
+                        WriteAttempt::Confirmed,
+                        Timestamp::new("2026-07-31T00:00:02Z"),
+                        Some(RecoveryState::NotRequired),
+                        None,
+                    ),
+                )
+                .await,
+            Err(HqpCoordinatorRefusal::StaleLease),
+            "once the exact fence is consumed, an old-epoch completion is stale again"
+        );
 
         publisher.manager_stopped().await.expect("manager stops");
         shutdown.cancel();

--- a/src/producers/hqplayer.rs
+++ b/src/producers/hqplayer.rs
@@ -957,6 +957,11 @@ const MAX_TERMINAL_OPERATIONS: usize = 32;
 /// silently treating an old gesture as new would repeat native I/O.
 const MAX_CORRELATION_TOMBSTONES: usize = 256;
 
+/// Retired instance identities retain bounded duplicate-correlation truth. Instance names are
+/// configuration input, so bounding each retired ledger is insufficient by itself: a stream of
+/// distinct removed names must not grow coordinator memory forever.
+const MAX_RETIRED_INSTANCES: usize = 64;
+
 /// An unresolved outcome carries real uncertainty and therefore must never be compacted away.
 /// The producer applies backpressure instead of allowing a disconnected/indeterminate stream to
 /// grow memory forever. One pipeline command may still be Pending in addition to these records.
@@ -1143,6 +1148,10 @@ struct HqpInstanceCoordinator {
     correlation_tombstones: HashMap<String, HqpCommandFingerprint>,
     correlation_tombstone_order: VecDeque<String>,
     active_pipeline: Option<u64>,
+    /// Generations whose final lease check passed and whose executor call has begun. This is
+    /// coordinator-only causality state: it is not write-attempt evidence and never enters the
+    /// producer document. Only the typed receipt may clear it.
+    dispatch_in_progress: HashSet<u64>,
     execution_target: Option<HqpNativeExecutionTarget>,
     deferred_commit: Option<HqpDeferredCommit>,
     retirement_requested: Option<ProducerEpoch>,
@@ -1153,6 +1162,7 @@ struct HqpDeferredCommit {
     tracker: RevisionTracker,
     ledger: Vec<OperationRecord>,
     active_pipeline: Option<u64>,
+    dispatch_in_progress: HashSet<u64>,
     correlation_tombstones: HashMap<String, HqpCommandFingerprint>,
     correlation_tombstone_order: VecDeque<String>,
 }
@@ -1196,7 +1206,12 @@ enum HqpCoordinatorCommand {
         request: HqpImmediateCommandRequest,
         reply: oneshot::Sender<Result<Option<HqpCommandReservation>, HqpCoordinatorRefusal>>,
     },
+    #[cfg(test)]
     Validate {
+        lease: HqpCommandLease,
+        reply: oneshot::Sender<Result<(), HqpCoordinatorRefusal>>,
+    },
+    BeginDispatch {
         lease: HqpCommandLease,
         reply: oneshot::Sender<Result<(), HqpCoordinatorRefusal>>,
     },
@@ -1221,12 +1236,32 @@ struct HqpPublisherCoordinator {
     run: Option<AdapterRun>,
     instances: HashMap<String, HqpInstanceCoordinator>,
     retired_instances: HashMap<String, HqpRetiredInstance>,
+    retired_instance_order: VecDeque<String>,
     #[cfg(test)]
     refused_publications: usize,
     stop_requested: bool,
 }
 
 impl HqpPublisherCoordinator {
+    fn retain_retired_instance(&mut self, instance_name: String, retired: HqpRetiredInstance) {
+        self.retired_instance_order
+            .retain(|retained| retained != &instance_name);
+        self.retired_instances
+            .insert(instance_name.clone(), retired);
+        self.retired_instance_order.push_back(instance_name);
+        while self.retired_instance_order.len() > MAX_RETIRED_INSTANCES {
+            if let Some(expired) = self.retired_instance_order.pop_front() {
+                self.retired_instances.remove(&expired);
+            }
+        }
+    }
+
+    fn remove_retired_instance(&mut self, instance_name: &str) {
+        self.retired_instances.remove(instance_name);
+        self.retired_instance_order
+            .retain(|retained| retained != instance_name);
+    }
+
     fn has_deferred_commits(&self) -> bool {
         self.instances
             .values()
@@ -1241,6 +1276,17 @@ impl HqpPublisherCoordinator {
                     .iter()
                     .any(|operation| operation.outcome == CommandOutcome::Pending)
         })
+    }
+
+    fn finish_stop_if_quiescent(&mut self) {
+        let quiescent = self.instances.values().all(|state| {
+            state.deferred_commit.is_none()
+                && state.dispatch_in_progress.is_empty()
+                && !has_pending_operations(state)
+        });
+        if self.stop_requested && quiescent {
+            self.run.take();
+        }
     }
 
     async fn retry_deferred_commits(&mut self) {
@@ -1283,9 +1329,7 @@ impl HqpPublisherCoordinator {
             }
             self.instances.insert(name, state);
         }
-        if self.stop_requested && !self.has_deferred_commits() {
-            self.run.take();
-        }
+        self.finish_stop_if_quiescent();
     }
 
     async fn retire_admitted_instance(
@@ -1295,6 +1339,7 @@ impl HqpPublisherCoordinator {
         producer_epoch: ProducerEpoch,
     ) -> Result<(), HqpCoordinatorRefusal> {
         debug_assert!(!has_pending_operations(&state));
+        debug_assert!(state.dispatch_in_progress.is_empty());
         if let Some(run) = self.run.as_ref() {
             let producer_id = format!("hqplayer:{instance_name}");
             let retirement = self
@@ -1316,7 +1361,7 @@ impl HqpPublisherCoordinator {
                 }
             }
         }
-        self.retired_instances.insert(
+        self.retain_retired_instance(
             instance_name,
             HqpRetiredInstance {
                 producer_epoch,
@@ -1342,6 +1387,7 @@ impl HqpPublisherCoordinator {
                 state.tracker = commit.tracker;
                 state.ledger = commit.ledger;
                 state.active_pipeline = commit.active_pipeline;
+                state.dispatch_in_progress = commit.dispatch_in_progress;
                 state.correlation_tombstones = commit.correlation_tombstones;
                 state.correlation_tombstone_order = commit.correlation_tombstone_order;
                 state.deferred_commit = None;
@@ -1397,8 +1443,12 @@ impl HqpPublisherCoordinator {
                 HqpCoordinatorCommand::LookupCorrelation { request, reply } => {
                     let _ = reply.send(self.lookup_correlation(&request));
                 }
+                #[cfg(test)]
                 HqpCoordinatorCommand::Validate { lease, reply } => {
                     let _ = reply.send(self.validate(&lease));
+                }
+                HqpCoordinatorCommand::BeginDispatch { lease, reply } => {
+                    let _ = reply.send(self.begin_dispatch(&lease));
                 }
                 HqpCoordinatorCommand::Complete {
                     lease,
@@ -1476,8 +1526,9 @@ impl HqpPublisherCoordinator {
         if let Some(error) = first_failure {
             return Err(error);
         }
-        // The sole run is dropped only after every pending audit transition was admitted.
-        self.run.take();
+        // The sole run is dropped only after every pending audit transition was admitted and no
+        // executor-begun fence is awaiting typed receipt truth.
+        self.finish_stop_if_quiescent();
         Ok(())
     }
 
@@ -1491,6 +1542,15 @@ impl HqpPublisherCoordinator {
         let mut changed = false;
         for operation in &mut candidate_ledger {
             if operation.outcome != CommandOutcome::Pending {
+                continue;
+            }
+            if operation
+                .generation
+                .is_some_and(|generation| state.dispatch_in_progress.contains(&generation))
+            {
+                // The executor call began, but its receipt has not reached the coordinator. Stop
+                // cannot call this a no-send or discard the operation; the typed completion owns
+                // that truth and will clear the fence.
                 continue;
             }
             operation.write_attempt = WriteAttempt::NotAttempted;
@@ -1510,8 +1570,18 @@ impl HqpPublisherCoordinator {
                 .map_err(|_| HqpCoordinatorRefusal::IllegalTransition)?;
             changed = true;
         }
+        let dispatch_still_in_progress = candidate_ledger.iter().any(|operation| {
+            operation.outcome == CommandOutcome::Pending
+                && operation
+                    .generation
+                    .is_some_and(|generation| state.dispatch_in_progress.contains(&generation))
+        });
         if !changed {
-            return Ok(());
+            return if dispatch_still_in_progress {
+                Err(HqpCoordinatorRefusal::LeaseStillCurrent)
+            } else {
+                Ok(())
+            };
         }
 
         let mut correlation_tombstones = state.correlation_tombstones.clone();
@@ -1538,11 +1608,17 @@ impl HqpPublisherCoordinator {
                 tracker: candidate_tracker,
                 ledger: candidate_ledger,
                 active_pipeline: None,
+                dispatch_in_progress: state.dispatch_in_progress.clone(),
                 correlation_tombstones,
                 correlation_tombstone_order,
             },
         )
-        .await
+        .await?;
+        if dispatch_still_in_progress {
+            Err(HqpCoordinatorRefusal::LeaseStillCurrent)
+        } else {
+            Ok(())
+        }
     }
 
     fn lookup_correlation(
@@ -1646,7 +1722,7 @@ impl HqpPublisherCoordinator {
             }
             // A strictly newer producer epoch is the only observation that can supersede an
             // instance retirement. Its correlation namespace is fresh by producer identity.
-            self.retired_instances.remove(&instance_name);
+            self.remove_retired_instance(&instance_name);
         }
         let mut state = self.instances.remove(&instance_name).unwrap_or_default();
         if let Some(commit) = state.deferred_commit.clone() {
@@ -1659,7 +1735,11 @@ impl HqpPublisherCoordinator {
             }
         }
         let mut candidate_ledger = state.ledger.clone();
-        let converged = reconcile_operations(&projected, &mut candidate_ledger)?;
+        let converged = reconcile_operations(
+            &projected,
+            &mut candidate_ledger,
+            &state.dispatch_in_progress,
+        )?;
         let mut correlation_tombstones = state.correlation_tombstones.clone();
         let mut correlation_tombstone_order = state.correlation_tombstone_order.clone();
         prune_terminal_history(
@@ -2001,6 +2081,28 @@ impl HqpPublisherCoordinator {
             .ok_or(HqpCoordinatorRefusal::StaleLease)
     }
 
+    fn begin_dispatch(&mut self, lease: &HqpCommandLease) -> Result<(), HqpCoordinatorRefusal> {
+        if self.stop_requested {
+            return Err(HqpCoordinatorRefusal::LifecycleNotRunning);
+        }
+        self.validate(lease)?;
+        let instance_name = lease
+            .producer_id
+            .strip_prefix("hqplayer:")
+            .ok_or(HqpCoordinatorRefusal::StaleLease)?;
+        let state = self
+            .instances
+            .get_mut(instance_name)
+            .ok_or(HqpCoordinatorRefusal::StaleLease)?;
+        if state.retirement_requested.is_some() {
+            return Err(HqpCoordinatorRefusal::StaleLease);
+        }
+        if !state.dispatch_in_progress.insert(lease.generation) {
+            return Err(HqpCoordinatorRefusal::LeaseStillCurrent);
+        }
+        Ok(())
+    }
+
     /// Return already-published terminal truth for a late actor callback. In particular, instance
     /// retirement removes the document from the public view, but must not make a completion retry
     /// look like a fresh lease or make the accepted operation's audit disappear.
@@ -2052,10 +2154,12 @@ impl HqpPublisherCoordinator {
                     if !has_pending_operations(&state) {
                         self.retire_admitted_instance(instance_name, state, epoch)
                             .await?;
+                        self.finish_stop_if_quiescent();
                         return Ok(completed);
                     }
                 }
                 self.instances.insert(instance_name, state);
+                self.finish_stop_if_quiescent();
                 Ok(completed)
             }
             Err(error) => {
@@ -2107,12 +2211,15 @@ impl HqpPublisherCoordinator {
         candidate_tracker
             .materialize(candidate_document)
             .map_err(|error| HqpCoordinatorRefusal::RevisionFailed(format!("{error:?}")))?;
+        let mut dispatch_in_progress = state.dispatch_in_progress.clone();
+        dispatch_in_progress.remove(&lease.generation);
         self.publish_deferred(
             state,
             HqpDeferredCommit {
                 tracker: candidate_tracker,
                 ledger: candidate_ledger,
                 active_pipeline: None,
+                dispatch_in_progress,
                 correlation_tombstones,
                 correlation_tombstone_order,
             },
@@ -2140,10 +2247,27 @@ impl HqpPublisherCoordinator {
             .remove(&instance_name)
             .ok_or(HqpCoordinatorRefusal::StaleLease)?;
         let result = self
-            .supersede_stale_for_instance(&mut state, lease, active_run, at)
+            .supersede_stale_for_instance(&mut state, lease, active_run, self.stop_requested, at)
             .await;
-        self.instances.insert(instance_name, state);
-        result
+        match result {
+            Ok(superseded) => {
+                if let Some(epoch) = state.retirement_requested {
+                    if !has_pending_operations(&state) {
+                        self.retire_admitted_instance(instance_name, state, epoch)
+                            .await?;
+                        self.finish_stop_if_quiescent();
+                        return Ok(superseded);
+                    }
+                }
+                self.instances.insert(instance_name, state);
+                self.finish_stop_if_quiescent();
+                Ok(superseded)
+            }
+            Err(error) => {
+                self.instances.insert(instance_name, state);
+                Err(error)
+            }
+        }
     }
 
     async fn supersede_stale_for_instance(
@@ -2151,10 +2275,16 @@ impl HqpPublisherCoordinator {
         state: &mut HqpInstanceCoordinator,
         lease: &HqpCommandLease,
         active_run: Option<AdapterRunId>,
+        lifecycle_stopping: bool,
         at: Timestamp,
     ) -> Result<OperationRecord, HqpCoordinatorRefusal> {
-        let invalidated =
-            lease.run_id != active_run || state.tracker.epoch != Some(lease.producer_epoch.0);
+        if state.dispatch_in_progress.contains(&lease.generation) {
+            return Err(HqpCoordinatorRefusal::LeaseStillCurrent);
+        }
+        let invalidated = lease.run_id != active_run
+            || state.tracker.epoch != Some(lease.producer_epoch.0)
+            || state.retirement_requested.is_some()
+            || lifecycle_stopping;
         if !invalidated {
             return Err(HqpCoordinatorRefusal::LeaseStillCurrent);
         }
@@ -2226,6 +2356,7 @@ impl HqpPublisherCoordinator {
                 tracker: candidate_tracker,
                 ledger: candidate_ledger,
                 active_pipeline: None,
+                dispatch_in_progress: state.dispatch_in_progress.clone(),
                 correlation_tombstones,
                 correlation_tombstone_order,
             },
@@ -2284,6 +2415,7 @@ fn semantic_request_matches(document: &ProducerDocument, request: &OperationRequ
 fn reconcile_operations(
     document: &ProducerDocument,
     ledger: &mut [OperationRecord],
+    dispatch_in_progress: &HashSet<u64>,
 ) -> Result<HashSet<OperationId>, HqpCoordinatorRefusal> {
     let mut converged = HashSet::new();
     for index in 0..ledger.len() {
@@ -2303,8 +2435,14 @@ fn reconcile_operations(
                     .as_ref()
                     .is_some_and(|later_request| later_request.control == request.control)
         });
+        let executor_begun = dispatch_in_progress.contains(&generation);
 
-        let resolution = if producer_restarted || (!matches && has_later_generation) {
+        let resolution = if executor_begun {
+            // The final lease check passed and the executor call began, but no receipt exists yet.
+            // Observations may update producer state while that call is in flight; they cannot
+            // claim this operation was a no-send or otherwise pre-empt its typed receipt.
+            None
+        } else if producer_restarted || (!matches && has_later_generation) {
             Some((
                 CommandOutcome::Superseded,
                 RecoveryState::ReplanRequired,
@@ -2471,6 +2609,7 @@ impl HqpAdaptivePublisher {
                 run: None,
                 instances: HashMap::new(),
                 retired_instances: HashMap::new(),
+                retired_instance_order: VecDeque::new(),
                 #[cfg(test)]
                 refused_publications: 0,
                 stop_requested: false,
@@ -2514,11 +2653,25 @@ impl HqpAdaptivePublisher {
         .await
     }
 
+    #[cfg(test)]
     pub(crate) async fn validate(
         &self,
         lease: &HqpCommandLease,
     ) -> Result<(), HqpCoordinatorRefusal> {
         self.request(|reply| HqpCoordinatorCommand::Validate {
+            lease: lease.clone(),
+            reply,
+        })
+        .await
+    }
+
+    /// Atomically perform the final lease check and fence this generation as executing.
+    /// The fence is internal ordering state, not evidence that a native write was attempted.
+    pub(crate) async fn begin_dispatch(
+        &self,
+        lease: &HqpCommandLease,
+    ) -> Result<(), HqpCoordinatorRefusal> {
+        self.request(|reply| HqpCoordinatorCommand::BeginDispatch {
             lease: lease.clone(),
             reply,
         })
@@ -3748,6 +3901,10 @@ mod tests {
             .await
             .expect("reservation admitted");
         publisher
+            .begin_dispatch(reservation.lease())
+            .await
+            .expect("final lease check fences the begun executor");
+        publisher
             .instance_removed("main", 7)
             .await
             .expect("removal waits for the actor's receipt completion");
@@ -3790,6 +3947,65 @@ mod tests {
             .expect("late duplicate preserves the attempted receipt audit");
         assert_eq!(duplicate.outcome, CommandOutcome::Indeterminate);
         assert_eq!(duplicate.write_attempt, WriteAttempt::Attempted);
+
+        shutdown.cancel();
+        actor_task.await.expect("actor joins");
+    }
+
+    #[tokio::test]
+    async fn manager_stop_cannot_terminalize_or_drop_an_executor_begun_operation() {
+        let (publisher, view, shutdown, actor_task) = coordinator_fixture().await;
+        let key = crate::producers::ProducerKey {
+            producer_id: "hqplayer:main".to_string(),
+            role: TargetRole::DspEngine,
+            zone_id: None,
+        };
+        let reservation = publisher
+            .reserve(validated_mode_command(
+                &view.snapshot(&key).expect("initial"),
+                "stop-during-executor",
+                "PCM",
+            ))
+            .await
+            .expect("reserve");
+        publisher
+            .begin_dispatch(reservation.lease())
+            .await
+            .expect("executor begun fence");
+
+        assert!(publisher.manager_stopped().await.is_err());
+        let pending = view.snapshot(&key).expect("in-flight snapshot retained");
+        let operation = pending
+            .document
+            .operations
+            .iter()
+            .find(|operation| operation.id == reservation.operation().id)
+            .expect("in-flight audit retained");
+        assert_eq!(operation.outcome, CommandOutcome::Pending);
+        assert_eq!(operation.write_attempt, WriteAttempt::NotAttempted);
+
+        publisher
+            .complete(
+                reservation.lease(),
+                HqpCommandCompletion::new(
+                    CommandOutcome::Indeterminate,
+                    WriteAttempt::Attempted,
+                    Timestamp::new("2026-07-31T00:00:01Z"),
+                    Some(RecoveryState::AwaitingReadback),
+                    None,
+                ),
+            )
+            .await
+            .expect("typed receipt survives stop race");
+        let retained = view.snapshot(&key).expect("last-known receipt audit");
+        assert_eq!(
+            retained.document.operations[0].outcome,
+            CommandOutcome::Indeterminate
+        );
+        assert_eq!(
+            retained.document.operations[0].write_attempt,
+            WriteAttempt::Attempted
+        );
 
         shutdown.cancel();
         actor_task.await.expect("actor joins");
@@ -4187,6 +4403,79 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn executor_begun_matching_observation_waits_for_typed_receipt_and_receipt_wins() {
+        let (publisher, view, shutdown, actor_task) = coordinator_fixture().await;
+        let key = crate::producers::ProducerKey {
+            producer_id: "hqplayer:main".to_string(),
+            role: TargetRole::DspEngine,
+            zone_id: None,
+        };
+        let reservation = publisher
+            .reserve(validated_mode_command(
+                &view.snapshot(&key).expect("initial"),
+                "executor-observation-barrier",
+                "PCM",
+            ))
+            .await
+            .expect("reserve");
+
+        publisher
+            .begin_dispatch(reservation.lease())
+            .await
+            .expect("final lease validation and executor-begun fence are atomic");
+        let mut matching = sample();
+        matching.mode_is_source = false;
+        matching.mode.selected = "PCM".to_string();
+        publisher
+            .observed(matching.clone())
+            .await
+            .expect("matching producer observation admitted behind fence");
+        let while_executing = view.snapshot(&key).expect("executing snapshot");
+        let operation = while_executing
+            .document
+            .operations
+            .iter()
+            .find(|operation| operation.id == reservation.operation().id)
+            .expect("operation retained");
+        assert_eq!(operation.outcome, CommandOutcome::Pending);
+        assert_eq!(operation.write_attempt, WriteAttempt::NotAttempted);
+
+        publisher
+            .complete(
+                reservation.lease(),
+                HqpCommandCompletion::new(
+                    CommandOutcome::Rejected,
+                    WriteAttempt::Attempted,
+                    Timestamp::new("2026-07-31T00:00:01Z"),
+                    Some(RecoveryState::NotRequired),
+                    None,
+                ),
+            )
+            .await
+            .expect("typed receipt clears fence and establishes operation truth");
+        publisher
+            .observed(matching)
+            .await
+            .expect("later matching observation cannot rewrite terminal receipt");
+        let terminal = view.snapshot(&key).expect("terminal snapshot");
+        let operation = terminal
+            .document
+            .operations
+            .iter()
+            .find(|operation| operation.id == reservation.operation().id)
+            .expect("terminal audit retained");
+        assert_eq!(operation.outcome, CommandOutcome::Rejected);
+        assert_eq!(operation.write_attempt, WriteAttempt::Attempted);
+        assert_eq!(operation.history.len(), 1);
+        assert_eq!(operation.history[0].from, CommandOutcome::Pending);
+        assert_eq!(operation.history[0].to, CommandOutcome::Rejected);
+
+        publisher.manager_stopped().await.expect("manager stops");
+        shutdown.cancel();
+        actor_task.await.expect("actor joins");
+    }
+
+    #[tokio::test]
     async fn terminal_ledger_and_correlation_tombstones_are_bounded_but_unresolved_are_retained() {
         let (publisher, view, shutdown, actor_task) = coordinator_fixture().await;
         let key = crate::producers::ProducerKey {
@@ -4248,6 +4537,93 @@ mod tests {
                 .expect("newest lookup")
                 .is_some(),
             "newest terminal correlation remains idempotent"
+        );
+
+        publisher.manager_stopped().await.expect("manager stops");
+        shutdown.cancel();
+        actor_task.await.expect("actor joins");
+    }
+
+    #[tokio::test]
+    async fn retired_instance_correlation_truth_is_globally_bounded_across_distinct_names() {
+        let (publisher, view, shutdown, actor_task) = coordinator_fixture().await;
+        publisher
+            .instance_removed("main", 7)
+            .await
+            .expect("fixture instance retires");
+
+        let mut oldest_request = None;
+        let mut newest_request = None;
+        for index in 0..=MAX_RETIRED_INSTANCES {
+            let instance_name = format!("retired-{index}");
+            let mut observation = sample();
+            observation.instance_name = instance_name.clone();
+            observation.instance_label = Some(instance_name.clone());
+            observation.execution_target.instance_name = instance_name.clone();
+            publisher
+                .observed(observation)
+                .await
+                .expect("distinct instance observation admits");
+
+            let key = crate::producers::ProducerKey {
+                producer_id: format!("hqplayer:{instance_name}"),
+                role: TargetRole::DspEngine,
+                zone_id: None,
+            };
+            let snapshot = view.snapshot(&key).expect("instance snapshot");
+            let request = crate::producers::hqplayer_command::HqpImmediateCommandRequest {
+                key,
+                expected: snapshot.document.position(),
+                control: ControlId::new(CONTROL_PIPELINE_MODE),
+                requested: ControlValue::choice(choice_id(CONTROL_PIPELINE_MODE, "PCM")),
+                lane: ApplyLane::Immediate,
+                correlation_id: format!("retired-correlation-{index}"),
+            };
+            if index == 0 {
+                oldest_request = Some(request.clone());
+            }
+            newest_request = Some(request.clone());
+            let reservation = publisher
+                .reserve(
+                    crate::producers::hqplayer_command::preflight(&snapshot, &request)
+                        .expect("retired request preflight"),
+                )
+                .await
+                .expect("retired request reserves");
+            publisher
+                .complete(
+                    reservation.lease(),
+                    HqpCommandCompletion::new(
+                        CommandOutcome::Applied,
+                        WriteAttempt::Confirmed,
+                        Timestamp::new(format!("2026-07-31T00:02:{:02}Z", index % 60)),
+                        Some(RecoveryState::NotRequired),
+                        None,
+                    ),
+                )
+                .await
+                .expect("retired request completes");
+            publisher
+                .instance_removed(&instance_name, 7)
+                .await
+                .expect("completed instance retires");
+        }
+
+        assert!(
+            publisher
+                .lookup_correlation(oldest_request.as_ref().expect("oldest request"))
+                .await
+                .expect("expired retired lookup is not an error")
+                .is_none(),
+            "the oldest distinct retired identity is evicted at the global bound"
+        );
+        assert!(
+            publisher
+                .lookup_correlation(newest_request.as_ref().expect("newest request"))
+                .await
+                .expect("newest retired lookup")
+                .is_some(),
+            "the newest retired identity keeps exact duplicate truth"
         );
 
         publisher.manager_stopped().await.expect("manager stops");

--- a/src/producers/hqplayer.rs
+++ b/src/producers/hqplayer.rs
@@ -50,8 +50,8 @@ const GROUP_PIPELINE: &str = "pipeline";
 ///
 /// This is intentionally a semantic, adapter-facing vocabulary rather than a wire vocabulary:
 /// callers carry names and decimal values, and [`crate::adapters::hqplayer::HqpAdapter`] resolves
-/// them against the daemon's current state before it writes. Issue #331 will add the checked
-/// dispatch path; this registry prevents its public command surface from inventing a second mapping.
+/// them against the daemon's current state before it writes. Issue #329 adds the checked internal
+/// dispatch path; #331's public consumers must reuse it instead of inventing a second mapping.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) enum HqpSemanticOperation {
     /// [`crate::adapters::hqplayer::HqpAdapter::play`].
@@ -86,8 +86,8 @@ pub(crate) struct HqpControlOperation {
 }
 
 // This is deliberately one registry, not a second set of string matches in every consumer. The
-// producer validates every dynamically mutable control against it before publication, and #331 can
-// use the same mapping after it has preflighted a client command.
+// producer validates every dynamically mutable control against it before publication, and #329's
+// command service uses the same mapping after it has preflighted a client command.
 const HQP_SEMANTIC_OPERATION_REGISTRY: [HqpControlOperation; 11] = [
     HqpControlOperation {
         control_id: CONTROL_TRANSPORT_PLAY,

--- a/src/producers/hqplayer.rs
+++ b/src/producers/hqplayer.rs
@@ -1229,6 +1229,10 @@ enum HqpCoordinatorCommand {
     RefuseNextPublication {
         reply: oneshot::Sender<Result<(), HqpCoordinatorRefusal>>,
     },
+    #[cfg(any(test, debug_assertions))]
+    RefuseNextRetirement {
+        reply: oneshot::Sender<Result<(), HqpCoordinatorRefusal>>,
+    },
 }
 
 struct HqpPublisherCoordinator {
@@ -1239,6 +1243,8 @@ struct HqpPublisherCoordinator {
     retired_instance_order: VecDeque<String>,
     #[cfg(test)]
     refused_publications: usize,
+    #[cfg(any(test, debug_assertions))]
+    refused_retirements: usize,
     stop_requested: bool,
 }
 
@@ -1352,6 +1358,14 @@ impl HqpPublisherCoordinator {
             self.instances.insert(instance_name, state);
             return Err(error);
         }
+        #[cfg(any(test, debug_assertions))]
+        if self.refused_retirements > 0 {
+            self.refused_retirements -= 1;
+            self.instances.insert(instance_name, state);
+            return Err(HqpCoordinatorRefusal::RetirementFailed(
+                "injected retirement refusal".to_string(),
+            ));
+        }
         if let Some(run) = self.run.as_ref() {
             let producer_id = format!("hqplayer:{instance_name}");
             let retirement = self
@@ -1390,6 +1404,7 @@ impl HqpPublisherCoordinator {
         at: Timestamp,
     ) -> Result<(), HqpCoordinatorRefusal> {
         let mut candidate_ledger = state.ledger.clone();
+        let mut expiration_frontier = HashSet::new();
         let mut changed = false;
         for operation in &mut candidate_ledger {
             if operation.outcome == CommandOutcome::Pending
@@ -1414,6 +1429,7 @@ impl HqpPublisherCoordinator {
                     }),
                 )
                 .map_err(|_| HqpCoordinatorRefusal::IllegalTransition)?;
+            expiration_frontier.insert(operation.id.clone());
             changed = true;
         }
         if !changed {
@@ -1422,11 +1438,15 @@ impl HqpPublisherCoordinator {
 
         let mut correlation_tombstones = state.correlation_tombstones.clone();
         let mut correlation_tombstone_order = state.correlation_tombstone_order.clone();
-        prune_terminal_history(
+        if expiration_frontier.len() > MAX_TERMINAL_OPERATIONS {
+            return Err(HqpCoordinatorRefusal::UnresolvedRetentionFull);
+        }
+        prune_terminal_history_preserving(
             &mut candidate_ledger,
             &state.correlations,
             &mut correlation_tombstones,
             &mut correlation_tombstone_order,
+            &expiration_frontier,
         );
         let mut candidate_document = state
             .tracker
@@ -1545,6 +1565,11 @@ impl HqpPublisherCoordinator {
                 #[cfg(test)]
                 HqpCoordinatorCommand::RefuseNextPublication { reply } => {
                     self.refused_publications += 1;
+                    let _ = reply.send(Ok(()));
+                }
+                #[cfg(any(test, debug_assertions))]
+                HqpCoordinatorCommand::RefuseNextRetirement { reply } => {
+                    self.refused_retirements += 1;
                     let _ = reply.send(Ok(()));
                 }
                     }
@@ -1947,8 +1972,24 @@ impl HqpPublisherCoordinator {
             self.instances.insert(instance_name, state);
             return Ok(());
         }
-        self.retire_admitted_instance(instance_name, state, epoch)
+        match self
+            .retire_admitted_instance(instance_name.clone(), state, epoch)
             .await
+        {
+            Ok(()) => Ok(()),
+            Err(error) => {
+                // `retire_admitted_instance` records retirement intent before any fallible
+                // publication/retire operation and reinserts the exact state on failure. From
+                // here the coordinator owns durable retry; reporting an error would make the
+                // manager restore a worker which this accepted retirement will later hide.
+                tracing::warn!(
+                    ?error,
+                    instance = %instance_name,
+                    "HQPlayer retirement committed for coordinator-owned retry"
+                );
+                Ok(())
+            }
+        }
     }
 
     async fn reserve(
@@ -2631,6 +2672,25 @@ fn prune_terminal_history(
     tombstones: &mut HashMap<String, HqpCommandFingerprint>,
     tombstone_order: &mut VecDeque<String>,
 ) {
+    prune_terminal_history_preserving(
+        ledger,
+        correlations,
+        tombstones,
+        tombstone_order,
+        &HashSet::new(),
+    );
+}
+
+/// Bound terminal history while preserving records created by the current serialization frontier.
+/// Retirement uses this to guarantee that newly explicit `Expired` truth is admitted at least
+/// once; older terminal audit is the first candidate for compaction instead.
+fn prune_terminal_history_preserving(
+    ledger: &mut Vec<OperationRecord>,
+    correlations: &HashMap<String, HqpCorrelationReservation>,
+    tombstones: &mut HashMap<String, HqpCommandFingerprint>,
+    tombstone_order: &mut VecDeque<String>,
+    protected: &HashSet<OperationId>,
+) {
     let terminal_count = ledger
         .iter()
         .filter(|operation| !operation_is_unresolved(operation))
@@ -2640,7 +2700,10 @@ fn prune_terminal_history(
         return;
     }
     ledger.retain(|operation| {
-        if terminal_to_drop > 0 && !operation_is_unresolved(operation) {
+        if terminal_to_drop > 0
+            && !operation_is_unresolved(operation)
+            && !protected.contains(&operation.id)
+        {
             terminal_to_drop -= 1;
             if let Some(reservation) = correlations.get(&operation.correlation_id) {
                 retain_correlation_tombstone(
@@ -2655,6 +2718,10 @@ fn prune_terminal_history(
             true
         }
     });
+    debug_assert_eq!(
+        terminal_to_drop, 0,
+        "the bounded unresolved cap must leave enough unprotected terminal history to compact"
+    );
 }
 
 fn retain_correlation_tombstone(
@@ -2720,6 +2787,8 @@ impl HqpAdaptivePublisher {
                 retired_instance_order: VecDeque::new(),
                 #[cfg(test)]
                 refused_publications: 0,
+                #[cfg(any(test, debug_assertions))]
+                refused_retirements: 0,
                 stop_requested: false,
             }
             .run(receiver),
@@ -2791,6 +2860,15 @@ impl HqpAdaptivePublisher {
         self.request(|reply| HqpCoordinatorCommand::RefuseNextPublication { reply })
             .await
             .expect("test coordinator accepts publication fault");
+    }
+
+    /// Debug-only conformance seam for proving committed retirement retry semantics.
+    #[cfg(debug_assertions)]
+    #[doc(hidden)]
+    pub async fn debug_refuse_next_retirement(&self) -> anyhow::Result<()> {
+        self.request(|reply| HqpCoordinatorCommand::RefuseNextRetirement { reply })
+            .await
+            .map_err(|error| anyhow!("HQPlayer retirement fault injection failed: {error:?}"))
     }
 
     pub(crate) async fn complete(
@@ -4173,10 +4251,13 @@ mod tests {
         for _ in 0..9 {
             publisher.refuse_next_publication().await;
         }
-        assert!(publisher.instance_removed("main", 7).await.is_err());
+        assert!(
+            publisher.instance_removed("main", 7).await.is_ok(),
+            "accepted retirement owns publication retry instead of inviting manager rollback"
+        );
         let still_visible = view
             .snapshot(&key)
-            .expect("failed expiration publication cannot retire the producer");
+            .expect("committed expiration remains visible until its publication succeeds");
         assert_eq!(
             still_visible.document.operations[0].outcome,
             CommandOutcome::Indeterminate
@@ -5035,6 +5116,97 @@ mod tests {
             .expect("retirement expiration transition");
         assert_eq!(expiration.from, CommandOutcome::Indeterminate);
         assert_eq!(expiration.to, CommandOutcome::Expired);
+
+        publisher.manager_stopped().await.expect("manager stops");
+        shutdown.cancel();
+        actor_task.await.expect("actor joins");
+    }
+
+    #[tokio::test]
+    async fn retirement_pruning_preserves_the_expiration_frontier_over_newer_terminal_history() {
+        let (publisher, view, shutdown, actor_task) = coordinator_fixture().await;
+        let key = crate::producers::ProducerKey {
+            producer_id: "hqplayer:main".to_string(),
+            role: TargetRole::DspEngine,
+            zone_id: None,
+        };
+        let initial = view.snapshot(&key).expect("initial snapshot");
+        let ambiguous_request = crate::producers::hqplayer_command::HqpImmediateCommandRequest {
+            key: key.clone(),
+            expected: initial.document.position(),
+            control: ControlId::new(CONTROL_PIPELINE_MODE),
+            requested: ControlValue::choice(choice_id(CONTROL_PIPELINE_MODE, "PCM")),
+            lane: ApplyLane::Immediate,
+            correlation_id: "old-ambiguous-before-full-terminal-history".to_string(),
+        };
+        let ambiguous = publisher
+            .reserve(
+                crate::producers::hqplayer_command::preflight(&initial, &ambiguous_request)
+                    .expect("ambiguous request preflight"),
+            )
+            .await
+            .expect("ambiguous request reserves");
+        publisher
+            .complete(
+                ambiguous.lease(),
+                HqpCommandCompletion::new(
+                    CommandOutcome::Indeterminate,
+                    WriteAttempt::Attempted,
+                    Timestamp::new("2026-07-31T00:03:00Z"),
+                    Some(RecoveryState::AwaitingReadback),
+                    None,
+                ),
+            )
+            .await
+            .expect("ambiguous receipt admits");
+
+        for index in 0..MAX_TERMINAL_OPERATIONS {
+            let reservation = publisher
+                .reserve(validated_mode_command(
+                    &view.snapshot(&key).expect("terminal iteration snapshot"),
+                    &format!("newer-terminal-{index}"),
+                    "PCM",
+                ))
+                .await
+                .expect("newer terminal request reserves");
+            publisher
+                .complete(
+                    reservation.lease(),
+                    HqpCommandCompletion::new(
+                        CommandOutcome::Applied,
+                        WriteAttempt::Confirmed,
+                        Timestamp::new(format!("2026-07-31T00:04:{index:02}Z")),
+                        Some(RecoveryState::NotRequired),
+                        None,
+                    ),
+                )
+                .await
+                .expect("newer terminal request completes");
+        }
+
+        publisher
+            .instance_removed("main", 7)
+            .await
+            .expect("retirement commits");
+        assert!(view.snapshot(&key).is_none(), "producer retired");
+        let retained = publisher
+            .lookup_correlation(&ambiguous_request)
+            .await
+            .expect("retired correlation lookup")
+            .expect("freshly expired frontier survives retirement pruning");
+        assert_eq!(retained.operation().outcome, CommandOutcome::Expired);
+        assert_eq!(retained.operation().write_attempt, WriteAttempt::Attempted);
+        assert_eq!(
+            retained.operation().recovery,
+            Some(RecoveryState::ReplanRequired)
+        );
+        let reason = retained
+            .operation()
+            .reason
+            .as_ref()
+            .expect("expired reason");
+        assert_eq!(reason.code, ReasonCode::Expired);
+        assert_eq!(reason.scope, ReasonScope::Producer);
 
         publisher.manager_stopped().await.expect("manager stops");
         shutdown.cancel();

--- a/src/producers/hqplayer.rs
+++ b/src/producers/hqplayer.rs
@@ -4,25 +4,34 @@
 //! the projector accepts exactly one coherent value and cannot reach a socket, cache,
 //! clock, or adapter handle.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 use std::time::SystemTime;
 
 use anyhow::{anyhow, Result};
-use tokio::sync::Mutex;
+use tokio::sync::{mpsc, oneshot};
 
 use crate::adapters::hqplayer::{
-    HqpNativeObservation, HqpNativeObservationSink, HqpNativeSelection, HqpNativeTransportState,
+    HqpNativeExecutionTarget, HqpNativeObservation, HqpNativeObservationSink, HqpNativeSelection,
+    HqpNativeTransportState,
 };
 use crate::adaptive::{
     ApplyEffect, ApplyLane, ApplySemantics, Availability, AvailabilityState, Choice, ChoiceSet,
-    Control, ControlGroup, ControlId, ControlKind, ControlValue, Disruption, DocumentRevisions,
-    Extensions, Freshness, LaneHealth, LaneState, LaneValue, NumericRange, ProducerDocument,
-    ProducerEpoch, ProducerIdentity, ProducerTarget, Provenance, Reason, ReasonCode, ReasonScope,
-    RiskClass, TargetRole, Timestamp, TransportLane, ValueLane, Verification,
+    CommandOutcome, Control, ControlGroup, ControlId, ControlKind, ControlValue, Disruption,
+    DocumentRevisions, Extensions, Freshness, LaneHealth, LaneState, LaneValue, NumericRange,
+    OperationId, OperationRecord, OperationRequest, ProducerDocument, ProducerEpoch,
+    ProducerIdentity, ProducerTarget, Provenance, Reason, ReasonCode, ReasonScope, RecoveryState,
+    RiskClass, TargetRole, Timestamp, TransportLane, ValueLane, Verification, WriteAttempt,
     CONSUMER_SCHEMA_VERSION,
 };
-use crate::producers::{AdapterRun, AdaptiveHandle, Admission, RetirementOutcome};
+use crate::producers::hqplayer_command::{
+    fingerprint, preflight, HqpCommandFingerprint, HqpImmediateCommandRequest, HqpPreflightRefusal,
+    HqpValidatedCommand,
+};
+use crate::producers::{
+    AdapterRun, AdapterRunId, AdaptiveHandle, Admission, ProducerKey, ProducerPresence,
+    ProducerSnapshot, RetirementOutcome,
+};
 
 const CONTROL_TRANSPORT_STATE: &str = "hqplayer.transport.state";
 const CONTROL_TRANSPORT_PLAY: &str = "hqplayer.transport.play";
@@ -184,7 +193,7 @@ pub(super) enum RevisionError {
     CounterExhausted { plane: &'static str },
 }
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub(super) struct RevisionTracker {
     epoch: Option<u64>,
     control_plane: u64,
@@ -907,7 +916,6 @@ fn canonical_state(document: &ProducerDocument) -> ProducerDocument {
     canonical.constraints.clear();
     canonical.draft_policy = None;
     canonical.change_sets.clear();
-    canonical.operations.clear();
     for control in &mut canonical.controls {
         control.kind = ControlKind::Text;
         control.label_key = None;
@@ -934,124 +942,1683 @@ fn canonical_state(document: &ProducerDocument) -> ProducerDocument {
 /// every adaptive concern: projection, per-instance revision history, the shared HQPlayer adapter
 /// run, last-known transitions and definitive retirement.
 pub struct HqpAdaptivePublisher {
+    commands: mpsc::Sender<HqpCoordinatorCommand>,
+}
+
+/// Terminal operation audit retained per HQPlayer instance after all unresolved records.
+///
+/// Correlation tombstones are retained for exactly the same records, so memory use is bounded
+/// without silently discarding an operation which may still converge after reconnect.
+const MAX_TERMINAL_OPERATIONS: usize = 32;
+
+/// Terminal operation records are compacted from the public document after this many entries,
+/// but their correlation fingerprints remain as a bounded no-replay fence for longer. A client
+/// must choose a fresh correlation once its original audit record no longer fits in the document;
+/// silently treating an old gesture as new would repeat native I/O.
+const MAX_CORRELATION_TOMBSTONES: usize = 256;
+
+/// An unresolved outcome carries real uncertainty and therefore must never be compacted away.
+/// The producer applies backpressure instead of allowing a disconnected/indeterminate stream to
+/// grow memory forever. One pipeline command may still be Pending in addition to these records.
+const MAX_UNRESOLVED_OPERATIONS: usize = 32;
+
+/// Correlations are opaque client input, but cannot be allowed to grow retained coordinator state
+/// without bound. This mirrors the command boundary and remains enforced here for internal callers.
+const MAX_CORRELATION_ID_BYTES: usize = 256;
+
+/// A terminal publication gets one coordinator-owned retry. Generated terminal documents are
+/// deterministic, so retrying cannot duplicate native I/O or allocate another operation.
+const TERMINAL_PUBLICATION_RETRIES: usize = 1;
+
+/// One conservative serialization domain for the first immediate HQPlayer slice.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HqpConflictSet {
+    Pipeline,
+}
+
+/// Opaque proof that one Pending operation was admitted by the active producer run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct HqpCommandLease {
+    producer_id: String,
+    producer_epoch: ProducerEpoch,
+    run_id: Option<AdapterRunId>,
+    conflict_set: HqpConflictSet,
+    generation: u64,
+    correlation_id: String,
+    operation_id: OperationId,
+    execution_target: Option<HqpNativeExecutionTarget>,
+}
+
+impl HqpCommandLease {
+    /// Test-only opaque token for command-actor fakes. A real coordinator always rejects it.
+    #[cfg(test)]
+    pub(crate) fn for_test(
+        producer_id: impl Into<String>,
+        producer_epoch: u64,
+        generation: u64,
+        correlation_id: impl Into<String>,
+    ) -> Self {
+        let producer_id = producer_id.into();
+        let correlation_id = correlation_id.into();
+        Self {
+            operation_id: OperationId::new(format!("{producer_id}:operation:{generation}")),
+            producer_id,
+            producer_epoch: ProducerEpoch(producer_epoch),
+            run_id: None,
+            conflict_set: HqpConflictSet::Pipeline,
+            generation,
+            correlation_id,
+            execution_target: None,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn for_test_with_execution_target(
+        producer_id: impl Into<String>,
+        producer_epoch: u64,
+        generation: u64,
+        correlation_id: impl Into<String>,
+        execution_target: HqpNativeExecutionTarget,
+    ) -> Self {
+        let mut lease = Self::for_test(producer_id, producer_epoch, generation, correlation_id);
+        lease.execution_target = Some(execution_target);
+        lease
+    }
+
+    /// Exact coherent native identity captured by the admitted producer observation.
+    pub(crate) fn execution_target(&self) -> Option<&HqpNativeExecutionTarget> {
+        self.execution_target.as_ref()
+    }
+}
+
+/// Whether a reservation allocated a new operation or found the caller's exact retry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HqpReservationDisposition {
+    New,
+    Duplicate,
+}
+
+/// An admitted Pending operation and the opaque token needed to dispatch it.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct HqpCommandReservation {
+    lease: HqpCommandLease,
+    operation: OperationRecord,
+    disposition: HqpReservationDisposition,
+}
+
+impl HqpCommandReservation {
+    #[cfg(test)]
+    pub(crate) fn for_test(
+        lease: HqpCommandLease,
+        operation: OperationRecord,
+        is_duplicate: bool,
+    ) -> Self {
+        Self {
+            lease,
+            operation,
+            disposition: if is_duplicate {
+                HqpReservationDisposition::Duplicate
+            } else {
+                HqpReservationDisposition::New
+            },
+        }
+    }
+
+    pub(crate) fn lease(&self) -> &HqpCommandLease {
+        &self.lease
+    }
+
+    pub(crate) fn execution_target(&self) -> Option<&HqpNativeExecutionTarget> {
+        self.lease.execution_target()
+    }
+
+    pub(crate) fn operation(&self) -> &OperationRecord {
+        &self.operation
+    }
+
+    pub(crate) fn is_duplicate(&self) -> bool {
+        self.disposition == HqpReservationDisposition::Duplicate
+    }
+}
+
+/// Typed evidence supplied by the command actor after native execution.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct HqpCommandCompletion {
+    outcome: CommandOutcome,
+    write_attempt: WriteAttempt,
+    at: Timestamp,
+    recovery: Option<RecoveryState>,
+    reason: Option<Reason>,
+}
+
+impl HqpCommandCompletion {
+    pub(crate) fn new(
+        outcome: CommandOutcome,
+        write_attempt: WriteAttempt,
+        at: Timestamp,
+        recovery: Option<RecoveryState>,
+        reason: Option<Reason>,
+    ) -> Self {
+        Self {
+            outcome,
+            write_attempt,
+            at,
+            recovery,
+            reason,
+        }
+    }
+}
+
+/// Typed coordinator refusals. They never get classified by parsing an error string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum HqpCoordinatorRefusal {
+    CoordinatorClosed,
+    LifecycleNotRunning,
+    ProducerUnknown,
+    Preflight(HqpPreflightRefusal),
+    CorrelationConflict,
+    InvalidCorrelation,
+    ConflictBusy,
+    UnresolvedRetentionFull,
+    StaleLease,
+    LeaseStillCurrent,
+    IllegalTransition,
+    RevisionFailed(String),
+    PublicationFailed(String),
+    RetirementFailed(String),
+}
+
+#[derive(Clone)]
+struct HqpCorrelationReservation {
+    fingerprint: HqpCommandFingerprint,
+    lease: HqpCommandLease,
+}
+
+#[derive(Clone, Default)]
+struct HqpInstanceCoordinator {
+    tracker: RevisionTracker,
+    ledger: Vec<OperationRecord>,
+    next_generation: u64,
+    correlations: HashMap<String, HqpCorrelationReservation>,
+    correlation_tombstones: HashMap<String, HqpCommandFingerprint>,
+    correlation_tombstone_order: VecDeque<String>,
+    active_pipeline: Option<u64>,
+    execution_target: Option<HqpNativeExecutionTarget>,
+    deferred_commit: Option<HqpDeferredCommit>,
+    retirement_requested: Option<ProducerEpoch>,
+}
+
+#[derive(Clone)]
+struct HqpDeferredCommit {
+    tracker: RevisionTracker,
+    ledger: Vec<OperationRecord>,
+    active_pipeline: Option<u64>,
+    correlation_tombstones: HashMap<String, HqpCommandFingerprint>,
+    correlation_tombstone_order: VecDeque<String>,
+}
+
+/// Retired producers are no longer visible to adaptive consumers, but retain exact terminal
+/// correlation truth long enough for an in-flight command actor (or a duplicate gesture) to
+/// learn the terminal outcome rather than accidentally treating removal as permission to replay.
+#[derive(Clone)]
+struct HqpRetiredInstance {
+    producer_epoch: ProducerEpoch,
+    ledger: Vec<OperationRecord>,
+    correlations: HashMap<String, HqpCorrelationReservation>,
+}
+
+enum HqpCoordinatorCommand {
+    ManagerStarted {
+        reply: oneshot::Sender<Result<(), HqpCoordinatorRefusal>>,
+    },
+    Observed {
+        observation: Box<HqpNativeObservation>,
+        reply: oneshot::Sender<Result<(), HqpCoordinatorRefusal>>,
+    },
+    TransientFailure {
+        instance_name: String,
+        observed_at: SystemTime,
+        reply: oneshot::Sender<Result<(), HqpCoordinatorRefusal>>,
+    },
+    InstanceRemoved {
+        instance_name: String,
+        producer_epoch: u64,
+        reply: oneshot::Sender<Result<(), HqpCoordinatorRefusal>>,
+    },
+    ManagerStopped {
+        reply: oneshot::Sender<Result<(), HqpCoordinatorRefusal>>,
+    },
+    Reserve {
+        command: HqpValidatedCommand,
+        reply: oneshot::Sender<Result<HqpCommandReservation, HqpCoordinatorRefusal>>,
+    },
+    LookupCorrelation {
+        request: HqpImmediateCommandRequest,
+        reply: oneshot::Sender<Result<Option<HqpCommandReservation>, HqpCoordinatorRefusal>>,
+    },
+    Validate {
+        lease: HqpCommandLease,
+        reply: oneshot::Sender<Result<(), HqpCoordinatorRefusal>>,
+    },
+    Complete {
+        lease: HqpCommandLease,
+        completion: HqpCommandCompletion,
+        reply: oneshot::Sender<Result<OperationRecord, HqpCoordinatorRefusal>>,
+    },
+    SupersedeStaleBeforeDispatch {
+        lease: HqpCommandLease,
+        at: Timestamp,
+        reply: oneshot::Sender<Result<OperationRecord, HqpCoordinatorRefusal>>,
+    },
+    #[cfg(test)]
+    RefuseNextPublication {
+        reply: oneshot::Sender<Result<(), HqpCoordinatorRefusal>>,
+    },
+}
+
+struct HqpPublisherCoordinator {
     handle: AdaptiveHandle,
-    run: Mutex<Option<Arc<AdapterRun>>>,
-    trackers: Mutex<HashMap<String, RevisionTracker>>,
+    run: Option<AdapterRun>,
+    instances: HashMap<String, HqpInstanceCoordinator>,
+    retired_instances: HashMap<String, HqpRetiredInstance>,
+    #[cfg(test)]
+    refused_publications: usize,
+    stop_requested: bool,
+}
+
+impl HqpPublisherCoordinator {
+    fn has_deferred_commits(&self) -> bool {
+        self.instances
+            .values()
+            .any(|state| state.deferred_commit.is_some())
+    }
+
+    fn has_requested_retirements(&self) -> bool {
+        self.instances.values().any(|state| {
+            state.retirement_requested.is_some()
+                && !state
+                    .ledger
+                    .iter()
+                    .any(|operation| operation.outcome == CommandOutcome::Pending)
+        })
+    }
+
+    async fn retry_deferred_commits(&mut self) {
+        let names = self.instances.keys().cloned().collect::<Vec<_>>();
+        for name in names {
+            let Some(mut state) = self.instances.remove(&name) else {
+                continue;
+            };
+            let admitted = if let Some(commit) = state.deferred_commit.clone() {
+                self.publish_deferred(&mut state, commit).await.is_ok()
+            } else {
+                true
+            };
+            if !admitted {
+                // Retained for the next bounded timer tick. The exact candidate is immutable, so
+                // retries cannot allocate a new operation or repeat native I/O.
+                self.instances.insert(name, state);
+                continue;
+            }
+            if let Some(epoch) = state.retirement_requested {
+                if !has_pending_operations(&state) {
+                    // The command actor may have been between native receipt and coordinator
+                    // completion when removal arrived. Retire only after that receipt's terminal
+                    // publication is admitted, never by guessing from a Pending record.
+                    let _ = self.retire_admitted_instance(name, state, epoch).await;
+                    continue;
+                }
+            }
+            if self.stop_requested {
+                // A deferred completion commit must become admitted before the
+                // stop transition can build on its revision. Chain the stop transition now rather
+                // than dropping the run with a freshly admitted Pending operation.
+                let _ = self
+                    .terminalize_pending_without_dispatch(
+                        &mut state,
+                        contract_timestamp(SystemTime::now()),
+                        "HQPlayer manager stopped before native execution",
+                    )
+                    .await;
+            }
+            self.instances.insert(name, state);
+        }
+        if self.stop_requested && !self.has_deferred_commits() {
+            self.run.take();
+        }
+    }
+
+    async fn retire_admitted_instance(
+        &mut self,
+        instance_name: String,
+        state: HqpInstanceCoordinator,
+        producer_epoch: ProducerEpoch,
+    ) -> Result<(), HqpCoordinatorRefusal> {
+        debug_assert!(!has_pending_operations(&state));
+        if let Some(run) = self.run.as_ref() {
+            let producer_id = format!("hqplayer:{instance_name}");
+            let retirement = self
+                .handle
+                .retire(run, &producer_id, producer_epoch)
+                .await
+                .map_err(|error| HqpCoordinatorRefusal::RetirementFailed(error.to_string()));
+            match retirement {
+                Ok(RetirementOutcome::Retired { .. } | RetirementOutcome::Committed) => {}
+                Ok(outcome) => {
+                    self.instances.insert(instance_name, state);
+                    return Err(HqpCoordinatorRefusal::RetirementFailed(format!(
+                        "{outcome:?}"
+                    )));
+                }
+                Err(error) => {
+                    self.instances.insert(instance_name, state);
+                    return Err(error);
+                }
+            }
+        }
+        self.retired_instances.insert(
+            instance_name,
+            HqpRetiredInstance {
+                producer_epoch,
+                ledger: state.ledger,
+                correlations: state.correlations,
+            },
+        );
+        Ok(())
+    }
+
+    async fn publish_deferred(
+        &mut self,
+        state: &mut HqpInstanceCoordinator,
+        commit: HqpDeferredCommit,
+    ) -> Result<(), HqpCoordinatorRefusal> {
+        let document = commit
+            .tracker
+            .last_document
+            .clone()
+            .ok_or(HqpCoordinatorRefusal::ProducerUnknown)?;
+        match self.publish_terminal(document).await {
+            Ok(()) => {
+                state.tracker = commit.tracker;
+                state.ledger = commit.ledger;
+                state.active_pipeline = commit.active_pipeline;
+                state.correlation_tombstones = commit.correlation_tombstones;
+                state.correlation_tombstone_order = commit.correlation_tombstone_order;
+                state.deferred_commit = None;
+                retain_live_correlations(state);
+                Ok(())
+            }
+            Err(error) => {
+                state.deferred_commit = Some(commit);
+                Err(error)
+            }
+        }
+    }
+
+    async fn run(mut self, mut commands: mpsc::Receiver<HqpCoordinatorCommand>) {
+        let mut retry = tokio::time::interval(std::time::Duration::from_millis(100));
+        retry.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            tokio::select! {
+                maybe_command = commands.recv() => {
+                    let Some(command) = maybe_command else { break };
+                    match command {
+                HqpCoordinatorCommand::ManagerStarted { reply } => {
+                    let _ = reply.send(self.manager_started());
+                }
+                HqpCoordinatorCommand::Observed { observation, reply } => {
+                    let result = self.observed(*observation).await;
+                    let _ = reply.send(result);
+                }
+                HqpCoordinatorCommand::TransientFailure {
+                    instance_name,
+                    observed_at,
+                    reply,
+                } => {
+                    let result = self.transient_failure(instance_name, observed_at).await;
+                    let _ = reply.send(result);
+                }
+                HqpCoordinatorCommand::InstanceRemoved {
+                    instance_name,
+                    producer_epoch,
+                    reply,
+                } => {
+                    let result = self.instance_removed(instance_name, producer_epoch).await;
+                    let _ = reply.send(result);
+                }
+                HqpCoordinatorCommand::ManagerStopped { reply } => {
+                    let result = self.manager_stopped().await;
+                    let _ = reply.send(result);
+                }
+                HqpCoordinatorCommand::Reserve { command, reply } => {
+                    let result = self.reserve(command).await;
+                    let _ = reply.send(result);
+                }
+                HqpCoordinatorCommand::LookupCorrelation { request, reply } => {
+                    let _ = reply.send(self.lookup_correlation(&request));
+                }
+                HqpCoordinatorCommand::Validate { lease, reply } => {
+                    let _ = reply.send(self.validate(&lease));
+                }
+                HqpCoordinatorCommand::Complete {
+                    lease,
+                    completion,
+                    reply,
+                } => {
+                    let result = self.complete(&lease, completion).await;
+                    let _ = reply.send(result);
+                }
+                HqpCoordinatorCommand::SupersedeStaleBeforeDispatch { lease, at, reply } => {
+                    let result = self.supersede_stale_before_dispatch(&lease, at).await;
+                    let _ = reply.send(result);
+                }
+                #[cfg(test)]
+                HqpCoordinatorCommand::RefuseNextPublication { reply } => {
+                    self.refused_publications += 1;
+                    let _ = reply.send(Ok(()));
+                }
+                    }
+                }
+                _ = retry.tick(), if self.has_deferred_commits() || self.has_requested_retirements() => {
+                    self.retry_deferred_commits().await;
+                }
+            }
+        }
+        // Dropping the sole, non-clone run lease synchronously ends publisher liveness.
+        self.run.take();
+    }
+
+    fn manager_started(&mut self) -> Result<(), HqpCoordinatorRefusal> {
+        if self.run.is_none() {
+            self.run = Some(self.handle.begin_run("hqplayer"));
+            self.stop_requested = false;
+        }
+        Ok(())
+    }
+
+    async fn manager_stopped(&mut self) -> Result<(), HqpCoordinatorRefusal> {
+        if self.run.is_none() {
+            return Ok(());
+        }
+        self.stop_requested = true;
+        let stopped_at = contract_timestamp(SystemTime::now());
+        let instance_names = self.instances.keys().cloned().collect::<Vec<_>>();
+        let mut first_failure = None;
+        for instance_name in instance_names {
+            let Some(mut state) = self.instances.remove(&instance_name) else {
+                continue;
+            };
+            let result = if let Some(commit) = state.deferred_commit.clone() {
+                match self.publish_deferred(&mut state, commit).await {
+                    Ok(()) => {
+                        self.terminalize_pending_without_dispatch(
+                            &mut state,
+                            stopped_at.clone(),
+                            "HQPlayer manager stopped before native execution",
+                        )
+                        .await
+                    }
+                    Err(error) => Err(error),
+                }
+            } else {
+                self.terminalize_pending_without_dispatch(
+                    &mut state,
+                    stopped_at.clone(),
+                    "HQPlayer manager stopped before native execution",
+                )
+                .await
+            };
+            self.instances.insert(instance_name, state);
+            if let Err(error) = result {
+                first_failure.get_or_insert(error);
+            }
+        }
+        if let Some(error) = first_failure {
+            return Err(error);
+        }
+        // The sole run is dropped only after every pending audit transition was admitted.
+        self.run.take();
+        Ok(())
+    }
+
+    async fn terminalize_pending_without_dispatch(
+        &mut self,
+        state: &mut HqpInstanceCoordinator,
+        at: Timestamp,
+        detail: &str,
+    ) -> Result<(), HqpCoordinatorRefusal> {
+        let mut candidate_ledger = state.ledger.clone();
+        let mut changed = false;
+        for operation in &mut candidate_ledger {
+            if operation.outcome != CommandOutcome::Pending {
+                continue;
+            }
+            operation.write_attempt = WriteAttempt::NotAttempted;
+            operation.recovery = Some(RecoveryState::ReplanRequired);
+            operation
+                .transition(
+                    CommandOutcome::Superseded,
+                    at.clone(),
+                    None,
+                    Some(Reason {
+                        code: ReasonCode::Superseded,
+                        scope: ReasonScope::Producer,
+                        display_text_key: None,
+                        detail: Some(detail.to_string()),
+                    }),
+                )
+                .map_err(|_| HqpCoordinatorRefusal::IllegalTransition)?;
+            changed = true;
+        }
+        if !changed {
+            return Ok(());
+        }
+
+        let mut correlation_tombstones = state.correlation_tombstones.clone();
+        let mut correlation_tombstone_order = state.correlation_tombstone_order.clone();
+        prune_terminal_history(
+            &mut candidate_ledger,
+            &state.correlations,
+            &mut correlation_tombstones,
+            &mut correlation_tombstone_order,
+        );
+        let mut candidate_document = state
+            .tracker
+            .last_document
+            .clone()
+            .ok_or(HqpCoordinatorRefusal::ProducerUnknown)?;
+        candidate_document.operations = candidate_ledger.clone();
+        let mut candidate_tracker = state.tracker.clone();
+        candidate_tracker
+            .materialize(candidate_document)
+            .map_err(|error| HqpCoordinatorRefusal::RevisionFailed(format!("{error:?}")))?;
+        self.publish_deferred(
+            state,
+            HqpDeferredCommit {
+                tracker: candidate_tracker,
+                ledger: candidate_ledger,
+                active_pipeline: None,
+                correlation_tombstones,
+                correlation_tombstone_order,
+            },
+        )
+        .await
+    }
+
+    fn lookup_correlation(
+        &self,
+        request: &HqpImmediateCommandRequest,
+    ) -> Result<Option<HqpCommandReservation>, HqpCoordinatorRefusal> {
+        validate_correlation(&request.correlation_id)?;
+        let instance_name = request
+            .key
+            .producer_id
+            .strip_prefix("hqplayer:")
+            .filter(|name| !name.is_empty())
+            .ok_or(HqpCoordinatorRefusal::ProducerUnknown)?;
+        let expected_fingerprint = fingerprint(request);
+        if let Some(state) = self.instances.get(instance_name) {
+            if let Some(existing) = state.correlations.get(&request.correlation_id) {
+                return reservation_for_correlation(existing, &state.ledger, &expected_fingerprint)
+                    .map(Some);
+            }
+            if state
+                .correlation_tombstones
+                .contains_key(&request.correlation_id)
+            {
+                return Err(HqpCoordinatorRefusal::CorrelationConflict);
+            }
+        }
+        if let Some(retired) = self.retired_instances.get(instance_name) {
+            if let Some(existing) = retired.correlations.get(&request.correlation_id) {
+                return reservation_for_correlation(
+                    existing,
+                    &retired.ledger,
+                    &expected_fingerprint,
+                )
+                .map(Some);
+            }
+        }
+        Ok(None)
+    }
+
+    async fn publish(&mut self, document: ProducerDocument) -> Result<(), HqpCoordinatorRefusal> {
+        #[cfg(test)]
+        if self.refused_publications > 0 {
+            self.refused_publications -= 1;
+            return Err(HqpCoordinatorRefusal::PublicationFailed(
+                "injected publication refusal".to_string(),
+            ));
+        }
+        let run = self
+            .run
+            .as_ref()
+            .ok_or(HqpCoordinatorRefusal::LifecycleNotRunning)?;
+        match self
+            .handle
+            .publish(run, document)
+            .await
+            .map_err(|error| HqpCoordinatorRefusal::PublicationFailed(error.to_string()))?
+        {
+            Admission::Admitted(_) => Ok(()),
+            Admission::Refused(refusal) => Err(HqpCoordinatorRefusal::PublicationFailed(format!(
+                "{refusal:?}"
+            ))),
+        }
+    }
+
+    async fn publish_terminal(
+        &mut self,
+        document: ProducerDocument,
+    ) -> Result<(), HqpCoordinatorRefusal> {
+        let mut last_failure = None;
+        for _ in 0..=TERMINAL_PUBLICATION_RETRIES {
+            match self.publish(document.clone()).await {
+                Ok(()) => return Ok(()),
+                Err(error @ HqpCoordinatorRefusal::PublicationFailed(_)) => {
+                    last_failure = Some(error);
+                }
+                Err(error) => return Err(error),
+            }
+        }
+        Err(last_failure.unwrap_or_else(|| {
+            HqpCoordinatorRefusal::PublicationFailed(
+                "terminal publication retry budget was empty".to_string(),
+            )
+        }))
+    }
+
+    async fn observed(
+        &mut self,
+        observation: HqpNativeObservation,
+    ) -> Result<(), HqpCoordinatorRefusal> {
+        if self.run.is_none() || self.stop_requested {
+            return Err(HqpCoordinatorRefusal::LifecycleNotRunning);
+        }
+        let instance_name = observation.instance_name.clone();
+        let execution_target = observation.execution_target.clone();
+        let mut projected = project_native(&observation).map_err(|error| {
+            HqpCoordinatorRefusal::RevisionFailed(format!("projection: {error:?}"))
+        })?;
+        if let Some(retired) = self.retired_instances.get(&instance_name) {
+            if observation.producer_epoch <= retired.producer_epoch.0 {
+                return Err(HqpCoordinatorRefusal::StaleLease);
+            }
+            // A strictly newer producer epoch is the only observation that can supersede an
+            // instance retirement. Its correlation namespace is fresh by producer identity.
+            self.retired_instances.remove(&instance_name);
+        }
+        let mut state = self.instances.remove(&instance_name).unwrap_or_default();
+        if let Some(commit) = state.deferred_commit.clone() {
+            // A deferred terminal commit is a serialization frontier. Materializing this poll
+            // from the prior tracker would otherwise offer the aggregator a different document
+            // at the terminal candidate's exact revision and strand the operation forever.
+            if let Err(error) = self.publish_deferred(&mut state, commit).await {
+                self.instances.insert(instance_name, state);
+                return Err(error);
+            }
+        }
+        let mut candidate_ledger = state.ledger.clone();
+        let converged = reconcile_operations(&projected, &mut candidate_ledger)?;
+        let mut correlation_tombstones = state.correlation_tombstones.clone();
+        let mut correlation_tombstone_order = state.correlation_tombstone_order.clone();
+        prune_terminal_history(
+            &mut candidate_ledger,
+            &state.correlations,
+            &mut correlation_tombstones,
+            &mut correlation_tombstone_order,
+        );
+        projected.operations = candidate_ledger.clone();
+        let mut candidate_tracker = state.tracker.clone();
+        let mut candidate = candidate_tracker
+            .materialize(projected)
+            .map_err(|error| HqpCoordinatorRefusal::RevisionFailed(format!("{error:?}")))?
+            .document;
+        if !converged.is_empty() {
+            let observed_revision = candidate.position();
+            for operation in &mut candidate_ledger {
+                if !converged.contains(&operation.id) {
+                    continue;
+                }
+                operation.observed = Some(observed_revision);
+                if let Some(transition) = operation.history.last_mut() {
+                    transition.observed = Some(observed_revision);
+                }
+            }
+            // Adding the citable revision does not create a second state transition: rematerialize
+            // from the admitted base so the observation and operation share one atomic position.
+            candidate.operations = candidate_ledger.clone();
+            candidate_tracker = state.tracker.clone();
+            candidate = candidate_tracker
+                .materialize(candidate)
+                .map_err(|error| HqpCoordinatorRefusal::RevisionFailed(format!("{error:?}")))?
+                .document;
+        }
+        let result = self.publish(candidate).await;
+        if result.is_ok() {
+            state.tracker = candidate_tracker;
+            state.ledger = candidate_ledger;
+            state.correlation_tombstones = correlation_tombstones;
+            state.correlation_tombstone_order = correlation_tombstone_order;
+            state.execution_target = Some(execution_target);
+            if state.active_pipeline.is_some_and(|generation| {
+                !state.ledger.iter().any(|operation| {
+                    operation.generation == Some(generation)
+                        && operation.outcome == CommandOutcome::Pending
+                })
+            }) {
+                state.active_pipeline = None;
+            }
+            retain_live_correlations(&mut state);
+        }
+        self.instances.insert(instance_name, state);
+        result
+    }
+
+    async fn transient_failure(
+        &mut self,
+        instance_name: String,
+        observed_at: SystemTime,
+    ) -> Result<(), HqpCoordinatorRefusal> {
+        if self.run.is_none() || self.stop_requested {
+            return Err(HqpCoordinatorRefusal::LifecycleNotRunning);
+        }
+        let mut state = self.instances.remove(&instance_name).unwrap_or_default();
+        if let Some(commit) = state.deferred_commit.clone() {
+            if let Err(error) = self.publish_deferred(&mut state, commit).await {
+                self.instances.insert(instance_name, state);
+                return Err(error);
+            }
+        }
+        let mut candidate_tracker = state.tracker.clone();
+        let candidate = candidate_tracker
+            .mark_transient_failure(contract_timestamp(observed_at))
+            .map_err(|error| HqpCoordinatorRefusal::RevisionFailed(format!("{error:?}")))?
+            .map(|outcome| outcome.document);
+        let result = if let Some(mut document) = candidate {
+            document.operations = state.ledger.clone();
+            // Re-materialize after overlaying the ledger. Ordinarily this is content-identical,
+            // but it keeps the invariant local if a future projector retains fewer records.
+            candidate_tracker = state.tracker.clone();
+            let candidate = candidate_tracker
+                .materialize(document)
+                .map_err(|error| HqpCoordinatorRefusal::RevisionFailed(format!("{error:?}")))?
+                .document;
+            let result = self.publish(candidate).await;
+            if result.is_ok() {
+                state.tracker = candidate_tracker;
+            }
+            result
+        } else {
+            Ok(())
+        };
+        self.instances.insert(instance_name, state);
+        result
+    }
+
+    async fn instance_removed(
+        &mut self,
+        instance_name: String,
+        producer_epoch: u64,
+    ) -> Result<(), HqpCoordinatorRefusal> {
+        let Some(mut state) = self.instances.remove(&instance_name) else {
+            return Ok(());
+        };
+        if let Some(commit) = state.deferred_commit.clone() {
+            if let Err(error) = self.publish_deferred(&mut state, commit).await {
+                self.instances.insert(instance_name, state);
+                return Err(error);
+            }
+        }
+        let epoch = ProducerEpoch(producer_epoch);
+        if has_pending_operations(&state) {
+            // `execute_reserved_native_setting` serializes removal against native I/O, but its
+            // typed receipt reaches this actor only after that method returns. Therefore removal
+            // may beat `complete` while Pending actually has write evidence in flight. Keep the
+            // coordinator and correlation alive, block new work, and retire only after the actor
+            // has admitted the receipt's terminal truth.
+            state.retirement_requested = Some(epoch);
+            self.instances.insert(instance_name, state);
+            return Ok(());
+        }
+        self.retire_admitted_instance(instance_name, state, epoch)
+            .await
+    }
+
+    async fn reserve(
+        &mut self,
+        command: HqpValidatedCommand,
+    ) -> Result<HqpCommandReservation, HqpCoordinatorRefusal> {
+        validate_correlation(&command.request.correlation_id)?;
+        if self.stop_requested {
+            return Err(HqpCoordinatorRefusal::LifecycleNotRunning);
+        }
+        let run_id = self
+            .run
+            .as_ref()
+            .map(AdapterRun::id)
+            .ok_or(HqpCoordinatorRefusal::LifecycleNotRunning)?;
+        let instance_name = command
+            .request
+            .key
+            .producer_id
+            .strip_prefix("hqplayer:")
+            .filter(|name| !name.is_empty())
+            .ok_or(HqpCoordinatorRefusal::ProducerUnknown)?
+            .to_string();
+        let mut state = self
+            .instances
+            .remove(&instance_name)
+            .ok_or(HqpCoordinatorRefusal::ProducerUnknown)?;
+        if let Some(commit) = state.deferred_commit.clone() {
+            if let Err(error) = self.publish_deferred(&mut state, commit).await {
+                self.instances.insert(instance_name, state);
+                return Err(error);
+            }
+        }
+
+        let result = self.reserve_for_instance(&mut state, command, run_id).await;
+        self.instances.insert(instance_name, state);
+        result
+    }
+
+    async fn reserve_for_instance(
+        &mut self,
+        state: &mut HqpInstanceCoordinator,
+        command: HqpValidatedCommand,
+        run_id: AdapterRunId,
+    ) -> Result<HqpCommandReservation, HqpCoordinatorRefusal> {
+        if state
+            .correlation_tombstones
+            .contains_key(&command.request.correlation_id)
+        {
+            // The public audit record was compacted, but replaying an old gesture must never
+            // allocate a fresh generation or repeat native I/O.
+            return Err(HqpCoordinatorRefusal::CorrelationConflict);
+        }
+        if let Some(existing) = state.correlations.get(&command.request.correlation_id) {
+            if existing.fingerprint != command.fingerprint {
+                return Err(HqpCoordinatorRefusal::CorrelationConflict);
+            }
+            let operation = state
+                .ledger
+                .iter()
+                .find(|operation| operation.id == existing.lease.operation_id)
+                .cloned()
+                .ok_or(HqpCoordinatorRefusal::StaleLease)?;
+            return Ok(HqpCommandReservation {
+                lease: existing.lease.clone(),
+                operation,
+                disposition: HqpReservationDisposition::Duplicate,
+            });
+        }
+        if state.retirement_requested.is_some() {
+            return Err(HqpCoordinatorRefusal::LifecycleNotRunning);
+        }
+
+        let document = state
+            .tracker
+            .last_document
+            .as_ref()
+            .cloned()
+            .ok_or(HqpCoordinatorRefusal::ProducerUnknown)?;
+        let snapshot = ProducerSnapshot {
+            key: ProducerKey::of(&document),
+            document: Arc::new(document),
+            lanes: BTreeMap::new(),
+            presence: ProducerPresence::Live,
+            repairs: Vec::new(),
+            last_refusal: None,
+        };
+        let checked =
+            preflight(&snapshot, &command.request).map_err(HqpCoordinatorRefusal::Preflight)?;
+        if checked.fingerprint != command.fingerprint {
+            return Err(HqpCoordinatorRefusal::CorrelationConflict);
+        }
+        if state.active_pipeline.is_some() {
+            return Err(HqpCoordinatorRefusal::ConflictBusy);
+        }
+        if state
+            .ledger
+            .iter()
+            .filter(|operation| operation_is_unresolved(operation))
+            .count()
+            >= MAX_UNRESOLVED_OPERATIONS
+        {
+            return Err(HqpCoordinatorRefusal::UnresolvedRetentionFull);
+        }
+
+        let generation = state.next_generation.checked_add(1).ok_or_else(|| {
+            HqpCoordinatorRefusal::RevisionFailed("operation generation exhausted".to_string())
+        })?;
+        let producer_epoch = snapshot.document.producer.epoch;
+        let execution_target = state
+            .execution_target
+            .clone()
+            .filter(|target| {
+                target.instance_name
+                    == instance_name_from_producer_id(&command.request.key.producer_id)
+                    && target.producer_epoch == producer_epoch.0
+            })
+            .ok_or(HqpCoordinatorRefusal::StaleLease)?;
+        let operation_id = OperationId::new(format!(
+            "{}:operation:{generation}",
+            command.request.key.producer_id
+        ));
+        let lease = HqpCommandLease {
+            producer_id: command.request.key.producer_id.clone(),
+            producer_epoch,
+            run_id: Some(run_id),
+            conflict_set: HqpConflictSet::Pipeline,
+            generation,
+            correlation_id: command.request.correlation_id.clone(),
+            operation_id: operation_id.clone(),
+            execution_target: Some(execution_target),
+        };
+        let operation = OperationRecord {
+            id: operation_id,
+            correlation_id: command.request.correlation_id.clone(),
+            request: Some(OperationRequest {
+                control: command.request.control.clone(),
+                requested: command.request.requested.clone(),
+                lane: command.request.lane.clone(),
+                base: command.request.expected,
+            }),
+            change_set: None,
+            generation: Some(generation),
+            write_attempt: WriteAttempt::NotAttempted,
+            outcome: CommandOutcome::Pending,
+            observed: Some(command.request.expected),
+            steps: Vec::new(),
+            revision_boundaries: Vec::new(),
+            history: Vec::new(),
+            recovery: None,
+            reason: None,
+            extensions: Extensions::default(),
+        };
+
+        let mut candidate_ledger = state.ledger.clone();
+        candidate_ledger.push(operation.clone());
+        let mut candidate_document = (*snapshot.document).clone();
+        candidate_document.operations = candidate_ledger.clone();
+        let mut candidate_tracker = state.tracker.clone();
+        let candidate = candidate_tracker
+            .materialize(candidate_document)
+            .map_err(|error| HqpCoordinatorRefusal::RevisionFailed(format!("{error:?}")))?
+            .document;
+        self.publish(candidate).await?;
+
+        state.tracker = candidate_tracker;
+        state.ledger = candidate_ledger;
+        state.next_generation = generation;
+        state.active_pipeline = Some(generation);
+        state.correlations.insert(
+            command.request.correlation_id,
+            HqpCorrelationReservation {
+                fingerprint: checked.fingerprint,
+                lease: lease.clone(),
+            },
+        );
+        Ok(HqpCommandReservation {
+            lease,
+            operation,
+            disposition: HqpReservationDisposition::New,
+        })
+    }
+
+    fn validate(&self, lease: &HqpCommandLease) -> Result<(), HqpCoordinatorRefusal> {
+        let active_run = self.run.as_ref().map(AdapterRun::id);
+        if lease.run_id.is_none() || lease.run_id != active_run {
+            return Err(HqpCoordinatorRefusal::StaleLease);
+        }
+        let instance_name = lease
+            .producer_id
+            .strip_prefix("hqplayer:")
+            .ok_or(HqpCoordinatorRefusal::StaleLease)?;
+        let state = self
+            .instances
+            .get(instance_name)
+            .ok_or(HqpCoordinatorRefusal::StaleLease)?;
+        if state.tracker.epoch != Some(lease.producer_epoch.0)
+            || lease.conflict_set != HqpConflictSet::Pipeline
+            || state.active_pipeline != Some(lease.generation)
+        {
+            return Err(HqpCoordinatorRefusal::StaleLease);
+        }
+        let Some(correlation) = state.correlations.get(&lease.correlation_id) else {
+            return Err(HqpCoordinatorRefusal::StaleLease);
+        };
+        if correlation.lease != *lease {
+            return Err(HqpCoordinatorRefusal::StaleLease);
+        }
+        let pending = state.ledger.iter().any(|operation| {
+            operation.id == lease.operation_id
+                && operation.generation == Some(lease.generation)
+                && operation.outcome == CommandOutcome::Pending
+        });
+        pending
+            .then_some(())
+            .ok_or(HqpCoordinatorRefusal::StaleLease)
+    }
+
+    /// Return already-published terminal truth for a late actor callback. In particular, instance
+    /// retirement removes the document from the public view, but must not make a completion retry
+    /// look like a fresh lease or make the accepted operation's audit disappear.
+    fn retained_terminal_operation(&self, lease: &HqpCommandLease) -> Option<OperationRecord> {
+        let instance_name = lease.producer_id.strip_prefix("hqplayer:")?;
+        let retired = self
+            .retired_instances
+            .get(instance_name)
+            .map(|state| (&state.ledger, &state.correlations));
+        retired.into_iter().find_map(|(ledger, correlations)| {
+            let correlation = correlations.get(&lease.correlation_id)?;
+            (correlation.lease == *lease).then_some(())?;
+            ledger
+                .iter()
+                .find(|operation| {
+                    operation.id == lease.operation_id
+                        && operation.generation == Some(lease.generation)
+                        && operation.outcome != CommandOutcome::Pending
+                })
+                .cloned()
+        })
+    }
+
+    async fn complete(
+        &mut self,
+        lease: &HqpCommandLease,
+        completion: HqpCommandCompletion,
+    ) -> Result<OperationRecord, HqpCoordinatorRefusal> {
+        if self.validate(lease).is_err() {
+            return self
+                .retained_terminal_operation(lease)
+                .ok_or(HqpCoordinatorRefusal::StaleLease);
+        }
+        let instance_name = lease
+            .producer_id
+            .strip_prefix("hqplayer:")
+            .ok_or(HqpCoordinatorRefusal::StaleLease)?
+            .to_string();
+        let mut state = self
+            .instances
+            .remove(&instance_name)
+            .ok_or(HqpCoordinatorRefusal::StaleLease)?;
+        match self
+            .complete_for_instance(&mut state, lease, completion)
+            .await
+        {
+            Ok(completed) => {
+                if let Some(epoch) = state.retirement_requested {
+                    if !has_pending_operations(&state) {
+                        self.retire_admitted_instance(instance_name, state, epoch)
+                            .await?;
+                        return Ok(completed);
+                    }
+                }
+                self.instances.insert(instance_name, state);
+                Ok(completed)
+            }
+            Err(error) => {
+                self.instances.insert(instance_name, state);
+                Err(error)
+            }
+        }
+    }
+
+    async fn complete_for_instance(
+        &mut self,
+        state: &mut HqpInstanceCoordinator,
+        lease: &HqpCommandLease,
+        completion: HqpCommandCompletion,
+    ) -> Result<OperationRecord, HqpCoordinatorRefusal> {
+        let mut candidate_ledger = state.ledger.clone();
+        let operation = candidate_ledger
+            .iter_mut()
+            .find(|operation| {
+                operation.id == lease.operation_id && operation.generation == Some(lease.generation)
+            })
+            .ok_or(HqpCoordinatorRefusal::StaleLease)?;
+        operation.write_attempt = completion.write_attempt;
+        operation.recovery = completion.recovery;
+        operation
+            // The native receipt may justify the outcome, but it cannot cite an adaptive
+            // observation revision that has not been projected and admitted yet. A later
+            // coherent observation can supply that revision without back-dating evidence.
+            .transition(completion.outcome, completion.at, None, completion.reason)
+            .map_err(|_| HqpCoordinatorRefusal::IllegalTransition)?;
+        let completed = operation.clone();
+
+        let mut correlation_tombstones = state.correlation_tombstones.clone();
+        let mut correlation_tombstone_order = state.correlation_tombstone_order.clone();
+        prune_terminal_history(
+            &mut candidate_ledger,
+            &state.correlations,
+            &mut correlation_tombstones,
+            &mut correlation_tombstone_order,
+        );
+
+        let mut candidate_document = state
+            .tracker
+            .last_document
+            .clone()
+            .ok_or(HqpCoordinatorRefusal::StaleLease)?;
+        candidate_document.operations = candidate_ledger.clone();
+        let mut candidate_tracker = state.tracker.clone();
+        candidate_tracker
+            .materialize(candidate_document)
+            .map_err(|error| HqpCoordinatorRefusal::RevisionFailed(format!("{error:?}")))?;
+        self.publish_deferred(
+            state,
+            HqpDeferredCommit {
+                tracker: candidate_tracker,
+                ledger: candidate_ledger,
+                active_pipeline: None,
+                correlation_tombstones,
+                correlation_tombstone_order,
+            },
+        )
+        .await?;
+        Ok(completed)
+    }
+
+    async fn supersede_stale_before_dispatch(
+        &mut self,
+        lease: &HqpCommandLease,
+        at: Timestamp,
+    ) -> Result<OperationRecord, HqpCoordinatorRefusal> {
+        if let Some(terminal) = self.retained_terminal_operation(lease) {
+            return Ok(terminal);
+        }
+        let active_run = self.run.as_ref().map(AdapterRun::id);
+        let instance_name = lease
+            .producer_id
+            .strip_prefix("hqplayer:")
+            .ok_or(HqpCoordinatorRefusal::StaleLease)?
+            .to_string();
+        let mut state = self
+            .instances
+            .remove(&instance_name)
+            .ok_or(HqpCoordinatorRefusal::StaleLease)?;
+        let result = self
+            .supersede_stale_for_instance(&mut state, lease, active_run, at)
+            .await;
+        self.instances.insert(instance_name, state);
+        result
+    }
+
+    async fn supersede_stale_for_instance(
+        &mut self,
+        state: &mut HqpInstanceCoordinator,
+        lease: &HqpCommandLease,
+        active_run: Option<AdapterRunId>,
+        at: Timestamp,
+    ) -> Result<OperationRecord, HqpCoordinatorRefusal> {
+        let invalidated =
+            lease.run_id != active_run || state.tracker.epoch != Some(lease.producer_epoch.0);
+        if !invalidated {
+            return Err(HqpCoordinatorRefusal::LeaseStillCurrent);
+        }
+        let correlation = state
+            .correlations
+            .get(&lease.correlation_id)
+            .ok_or(HqpCoordinatorRefusal::StaleLease)?;
+        if correlation.lease != *lease {
+            return Err(HqpCoordinatorRefusal::StaleLease);
+        }
+        if let Some(operation) = state.ledger.iter().find(|operation| {
+            operation.id == lease.operation_id
+                && operation.generation == Some(lease.generation)
+                && operation.outcome == CommandOutcome::Superseded
+                && operation.write_attempt == WriteAttempt::NotAttempted
+        }) {
+            return Ok(operation.clone());
+        }
+        if state.active_pipeline != Some(lease.generation) {
+            return Err(HqpCoordinatorRefusal::StaleLease);
+        }
+
+        let mut candidate_ledger = state.ledger.clone();
+        let operation = candidate_ledger
+            .iter_mut()
+            .find(|operation| {
+                operation.id == lease.operation_id
+                    && operation.generation == Some(lease.generation)
+                    && operation.outcome == CommandOutcome::Pending
+            })
+            .ok_or(HqpCoordinatorRefusal::StaleLease)?;
+        operation.write_attempt = WriteAttempt::NotAttempted;
+        operation.recovery = Some(RecoveryState::ReplanRequired);
+        let reason = Reason {
+            code: ReasonCode::Superseded,
+            scope: ReasonScope::Producer,
+            display_text_key: None,
+            detail: Some(
+                "producer run or epoch advanced before HQPlayer native dispatch".to_string(),
+            ),
+        };
+        operation
+            .transition(CommandOutcome::Superseded, at, None, Some(reason))
+            .map_err(|_| HqpCoordinatorRefusal::IllegalTransition)?;
+        let superseded = operation.clone();
+
+        let mut correlation_tombstones = state.correlation_tombstones.clone();
+        let mut correlation_tombstone_order = state.correlation_tombstone_order.clone();
+        prune_terminal_history(
+            &mut candidate_ledger,
+            &state.correlations,
+            &mut correlation_tombstones,
+            &mut correlation_tombstone_order,
+        );
+
+        let mut candidate_document = state
+            .tracker
+            .last_document
+            .clone()
+            .ok_or(HqpCoordinatorRefusal::StaleLease)?;
+        candidate_document.operations = candidate_ledger.clone();
+        let mut candidate_tracker = state.tracker.clone();
+        candidate_tracker
+            .materialize(candidate_document)
+            .map_err(|error| HqpCoordinatorRefusal::RevisionFailed(format!("{error:?}")))?;
+        self.publish_deferred(
+            state,
+            HqpDeferredCommit {
+                tracker: candidate_tracker,
+                ledger: candidate_ledger,
+                active_pipeline: None,
+                correlation_tombstones,
+                correlation_tombstone_order,
+            },
+        )
+        .await?;
+        Ok(superseded)
+    }
+}
+
+fn validate_correlation(correlation_id: &str) -> Result<(), HqpCoordinatorRefusal> {
+    if correlation_id.is_empty() || correlation_id.len() > MAX_CORRELATION_ID_BYTES {
+        return Err(HqpCoordinatorRefusal::InvalidCorrelation);
+    }
+    Ok(())
+}
+
+fn instance_name_from_producer_id(producer_id: &str) -> &str {
+    producer_id.strip_prefix("hqplayer:").unwrap_or_default()
+}
+
+fn operation_is_unresolved(operation: &OperationRecord) -> bool {
+    operation.outcome.awaits_convergence()
+}
+
+fn has_pending_operations(state: &HqpInstanceCoordinator) -> bool {
+    state
+        .ledger
+        .iter()
+        .any(|operation| operation.outcome == CommandOutcome::Pending)
+}
+
+fn semantic_request_matches(document: &ProducerDocument, request: &OperationRequest) -> bool {
+    let Some(control) = document.control(&request.control) else {
+        return false;
+    };
+    if control.observed() == Some(&request.requested) {
+        return true;
+    }
+
+    // HQPlayer reports its `[source]` mode through the contract's meaningful `Empty` value. It is
+    // still selected through the runtime choice identity, so convergence must compare that choice's
+    // engine identity rather than treating every `Empty` observation as a match.
+    control.id.as_str() == CONTROL_PIPELINE_MODE
+        && control.observed() == Some(&ControlValue::Empty)
+        && matches!(
+            &request.requested,
+            ControlValue::Choice(requested)
+                if control.choices.as_ref().is_some_and(|choices| {
+                    choices.choices.iter().any(|choice| {
+                        choice.id == *requested && choice.engine_name.as_deref() == Some("[source]")
+                    })
+                })
+        )
+}
+
+fn reconcile_operations(
+    document: &ProducerDocument,
+    ledger: &mut [OperationRecord],
+) -> Result<HashSet<OperationId>, HqpCoordinatorRefusal> {
+    let mut converged = HashSet::new();
+    for index in 0..ledger.len() {
+        if !ledger[index].outcome.awaits_convergence() {
+            continue;
+        }
+        let Some(request) = ledger[index].request.clone() else {
+            continue;
+        };
+        let matches = semantic_request_matches(document, &request);
+        let generation = ledger[index].generation.unwrap_or_default();
+        let producer_restarted = request.base.epoch != document.producer.epoch;
+        let has_later_generation = ledger.iter().skip(index + 1).any(|later| {
+            later.generation.unwrap_or_default() > generation
+                && later
+                    .request
+                    .as_ref()
+                    .is_some_and(|later_request| later_request.control == request.control)
+        });
+
+        let resolution = if producer_restarted || (!matches && has_later_generation) {
+            Some((
+                CommandOutcome::Superseded,
+                RecoveryState::ReplanRequired,
+                Some(Reason {
+                    code: ReasonCode::Superseded,
+                    scope: ReasonScope::Producer,
+                    display_text_key: None,
+                    detail: Some(if producer_restarted {
+                        "HQPlayer producer epoch advanced before convergence".to_string()
+                    } else {
+                        "a later HQPlayer operation generation replaced this request".to_string()
+                    }),
+                }),
+            ))
+        } else if matches {
+            // A matching poll can race a queued command before the native executor runs. It is
+            // authoritative evidence that the requested value is already present, but it is not
+            // evidence that this operation sent anything. Keep that distinction explicit so the
+            // actor cannot later turn a no-send into a claimed write.
+            let no_send = ledger[index].outcome == CommandOutcome::Pending
+                && ledger[index].write_attempt == WriteAttempt::NotAttempted;
+            Some((
+                if no_send {
+                    CommandOutcome::Ignored
+                } else {
+                    CommandOutcome::Applied
+                },
+                RecoveryState::NotRequired,
+                None,
+            ))
+        } else if matches!(
+            ledger[index].outcome,
+            CommandOutcome::Indeterminate | CommandOutcome::TimedOut
+        ) {
+            Some((
+                CommandOutcome::Divergent,
+                RecoveryState::ReplanRequired,
+                None,
+            ))
+        } else {
+            None
+        };
+
+        let Some((outcome, recovery, reason)) = resolution else {
+            continue;
+        };
+        let operation = &mut ledger[index];
+        operation.write_attempt = if outcome == CommandOutcome::Applied {
+            WriteAttempt::Confirmed
+        } else {
+            operation.write_attempt.clone()
+        };
+        operation.recovery = Some(recovery);
+        operation
+            .transition(
+                outcome,
+                document
+                    .lanes
+                    .iter()
+                    .find(|lane| lane.lane == TransportLane::Native)
+                    .and_then(|lane| lane.freshness.observed_at.clone())
+                    .unwrap_or_else(|| Timestamp::new("unknown")),
+                None,
+                reason,
+            )
+            .map_err(|_| HqpCoordinatorRefusal::IllegalTransition)?;
+        converged.insert(operation.id.clone());
+    }
+    Ok(converged)
+}
+
+/// Keep every unresolved operation and only the newest bounded terminal audit records. Compacting
+/// a document record does not forget its correlation: a separate bounded tombstone prevents an
+/// old gesture from becoming a fresh native write merely because its audit fell off the surface.
+fn prune_terminal_history(
+    ledger: &mut Vec<OperationRecord>,
+    correlations: &HashMap<String, HqpCorrelationReservation>,
+    tombstones: &mut HashMap<String, HqpCommandFingerprint>,
+    tombstone_order: &mut VecDeque<String>,
+) {
+    let terminal_count = ledger
+        .iter()
+        .filter(|operation| !operation_is_unresolved(operation))
+        .count();
+    let mut terminal_to_drop = terminal_count.saturating_sub(MAX_TERMINAL_OPERATIONS);
+    if terminal_to_drop == 0 {
+        return;
+    }
+    ledger.retain(|operation| {
+        if terminal_to_drop > 0 && !operation_is_unresolved(operation) {
+            terminal_to_drop -= 1;
+            if let Some(reservation) = correlations.get(&operation.correlation_id) {
+                retain_correlation_tombstone(
+                    tombstones,
+                    tombstone_order,
+                    operation.correlation_id.clone(),
+                    reservation.fingerprint.clone(),
+                );
+            }
+            false
+        } else {
+            true
+        }
+    });
+}
+
+fn retain_correlation_tombstone(
+    tombstones: &mut HashMap<String, HqpCommandFingerprint>,
+    order: &mut VecDeque<String>,
+    correlation_id: String,
+    fingerprint: HqpCommandFingerprint,
+) {
+    if tombstones
+        .insert(correlation_id.clone(), fingerprint)
+        .is_none()
+    {
+        order.push_back(correlation_id);
+    }
+    while order.len() > MAX_CORRELATION_TOMBSTONES {
+        if let Some(expired) = order.pop_front() {
+            tombstones.remove(&expired);
+        }
+    }
+}
+
+fn reservation_for_correlation(
+    existing: &HqpCorrelationReservation,
+    ledger: &[OperationRecord],
+    expected_fingerprint: &HqpCommandFingerprint,
+) -> Result<HqpCommandReservation, HqpCoordinatorRefusal> {
+    if existing.fingerprint != *expected_fingerprint {
+        return Err(HqpCoordinatorRefusal::CorrelationConflict);
+    }
+    let operation = ledger
+        .iter()
+        .find(|operation| operation.id == existing.lease.operation_id)
+        .cloned()
+        .ok_or(HqpCoordinatorRefusal::StaleLease)?;
+    Ok(HqpCommandReservation {
+        lease: existing.lease.clone(),
+        operation,
+        disposition: HqpReservationDisposition::Duplicate,
+    })
+}
+
+fn retain_live_correlations(state: &mut HqpInstanceCoordinator) {
+    let retained = state
+        .ledger
+        .iter()
+        .map(|operation| operation.id.clone())
+        .collect::<HashSet<_>>();
+    state
+        .correlations
+        .retain(|_, reservation| retained.contains(&reservation.lease.operation_id));
 }
 
 impl HqpAdaptivePublisher {
     pub fn new(handle: AdaptiveHandle) -> Self {
-        Self {
-            handle,
-            run: Mutex::new(None),
-            trackers: Mutex::new(HashMap::new()),
-        }
+        const COORDINATOR_CAPACITY: usize = 32;
+        let (commands, receiver) = mpsc::channel(COORDINATOR_CAPACITY);
+        tokio::spawn(
+            HqpPublisherCoordinator {
+                handle,
+                run: None,
+                instances: HashMap::new(),
+                retired_instances: HashMap::new(),
+                #[cfg(test)]
+                refused_publications: 0,
+                stop_requested: false,
+            }
+            .run(receiver),
+        );
+        Self { commands }
     }
 
-    async fn current_run(&self) -> Result<Arc<AdapterRun>> {
-        self.run
-            .lock()
+    async fn request<T>(
+        &self,
+        build: impl FnOnce(oneshot::Sender<Result<T, HqpCoordinatorRefusal>>) -> HqpCoordinatorCommand,
+    ) -> Result<T, HqpCoordinatorRefusal> {
+        let (reply, response) = oneshot::channel();
+        self.commands
+            .send(build(reply))
             .await
-            .clone()
-            .ok_or_else(|| anyhow!("HQPlayer producer lifecycle is not running"))
+            .map_err(|_| HqpCoordinatorRefusal::CoordinatorClosed)?;
+        response
+            .await
+            .map_err(|_| HqpCoordinatorRefusal::CoordinatorClosed)?
     }
 
-    async fn publish(&self, run: &AdapterRun, document: ProducerDocument) -> Result<()> {
-        match self.handle.publish(run, document).await? {
-            Admission::Admitted(_) => Ok(()),
-            Admission::Refused(refusal) => Err(anyhow!(
-                "HQPlayer producer document was refused: {refusal:?}"
-            )),
-        }
+    pub(crate) async fn reserve(
+        &self,
+        command: HqpValidatedCommand,
+    ) -> Result<HqpCommandReservation, HqpCoordinatorRefusal> {
+        self.request(|reply| HqpCoordinatorCommand::Reserve { command, reply })
+            .await
+    }
+
+    /// Find an exact prior correlation before checking the caller's now-stale base revision.
+    pub(crate) async fn lookup_correlation(
+        &self,
+        request: &HqpImmediateCommandRequest,
+    ) -> Result<Option<HqpCommandReservation>, HqpCoordinatorRefusal> {
+        self.request(|reply| HqpCoordinatorCommand::LookupCorrelation {
+            request: request.clone(),
+            reply,
+        })
+        .await
+    }
+
+    pub(crate) async fn validate(
+        &self,
+        lease: &HqpCommandLease,
+    ) -> Result<(), HqpCoordinatorRefusal> {
+        self.request(|reply| HqpCoordinatorCommand::Validate {
+            lease: lease.clone(),
+            reply,
+        })
+        .await
+    }
+
+    #[cfg(test)]
+    async fn refuse_next_publication(&self) {
+        self.request(|reply| HqpCoordinatorCommand::RefuseNextPublication { reply })
+            .await
+            .expect("test coordinator accepts publication fault");
+    }
+
+    pub(crate) async fn complete(
+        &self,
+        lease: &HqpCommandLease,
+        completion: HqpCommandCompletion,
+    ) -> Result<OperationRecord, HqpCoordinatorRefusal> {
+        self.request(|reply| HqpCoordinatorCommand::Complete {
+            lease: lease.clone(),
+            completion,
+            reply,
+        })
+        .await
+    }
+
+    /// Terminalize an exact Pending lease which became stale before native dispatch.
+    ///
+    /// This is deliberately separate from completion: only the command actor at its
+    /// immediately-before-I/O validation point can truthfully assert `NotAttempted`.
+    pub(crate) async fn supersede_stale_before_dispatch(
+        &self,
+        lease: &HqpCommandLease,
+        at: Timestamp,
+    ) -> Result<OperationRecord, HqpCoordinatorRefusal> {
+        self.request(
+            |reply| HqpCoordinatorCommand::SupersedeStaleBeforeDispatch {
+                lease: lease.clone(),
+                at,
+                reply,
+            },
+        )
+        .await
     }
 }
 
 #[async_trait::async_trait]
 impl HqpNativeObservationSink for HqpAdaptivePublisher {
     async fn manager_started(&self) -> Result<()> {
-        let mut run = self.run.lock().await;
-        if run.is_none() {
-            *run = Some(Arc::new(self.handle.begin_run("hqplayer")));
-        }
-        Ok(())
+        self.request(|reply| HqpCoordinatorCommand::ManagerStarted { reply })
+            .await
+            .map_err(|error| anyhow!("HQPlayer coordinator start failed: {error:?}"))
     }
 
     async fn observed(&self, observation: HqpNativeObservation) -> Result<()> {
-        let instance_name = observation.instance_name.clone();
-        let projected = project_native(&observation).map_err(|error| {
-            anyhow!("HQPlayer adaptive projection refused coherent observation: {error:?}")
-        })?;
-        let document = {
-            let mut trackers = self.trackers.lock().await;
-            trackers
-                .entry(instance_name)
-                .or_default()
-                .materialize(projected)
-                .map_err(|error| {
-                    anyhow!("HQPlayer adaptive revision refused observation: {error:?}")
-                })?
-                .document
-        };
-        let run = self.current_run().await?;
-        self.publish(&run, document).await
+        self.request(|reply| HqpCoordinatorCommand::Observed {
+            observation: Box::new(observation),
+            reply,
+        })
+        .await
+        .map_err(|error| anyhow!("HQPlayer coordinator observation failed: {error:?}"))
     }
 
     async fn transient_failure(&self, instance_name: &str, observed_at: SystemTime) -> Result<()> {
-        let document = {
-            let mut trackers = self.trackers.lock().await;
-            trackers
-                .entry(instance_name.to_string())
-                .or_default()
-                .mark_transient_failure(contract_timestamp(observed_at))
-                .map_err(|error| {
-                    anyhow!(
-                        "HQPlayer adaptive tracker could not retain failed observation: {error:?}"
-                    )
-                })?
-                .map(|outcome| outcome.document)
-        };
-        let Some(document) = document else {
-            return Ok(());
-        };
-        let run = self.current_run().await?;
-        self.publish(&run, document).await
+        self.request(|reply| HqpCoordinatorCommand::TransientFailure {
+            instance_name: instance_name.to_string(),
+            observed_at,
+            reply,
+        })
+        .await
+        .map_err(|error| anyhow!("HQPlayer coordinator failure update failed: {error:?}"))
     }
 
     async fn instance_removed(&self, instance_name: &str, producer_epoch: u64) -> Result<()> {
-        let run = self.run.lock().await.clone();
-        if let Some(run) = run {
-            let producer_id = format!("hqplayer:{instance_name}");
-            match self
-                .handle
-                .retire(&run, &producer_id, ProducerEpoch(producer_epoch))
-                .await?
-            {
-                RetirementOutcome::Retired { .. } | RetirementOutcome::Committed => {}
-                outcome => {
-                    return Err(anyhow!(
-                        "HQPlayer producer retirement was not applied: {outcome:?}"
-                    ));
-                }
-            }
-        }
-        self.trackers.lock().await.remove(instance_name);
-        Ok(())
+        self.request(|reply| HqpCoordinatorCommand::InstanceRemoved {
+            instance_name: instance_name.to_string(),
+            producer_epoch,
+            reply,
+        })
+        .await
+        .map_err(|error| anyhow!("HQPlayer coordinator retirement failed: {error:?}"))
     }
 
     async fn manager_stopped(&self) -> Result<()> {
         // Ending the shared lease after all native workers join makes every retained HQPlayer
         // document last-known. Ordinary shutdown does not retire producer identities.
-        self.run.lock().await.take();
-        Ok(())
+        self.request(|reply| HqpCoordinatorCommand::ManagerStopped { reply })
+            .await
+            .map_err(|error| anyhow!("HQPlayer coordinator stop failed: {error:?}"))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::adapters::hqplayer::{HqpNativeMetadata, HqpNativeVolume};
+    use crate::adapters::hqplayer::{HqpNativeExecutionTarget, HqpNativeMetadata, HqpNativeVolume};
     use crate::adaptive::{
-        AvailabilityState, ControlId, ControlKind, ControlValue, LaneState, TargetRole, ValueLane,
+        ApplyLane, AvailabilityState, CommandOutcome, ControlId, ControlKind, ControlValue,
+        LaneState, OperationId, OperationRecord, OperationRequest, RevisionRef, TargetRole,
+        ValueLane, WriteAttempt,
     };
     use crate::producers::{admit, Admission, AdmissionKind};
     use std::time::Duration;
@@ -1062,6 +2629,12 @@ mod tests {
             instance_label: Some("Listening room".to_string()),
             product_version: Some("6.0.2".to_string()),
             producer_epoch: 7,
+            execution_target: HqpNativeExecutionTarget {
+                instance_name: "main".to_string(),
+                producer_epoch: 7,
+                endpoint_generation: 1,
+                transport_generation: 1,
+            },
             observed_at: SystemTime::UNIX_EPOCH + Duration::from_secs(1_786_016_400),
             transport: HqpNativeTransportState::Playing,
             metadata: HqpNativeMetadata {
@@ -1119,6 +2692,54 @@ mod tests {
             Some(ControlValue::Choice(choice)) => choice.clone(),
             other => panic!("{id} did not carry an observed choice: {other:?}"),
         }
+    }
+
+    fn pending_operation(base: RevisionRef) -> OperationRecord {
+        OperationRecord {
+            id: OperationId::new("hqplayer:main:operation:1"),
+            correlation_id: "gesture-1".to_string(),
+            request: Some(OperationRequest {
+                control: ControlId::new(CONTROL_PIPELINE_MODE),
+                requested: ControlValue::choice(choice_id(CONTROL_PIPELINE_MODE, "PCM")),
+                lane: ApplyLane::Immediate,
+                base,
+            }),
+            change_set: None,
+            generation: Some(1),
+            write_attempt: WriteAttempt::NotAttempted,
+            outcome: CommandOutcome::Pending,
+            observed: Some(base),
+            steps: Vec::new(),
+            revision_boundaries: Vec::new(),
+            history: Vec::new(),
+            recovery: None,
+            reason: None,
+            extensions: Extensions::default(),
+        }
+    }
+
+    #[test]
+    fn operation_only_changes_advance_state_revision_without_advancing_control_plane() {
+        let mut tracker = RevisionTracker::default();
+        let first = tracker
+            .materialize(project_native(&sample()).expect("initial projection"))
+            .expect("initial revision");
+        let base = first.document.position();
+
+        let mut with_pending = project_native(&sample()).expect("pending projection");
+        with_pending.operations.push(pending_operation(base));
+        let pending = tracker
+            .materialize(with_pending)
+            .expect("operation-only revision");
+
+        assert!(!pending.control_plane_advanced);
+        assert!(pending.state_advanced);
+        assert_eq!(
+            pending.document.revisions,
+            DocumentRevisions::new(1, 2),
+            "admitting Pending must be visible as a producer state change"
+        );
+        assert_eq!(pending.document.operations.len(), 1);
     }
 
     #[test]
@@ -1584,5 +3205,1125 @@ mod tests {
             .materialize(project_native(&next_epoch).expect("new-epoch projection"))
             .expect("new epoch resets exhausted counters");
         assert_eq!(recovered.document.revisions, DocumentRevisions::new(1, 1));
+    }
+
+    async fn coordinator_fixture() -> (
+        HqpAdaptivePublisher,
+        crate::producers::AdaptiveView,
+        tokio_util::sync::CancellationToken,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let shutdown = tokio_util::sync::CancellationToken::new();
+        let (handle, actor, view) = crate::producers::AdaptiveRuntime::build(shutdown.clone(), 16);
+        let actor_task = tokio::spawn(actor.run());
+        let publisher = HqpAdaptivePublisher::new(handle);
+        publisher.manager_started().await.expect("manager starts");
+        publisher.observed(sample()).await.expect("sample admitted");
+        (publisher, view, shutdown, actor_task)
+    }
+
+    fn validated_mode_command(
+        snapshot: &crate::producers::ProducerSnapshot,
+        correlation_id: &str,
+        engine_name: &str,
+    ) -> crate::producers::hqplayer_command::HqpValidatedCommand {
+        let request = crate::producers::hqplayer_command::HqpImmediateCommandRequest {
+            key: snapshot.key.clone(),
+            expected: snapshot.document.position(),
+            control: ControlId::new(CONTROL_PIPELINE_MODE),
+            requested: ControlValue::choice(choice_id(CONTROL_PIPELINE_MODE, engine_name)),
+            lane: ApplyLane::Immediate,
+            correlation_id: correlation_id.to_string(),
+        };
+        crate::producers::hqplayer_command::preflight(snapshot, &request)
+            .expect("mode request passes advisory preflight")
+    }
+
+    #[tokio::test]
+    async fn coordinator_reserves_pending_before_returning_and_preserves_it_across_observation() {
+        let (publisher, view, shutdown, actor_task) = coordinator_fixture().await;
+        let key = crate::producers::ProducerKey {
+            producer_id: "hqplayer:main".to_string(),
+            role: TargetRole::DspEngine,
+            zone_id: None,
+        };
+        let before = view.snapshot(&key).expect("initial snapshot");
+
+        let reservation = publisher
+            .reserve(validated_mode_command(&before, "gesture-1", "PCM"))
+            .await
+            .expect("pending reservation");
+
+        assert!(!reservation.is_duplicate());
+        let pending = view.snapshot(&key).expect("pending snapshot");
+        assert_eq!(
+            pending.document.revisions.control_plane,
+            before.document.revisions.control_plane
+        );
+        assert_eq!(
+            pending.document.revisions.state.0,
+            before.document.revisions.state.0 + 1
+        );
+        assert_eq!(pending.document.operations.len(), 1);
+        assert_eq!(
+            pending.document.operations[0].outcome,
+            CommandOutcome::Pending
+        );
+        assert_eq!(
+            pending.document.operations[0]
+                .request
+                .as_ref()
+                .expect("request")
+                .base,
+            before.document.position()
+        );
+
+        let mut next_observation = sample();
+        next_observation.metadata.title = Some("Next signal".to_string());
+        publisher
+            .observed(next_observation)
+            .await
+            .expect("later observation admitted");
+        let observed = view.snapshot(&key).expect("observed snapshot");
+        assert_eq!(observed.document.operations, pending.document.operations);
+        assert_eq!(
+            observed.document.revisions.state.0,
+            pending.document.revisions.state.0 + 1
+        );
+
+        publisher.manager_stopped().await.expect("manager stops");
+        shutdown.cancel();
+        actor_task.await.expect("actor joins");
+    }
+
+    #[tokio::test]
+    async fn coordinator_deduplicates_a_correlation_and_refuses_conflicting_reuse() {
+        let (publisher, view, shutdown, actor_task) = coordinator_fixture().await;
+        let key = crate::producers::ProducerKey {
+            producer_id: "hqplayer:main".to_string(),
+            role: TargetRole::DspEngine,
+            zone_id: None,
+        };
+        let snapshot = view.snapshot(&key).expect("initial snapshot");
+        let original = validated_mode_command(&snapshot, "gesture-1", "PCM");
+        let conflicting = validated_mode_command(&snapshot, "gesture-1", "SDM");
+
+        let first = publisher
+            .reserve(original.clone())
+            .await
+            .expect("first reserve");
+        let duplicate = publisher
+            .reserve(original)
+            .await
+            .expect("deduplicated reserve");
+        assert!(duplicate.is_duplicate());
+        assert_eq!(duplicate.operation().id, first.operation().id);
+        assert_eq!(
+            view.snapshot(&key)
+                .expect("snapshot")
+                .document
+                .operations
+                .len(),
+            1
+        );
+
+        assert_eq!(
+            publisher.reserve(conflicting).await,
+            Err(HqpCoordinatorRefusal::CorrelationConflict)
+        );
+
+        let pending = view.snapshot(&key).expect("pending snapshot");
+        let another_correlation = validated_mode_command(&pending, "gesture-2", "SDM");
+        assert_eq!(
+            publisher.reserve(another_correlation).await,
+            Err(HqpCoordinatorRefusal::ConflictBusy),
+            "the five coupled pipeline controls share one conservative conflict set"
+        );
+        publisher
+            .complete(
+                first.lease(),
+                HqpCommandCompletion::new(
+                    CommandOutcome::Superseded,
+                    WriteAttempt::NotAttempted,
+                    Timestamp::new("2026-07-31T00:00:01Z"),
+                    None,
+                    None,
+                ),
+            )
+            .await
+            .expect("test releases first conflict");
+
+        publisher.manager_stopped().await.expect("manager stops");
+        shutdown.cancel();
+        actor_task.await.expect("actor joins");
+    }
+
+    #[tokio::test]
+    async fn coordinator_rejects_stale_run_lease_and_does_not_publish_its_completion() {
+        let (publisher, view, shutdown, actor_task) = coordinator_fixture().await;
+        let key = crate::producers::ProducerKey {
+            producer_id: "hqplayer:main".to_string(),
+            role: TargetRole::DspEngine,
+            zone_id: None,
+        };
+        let snapshot = view.snapshot(&key).expect("initial snapshot");
+        let reservation = publisher
+            .reserve(validated_mode_command(&snapshot, "gesture-1", "PCM"))
+            .await
+            .expect("reserve");
+        publisher.manager_stopped().await.expect("old run stops");
+        publisher.manager_started().await.expect("new run starts");
+        assert_eq!(
+            publisher.validate(reservation.lease()).await,
+            Err(HqpCoordinatorRefusal::StaleLease)
+        );
+        assert_eq!(
+            publisher
+                .complete(
+                    reservation.lease(),
+                    HqpCommandCompletion::new(
+                        CommandOutcome::Applied,
+                        WriteAttempt::Confirmed,
+                        Timestamp::new("2026-07-31T00:00:01Z"),
+                        None,
+                        None,
+                    ),
+                )
+                .await,
+            Err(HqpCoordinatorRefusal::StaleLease)
+        );
+        let stopped = view.snapshot(&key).expect("terminal retained snapshot");
+        assert_eq!(
+            stopped.document.operations[0].outcome,
+            CommandOutcome::Superseded
+        );
+        assert_eq!(
+            stopped.document.operations[0].write_attempt,
+            WriteAttempt::NotAttempted
+        );
+
+        publisher.manager_stopped().await.expect("new run stops");
+        shutdown.cancel();
+        actor_task.await.expect("actor joins");
+    }
+
+    #[tokio::test]
+    async fn coordinator_supersedes_a_pending_generation_invalidated_before_dispatch() {
+        let (publisher, view, shutdown, actor_task) = coordinator_fixture().await;
+        let key = crate::producers::ProducerKey {
+            producer_id: "hqplayer:main".to_string(),
+            role: TargetRole::DspEngine,
+            zone_id: None,
+        };
+        let initial = view.snapshot(&key).expect("initial snapshot");
+        let reservation = publisher
+            .reserve(validated_mode_command(&initial, "gesture-1", "PCM"))
+            .await
+            .expect("reserve before producer restart");
+
+        let mut restarted = sample();
+        restarted.producer_epoch += 1;
+        restarted.execution_target.producer_epoch += 1;
+        publisher
+            .observed(restarted)
+            .await
+            .expect("new producer epoch admitted");
+        assert_eq!(
+            publisher.validate(reservation.lease()).await,
+            Err(HqpCoordinatorRefusal::StaleLease)
+        );
+
+        let superseded = publisher
+            .supersede_stale_before_dispatch(
+                reservation.lease(),
+                Timestamp::new("2026-07-31T00:00:01Z"),
+            )
+            .await
+            .expect("stale pre-dispatch generation terminalizes");
+        assert_eq!(superseded.outcome, CommandOutcome::Superseded);
+        assert_eq!(superseded.write_attempt, WriteAttempt::NotAttempted);
+        assert_eq!(superseded.recovery, Some(RecoveryState::ReplanRequired));
+        let reason = superseded.reason.as_ref().expect("supersession reason");
+        assert_eq!(reason.code, ReasonCode::Superseded);
+        assert_eq!(reason.scope, ReasonScope::Producer);
+
+        let after_invalidation = view.snapshot(&key).expect("superseded snapshot");
+        assert_eq!(
+            after_invalidation.document.operations[0].outcome,
+            CommandOutcome::Superseded
+        );
+        let next = publisher
+            .reserve(validated_mode_command(
+                &after_invalidation,
+                "gesture-2",
+                "SDM",
+            ))
+            .await
+            .expect("released conflict admits later command");
+        assert_eq!(
+            publisher
+                .complete(
+                    reservation.lease(),
+                    HqpCommandCompletion::new(
+                        CommandOutcome::Applied,
+                        WriteAttempt::Confirmed,
+                        Timestamp::new("2026-07-31T00:00:02Z"),
+                        None,
+                        None,
+                    ),
+                )
+                .await,
+            Err(HqpCoordinatorRefusal::StaleLease),
+            "late completion from the invalidated generation cannot overwrite its successor"
+        );
+        publisher
+            .complete(
+                next.lease(),
+                HqpCommandCompletion::new(
+                    CommandOutcome::Superseded,
+                    WriteAttempt::NotAttempted,
+                    Timestamp::new("2026-07-31T00:00:03Z"),
+                    None,
+                    None,
+                ),
+            )
+            .await
+            .expect("test releases successor");
+
+        publisher.manager_stopped().await.expect("manager stops");
+        shutdown.cancel();
+        actor_task.await.expect("actor joins");
+    }
+
+    #[tokio::test]
+    async fn coordinator_terminal_transition_advances_revision_and_releases_conflict_set() {
+        let (publisher, view, shutdown, actor_task) = coordinator_fixture().await;
+        let key = crate::producers::ProducerKey {
+            producer_id: "hqplayer:main".to_string(),
+            role: TargetRole::DspEngine,
+            zone_id: None,
+        };
+        let snapshot = view.snapshot(&key).expect("initial snapshot");
+        let reservation = publisher
+            .reserve(validated_mode_command(&snapshot, "gesture-1", "PCM"))
+            .await
+            .expect("reserve");
+        let pending = view.snapshot(&key).expect("pending snapshot");
+
+        publisher
+            .complete(
+                reservation.lease(),
+                HqpCommandCompletion::new(
+                    CommandOutcome::Applied,
+                    WriteAttempt::Confirmed,
+                    Timestamp::new("2026-07-31T00:00:01Z"),
+                    None,
+                    None,
+                ),
+            )
+            .await
+            .expect("terminal completion");
+
+        let complete = view.snapshot(&key).expect("terminal snapshot");
+        assert_eq!(
+            complete.document.revisions.state.0,
+            pending.document.revisions.state.0 + 1
+        );
+        let operation = &complete.document.operations[0];
+        assert_eq!(operation.outcome, CommandOutcome::Applied);
+        assert_eq!(operation.write_attempt, WriteAttempt::Confirmed);
+        assert_eq!(operation.history.len(), 1);
+        assert_eq!(operation.history[0].from, CommandOutcome::Pending);
+        assert_eq!(operation.history[0].to, CommandOutcome::Applied);
+
+        let next_snapshot = view.snapshot(&key).expect("completed snapshot");
+        let next = publisher
+            .reserve(validated_mode_command(&next_snapshot, "gesture-2", "SDM"))
+            .await
+            .expect("new generation reserves after terminal completion");
+        assert_eq!(
+            publisher
+                .complete(
+                    reservation.lease(),
+                    HqpCommandCompletion::new(
+                        CommandOutcome::Applied,
+                        WriteAttempt::Confirmed,
+                        Timestamp::new("2026-07-31T00:00:02Z"),
+                        None,
+                        None,
+                    ),
+                )
+                .await,
+            Err(HqpCoordinatorRefusal::StaleLease),
+            "an older generation cannot overwrite the newer Pending operation"
+        );
+        let indeterminate = publisher
+            .complete(
+                next.lease(),
+                HqpCommandCompletion::new(
+                    CommandOutcome::Indeterminate,
+                    WriteAttempt::Attempted,
+                    Timestamp::new("2026-07-31T00:00:03Z"),
+                    Some(RecoveryState::AwaitingReadback),
+                    None,
+                ),
+            )
+            .await
+            .expect("native ambiguity is retained truthfully");
+        assert_eq!(indeterminate.outcome, CommandOutcome::Indeterminate);
+        assert_eq!(indeterminate.write_attempt, WriteAttempt::Attempted);
+        assert_eq!(
+            indeterminate.recovery,
+            Some(RecoveryState::AwaitingReadback)
+        );
+
+        publisher.manager_stopped().await.expect("manager stops");
+        shutdown.cancel();
+        actor_task.await.expect("actor joins");
+    }
+
+    #[tokio::test]
+    async fn coordinator_stop_terminalizes_every_pre_receipt_pending_as_no_send_before_run_ends() {
+        let (publisher, view, shutdown, actor_task) = coordinator_fixture().await;
+        let main_key = crate::producers::ProducerKey {
+            producer_id: "hqplayer:main".to_string(),
+            role: TargetRole::DspEngine,
+            zone_id: None,
+        };
+        let mut second_observation = sample();
+        second_observation.instance_name = "second".to_string();
+        second_observation.execution_target.instance_name = "second".to_string();
+        publisher
+            .observed(second_observation)
+            .await
+            .expect("second producer admitted");
+        let second_key = crate::producers::ProducerKey {
+            producer_id: "hqplayer:second".to_string(),
+            role: TargetRole::DspEngine,
+            zone_id: None,
+        };
+
+        let reserved = publisher
+            .reserve(validated_mode_command(
+                &view.snapshot(&main_key).expect("main snapshot"),
+                "reserved-on-stop",
+                "PCM",
+            ))
+            .await
+            .expect("reserved operation");
+        let second_reserved = publisher
+            .reserve(validated_mode_command(
+                &view.snapshot(&second_key).expect("second snapshot"),
+                "second-reserved-on-stop",
+                "PCM",
+            ))
+            .await
+            .expect("second reserved operation");
+
+        publisher.manager_stopped().await.expect("manager stops");
+
+        let reserved_terminal = view.snapshot(&main_key).expect("main retained");
+        let reserved_operation = reserved_terminal
+            .document
+            .operations
+            .iter()
+            .find(|operation| operation.id == reserved.operation().id)
+            .expect("reserved audit retained");
+        assert_eq!(reserved_operation.outcome, CommandOutcome::Superseded);
+        assert_eq!(reserved_operation.write_attempt, WriteAttempt::NotAttempted);
+        assert_eq!(
+            reserved_operation.recovery,
+            Some(RecoveryState::ReplanRequired)
+        );
+        assert!(reserved_operation.reason.is_some());
+
+        let second_terminal = view.snapshot(&second_key).expect("second retained");
+        let second_operation = second_terminal
+            .document
+            .operations
+            .iter()
+            .find(|operation| operation.id == second_reserved.operation().id)
+            .expect("second audit retained");
+        assert_eq!(second_operation.outcome, CommandOutcome::Superseded);
+        assert_eq!(second_operation.write_attempt, WriteAttempt::NotAttempted);
+        assert_eq!(
+            second_operation.recovery,
+            Some(RecoveryState::ReplanRequired)
+        );
+        assert!(second_operation.reason.is_some());
+        assert_eq!(
+            publisher.validate(reserved.lease()).await,
+            Err(HqpCoordinatorRefusal::StaleLease)
+        );
+        assert_eq!(
+            publisher.validate(second_reserved.lease()).await,
+            Err(HqpCoordinatorRefusal::StaleLease)
+        );
+
+        shutdown.cancel();
+        actor_task.await.expect("actor joins");
+    }
+
+    #[tokio::test]
+    async fn instance_removal_defers_retirement_until_inflight_reservation_reports_no_send_truth() {
+        let (publisher, view, shutdown, actor_task) = coordinator_fixture().await;
+        let key = crate::producers::ProducerKey {
+            producer_id: "hqplayer:main".to_string(),
+            role: TargetRole::DspEngine,
+            zone_id: None,
+        };
+        let reservation = publisher
+            .reserve(validated_mode_command(
+                &view.snapshot(&key).expect("initial"),
+                "remove-before-receipt",
+                "PCM",
+            ))
+            .await
+            .expect("reservation admitted before removal");
+
+        publisher
+            .instance_removed("main", 7)
+            .await
+            .expect("removal records retirement intent without erasing accepted work");
+        assert!(
+            view.snapshot(&key).is_some(),
+            "the producer remains until the actor reports whether native I/O happened"
+        );
+
+        let no_send = publisher
+            .complete(
+                reservation.lease(),
+                HqpCommandCompletion::new(
+                    CommandOutcome::Superseded,
+                    WriteAttempt::NotAttempted,
+                    Timestamp::new("2026-07-31T00:00:01Z"),
+                    Some(RecoveryState::ReplanRequired),
+                    None,
+                ),
+            )
+            .await
+            .expect("no-send receipt terminalizes before retirement");
+        assert_eq!(no_send.outcome, CommandOutcome::Superseded);
+        assert_eq!(no_send.write_attempt, WriteAttempt::NotAttempted);
+        assert!(
+            view.snapshot(&key).is_none(),
+            "retirement follows terminal admission"
+        );
+
+        let late = publisher
+            .complete(
+                reservation.lease(),
+                HqpCommandCompletion::new(
+                    CommandOutcome::Applied,
+                    WriteAttempt::Confirmed,
+                    Timestamp::new("2026-07-31T00:00:02Z"),
+                    Some(RecoveryState::NotRequired),
+                    None,
+                ),
+            )
+            .await
+            .expect("late duplicate reads retained terminal audit rather than disappearing");
+        assert_eq!(late.outcome, CommandOutcome::Superseded);
+        assert_eq!(late.write_attempt, WriteAttempt::NotAttempted);
+        assert_eq!(late.recovery, Some(RecoveryState::ReplanRequired));
+
+        shutdown.cancel();
+        actor_task.await.expect("actor joins");
+    }
+
+    #[tokio::test]
+    async fn instance_removal_arriving_before_typed_receipt_completion_preserves_attempt_truth() {
+        let (publisher, view, shutdown, actor_task) = coordinator_fixture().await;
+        let key = crate::producers::ProducerKey {
+            producer_id: "hqplayer:main".to_string(),
+            role: TargetRole::DspEngine,
+            zone_id: None,
+        };
+        let reservation = publisher
+            .reserve(validated_mode_command(
+                &view.snapshot(&key).expect("initial"),
+                "remove-after-receipt",
+                "PCM",
+            ))
+            .await
+            .expect("reservation admitted");
+        publisher
+            .instance_removed("main", 7)
+            .await
+            .expect("removal waits for the actor's receipt completion");
+        assert!(
+            view.snapshot(&key).is_some(),
+            "removal must not classify a still-Pending write as no-send"
+        );
+        let retained = publisher
+            .complete(
+                reservation.lease(),
+                HqpCommandCompletion::new(
+                    CommandOutcome::Indeterminate,
+                    WriteAttempt::Attempted,
+                    Timestamp::new("2026-07-31T00:00:01Z"),
+                    Some(RecoveryState::AwaitingReadback),
+                    None,
+                ),
+            )
+            .await
+            .expect("receipt terminalizes before deferred retirement");
+        assert_eq!(retained.outcome, CommandOutcome::Indeterminate);
+        assert_eq!(retained.write_attempt, WriteAttempt::Attempted);
+        assert!(
+            view.snapshot(&key).is_none(),
+            "retirement follows attempted receipt truth"
+        );
+
+        let duplicate = publisher
+            .complete(
+                reservation.lease(),
+                HqpCommandCompletion::new(
+                    CommandOutcome::Superseded,
+                    WriteAttempt::NotAttempted,
+                    Timestamp::new("2026-07-31T00:00:02Z"),
+                    Some(RecoveryState::ReplanRequired),
+                    None,
+                ),
+            )
+            .await
+            .expect("late duplicate preserves the attempted receipt audit");
+        assert_eq!(duplicate.outcome, CommandOutcome::Indeterminate);
+        assert_eq!(duplicate.write_attempt, WriteAttempt::Attempted);
+
+        shutdown.cancel();
+        actor_task.await.expect("actor joins");
+    }
+
+    #[tokio::test]
+    async fn coordinator_retries_one_terminal_publication_failure_without_stranding_conflict() {
+        let (publisher, view, shutdown, actor_task) = coordinator_fixture().await;
+        let key = crate::producers::ProducerKey {
+            producer_id: "hqplayer:main".to_string(),
+            role: TargetRole::DspEngine,
+            zone_id: None,
+        };
+        let reservation = publisher
+            .reserve(validated_mode_command(
+                &view.snapshot(&key).expect("initial"),
+                "retry-publication",
+                "PCM",
+            ))
+            .await
+            .expect("reserve");
+        publisher.refuse_next_publication().await;
+        publisher
+            .complete(
+                reservation.lease(),
+                HqpCommandCompletion::new(
+                    CommandOutcome::Applied,
+                    WriteAttempt::Confirmed,
+                    Timestamp::new("2026-07-31T00:00:01Z"),
+                    Some(RecoveryState::NotRequired),
+                    None,
+                ),
+            )
+            .await
+            .expect("coordinator-owned retry admits terminal state");
+
+        let next_snapshot = view.snapshot(&key).expect("terminal snapshot");
+        publisher
+            .reserve(validated_mode_command(
+                &next_snapshot,
+                "after-publication-retry",
+                "SDM",
+            ))
+            .await
+            .expect("publication retry releases the conflict set");
+
+        publisher.manager_stopped().await.expect("manager stops");
+        shutdown.cancel();
+        actor_task.await.expect("actor joins");
+    }
+
+    #[tokio::test]
+    async fn coordinator_durably_retries_terminal_publication_after_caller_returns() {
+        let (publisher, view, shutdown, actor_task) = coordinator_fixture().await;
+        let key = crate::producers::ProducerKey {
+            producer_id: "hqplayer:main".to_string(),
+            role: TargetRole::DspEngine,
+            zone_id: None,
+        };
+        let reservation = publisher
+            .reserve(validated_mode_command(
+                &view.snapshot(&key).expect("initial"),
+                "durable-publication",
+                "PCM",
+            ))
+            .await
+            .expect("reserve");
+        for _ in 0..3 {
+            publisher.refuse_next_publication().await;
+        }
+        assert!(matches!(
+            publisher
+                .complete(
+                    reservation.lease(),
+                    HqpCommandCompletion::new(
+                        CommandOutcome::Applied,
+                        WriteAttempt::Confirmed,
+                        Timestamp::new("2026-07-31T00:00:01Z"),
+                        Some(RecoveryState::NotRequired),
+                        None,
+                    ),
+                )
+                .await,
+            Err(HqpCoordinatorRefusal::PublicationFailed(_))
+        ));
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                if view
+                    .snapshot(&key)
+                    .expect("snapshot retained")
+                    .document
+                    .operations[0]
+                    .outcome
+                    == CommandOutcome::Applied
+                {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("coordinator retries its immutable deferred terminal commit");
+
+        let next_snapshot = view.snapshot(&key).expect("deferred commit admitted");
+        publisher
+            .reserve(validated_mode_command(
+                &next_snapshot,
+                "after-durable-retry",
+                "SDM",
+            ))
+            .await
+            .expect("admitted deferred commit releases conflict");
+
+        publisher.manager_stopped().await.expect("manager stops");
+        shutdown.cancel();
+        actor_task.await.expect("actor joins");
+    }
+
+    #[tokio::test]
+    async fn deferred_terminal_commit_blocks_observation_until_its_revision_is_admitted() {
+        let (publisher, view, shutdown, actor_task) = coordinator_fixture().await;
+        let key = crate::producers::ProducerKey {
+            producer_id: "hqplayer:main".to_string(),
+            role: TargetRole::DspEngine,
+            zone_id: None,
+        };
+        let reservation = publisher
+            .reserve(validated_mode_command(
+                &view.snapshot(&key).expect("initial"),
+                "terminal-frontier",
+                "PCM",
+            ))
+            .await
+            .expect("reserve");
+        // `complete` owns two immediate terminal attempts; the third fault is consumed by the
+        // concurrent observation's frontier flush. It must not publish a competing document at
+        // the terminal candidate's same next revision.
+        for _ in 0..3 {
+            publisher.refuse_next_publication().await;
+        }
+        assert!(matches!(
+            publisher
+                .complete(
+                    reservation.lease(),
+                    HqpCommandCompletion::new(
+                        CommandOutcome::Applied,
+                        WriteAttempt::Confirmed,
+                        Timestamp::new("2026-07-31T00:00:01Z"),
+                        Some(RecoveryState::NotRequired),
+                        None,
+                    ),
+                )
+                .await,
+            Err(HqpCoordinatorRefusal::PublicationFailed(_))
+        ));
+
+        let mut competing_observation = sample();
+        competing_observation.metadata.title = Some("must wait behind terminal".to_string());
+        publisher
+            .observed(competing_observation)
+            .await
+            .expect("observation either flushes the terminal frontier first or follows it");
+        assert_eq!(
+            view.snapshot(&key)
+                .expect("frontier snapshot")
+                .document
+                .operations[0]
+                .outcome,
+            CommandOutcome::Applied,
+            "the terminal candidate is admitted before the competing observation can advance"
+        );
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                if view
+                    .snapshot(&key)
+                    .expect("terminal snapshot")
+                    .document
+                    .operations[0]
+                    .outcome
+                    == CommandOutcome::Applied
+                {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("deferred terminal retry is admitted before a successor");
+
+        let successor = publisher
+            .reserve(validated_mode_command(
+                &view.snapshot(&key).expect("terminal snapshot"),
+                "successor-after-frontier",
+                "SDM",
+            ))
+            .await
+            .expect("successor is usable after terminal frontier clears");
+        assert_eq!(successor.operation().outcome, CommandOutcome::Pending);
+
+        publisher.manager_stopped().await.expect("manager stops");
+        shutdown.cancel();
+        actor_task.await.expect("actor joins");
+    }
+
+    #[tokio::test]
+    async fn coherent_observation_converges_pending_and_source_empty_semantically() {
+        let (publisher, view, shutdown, actor_task) = coordinator_fixture().await;
+        let key = crate::producers::ProducerKey {
+            producer_id: "hqplayer:main".to_string(),
+            role: TargetRole::DspEngine,
+            zone_id: None,
+        };
+        let pcm = publisher
+            .reserve(validated_mode_command(
+                &view.snapshot(&key).expect("source snapshot"),
+                "to-pcm",
+                "PCM",
+            ))
+            .await
+            .expect("PCM reserved");
+        let mut pcm_observation = sample();
+        pcm_observation.mode_is_source = false;
+        pcm_observation.mode.selected = "PCM".to_string();
+        publisher
+            .observed(pcm_observation.clone())
+            .await
+            .expect("PCM converged");
+        let pcm_snapshot = view.snapshot(&key).expect("PCM snapshot");
+        let pcm_operation = pcm_snapshot
+            .document
+            .operations
+            .iter()
+            .find(|operation| operation.id == pcm.operation().id)
+            .expect("PCM operation");
+        assert_eq!(pcm_operation.outcome, CommandOutcome::Ignored);
+        assert_eq!(pcm_operation.write_attempt, WriteAttempt::NotAttempted);
+        assert_eq!(
+            pcm_operation.observed,
+            Some(pcm_snapshot.document.position())
+        );
+
+        let source = publisher
+            .reserve(validated_mode_command(
+                &pcm_snapshot,
+                "to-source",
+                "[source]",
+            ))
+            .await
+            .expect("source reserved");
+        publisher
+            .observed(sample())
+            .await
+            .expect("source Empty converged");
+        let source_snapshot = view.snapshot(&key).expect("source snapshot");
+        assert_eq!(
+            control(&source_snapshot.document, CONTROL_PIPELINE_MODE).observed(),
+            Some(&ControlValue::Empty)
+        );
+        let source_operation = source_snapshot
+            .document
+            .operations
+            .iter()
+            .find(|operation| operation.id == source.operation().id)
+            .expect("source operation");
+        assert_eq!(source_operation.outcome, CommandOutcome::Ignored);
+        assert_eq!(source_operation.write_attempt, WriteAttempt::NotAttempted);
+        assert_eq!(
+            source_operation.observed,
+            Some(source_snapshot.document.position())
+        );
+
+        publisher.manager_stopped().await.expect("manager stops");
+        shutdown.cancel();
+        actor_task.await.expect("actor joins");
+    }
+
+    #[tokio::test]
+    async fn later_generation_supersedes_unresolved_predecessor_during_convergence() {
+        let (publisher, view, shutdown, actor_task) = coordinator_fixture().await;
+        let key = crate::producers::ProducerKey {
+            producer_id: "hqplayer:main".to_string(),
+            role: TargetRole::DspEngine,
+            zone_id: None,
+        };
+        let first = publisher
+            .reserve(validated_mode_command(
+                &view.snapshot(&key).expect("initial"),
+                "first-generation",
+                "PCM",
+            ))
+            .await
+            .expect("first reserved");
+        publisher
+            .complete(
+                first.lease(),
+                HqpCommandCompletion::new(
+                    CommandOutcome::Indeterminate,
+                    WriteAttempt::Attempted,
+                    Timestamp::new("2026-07-31T00:00:01Z"),
+                    Some(RecoveryState::AwaitingReadback),
+                    None,
+                ),
+            )
+            .await
+            .expect("first unresolved");
+        let second = publisher
+            .reserve(validated_mode_command(
+                &view.snapshot(&key).expect("unresolved snapshot"),
+                "second-generation",
+                "SDM",
+            ))
+            .await
+            .expect("second reserved");
+
+        let mut observed = sample();
+        observed.mode_is_source = false;
+        observed.mode.selected = "SDM".to_string();
+        publisher.observed(observed).await.expect("SDM observed");
+        let converged = view.snapshot(&key).expect("converged snapshot");
+        let first = converged
+            .document
+            .operations
+            .iter()
+            .find(|operation| operation.id == first.operation().id)
+            .expect("first retained");
+        let second = converged
+            .document
+            .operations
+            .iter()
+            .find(|operation| operation.id == second.operation().id)
+            .expect("second retained");
+        assert_eq!(first.outcome, CommandOutcome::Superseded);
+        assert_eq!(second.outcome, CommandOutcome::Ignored);
+        assert_eq!(second.write_attempt, WriteAttempt::NotAttempted);
+
+        publisher.manager_stopped().await.expect("manager stops");
+        shutdown.cancel();
+        actor_task.await.expect("actor joins");
+    }
+
+    #[tokio::test]
+    async fn matching_poll_before_native_execution_resolves_as_ignored_no_send() {
+        let (publisher, view, shutdown, actor_task) = coordinator_fixture().await;
+        let key = crate::producers::ProducerKey {
+            producer_id: "hqplayer:main".to_string(),
+            role: TargetRole::DspEngine,
+            zone_id: None,
+        };
+        let reservation = publisher
+            .reserve(validated_mode_command(
+                &view.snapshot(&key).expect("initial"),
+                "setter-poll-race",
+                "PCM",
+            ))
+            .await
+            .expect("reserve");
+        let mut racing_poll = sample();
+        racing_poll.metadata.title = Some("poll raced setter".to_string());
+        publisher
+            .observed(racing_poll)
+            .await
+            .expect("racing observation admitted");
+        let raced = view.snapshot(&key).expect("raced snapshot");
+        let operation = raced
+            .document
+            .operations
+            .iter()
+            .find(|operation| operation.id == reservation.operation().id)
+            .expect("operation retained");
+        assert_eq!(operation.outcome, CommandOutcome::Pending);
+        assert_eq!(operation.write_attempt, WriteAttempt::NotAttempted);
+
+        let mut converged = sample();
+        converged.mode_is_source = false;
+        converged.mode.selected = "PCM".to_string();
+        publisher
+            .observed(converged)
+            .await
+            .expect("later convergence");
+        let ignored = view.snapshot(&key).expect("ignored snapshot");
+        assert_eq!(
+            ignored.document.operations[0].outcome,
+            CommandOutcome::Ignored
+        );
+        assert_eq!(
+            ignored.document.operations[0].write_attempt,
+            WriteAttempt::NotAttempted
+        );
+
+        publisher.manager_stopped().await.expect("manager stops");
+        shutdown.cancel();
+        actor_task.await.expect("actor joins");
+    }
+
+    #[tokio::test]
+    async fn terminal_ledger_and_correlation_tombstones_are_bounded_but_unresolved_are_retained() {
+        let (publisher, view, shutdown, actor_task) = coordinator_fixture().await;
+        let key = crate::producers::ProducerKey {
+            producer_id: "hqplayer:main".to_string(),
+            role: TargetRole::DspEngine,
+            zone_id: None,
+        };
+        let mut oldest_request = None;
+        let mut newest_request = None;
+        for index in 0..(MAX_TERMINAL_OPERATIONS + 3) {
+            let snapshot = view.snapshot(&key).expect("iteration snapshot");
+            let request = crate::producers::hqplayer_command::HqpImmediateCommandRequest {
+                key: key.clone(),
+                expected: snapshot.document.position(),
+                control: ControlId::new(CONTROL_PIPELINE_MODE),
+                requested: ControlValue::choice(choice_id(CONTROL_PIPELINE_MODE, "PCM")),
+                lane: ApplyLane::Immediate,
+                correlation_id: format!("bounded-{index}"),
+            };
+            if index == 0 {
+                oldest_request = Some(request.clone());
+            }
+            newest_request = Some(request.clone());
+            let reservation = publisher
+                .reserve(
+                    crate::producers::hqplayer_command::preflight(&snapshot, &request)
+                        .expect("request preflight"),
+                )
+                .await
+                .expect("reserve");
+            publisher
+                .complete(
+                    reservation.lease(),
+                    HqpCommandCompletion::new(
+                        CommandOutcome::Applied,
+                        WriteAttempt::Confirmed,
+                        Timestamp::new(format!("2026-07-31T00:00:{index:02}Z")),
+                        Some(RecoveryState::NotRequired),
+                        None,
+                    ),
+                )
+                .await
+                .expect("complete");
+        }
+
+        let retained = view.snapshot(&key).expect("retained snapshot");
+        assert_eq!(retained.document.operations.len(), MAX_TERMINAL_OPERATIONS);
+        assert_eq!(
+            publisher
+                .lookup_correlation(oldest_request.as_ref().expect("oldest"))
+                .await,
+            Err(HqpCoordinatorRefusal::CorrelationConflict),
+            "compacted terminal correlations remain no-replay tombstones"
+        );
+        assert!(
+            publisher
+                .lookup_correlation(newest_request.as_ref().expect("newest"))
+                .await
+                .expect("newest lookup")
+                .is_some(),
+            "newest terminal correlation remains idempotent"
+        );
+
+        publisher.manager_stopped().await.expect("manager stops");
+        shutdown.cancel();
+        actor_task.await.expect("actor joins");
+    }
+
+    #[tokio::test]
+    async fn unresolved_operation_retention_applies_backpressure_instead_of_growing_without_bound()
+    {
+        let (publisher, view, shutdown, actor_task) = coordinator_fixture().await;
+        let key = crate::producers::ProducerKey {
+            producer_id: "hqplayer:main".to_string(),
+            role: TargetRole::DspEngine,
+            zone_id: None,
+        };
+        for index in 0..MAX_UNRESOLVED_OPERATIONS {
+            let reservation = publisher
+                .reserve(validated_mode_command(
+                    &view.snapshot(&key).expect("current snapshot"),
+                    &format!("unresolved-{index}"),
+                    "PCM",
+                ))
+                .await
+                .expect("bounded unresolved record admits before cap");
+            publisher
+                .complete(
+                    reservation.lease(),
+                    HqpCommandCompletion::new(
+                        CommandOutcome::Indeterminate,
+                        WriteAttempt::Attempted,
+                        Timestamp::new(format!("2026-07-31T00:01:{index:02}Z")),
+                        Some(RecoveryState::AwaitingReadback),
+                        None,
+                    ),
+                )
+                .await
+                .expect("unresolved receipt is retained");
+        }
+        assert_eq!(
+            publisher
+                .reserve(validated_mode_command(
+                    &view.snapshot(&key).expect("cap snapshot"),
+                    "unresolved-over-cap",
+                    "PCM",
+                ))
+                .await,
+            Err(HqpCoordinatorRefusal::UnresolvedRetentionFull),
+            "the coordinator backpressures rather than silently evicting uncertainty"
+        );
+
+        publisher.manager_stopped().await.expect("manager stops");
+        shutdown.cancel();
+        actor_task.await.expect("actor joins");
+    }
+
+    #[tokio::test]
+    async fn coordinator_rejects_empty_and_oversized_correlations_even_if_preflight_is_bypassed() {
+        let (publisher, view, shutdown, actor_task) = coordinator_fixture().await;
+        let key = crate::producers::ProducerKey {
+            producer_id: "hqplayer:main".to_string(),
+            role: TargetRole::DspEngine,
+            zone_id: None,
+        };
+        let snapshot = view.snapshot(&key).expect("initial");
+        for correlation_id in [String::new(), "x".repeat(MAX_CORRELATION_ID_BYTES + 1)] {
+            let mut command = validated_mode_command(&snapshot, "valid", "PCM");
+            command.request.correlation_id = correlation_id;
+            assert_eq!(
+                publisher.reserve(command).await,
+                Err(HqpCoordinatorRefusal::InvalidCorrelation)
+            );
+        }
+
+        publisher.manager_stopped().await.expect("manager stops");
+        shutdown.cancel();
+        actor_task.await.expect("actor joins");
     }
 }

--- a/src/producers/hqplayer.rs
+++ b/src/producers/hqplayer.rs
@@ -1335,11 +1335,23 @@ impl HqpPublisherCoordinator {
     async fn retire_admitted_instance(
         &mut self,
         instance_name: String,
-        state: HqpInstanceCoordinator,
+        mut state: HqpInstanceCoordinator,
         producer_epoch: ProducerEpoch,
     ) -> Result<(), HqpCoordinatorRefusal> {
         debug_assert!(!has_pending_operations(&state));
         debug_assert!(state.dispatch_in_progress.is_empty());
+        // Retirement is definitive: no later producer observation can converge an ambiguous
+        // receipt. Make that boundary visible and admitted before the compact retired map can
+        // retain or eventually evict the audit. Keeping the retirement request on publication
+        // failure lets the deferred retry resume here without retiring early.
+        state.retirement_requested = Some(producer_epoch);
+        if let Err(error) = self
+            .expire_unresolved_before_retirement(&mut state, contract_timestamp(SystemTime::now()))
+            .await
+        {
+            self.instances.insert(instance_name, state);
+            return Err(error);
+        }
         if let Some(run) = self.run.as_ref() {
             let producer_id = format!("hqplayer:{instance_name}");
             let retirement = self
@@ -1370,6 +1382,74 @@ impl HqpPublisherCoordinator {
             },
         );
         Ok(())
+    }
+
+    async fn expire_unresolved_before_retirement(
+        &mut self,
+        state: &mut HqpInstanceCoordinator,
+        at: Timestamp,
+    ) -> Result<(), HqpCoordinatorRefusal> {
+        let mut candidate_ledger = state.ledger.clone();
+        let mut changed = false;
+        for operation in &mut candidate_ledger {
+            if operation.outcome == CommandOutcome::Pending
+                || !operation.outcome.awaits_convergence()
+            {
+                continue;
+            }
+            operation.recovery = Some(RecoveryState::ReplanRequired);
+            operation
+                .transition(
+                    CommandOutcome::Expired,
+                    at.clone(),
+                    None,
+                    Some(Reason {
+                        code: ReasonCode::Expired,
+                        scope: ReasonScope::Producer,
+                        display_text_key: None,
+                        detail: Some(
+                            "HQPlayer instance retired before authoritative convergence"
+                                .to_string(),
+                        ),
+                    }),
+                )
+                .map_err(|_| HqpCoordinatorRefusal::IllegalTransition)?;
+            changed = true;
+        }
+        if !changed {
+            return Ok(());
+        }
+
+        let mut correlation_tombstones = state.correlation_tombstones.clone();
+        let mut correlation_tombstone_order = state.correlation_tombstone_order.clone();
+        prune_terminal_history(
+            &mut candidate_ledger,
+            &state.correlations,
+            &mut correlation_tombstones,
+            &mut correlation_tombstone_order,
+        );
+        let mut candidate_document = state
+            .tracker
+            .last_document
+            .clone()
+            .ok_or(HqpCoordinatorRefusal::ProducerUnknown)?;
+        candidate_document.operations = candidate_ledger.clone();
+        let mut candidate_tracker = state.tracker.clone();
+        candidate_tracker
+            .materialize(candidate_document)
+            .map_err(|error| HqpCoordinatorRefusal::RevisionFailed(format!("{error:?}")))?;
+        self.publish_deferred(
+            state,
+            HqpDeferredCommit {
+                tracker: candidate_tracker,
+                ledger: candidate_ledger,
+                active_pipeline: state.active_pipeline,
+                dispatch_in_progress: state.dispatch_in_progress.clone(),
+                correlation_tombstones,
+                correlation_tombstone_order,
+            },
+        )
+        .await
     }
 
     async fn publish_deferred(
@@ -3980,8 +4060,12 @@ mod tests {
             )
             .await
             .expect("late duplicate preserves the attempted receipt audit");
-        assert_eq!(duplicate.outcome, CommandOutcome::Indeterminate);
+        assert_eq!(duplicate.outcome, CommandOutcome::Expired);
         assert_eq!(duplicate.write_attempt, WriteAttempt::Attempted);
+        assert_eq!(duplicate.recovery, Some(RecoveryState::ReplanRequired));
+        let reason = duplicate.reason.as_ref().expect("retirement reason");
+        assert_eq!(reason.code, ReasonCode::Expired);
+        assert_eq!(reason.scope, ReasonScope::Producer);
 
         shutdown.cancel();
         actor_task.await.expect("actor joins");
@@ -4042,6 +4126,92 @@ mod tests {
             WriteAttempt::Attempted
         );
 
+        shutdown.cancel();
+        actor_task.await.expect("actor joins");
+    }
+
+    #[tokio::test]
+    async fn retirement_waits_for_expiration_publication_before_hiding_the_instance() {
+        let (publisher, view, shutdown, actor_task) = coordinator_fixture().await;
+        let key = crate::producers::ProducerKey {
+            producer_id: "hqplayer:main".to_string(),
+            role: TargetRole::DspEngine,
+            zone_id: None,
+        };
+        let request = crate::producers::hqplayer_command::HqpImmediateCommandRequest {
+            key: key.clone(),
+            expected: view.snapshot(&key).expect("initial").document.position(),
+            control: ControlId::new(CONTROL_PIPELINE_MODE),
+            requested: ControlValue::choice(choice_id(CONTROL_PIPELINE_MODE, "PCM")),
+            lane: ApplyLane::Immediate,
+            correlation_id: "retirement-expiration-publication".to_string(),
+        };
+        let reservation = publisher
+            .reserve(
+                crate::producers::hqplayer_command::preflight(
+                    &view.snapshot(&key).expect("preflight snapshot"),
+                    &request,
+                )
+                .expect("request preflight"),
+            )
+            .await
+            .expect("reserve");
+        publisher
+            .complete(
+                reservation.lease(),
+                HqpCommandCompletion::new(
+                    CommandOutcome::Indeterminate,
+                    WriteAttempt::Attempted,
+                    Timestamp::new("2026-07-31T00:00:01Z"),
+                    Some(RecoveryState::AwaitingReadback),
+                    None,
+                ),
+            )
+            .await
+            .expect("ambiguous receipt audit admits");
+
+        for _ in 0..9 {
+            publisher.refuse_next_publication().await;
+        }
+        assert!(publisher.instance_removed("main", 7).await.is_err());
+        let still_visible = view
+            .snapshot(&key)
+            .expect("failed expiration publication cannot retire the producer");
+        assert_eq!(
+            still_visible.document.operations[0].outcome,
+            CommandOutcome::Indeterminate
+        );
+
+        let expired = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                if let Some(found) = publisher
+                    .lookup_correlation(&request)
+                    .await
+                    .expect("correlation lookup remains available")
+                {
+                    if found.operation().outcome == CommandOutcome::Expired {
+                        break found;
+                    }
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("deferred expiration publishes and retirement completes");
+        assert_eq!(expired.operation().write_attempt, WriteAttempt::Attempted);
+        assert_eq!(
+            expired.operation().recovery,
+            Some(RecoveryState::ReplanRequired)
+        );
+        let reason = expired.operation().reason.as_ref().expect("expired reason");
+        assert_eq!(reason.code, ReasonCode::Expired);
+        assert_eq!(reason.scope, ReasonScope::Producer);
+        assert!(
+            view.snapshot(&key).is_none(),
+            "producer becomes hidden only after expiration was admitted"
+        );
+
+        publisher.manager_stopped().await.expect("manager stops");
         shutdown.cancel();
         actor_task.await.expect("actor joins");
     }
@@ -4796,10 +4966,10 @@ mod tests {
                 .complete(
                     reservation.lease(),
                     HqpCommandCompletion::new(
-                        CommandOutcome::Applied,
-                        WriteAttempt::Confirmed,
+                        CommandOutcome::Indeterminate,
+                        WriteAttempt::Attempted,
                         Timestamp::new(format!("2026-07-31T00:02:{:02}Z", index % 60)),
-                        Some(RecoveryState::NotRequired),
+                        Some(RecoveryState::AwaitingReadback),
                         None,
                     ),
                 )
@@ -4809,6 +4979,34 @@ mod tests {
                 .instance_removed(&instance_name, 7)
                 .await
                 .expect("completed instance retires");
+
+            if index == MAX_RETIRED_INSTANCES - 1 {
+                let oldest_before_eviction = publisher
+                    .lookup_correlation(oldest_request.as_ref().expect("oldest request"))
+                    .await
+                    .expect("oldest retained lookup")
+                    .expect("oldest is retained until the next distinct retirement");
+                assert_eq!(
+                    oldest_before_eviction.operation().outcome,
+                    CommandOutcome::Expired,
+                    "retirement makes unresolved convergence explicitly terminal before eviction"
+                );
+                assert_eq!(
+                    oldest_before_eviction.operation().write_attempt,
+                    WriteAttempt::Attempted
+                );
+                assert_eq!(
+                    oldest_before_eviction.operation().recovery,
+                    Some(RecoveryState::ReplanRequired)
+                );
+                let reason = oldest_before_eviction
+                    .operation()
+                    .reason
+                    .as_ref()
+                    .expect("expiration reason");
+                assert_eq!(reason.code, ReasonCode::Expired);
+                assert_eq!(reason.scope, ReasonScope::Producer);
+            }
         }
 
         assert!(
@@ -4817,16 +5015,26 @@ mod tests {
                 .await
                 .expect("expired retired lookup is not an error")
                 .is_none(),
-            "the oldest distinct retired identity is evicted at the global bound"
+            "the oldest distinct retired identity is evicted only after its audit is terminal"
         );
-        assert!(
-            publisher
-                .lookup_correlation(newest_request.as_ref().expect("newest request"))
-                .await
-                .expect("newest retired lookup")
-                .is_some(),
-            "the newest retired identity keeps exact duplicate truth"
+        let newest = publisher
+            .lookup_correlation(newest_request.as_ref().expect("newest request"))
+            .await
+            .expect("newest retired lookup")
+            .expect("newest retired identity keeps exact duplicate truth");
+        assert_eq!(newest.operation().outcome, CommandOutcome::Expired);
+        assert_eq!(newest.operation().write_attempt, WriteAttempt::Attempted);
+        assert_eq!(
+            newest.operation().recovery,
+            Some(RecoveryState::ReplanRequired)
         );
+        let expiration = newest
+            .operation()
+            .history
+            .last()
+            .expect("retirement expiration transition");
+        assert_eq!(expiration.from, CommandOutcome::Indeterminate);
+        assert_eq!(expiration.to, CommandOutcome::Expired);
 
         publisher.manager_stopped().await.expect("manager stops");
         shutdown.cancel();

--- a/src/producers/hqplayer.rs
+++ b/src/producers/hqplayer.rs
@@ -1235,6 +1235,12 @@ enum HqpCoordinatorCommand {
     },
 }
 
+fn send_coordinator_reply<T>(reply: oneshot::Sender<T>, value: T, command: &'static str) {
+    if reply.send(value).is_err() {
+        tracing::trace!(command, "HQPlayer coordinator caller dropped before reply");
+    }
+}
+
 struct HqpPublisherCoordinator {
     handle: AdaptiveHandle,
     run: Option<AdapterRun>,
@@ -1289,6 +1295,7 @@ impl HqpPublisherCoordinator {
             state.deferred_commit.is_none()
                 && state.dispatch_in_progress.is_empty()
                 && !has_pending_operations(state)
+                && state.retirement_requested.is_none()
         });
         if self.stop_requested && quiescent {
             self.run.take();
@@ -1351,6 +1358,13 @@ impl HqpPublisherCoordinator {
         // retain or eventually evict the audit. Keeping the retirement request on publication
         // failure lets the deferred retry resume here without retiring early.
         state.retirement_requested = Some(producer_epoch);
+        // A configured instance can be removed after ordinary manager stop has ended its run.
+        // Retirement may first need to publish explicit Expired audit truth, so authority must be
+        // installed before any retirement-stage publication rather than only around the final
+        // Retire command. On retry we retain this run until the request is fully committed.
+        if self.run.is_none() {
+            self.run = Some(self.handle.begin_run("hqplayer"));
+        }
         if let Err(error) = self
             .expire_unresolved_before_retirement(&mut state, contract_timestamp(SystemTime::now()))
             .await
@@ -1366,25 +1380,29 @@ impl HqpPublisherCoordinator {
                 "injected retirement refusal".to_string(),
             ));
         }
-        if let Some(run) = self.run.as_ref() {
-            let producer_id = format!("hqplayer:{instance_name}");
-            let retirement = self
-                .handle
-                .retire(run, &producer_id, producer_epoch)
-                .await
-                .map_err(|error| HqpCoordinatorRefusal::RetirementFailed(error.to_string()));
-            match retirement {
-                Ok(RetirementOutcome::Retired { .. } | RetirementOutcome::Committed) => {}
-                Ok(outcome) => {
-                    self.instances.insert(instance_name, state);
-                    return Err(HqpCoordinatorRefusal::RetirementFailed(format!(
-                        "{outcome:?}"
-                    )));
-                }
-                Err(error) => {
-                    self.instances.insert(instance_name, state);
-                    return Err(error);
-                }
+        let Some(run) = self.run.as_ref() else {
+            self.instances.insert(instance_name, state);
+            return Err(HqpCoordinatorRefusal::RetirementFailed(
+                "could not establish HQPlayer retirement authority".to_string(),
+            ));
+        };
+        let producer_id = format!("hqplayer:{instance_name}");
+        let retirement = self
+            .handle
+            .retire(run, &producer_id, producer_epoch)
+            .await
+            .map_err(|error| HqpCoordinatorRefusal::RetirementFailed(error.to_string()));
+        match retirement {
+            Ok(RetirementOutcome::Retired { .. } | RetirementOutcome::Committed) => {}
+            Ok(outcome) => {
+                self.instances.insert(instance_name, state);
+                return Err(HqpCoordinatorRefusal::RetirementFailed(format!(
+                    "{outcome:?}"
+                )));
+            }
+            Err(error) => {
+                self.instances.insert(instance_name, state);
+                return Err(error);
             }
         }
         self.retain_retired_instance(
@@ -1395,6 +1413,7 @@ impl HqpPublisherCoordinator {
                 correlations: state.correlations,
             },
         );
+        self.finish_stop_if_quiescent();
         Ok(())
     }
 
@@ -1510,11 +1529,11 @@ impl HqpPublisherCoordinator {
                     let Some(command) = maybe_command else { break };
                     match command {
                 HqpCoordinatorCommand::ManagerStarted { reply } => {
-                    let _ = reply.send(self.manager_started());
+                    send_coordinator_reply(reply, self.manager_started(), "manager_started");
                 }
                 HqpCoordinatorCommand::Observed { observation, reply } => {
                     let result = self.observed(*observation).await;
-                    let _ = reply.send(result);
+                    send_coordinator_reply(reply, result, "observed");
                 }
                 HqpCoordinatorCommand::TransientFailure {
                     instance_name,
@@ -1522,7 +1541,7 @@ impl HqpPublisherCoordinator {
                     reply,
                 } => {
                     let result = self.transient_failure(instance_name, observed_at).await;
-                    let _ = reply.send(result);
+                    send_coordinator_reply(reply, result, "transient_failure");
                 }
                 HqpCoordinatorCommand::InstanceRemoved {
                     instance_name,
@@ -1530,25 +1549,29 @@ impl HqpPublisherCoordinator {
                     reply,
                 } => {
                     let result = self.instance_removed(instance_name, producer_epoch).await;
-                    let _ = reply.send(result);
+                    send_coordinator_reply(reply, result, "instance_removed");
                 }
                 HqpCoordinatorCommand::ManagerStopped { reply } => {
                     let result = self.manager_stopped().await;
-                    let _ = reply.send(result);
+                    send_coordinator_reply(reply, result, "manager_stopped");
                 }
                 HqpCoordinatorCommand::Reserve { command, reply } => {
                     let result = self.reserve(command).await;
-                    let _ = reply.send(result);
+                    send_coordinator_reply(reply, result, "reserve");
                 }
                 HqpCoordinatorCommand::LookupCorrelation { request, reply } => {
-                    let _ = reply.send(self.lookup_correlation(&request));
+                    send_coordinator_reply(
+                        reply,
+                        self.lookup_correlation(&request),
+                        "lookup_correlation",
+                    );
                 }
                 #[cfg(test)]
                 HqpCoordinatorCommand::Validate { lease, reply } => {
-                    let _ = reply.send(self.validate(&lease));
+                    send_coordinator_reply(reply, self.validate(&lease), "validate");
                 }
                 HqpCoordinatorCommand::BeginDispatch { lease, reply } => {
-                    let _ = reply.send(self.begin_dispatch(&lease));
+                    send_coordinator_reply(reply, self.begin_dispatch(&lease), "begin_dispatch");
                 }
                 HqpCoordinatorCommand::Complete {
                     lease,
@@ -1556,21 +1579,21 @@ impl HqpPublisherCoordinator {
                     reply,
                 } => {
                     let result = self.complete(&lease, completion).await;
-                    let _ = reply.send(result);
+                    send_coordinator_reply(reply, result, "complete");
                 }
                 HqpCoordinatorCommand::SupersedeStaleBeforeDispatch { lease, at, reply } => {
                     let result = self.supersede_stale_before_dispatch(&lease, at).await;
-                    let _ = reply.send(result);
+                    send_coordinator_reply(reply, result, "supersede_stale_before_dispatch");
                 }
                 #[cfg(test)]
                 HqpCoordinatorCommand::RefuseNextPublication { reply } => {
                     self.refused_publications += 1;
-                    let _ = reply.send(Ok(()));
+                    send_coordinator_reply(reply, Ok(()), "refuse_next_publication");
                 }
                 #[cfg(any(test, debug_assertions))]
                 HqpCoordinatorCommand::RefuseNextRetirement { reply } => {
                     self.refused_retirements += 1;
-                    let _ = reply.send(Ok(()));
+                    send_coordinator_reply(reply, Ok(()), "refuse_next_retirement");
                 }
                     }
                 }
@@ -1836,6 +1859,14 @@ impl HqpPublisherCoordinator {
             self.remove_retired_instance(&instance_name);
         }
         let mut state = self.instances.remove(&instance_name).unwrap_or_default();
+        if state.retirement_requested.is_some() {
+            // A same-name replacement is a distinct producer lifetime. Do not let it inherit the
+            // retiring lifetime's tracker, correlations, or audit ledger while retirement is
+            // waiting for publication/actor admission. The worker will retry after the coordinator
+            // has moved the old state behind its retirement floor.
+            self.instances.insert(instance_name, state);
+            return Err(HqpCoordinatorRefusal::LifecycleNotRunning);
+        }
         if let Some(commit) = state.deferred_commit.clone() {
             // A deferred terminal commit is a serialization frontier. Materializing this poll
             // from the prior tracker would otherwise offer the aggregator a different document
@@ -2301,8 +2332,19 @@ impl HqpPublisherCoordinator {
             Ok(completed) => {
                 if let Some(epoch) = state.retirement_requested {
                     if !has_pending_operations(&state) {
-                        self.retire_admitted_instance(instance_name, state, epoch)
-                            .await?;
+                        if let Err(error) = self
+                            .retire_admitted_instance(instance_name.clone(), state, epoch)
+                            .await
+                        {
+                            // The typed receipt is already admitted public truth. Retirement intent
+                            // is also committed and reinserted for retry, so reporting completion as
+                            // failed would falsely tell the command actor publication was lost.
+                            tracing::warn!(
+                                ?error,
+                                instance = %instance_name,
+                                "HQPlayer terminal receipt admitted; retirement retained for retry"
+                            );
+                        }
                         self.finish_stop_if_quiescent();
                         return Ok(completed);
                     }
@@ -2402,8 +2444,16 @@ impl HqpPublisherCoordinator {
             Ok(superseded) => {
                 if let Some(epoch) = state.retirement_requested {
                     if !has_pending_operations(&state) {
-                        self.retire_admitted_instance(instance_name, state, epoch)
-                            .await?;
+                        if let Err(error) = self
+                            .retire_admitted_instance(instance_name.clone(), state, epoch)
+                            .await
+                        {
+                            tracing::warn!(
+                                ?error,
+                                instance = %instance_name,
+                                "HQPlayer no-send terminal admitted; retirement retained for retry"
+                            );
+                        }
                         self.finish_stop_if_quiescent();
                         return Ok(superseded);
                     }
@@ -2959,8 +3009,9 @@ mod tests {
         LaneState, OperationId, OperationRecord, OperationRequest, RevisionRef, TargetRole,
         ValueLane, WriteAttempt,
     };
-    use crate::producers::{admit, Admission, AdmissionKind};
+    use crate::producers::{admit, AdaptiveRuntime, Admission, AdmissionKind};
     use std::time::Duration;
+    use tokio_util::sync::CancellationToken;
 
     fn sample() -> HqpNativeObservation {
         HqpNativeObservation {
@@ -4071,6 +4122,134 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn replacement_observation_waits_for_committed_retirement_retry() {
+        let shutdown = CancellationToken::new();
+        let (handle, actor, view) = AdaptiveRuntime::build(shutdown.clone(), 32);
+        let actor_task = tokio::spawn(async move { actor.run().await });
+        let mut coordinator = HqpPublisherCoordinator {
+            handle,
+            run: None,
+            instances: HashMap::new(),
+            retired_instances: HashMap::new(),
+            retired_instance_order: VecDeque::new(),
+            refused_publications: 0,
+            refused_retirements: 0,
+            stop_requested: false,
+        };
+        coordinator.manager_started().expect("manager run starts");
+        coordinator
+            .observed(sample())
+            .await
+            .expect("original producer admitted");
+        coordinator.refused_retirements = 1;
+        coordinator
+            .instance_removed("main".to_string(), 7)
+            .await
+            .expect("retirement intent is committed for retry");
+
+        let mut replacement = sample();
+        replacement.producer_epoch = 8;
+        replacement.execution_target.producer_epoch = 8;
+        assert_eq!(
+            coordinator.observed(replacement.clone()).await,
+            Err(HqpCoordinatorRefusal::LifecycleNotRunning),
+            "a replacement cannot inherit the retiring producer's tracker and correlations"
+        );
+
+        coordinator.retry_deferred_commits().await;
+        let key = ProducerKey {
+            producer_id: "hqplayer:main".to_string(),
+            role: TargetRole::DspEngine,
+            zone_id: None,
+        };
+        assert!(view.snapshot(&key).is_none(), "old producer retires first");
+        coordinator
+            .observed(replacement)
+            .await
+            .expect("strictly newer replacement starts with fresh coordinator state");
+        assert!(
+            view.snapshot(&key)
+                .expect("replacement admitted")
+                .document
+                .operations
+                .is_empty(),
+            "the replacement correlation namespace is fresh"
+        );
+
+        shutdown.cancel();
+        actor_task.await.expect("actor joins");
+    }
+
+    #[tokio::test]
+    async fn admitted_terminal_receipt_succeeds_when_retirement_moves_to_owned_retry() {
+        let shutdown = CancellationToken::new();
+        let (handle, actor, view) = AdaptiveRuntime::build(shutdown.clone(), 32);
+        let actor_task = tokio::spawn(async move { actor.run().await });
+        let mut coordinator = HqpPublisherCoordinator {
+            handle,
+            run: None,
+            instances: HashMap::new(),
+            retired_instances: HashMap::new(),
+            retired_instance_order: VecDeque::new(),
+            refused_publications: 0,
+            refused_retirements: 0,
+            stop_requested: false,
+        };
+        coordinator.manager_started().expect("manager run starts");
+        coordinator
+            .observed(sample())
+            .await
+            .expect("producer admitted");
+        let key = ProducerKey {
+            producer_id: "hqplayer:main".to_string(),
+            role: TargetRole::DspEngine,
+            zone_id: None,
+        };
+        let reservation = coordinator
+            .reserve(validated_mode_command(
+                &view.snapshot(&key).expect("initial snapshot"),
+                "receipt-before-retirement-retry",
+                "PCM",
+            ))
+            .await
+            .expect("reservation admitted");
+        coordinator
+            .instance_removed("main".to_string(), 7)
+            .await
+            .expect("retirement waits for the pending receipt");
+        coordinator.refused_retirements = 1;
+
+        let completed = coordinator
+            .complete(
+                reservation.lease(),
+                HqpCommandCompletion::new(
+                    CommandOutcome::Applied,
+                    WriteAttempt::Confirmed,
+                    Timestamp::new("2026-07-31T00:00:01Z"),
+                    Some(RecoveryState::NotRequired),
+                    None,
+                ),
+            )
+            .await
+            .expect("admitted receipt is successful even when retirement needs retry");
+        assert_eq!(completed.outcome, CommandOutcome::Applied);
+        assert_eq!(completed.write_attempt, WriteAttempt::Confirmed);
+        assert!(
+            view.snapshot(&key).is_some(),
+            "producer remains visible until the owned retirement retry commits"
+        );
+
+        coordinator.retry_deferred_commits().await;
+        assert!(
+            view.snapshot(&key).is_none(),
+            "owned retry retires producer"
+        );
+
+        shutdown.cancel();
+        actor_task.await.expect("actor joins");
+    }
+
+    #[tokio::test]
     async fn instance_removal_arriving_before_typed_receipt_completion_preserves_attempt_truth() {
         let (publisher, view, shutdown, actor_task) = coordinator_fixture().await;
         let key = crate::producers::ProducerKey {
@@ -4293,6 +4472,68 @@ mod tests {
         );
 
         publisher.manager_stopped().await.expect("manager stops");
+        shutdown.cancel();
+        actor_task.await.expect("actor joins");
+    }
+
+    #[tokio::test]
+    async fn stopped_removal_can_publish_expired_truth_before_retiring() {
+        let (publisher, view, shutdown, actor_task) = coordinator_fixture().await;
+        let key = ProducerKey {
+            producer_id: "hqplayer:main".to_string(),
+            role: TargetRole::DspEngine,
+            zone_id: None,
+        };
+        let request = crate::producers::hqplayer_command::HqpImmediateCommandRequest {
+            key: key.clone(),
+            expected: view.snapshot(&key).expect("initial").document.position(),
+            control: ControlId::new(CONTROL_PIPELINE_MODE),
+            requested: ControlValue::choice(choice_id(CONTROL_PIPELINE_MODE, "PCM")),
+            lane: ApplyLane::Immediate,
+            correlation_id: "stopped-removal-expiration".to_string(),
+        };
+        let reservation = publisher
+            .reserve(
+                crate::producers::hqplayer_command::preflight(
+                    &view.snapshot(&key).expect("preflight snapshot"),
+                    &request,
+                )
+                .expect("preflight"),
+            )
+            .await
+            .expect("reserve");
+        publisher
+            .complete(
+                reservation.lease(),
+                HqpCommandCompletion::new(
+                    CommandOutcome::Indeterminate,
+                    WriteAttempt::Attempted,
+                    Timestamp::new("2026-07-31T00:00:01Z"),
+                    Some(RecoveryState::AwaitingReadback),
+                    None,
+                ),
+            )
+            .await
+            .expect("ambiguous receipt admitted");
+        publisher.manager_stopped().await.expect("manager stops");
+
+        publisher
+            .instance_removed("main", 7)
+            .await
+            .expect("stopped removal commits expiration and retirement");
+        assert!(view.snapshot(&key).is_none(), "producer retired");
+        let retained = publisher
+            .lookup_correlation(&request)
+            .await
+            .expect("retired lookup")
+            .expect("expired audit retained");
+        assert_eq!(retained.operation().outcome, CommandOutcome::Expired);
+        assert_eq!(retained.operation().write_attempt, WriteAttempt::Attempted);
+        assert_eq!(
+            retained.operation().recovery,
+            Some(RecoveryState::ReplanRequired)
+        );
+
         shutdown.cancel();
         actor_task.await.expect("actor joins");
     }

--- a/src/producers/hqplayer_command.rs
+++ b/src/producers/hqplayer_command.rs
@@ -1,0 +1,974 @@
+//! Pure, advisory admission checks for HQPlayer's immediate adaptive commands.
+//!
+//! This module deliberately knows only an admitted producer snapshot. Reserving a command,
+//! native execution, and outcome publication belong to the HQPlayer publisher coordinator; a
+//! successful result here is therefore never permission to write by itself.
+
+use crate::adaptive::{
+    ApplyLane, Choice, ControlId, ControlKind, ControlValue, RevisionRef, TransportLane,
+};
+
+use super::hqplayer::{hqp_semantic_operation, HqpSemanticOperation};
+use super::{ProducerKey, ProducerPresence, ProducerSnapshot};
+
+/// One surface's proposed immediate semantic HQPlayer mutation.
+///
+/// The coordinator repeats these checks while reserving the command, so this request carries a
+/// complete citable snapshot position instead of relying on a mutable cache or a native index.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct HqpImmediateCommandRequest {
+    /// Exact aggregate producer identity addressed by the surface.
+    pub key: ProducerKey,
+    /// Epoch and revisions observed by the caller.
+    pub expected: RevisionRef,
+    /// Semantic control to mutate.
+    pub control: ControlId,
+    /// Desired semantic control value.
+    pub requested: ControlValue,
+    /// This first path accepts only immediate writes.
+    pub lane: ApplyLane,
+    /// Caller supplied idempotency correlation. It is opaque to this advisory layer.
+    pub correlation_id: String,
+}
+
+/// A deterministic semantic identity for one request.
+///
+/// It deliberately omits a correlation id: the coordinator uses the correlation *with* this
+/// fingerprint to distinguish a retry from a conflicting reuse of the same correlation.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct HqpCommandFingerprint(Vec<u8>);
+
+const MAX_CORRELATION_ID_BYTES: usize = 256;
+
+/// Validated value forwarded to the typed HQPlayer executor.
+///
+/// It contains an engine *name* or exact rate, never an enumerated native index.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum HqpEngineValue {
+    /// An exact engine supplied mode/filter/shaper name.
+    Name(String),
+    /// An exact integer output rate parsed from the engine-supplied rate name.
+    Rate(u32),
+}
+
+/// A request that is safe to offer to the publisher coordinator for atomic reservation.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct HqpValidatedCommand {
+    /// Original semantic request; the coordinator records this intent verbatim.
+    pub request: HqpImmediateCommandRequest,
+    /// The registered typed operation, not a consumer-owned string switch.
+    pub operation: HqpSemanticOperation,
+    /// The exact engine value selected from the current runtime enumeration.
+    pub engine_value: HqpEngineValue,
+    /// Identity used with correlation id for at-most-once reservation.
+    pub fingerprint: HqpCommandFingerprint,
+}
+
+/// A typed refusal before command reservation or native I/O.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum HqpPreflightRefusal {
+    /// An empty correlation cannot identify a retry.
+    CorrelationIdEmpty,
+    /// Correlations are retained for the lifetime of a producer run, so bound caller input.
+    CorrelationIdTooLong {
+        /// Maximum accepted UTF-8 byte length.
+        max_bytes: usize,
+        /// Supplied UTF-8 byte length.
+        actual_bytes: usize,
+    },
+    /// The selected snapshot belongs to another producer or target role.
+    ProducerMismatch,
+    /// The caller's position is no longer the current atomic producer position.
+    RevisionMismatch {
+        /// Position the caller used.
+        expected: RevisionRef,
+        /// Position currently served by the aggregator.
+        actual: RevisionRef,
+    },
+    /// Last-known data is never a write target.
+    ProducerNotLive,
+    /// The producer itself labels this otherwise-live document stale.
+    ProducerStale,
+    /// No native control lane is represented by the document.
+    NativeLaneMissing,
+    /// Native control is not connected.
+    NativeLaneUnavailable,
+    /// Native control readings are no longer current enough to mutate from.
+    NativeLaneStale,
+    /// The control is absent from the exact document.
+    ControlUnknown,
+    /// The control exists but is not presently offered for mutation.
+    ControlUnavailable,
+    /// The control has no apply semantics or is otherwise not mutable.
+    ControlReadOnly,
+    /// The request selected a write lane different from the descriptor's lane.
+    WrongApplyLane,
+    /// This initial service only executes `immediate` requests.
+    NonImmediateRequest,
+    /// The first pipeline slice requires one semantic enumeration choice.
+    WrongControlKind,
+    /// The requested value is not a semantic choice id.
+    WrongValueKind,
+    /// The semantic choice is not in the exact current runtime enumeration.
+    UnknownChoice,
+    /// A choice is known but currently disabled by the producer.
+    ChoiceUnavailable,
+    /// The runtime choice lacks an engine name, so it cannot be sent truthfully.
+    ChoiceMissingEngineName,
+    /// The engine rate spelling is not the exact non-negative integer expected by `set_rate`.
+    InvalidRateEngineName,
+    /// A mutable HQPlayer operation deliberately held for #328 until it has a truthful receipt.
+    DeferredToIssue328 {
+        /// The registered semantic operation which has been deferred.
+        operation: HqpSemanticOperation,
+    },
+    /// The document contains a control the HQPlayer registry does not make executable.
+    UnsupportedControl,
+}
+
+/// Check one already-admitted snapshot without mutating any retained state.
+///
+/// This is deliberately advisory. The publisher coordinator must repeat the exact identity,
+/// revision, and actionability checks while atomically recording `Pending` before execution.
+pub(crate) fn preflight(
+    snapshot: &ProducerSnapshot,
+    request: &HqpImmediateCommandRequest,
+) -> Result<HqpValidatedCommand, HqpPreflightRefusal> {
+    validate_correlation_id(&request.correlation_id)?;
+    if snapshot.key != request.key {
+        return Err(HqpPreflightRefusal::ProducerMismatch);
+    }
+
+    let actual = snapshot.document.position();
+    if actual != request.expected {
+        return Err(HqpPreflightRefusal::RevisionMismatch {
+            expected: request.expected,
+            actual,
+        });
+    }
+    if snapshot.presence != ProducerPresence::Live {
+        return Err(HqpPreflightRefusal::ProducerNotLive);
+    }
+    if snapshot.document.stale {
+        return Err(HqpPreflightRefusal::ProducerStale);
+    }
+
+    let native = snapshot
+        .document
+        .lane_health(&TransportLane::Native)
+        .ok_or(HqpPreflightRefusal::NativeLaneMissing)?;
+    if native.state != crate::adaptive::LaneState::Connected {
+        return Err(HqpPreflightRefusal::NativeLaneUnavailable);
+    }
+    if native.freshness.stale {
+        return Err(HqpPreflightRefusal::NativeLaneStale);
+    }
+
+    if request.lane != ApplyLane::Immediate {
+        return Err(HqpPreflightRefusal::NonImmediateRequest);
+    }
+
+    let operation =
+        hqp_semantic_operation(&request.control).ok_or(HqpPreflightRefusal::UnsupportedControl)?;
+    if matches!(
+        operation,
+        HqpSemanticOperation::Play
+            | HqpSemanticOperation::Pause
+            | HqpSemanticOperation::Stop
+            | HqpSemanticOperation::Previous
+            | HqpSemanticOperation::Next
+            | HqpSemanticOperation::SetVolumeDb
+    ) {
+        return Err(HqpPreflightRefusal::DeferredToIssue328 { operation });
+    }
+
+    let control = snapshot
+        .document
+        .control(&request.control)
+        .ok_or(HqpPreflightRefusal::ControlUnknown)?;
+    if !control.availability.permits_mutation() {
+        return Err(HqpPreflightRefusal::ControlUnavailable);
+    }
+    if !control.is_mutable() {
+        return Err(HqpPreflightRefusal::ControlReadOnly);
+    }
+    let Some(apply) = control.apply.as_ref() else {
+        return Err(HqpPreflightRefusal::ControlReadOnly);
+    };
+    if apply.lane != request.lane {
+        return Err(HqpPreflightRefusal::WrongApplyLane);
+    }
+    if control.kind != ControlKind::Enumeration {
+        return Err(HqpPreflightRefusal::WrongControlKind);
+    }
+
+    let ControlValue::Choice(requested_choice) = &request.requested else {
+        return Err(HqpPreflightRefusal::WrongValueKind);
+    };
+    let choice = control
+        .choices
+        .as_ref()
+        .and_then(|choices| {
+            choices
+                .choices
+                .iter()
+                .find(|choice| choice.id == *requested_choice)
+        })
+        .ok_or(HqpPreflightRefusal::UnknownChoice)?;
+    if !choice_is_mutable(choice) {
+        return Err(HqpPreflightRefusal::ChoiceUnavailable);
+    }
+    let engine_name = choice
+        .engine_name
+        .as_deref()
+        .filter(|name| !name.is_empty())
+        .ok_or(HqpPreflightRefusal::ChoiceMissingEngineName)?;
+
+    let engine_value = match operation {
+        HqpSemanticOperation::SetMode
+        | HqpSemanticOperation::SetFilter1x
+        | HqpSemanticOperation::SetFilterNx
+        | HqpSemanticOperation::SetShaper => HqpEngineValue::Name(engine_name.to_string()),
+        HqpSemanticOperation::SetRate => HqpEngineValue::Rate(
+            engine_name
+                .parse::<u32>()
+                .map_err(|_| HqpPreflightRefusal::InvalidRateEngineName)?,
+        ),
+        HqpSemanticOperation::Play
+        | HqpSemanticOperation::Pause
+        | HqpSemanticOperation::Stop
+        | HqpSemanticOperation::Previous
+        | HqpSemanticOperation::Next
+        | HqpSemanticOperation::SetVolumeDb => {
+            return Err(HqpPreflightRefusal::DeferredToIssue328 { operation });
+        }
+    };
+
+    Ok(HqpValidatedCommand {
+        request: request.clone(),
+        operation,
+        engine_value,
+        fingerprint: fingerprint(request),
+    })
+}
+
+fn choice_is_mutable(choice: &Choice) -> bool {
+    choice
+        .availability
+        .as_ref()
+        .is_none_or(|availability| availability.permits_mutation())
+}
+
+pub(crate) fn fingerprint(request: &HqpImmediateCommandRequest) -> HqpCommandFingerprint {
+    // The correlation id is deliberately not part of the fingerprint: the coordinator indexes by
+    // correlation and compares this exact semantic identity to distinguish retry from reuse.
+    // Every variable-width value is length-delimited and every sum variant has its own tag, so
+    // distinct requests cannot alias because of separators, field boundaries, or value types.
+    let mut canonical = Vec::new();
+    canonical.extend_from_slice(b"hqp-immediate-command-v1\0");
+    append_bytes(&mut canonical, request.key.producer_id.as_bytes());
+    append_bytes(&mut canonical, request.key.role.as_str().as_bytes());
+    append_optional_bytes(
+        &mut canonical,
+        request.key.zone_id.as_deref().map(str::as_bytes),
+    );
+    canonical.extend_from_slice(&request.expected.epoch.0.to_be_bytes());
+    canonical.extend_from_slice(&request.expected.control_plane.0.to_be_bytes());
+    canonical.extend_from_slice(&request.expected.state.0.to_be_bytes());
+    append_bytes(&mut canonical, request.control.as_str().as_bytes());
+    append_bytes(&mut canonical, request.lane.as_str().as_bytes());
+    append_control_value(&mut canonical, &request.requested);
+    HqpCommandFingerprint(canonical)
+}
+
+pub(crate) fn validate_correlation_id(correlation_id: &str) -> Result<(), HqpPreflightRefusal> {
+    if correlation_id.is_empty() {
+        return Err(HqpPreflightRefusal::CorrelationIdEmpty);
+    }
+    let actual_bytes = correlation_id.len();
+    if actual_bytes > MAX_CORRELATION_ID_BYTES {
+        return Err(HqpPreflightRefusal::CorrelationIdTooLong {
+            max_bytes: MAX_CORRELATION_ID_BYTES,
+            actual_bytes,
+        });
+    }
+    Ok(())
+}
+
+fn append_optional_bytes(output: &mut Vec<u8>, value: Option<&[u8]>) {
+    match value {
+        None => output.push(0),
+        Some(value) => {
+            output.push(1);
+            append_bytes(output, value);
+        }
+    }
+}
+
+fn append_bytes(output: &mut Vec<u8>, value: &[u8]) {
+    output.extend_from_slice(&(value.len() as u64).to_be_bytes());
+    output.extend_from_slice(value);
+}
+
+fn append_control_value(output: &mut Vec<u8>, value: &ControlValue) {
+    match value {
+        ControlValue::Empty => output.push(0),
+        ControlValue::Bool(value) => {
+            output.push(1);
+            output.push(u8::from(*value));
+        }
+        ControlValue::Integer(value) => {
+            output.push(2);
+            output.extend_from_slice(&value.to_be_bytes());
+        }
+        ControlValue::Decimal(value) => {
+            output.push(3);
+            output.extend_from_slice(&value.to_bits().to_be_bytes());
+        }
+        ControlValue::Text(value) => {
+            output.push(4);
+            append_bytes(output, value.as_bytes());
+        }
+        ControlValue::Choice(value) => {
+            output.push(5);
+            append_bytes(output, value.as_bytes());
+        }
+        ControlValue::Composite(values) => {
+            output.push(6);
+            output.extend_from_slice(&(values.len() as u64).to_be_bytes());
+            for (key, value) in values {
+                append_bytes(output, key.as_bytes());
+                append_control_value(output, value);
+            }
+        }
+        ControlValue::List(values) => {
+            output.push(7);
+            output.extend_from_slice(&(values.len() as u64).to_be_bytes());
+            for value in values {
+                append_control_value(output, value);
+            }
+        }
+        ControlValue::Unrecognized { kind, raw } => {
+            output.push(8);
+            append_bytes(output, kind.as_bytes());
+            append_json_value(output, raw);
+        }
+    }
+}
+
+fn append_json_value(output: &mut Vec<u8>, value: &serde_json::Value) {
+    match value {
+        serde_json::Value::Null => output.push(0),
+        serde_json::Value::Bool(value) => {
+            output.push(1);
+            output.push(u8::from(*value));
+        }
+        serde_json::Value::Number(value) => {
+            output.push(2);
+            append_bytes(output, value.to_string().as_bytes());
+        }
+        serde_json::Value::String(value) => {
+            output.push(3);
+            append_bytes(output, value.as_bytes());
+        }
+        serde_json::Value::Array(values) => {
+            output.push(4);
+            output.extend_from_slice(&(values.len() as u64).to_be_bytes());
+            for value in values {
+                append_json_value(output, value);
+            }
+        }
+        serde_json::Value::Object(values) => {
+            output.push(5);
+            output.extend_from_slice(&(values.len() as u64).to_be_bytes());
+            let mut entries = values.iter().collect::<Vec<_>>();
+            entries.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
+            for (key, value) in entries {
+                append_bytes(output, key.as_bytes());
+                append_json_value(output, value);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::adaptive::{
+        ApplyEffect, ApplySemantics, Availability, ChoiceSet, Control, Disruption,
+        DocumentRevisions, Extensions, Freshness, LaneHealth, LaneState, ProducerDocument,
+        ProducerEpoch, ProducerIdentity, ProducerTarget, RiskClass, TargetRole, Timestamp,
+        Verification, CONSUMER_SCHEMA_VERSION,
+    };
+    use crate::producers::ProducerSnapshot;
+
+    const MODE: &str = "hqplayer.pipeline.mode";
+    const FILTER_1X: &str = "hqplayer.pipeline.filter_1x";
+    const FILTER_NX: &str = "hqplayer.pipeline.filter_nx";
+    const SHAPER: &str = "hqplayer.pipeline.shaper";
+    const RATE: &str = "hqplayer.pipeline.rate";
+
+    fn snapshot() -> ProducerSnapshot {
+        let document = ProducerDocument {
+            schema_version: CONSUMER_SCHEMA_VERSION,
+            producer: ProducerIdentity {
+                producer_id: "hqplayer:main".to_string(),
+                producer_type: "hqplayer".to_string(),
+                instance_label: None,
+                product_version: None,
+                epoch: ProducerEpoch(7),
+                extensions: Extensions::default(),
+            },
+            target: ProducerTarget {
+                role: TargetRole::DspEngine,
+                zone_id: None,
+                extensions: Extensions::default(),
+            },
+            revisions: DocumentRevisions::new(3, 9),
+            lanes: vec![LaneHealth {
+                lane: TransportLane::Native,
+                state: LaneState::Connected,
+                last_success: Some(Timestamp::new("2026-07-31T00:00:00Z")),
+                last_error: None,
+                freshness: Freshness::default(),
+                extensions: Extensions::default(),
+            }],
+            groups: Vec::new(),
+            controls: vec![
+                selection(MODE, "PCM"),
+                selection(FILTER_1X, "poly-sinc-gauss"),
+                selection(FILTER_NX, "poly-sinc-xtr"),
+                selection(SHAPER, "NS9"),
+                selection(RATE, "192000"),
+            ],
+            constraints: Vec::new(),
+            draft_policy: None,
+            change_sets: Vec::new(),
+            operations: Vec::new(),
+            stale: false,
+            extensions: Extensions::default(),
+        };
+        let key = ProducerKey::of(&document);
+        ProducerSnapshot {
+            key,
+            document: Arc::new(document),
+            lanes: BTreeMap::new(),
+            presence: ProducerPresence::Live,
+            repairs: Vec::new(),
+            last_refusal: None,
+        }
+    }
+
+    fn selection(id: &str, engine_name: &str) -> Control {
+        Control {
+            id: ControlId::new(id),
+            kind: ControlKind::Enumeration,
+            label_key: None,
+            description_key: None,
+            group: None,
+            order: None,
+            widget_hint: None,
+            unit: None,
+            values: Vec::new(),
+            choices: Some(ChoiceSet::runtime(vec![Choice::new(
+                format!("{id}.engine.{}", hex(engine_name)),
+                engine_name,
+            )])),
+            range: None,
+            availability: Availability::available(),
+            apply: Some(ApplySemantics {
+                lane: ApplyLane::Immediate,
+                effect: ApplyEffect::LiveImmediate,
+                disruption: Disruption::NoDisruption,
+                risk: RiskClass::Safe,
+                verification: Verification::own_observed(),
+                invalidates: Vec::new(),
+                coupled_with: Vec::new(),
+            }),
+            divergences: Vec::new(),
+            members: Vec::new(),
+            extensions: Extensions::default(),
+        }
+    }
+
+    fn hex(value: &str) -> String {
+        value
+            .as_bytes()
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect()
+    }
+
+    fn request(
+        snapshot: &ProducerSnapshot,
+        control: &str,
+        choice: &str,
+    ) -> HqpImmediateCommandRequest {
+        HqpImmediateCommandRequest {
+            key: snapshot.key.clone(),
+            expected: snapshot.document.position(),
+            control: ControlId::new(control),
+            requested: ControlValue::choice(choice),
+            lane: ApplyLane::Immediate,
+            correlation_id: "gesture-1".to_string(),
+        }
+    }
+
+    #[test]
+    fn resolves_a_current_pipeline_choice_to_its_engine_name() {
+        let snapshot = snapshot();
+        let choice = "hqplayer.pipeline.mode.engine.50434d";
+
+        let validated = preflight(&snapshot, &request(&snapshot, MODE, choice))
+            .expect("the current semantic choice is invokable");
+
+        assert_eq!(validated.operation, HqpSemanticOperation::SetMode);
+        assert_eq!(
+            validated.engine_value,
+            HqpEngineValue::Name("PCM".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_rate_only_from_the_current_engine_choice_name() {
+        let snapshot = snapshot();
+        let choice = "hqplayer.pipeline.rate.engine.313932303030";
+
+        let validated = preflight(&snapshot, &request(&snapshot, RATE, choice))
+            .expect("current numeric engine spelling is invokable");
+
+        assert_eq!(validated.engine_value, HqpEngineValue::Rate(192_000));
+    }
+
+    #[test]
+    fn every_first_slice_pipeline_control_resolves_through_the_shared_registry() {
+        let snapshot = snapshot();
+        for (control, choice, operation, engine) in [
+            (MODE, "PCM", HqpSemanticOperation::SetMode, "PCM"),
+            (
+                FILTER_1X,
+                "poly-sinc-gauss",
+                HqpSemanticOperation::SetFilter1x,
+                "poly-sinc-gauss",
+            ),
+            (
+                FILTER_NX,
+                "poly-sinc-xtr",
+                HqpSemanticOperation::SetFilterNx,
+                "poly-sinc-xtr",
+            ),
+            (SHAPER, "NS9", HqpSemanticOperation::SetShaper, "NS9"),
+        ] {
+            let choice = format!("{control}.engine.{}", hex(choice));
+            let validated = preflight(&snapshot, &request(&snapshot, control, &choice))
+                .unwrap_or_else(|error| panic!("{control} did not preflight: {error:?}"));
+            assert_eq!(validated.operation, operation);
+            assert_eq!(
+                validated.engine_value,
+                HqpEngineValue::Name(engine.to_string())
+            );
+        }
+    }
+
+    #[test]
+    fn refuses_a_stale_revision_before_a_choice_can_be_resolved() {
+        let snapshot = snapshot();
+        let mut request = request(&snapshot, MODE, "hqplayer.pipeline.mode.engine.50434d");
+        request.expected.state.0 -= 1;
+
+        assert!(matches!(
+            preflight(&snapshot, &request),
+            Err(HqpPreflightRefusal::RevisionMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn defers_transport_and_volume_through_a_typed_policy() {
+        let snapshot = snapshot();
+        for control in ["hqplayer.transport.play", "hqplayer.volume.level"] {
+            let mut request = request(&snapshot, control, "not-used");
+            request.requested = ControlValue::Empty;
+            assert!(matches!(
+                preflight(&snapshot, &request),
+                Err(HqpPreflightRefusal::DeferredToIssue328 { .. })
+            ));
+        }
+    }
+
+    #[test]
+    fn refuses_unavailable_choices_and_stale_native_state() {
+        let mut snapshot = snapshot();
+        Arc::make_mut(&mut snapshot.document).lanes[0]
+            .freshness
+            .stale = true;
+        assert_eq!(
+            preflight(
+                &snapshot,
+                &request(&snapshot, MODE, "hqplayer.pipeline.mode.engine.50434d"),
+            ),
+            Err(HqpPreflightRefusal::NativeLaneStale)
+        );
+
+        Arc::make_mut(&mut snapshot.document).lanes[0]
+            .freshness
+            .stale = false;
+        Arc::make_mut(&mut snapshot.document).controls[0]
+            .choices
+            .as_mut()
+            .unwrap()
+            .choices[0]
+            .availability = Some(Availability::unavailable(crate::adaptive::Reason {
+            code: crate::adaptive::ReasonCode::LockedByProducer,
+            scope: crate::adaptive::ReasonScope::Producer,
+            display_text_key: None,
+            detail: None,
+        }));
+        assert_eq!(
+            preflight(
+                &snapshot,
+                &request(&snapshot, MODE, "hqplayer.pipeline.mode.engine.50434d"),
+            ),
+            Err(HqpPreflightRefusal::ChoiceUnavailable)
+        );
+    }
+
+    #[test]
+    fn fingerprint_covers_the_complete_semantic_request() {
+        let snapshot = snapshot();
+        let base = request(&snapshot, MODE, "hqplayer.pipeline.mode.engine.50434d");
+        let base_fingerprint = fingerprint(&base);
+
+        let mutations: Vec<HqpImmediateCommandRequest> = vec![
+            HqpImmediateCommandRequest {
+                key: ProducerKey {
+                    producer_id: "hqplayer:other".to_string(),
+                    ..base.key.clone()
+                },
+                ..base.clone()
+            },
+            HqpImmediateCommandRequest {
+                key: ProducerKey {
+                    role: TargetRole::Instance,
+                    ..base.key.clone()
+                },
+                ..base.clone()
+            },
+            HqpImmediateCommandRequest {
+                key: ProducerKey {
+                    zone_id: Some("hqplayer:zone".to_string()),
+                    ..base.key.clone()
+                },
+                ..base.clone()
+            },
+            HqpImmediateCommandRequest {
+                expected: RevisionRef {
+                    epoch: ProducerEpoch(base.expected.epoch.0 + 1),
+                    ..base.expected
+                },
+                ..base.clone()
+            },
+            HqpImmediateCommandRequest {
+                expected: RevisionRef {
+                    control_plane: crate::adaptive::Revision(base.expected.control_plane.0 + 1),
+                    ..base.expected
+                },
+                ..base.clone()
+            },
+            HqpImmediateCommandRequest {
+                expected: RevisionRef {
+                    state: crate::adaptive::Revision(base.expected.state.0 + 1),
+                    ..base.expected
+                },
+                ..base.clone()
+            },
+            HqpImmediateCommandRequest {
+                control: ControlId::new(FILTER_1X),
+                ..base.clone()
+            },
+            HqpImmediateCommandRequest {
+                lane: ApplyLane::Persistent,
+                ..base.clone()
+            },
+            HqpImmediateCommandRequest {
+                requested: ControlValue::choice("hqplayer.pipeline.mode.engine.53444d"),
+                ..base.clone()
+            },
+        ];
+
+        for mutation in mutations {
+            assert_ne!(
+                fingerprint(&mutation),
+                base_fingerprint,
+                "every semantic field participates in idempotency"
+            );
+        }
+    }
+
+    #[test]
+    fn fingerprint_is_unambiguous_for_boundary_shifting_strings_and_all_value_kinds() {
+        let snapshot = snapshot();
+        let base = request(&snapshot, MODE, "hqplayer.pipeline.mode.engine.50434d");
+        let values = vec![
+            ControlValue::Empty,
+            ControlValue::Bool(false),
+            ControlValue::Bool(true),
+            ControlValue::Integer(1),
+            ControlValue::Decimal(1.0),
+            ControlValue::Text("x:y".to_string()),
+            ControlValue::Choice("x:y".to_string()),
+            ControlValue::Composite(BTreeMap::from([
+                ("a".to_string(), ControlValue::Integer(1)),
+                ("b".to_string(), ControlValue::text("2")),
+            ])),
+            ControlValue::List(vec![ControlValue::Integer(1), ControlValue::text("2")]),
+            ControlValue::Unrecognized {
+                kind: "future".to_string(),
+                raw: serde_json::json!({"z": [1, true], "a": "value"}),
+            },
+        ];
+        let fingerprints = values
+            .into_iter()
+            .map(|requested| {
+                fingerprint(&HqpImmediateCommandRequest {
+                    requested,
+                    ..base.clone()
+                })
+            })
+            .collect::<std::collections::HashSet<_>>();
+
+        assert_eq!(
+            fingerprints.len(),
+            10,
+            "value types and payloads cannot alias"
+        );
+
+        let shifted_a = HqpImmediateCommandRequest {
+            key: ProducerKey {
+                producer_id: "ab".to_string(),
+                ..base.key.clone()
+            },
+            control: ControlId::new("c"),
+            requested: ControlValue::choice("de"),
+            ..base.clone()
+        };
+        let shifted_b = HqpImmediateCommandRequest {
+            key: ProducerKey {
+                producer_id: "a".to_string(),
+                ..base.key.clone()
+            },
+            control: ControlId::new("bc"),
+            requested: ControlValue::choice("de"),
+            ..base
+        };
+        assert_ne!(fingerprint(&shifted_a), fingerprint(&shifted_b));
+    }
+
+    #[test]
+    fn correlation_id_must_be_nonempty_and_bounded() {
+        let snapshot = snapshot();
+        let mut command = request(&snapshot, MODE, "hqplayer.pipeline.mode.engine.50434d");
+        command.correlation_id.clear();
+        assert_eq!(
+            preflight(&snapshot, &command),
+            Err(HqpPreflightRefusal::CorrelationIdEmpty)
+        );
+
+        command.correlation_id = "x".repeat(257);
+        assert_eq!(
+            preflight(&snapshot, &command),
+            Err(HqpPreflightRefusal::CorrelationIdTooLong {
+                max_bytes: 256,
+                actual_bytes: 257,
+            })
+        );
+    }
+
+    #[test]
+    fn refuses_every_non_actionable_snapshot_and_lane_state() {
+        let choice = "hqplayer.pipeline.mode.engine.50434d";
+
+        let mut last_known = snapshot();
+        last_known.presence = ProducerPresence::LastKnown;
+        assert_eq!(
+            preflight(&last_known, &request(&last_known, MODE, choice)),
+            Err(HqpPreflightRefusal::ProducerNotLive)
+        );
+
+        let mut document_stale = snapshot();
+        Arc::make_mut(&mut document_stale.document).stale = true;
+        assert_eq!(
+            preflight(&document_stale, &request(&document_stale, MODE, choice),),
+            Err(HqpPreflightRefusal::ProducerStale)
+        );
+
+        let mut missing_lane = snapshot();
+        Arc::make_mut(&mut missing_lane.document).lanes.clear();
+        assert_eq!(
+            preflight(&missing_lane, &request(&missing_lane, MODE, choice)),
+            Err(HqpPreflightRefusal::NativeLaneMissing)
+        );
+
+        let mut disconnected = snapshot();
+        Arc::make_mut(&mut disconnected.document).lanes[0].state = LaneState::Disconnected;
+        assert_eq!(
+            preflight(&disconnected, &request(&disconnected, MODE, choice)),
+            Err(HqpPreflightRefusal::NativeLaneUnavailable)
+        );
+
+        let mut stale_lane = snapshot();
+        Arc::make_mut(&mut stale_lane.document).lanes[0]
+            .freshness
+            .stale = true;
+        assert_eq!(
+            preflight(&stale_lane, &request(&stale_lane, MODE, choice)),
+            Err(HqpPreflightRefusal::NativeLaneStale)
+        );
+    }
+
+    #[test]
+    fn refuses_every_non_actionable_control_and_choice_shape() {
+        let choice = "hqplayer.pipeline.mode.engine.50434d";
+
+        let unknown = snapshot();
+        assert_eq!(
+            preflight(
+                &unknown,
+                &request(&unknown, "hqplayer.pipeline.unknown", choice)
+            ),
+            Err(HqpPreflightRefusal::UnsupportedControl)
+        );
+
+        let mut missing_control = snapshot();
+        Arc::make_mut(&mut missing_control.document)
+            .controls
+            .retain(|control| control.id.as_str() != MODE);
+        assert_eq!(
+            preflight(&missing_control, &request(&missing_control, MODE, choice),),
+            Err(HqpPreflightRefusal::ControlUnknown)
+        );
+
+        let mut unavailable = snapshot();
+        Arc::make_mut(&mut unavailable.document).controls[0].availability = unavailable_reason();
+        assert_eq!(
+            preflight(&unavailable, &request(&unavailable, MODE, choice)),
+            Err(HqpPreflightRefusal::ControlUnavailable)
+        );
+
+        let mut read_only = snapshot();
+        Arc::make_mut(&mut read_only.document).controls[0].apply = None;
+        assert_eq!(
+            preflight(&read_only, &request(&read_only, MODE, choice)),
+            Err(HqpPreflightRefusal::ControlReadOnly)
+        );
+
+        let mut wrong_lane = snapshot();
+        Arc::make_mut(&mut wrong_lane.document).controls[0]
+            .apply
+            .as_mut()
+            .unwrap()
+            .lane = ApplyLane::Persistent;
+        assert_eq!(
+            preflight(&wrong_lane, &request(&wrong_lane, MODE, choice)),
+            Err(HqpPreflightRefusal::WrongApplyLane)
+        );
+
+        let non_immediate = snapshot();
+        let mut non_immediate_request = request(&non_immediate, MODE, choice);
+        non_immediate_request.lane = ApplyLane::Persistent;
+        assert_eq!(
+            preflight(&non_immediate, &non_immediate_request),
+            Err(HqpPreflightRefusal::NonImmediateRequest)
+        );
+
+        let mut wrong_kind = snapshot();
+        Arc::make_mut(&mut wrong_kind.document).controls[0].kind = ControlKind::Boolean;
+        assert_eq!(
+            preflight(&wrong_kind, &request(&wrong_kind, MODE, choice)),
+            Err(HqpPreflightRefusal::WrongControlKind)
+        );
+
+        let wrong_value = snapshot();
+        let mut wrong_value_request = request(&wrong_value, MODE, choice);
+        wrong_value_request.requested = ControlValue::Text(choice.to_string());
+        assert_eq!(
+            preflight(&wrong_value, &wrong_value_request),
+            Err(HqpPreflightRefusal::WrongValueKind)
+        );
+
+        let unknown_choice = snapshot();
+        assert_eq!(
+            preflight(
+                &unknown_choice,
+                &request(
+                    &unknown_choice,
+                    MODE,
+                    "hqplayer.pipeline.mode.engine.unknown"
+                ),
+            ),
+            Err(HqpPreflightRefusal::UnknownChoice)
+        );
+
+        let mut unavailable_choice = snapshot();
+        Arc::make_mut(&mut unavailable_choice.document).controls[0]
+            .choices
+            .as_mut()
+            .unwrap()
+            .choices[0]
+            .availability = Some(unavailable_reason());
+        assert_eq!(
+            preflight(
+                &unavailable_choice,
+                &request(&unavailable_choice, MODE, choice),
+            ),
+            Err(HqpPreflightRefusal::ChoiceUnavailable)
+        );
+
+        let mut missing_engine = snapshot();
+        Arc::make_mut(&mut missing_engine.document).controls[0]
+            .choices
+            .as_mut()
+            .unwrap()
+            .choices[0]
+            .engine_name = None;
+        assert_eq!(
+            preflight(&missing_engine, &request(&missing_engine, MODE, choice)),
+            Err(HqpPreflightRefusal::ChoiceMissingEngineName)
+        );
+    }
+
+    #[test]
+    fn source_mode_rate_is_not_actionable() {
+        let mut source_mode = snapshot();
+        let rate = Arc::make_mut(&mut source_mode.document)
+            .controls
+            .iter_mut()
+            .find(|control| control.id.as_str() == RATE)
+            .unwrap();
+        rate.availability = unavailable_reason();
+        rate.apply = None;
+
+        assert_eq!(
+            preflight(
+                &source_mode,
+                &request(
+                    &source_mode,
+                    RATE,
+                    "hqplayer.pipeline.rate.engine.313932303030",
+                ),
+            ),
+            Err(HqpPreflightRefusal::ControlUnavailable)
+        );
+    }
+
+    fn unavailable_reason() -> Availability {
+        Availability::unavailable(crate::adaptive::Reason {
+            code: crate::adaptive::ReasonCode::LockedByProducer,
+            scope: crate::adaptive::ReasonScope::Producer,
+            display_text_key: None,
+            detail: None,
+        })
+    }
+}

--- a/src/producers/hqplayer_command_service.rs
+++ b/src/producers/hqplayer_command_service.rs
@@ -1,0 +1,1444 @@
+//! Bounded, actor-owned execution for HQPlayer immediate adaptive commands.
+//!
+//! Advisory reads and producer reservation deliberately happen before native I/O. Once the
+//! bounded actor accepts a message, it owns the reserved operation through completion even if the
+//! submitting task disappears.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::{mpsc, oneshot};
+
+use crate::adapters::hqplayer::{
+    HqpInstanceManager, HqpNativeExecutionTarget, HqpNativeSetting, NativeSettingReadback,
+    NativeSettingReceipt,
+};
+use crate::adaptive::{
+    CommandOutcome, OperationRecord, Reason, ReasonCode, ReasonScope, RecoveryState, Timestamp,
+    WriteAttempt,
+};
+
+use super::hqplayer::{
+    HqpAdaptivePublisher, HqpCommandCompletion, HqpCommandLease, HqpCommandReservation,
+    HqpCoordinatorRefusal, HqpSemanticOperation,
+};
+use super::hqplayer_command::{
+    preflight, validate_correlation_id, HqpEngineValue, HqpImmediateCommandRequest,
+    HqpPreflightRefusal, HqpValidatedCommand,
+};
+use super::{AdaptiveView, ProducerKey, ProducerSnapshot};
+
+/// A command accepted only after its `Pending` operation has been admitted.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct HqpCommandAcknowledgement {
+    pub operation: OperationRecord,
+    pub duplicate: bool,
+}
+
+/// Refusals returned before a new native execution is admitted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum HqpCommandServiceRefusal {
+    ProducerUnknown,
+    InvalidProducerIdentity,
+    Preflight(HqpPreflightRefusal),
+    Coordinator(HqpCoordinatorRefusal),
+    // #329 intentionally adds no public consumer. #331 will construct this refusal when its
+    // adaptive surface submits after shutdown.
+    #[cfg_attr(not(test), allow(dead_code))]
+    ServiceClosed,
+}
+
+trait HqpCommandSnapshotView: Send + Sync {
+    fn snapshot(&self, key: &ProducerKey) -> Option<ProducerSnapshot>;
+}
+
+impl HqpCommandSnapshotView for AdaptiveView {
+    fn snapshot(&self, key: &ProducerKey) -> Option<ProducerSnapshot> {
+        AdaptiveView::snapshot(self, key)
+    }
+}
+
+#[async_trait]
+trait HqpCommandCoordinator: Send + Sync {
+    async fn lookup_correlation(
+        &self,
+        request: &HqpImmediateCommandRequest,
+    ) -> Result<Option<HqpCommandReservation>, HqpCoordinatorRefusal>;
+
+    async fn reserve(
+        &self,
+        command: HqpValidatedCommand,
+    ) -> Result<HqpCommandReservation, HqpCoordinatorRefusal>;
+
+    async fn validate(&self, lease: &HqpCommandLease) -> Result<(), HqpCoordinatorRefusal>;
+
+    async fn complete(
+        &self,
+        lease: &HqpCommandLease,
+        completion: HqpCommandCompletion,
+    ) -> Result<OperationRecord, HqpCoordinatorRefusal>;
+
+    async fn supersede_stale_before_dispatch(
+        &self,
+        lease: &HqpCommandLease,
+        at: Timestamp,
+    ) -> Result<OperationRecord, HqpCoordinatorRefusal>;
+}
+
+#[async_trait]
+impl HqpCommandCoordinator for HqpAdaptivePublisher {
+    async fn lookup_correlation(
+        &self,
+        request: &HqpImmediateCommandRequest,
+    ) -> Result<Option<HqpCommandReservation>, HqpCoordinatorRefusal> {
+        HqpAdaptivePublisher::lookup_correlation(self, request).await
+    }
+
+    async fn reserve(
+        &self,
+        command: HqpValidatedCommand,
+    ) -> Result<HqpCommandReservation, HqpCoordinatorRefusal> {
+        HqpAdaptivePublisher::reserve(self, command).await
+    }
+
+    async fn validate(&self, lease: &HqpCommandLease) -> Result<(), HqpCoordinatorRefusal> {
+        HqpAdaptivePublisher::validate(self, lease).await
+    }
+
+    async fn complete(
+        &self,
+        lease: &HqpCommandLease,
+        completion: HqpCommandCompletion,
+    ) -> Result<OperationRecord, HqpCoordinatorRefusal> {
+        HqpAdaptivePublisher::complete(self, lease, completion).await
+    }
+
+    async fn supersede_stale_before_dispatch(
+        &self,
+        lease: &HqpCommandLease,
+        at: Timestamp,
+    ) -> Result<OperationRecord, HqpCoordinatorRefusal> {
+        HqpAdaptivePublisher::supersede_stale_before_dispatch(self, lease, at).await
+    }
+}
+
+#[async_trait]
+trait HqpNativeSettingExecutor: Send + Sync {
+    async fn execute(
+        &self,
+        target: &HqpNativeExecutionTarget,
+        setting: HqpNativeSetting,
+    ) -> anyhow::Result<NativeSettingReceipt>;
+}
+
+#[async_trait]
+impl HqpNativeSettingExecutor for HqpInstanceManager {
+    async fn execute(
+        &self,
+        target: &HqpNativeExecutionTarget,
+        setting: HqpNativeSetting,
+    ) -> anyhow::Result<NativeSettingReceipt> {
+        self.execute_reserved_native_setting(target, setting).await
+    }
+}
+
+enum HqpCommandActorMessage {
+    // The first public consumer lands in #331; keeping the variant in the production actor now is
+    // what lets that issue remain a thin projection instead of redesigning accepted-job lifetime.
+    #[cfg_attr(not(test), allow(dead_code))]
+    Submit {
+        request: Box<HqpImmediateCommandRequest>,
+        reply: oneshot::Sender<Result<HqpCommandAcknowledgement, HqpCommandServiceRefusal>>,
+    },
+    Shutdown {
+        reply: oneshot::Sender<()>,
+    },
+}
+
+/// Cloneable ingress for the bounded immediate-command actor.
+#[derive(Clone)]
+#[doc(hidden)]
+pub struct HqpImmediateCommandHandle {
+    commands: mpsc::Sender<HqpCommandActorMessage>,
+}
+
+impl HqpImmediateCommandHandle {
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) async fn submit(
+        &self,
+        request: HqpImmediateCommandRequest,
+    ) -> Result<HqpCommandAcknowledgement, HqpCommandServiceRefusal> {
+        let (reply, response) = oneshot::channel();
+        self.commands
+            .send(HqpCommandActorMessage::Submit {
+                request: Box::new(request),
+                reply,
+            })
+            .await
+            .map_err(|_| HqpCommandServiceRefusal::ServiceClosed)?;
+        response
+            .await
+            .map_err(|_| HqpCommandServiceRefusal::ServiceClosed)?
+    }
+
+    /// Close ingress and wait until every message accepted before closure has terminalized.
+    pub async fn shutdown(&self) -> Result<(), HqpCommandShutdownError> {
+        let (reply, response) = oneshot::channel();
+        self.commands
+            .send(HqpCommandActorMessage::Shutdown { reply })
+            .await
+            .map_err(|_| HqpCommandShutdownError)?;
+        response.await.map_err(|_| HqpCommandShutdownError)
+    }
+}
+
+/// The actor ended before acknowledging a requested graceful drain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[doc(hidden)]
+pub struct HqpCommandShutdownError;
+
+impl std::fmt::Display for HqpCommandShutdownError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("HQPlayer command actor closed before completing its drain")
+    }
+}
+
+impl std::error::Error for HqpCommandShutdownError {}
+
+/// The single owner of accepted command jobs.
+#[doc(hidden)]
+pub struct HqpImmediateCommandActor {
+    commands: mpsc::Receiver<HqpCommandActorMessage>,
+    view: Arc<dyn HqpCommandSnapshotView>,
+    coordinator: Arc<dyn HqpCommandCoordinator>,
+    executor: Arc<dyn HqpNativeSettingExecutor>,
+}
+
+impl HqpImmediateCommandActor {
+    /// Build a bounded service. Capacity must be non-zero (the same requirement as Tokio's
+    /// bounded channel).
+    pub fn build(
+        view: AdaptiveView,
+        coordinator: Arc<HqpAdaptivePublisher>,
+        executor: Arc<HqpInstanceManager>,
+        capacity: usize,
+    ) -> (HqpImmediateCommandHandle, Self) {
+        Self::build_with(Arc::new(view), coordinator, executor, capacity)
+    }
+
+    fn build_with(
+        view: Arc<dyn HqpCommandSnapshotView>,
+        coordinator: Arc<dyn HqpCommandCoordinator>,
+        executor: Arc<dyn HqpNativeSettingExecutor>,
+        capacity: usize,
+    ) -> (HqpImmediateCommandHandle, Self) {
+        let (commands, receiver) = mpsc::channel(capacity);
+        (
+            HqpImmediateCommandHandle { commands },
+            Self {
+                commands: receiver,
+                view,
+                coordinator,
+                executor,
+            },
+        )
+    }
+
+    pub async fn run(mut self) {
+        while let Some(message) = self.commands.recv().await {
+            match message {
+                HqpCommandActorMessage::Submit { request, reply } => {
+                    self.process(*request, reply).await;
+                }
+                HqpCommandActorMessage::Shutdown { reply } => {
+                    // Closing first prevents new sends. Messages which already acquired capacity
+                    // remain in the receiver and are owned by this actor, so drain them too.
+                    self.commands.close();
+                    let mut shutdown_replies = vec![reply];
+                    while let Some(accepted) = self.commands.recv().await {
+                        match accepted {
+                            HqpCommandActorMessage::Submit { request, reply } => {
+                                self.process(*request, reply).await;
+                            }
+                            HqpCommandActorMessage::Shutdown { reply } => {
+                                shutdown_replies.push(reply);
+                            }
+                        }
+                    }
+                    for waiter in shutdown_replies {
+                        let _ = waiter.send(());
+                    }
+                    return;
+                }
+            }
+        }
+    }
+
+    async fn process(
+        &self,
+        request: HqpImmediateCommandRequest,
+        reply: oneshot::Sender<Result<HqpCommandAcknowledgement, HqpCommandServiceRefusal>>,
+    ) {
+        if let Err(refusal) = validate_correlation_id(&request.correlation_id) {
+            let _ = reply.send(Err(HqpCommandServiceRefusal::Preflight(refusal)));
+            return;
+        }
+        match self.coordinator.lookup_correlation(&request).await {
+            Ok(Some(reservation)) => {
+                let _ = reply.send(Ok(HqpCommandAcknowledgement {
+                    operation: reservation.operation().clone(),
+                    duplicate: true,
+                }));
+                return;
+            }
+            Ok(None) => {}
+            Err(refusal) => {
+                let _ = reply.send(Err(HqpCommandServiceRefusal::Coordinator(refusal)));
+                return;
+            }
+        }
+        let Some(snapshot) = self.view.snapshot(&request.key) else {
+            let _ = reply.send(Err(HqpCommandServiceRefusal::ProducerUnknown));
+            return;
+        };
+        let validated = match preflight(&snapshot, &request) {
+            Ok(validated) => validated,
+            Err(refusal) => {
+                let _ = reply.send(Err(HqpCommandServiceRefusal::Preflight(refusal)));
+                return;
+            }
+        };
+        if instance_name(&validated).is_none() {
+            let _ = reply.send(Err(HqpCommandServiceRefusal::InvalidProducerIdentity));
+            return;
+        }
+        let setting = native_setting(&validated);
+        let reservation = match self.coordinator.reserve(validated).await {
+            Ok(reservation) => reservation,
+            Err(refusal) => {
+                let _ = reply.send(Err(HqpCommandServiceRefusal::Coordinator(refusal)));
+                return;
+            }
+        };
+        let lease = reservation.lease().clone();
+        let execution_target = reservation.execution_target().cloned();
+        let duplicate = reservation.is_duplicate();
+        let acknowledgement = HqpCommandAcknowledgement {
+            operation: reservation.operation().clone(),
+            duplicate,
+        };
+        // The accepted job no longer depends on this send succeeding. A disconnected submitter
+        // drops only its acknowledgement receiver, never the actor-owned reservation.
+        let _ = reply.send(Ok(acknowledgement));
+        if duplicate {
+            return;
+        }
+
+        if let Err(refusal) = self.coordinator.validate(&lease).await {
+            if let Err(error) = self
+                .coordinator
+                .supersede_stale_before_dispatch(&lease, now())
+                .await
+            {
+                tracing::debug!(
+                    ?refusal,
+                    ?error,
+                    "stale HQPlayer operation could not publish supersession"
+                );
+            }
+            return;
+        }
+
+        let Some(execution_target) = execution_target else {
+            let evidence = CompletionEvidence {
+                outcome: CommandOutcome::Superseded,
+                write_attempt: WriteAttempt::NotAttempted,
+                recovery: RecoveryState::ReplanRequired,
+                reason: Some(reason(
+                    ReasonCode::Superseded,
+                    ReasonScope::Producer,
+                    "the admitted HQPlayer command did not retain its native execution target"
+                        .to_string(),
+                )),
+            };
+            if let Err(error) = self
+                .coordinator
+                .complete(&lease, completion(evidence))
+                .await
+            {
+                tracing::warn!(?error, "targetless HQPlayer command was not terminalized");
+            }
+            return;
+        };
+
+        // The executor's typed receipt is the sole source of native-attempt evidence. In
+        // particular, do not publish `Attempted` merely because this actor is about to make the
+        // call: lifecycle stop between such a marker and the first native byte is a proven
+        // no-write case. The reserved target makes that stop race safe: a moved/removed instance
+        // returns `NativeSettingReceipt::NotAttempted` and no stale target is replayed.
+        let evidence = match setting {
+            Some(setting) => match self.executor.execute(&execution_target, setting).await {
+                Ok(receipt) => receipt_evidence(receipt),
+                Err(error) => execution_error_evidence(error),
+            },
+            None => CompletionEvidence {
+                outcome: CommandOutcome::Superseded,
+                write_attempt: WriteAttempt::NotAttempted,
+                recovery: RecoveryState::ReplanRequired,
+                reason: Some(reason(
+                    ReasonCode::Superseded,
+                    ReasonScope::Producer,
+                    "the validated command had no #329 native setting arm".to_string(),
+                )),
+            },
+        };
+        let completion = completion(evidence);
+        if let Err(error) = self.coordinator.complete(&lease, completion).await {
+            tracing::warn!(?error, "HQPlayer command completion was not published");
+        }
+    }
+}
+
+fn instance_name(command: &HqpValidatedCommand) -> Option<String> {
+    command
+        .request
+        .key
+        .producer_id
+        .strip_prefix("hqplayer:")
+        .filter(|name| !name.is_empty())
+        .map(str::to_string)
+}
+
+fn native_setting(command: &HqpValidatedCommand) -> Option<HqpNativeSetting> {
+    match (&command.operation, &command.engine_value) {
+        (HqpSemanticOperation::SetMode, HqpEngineValue::Name(value)) => {
+            Some(HqpNativeSetting::Mode(value.clone()))
+        }
+        (HqpSemanticOperation::SetFilter1x, HqpEngineValue::Name(value)) => {
+            Some(HqpNativeSetting::Filter1x(value.clone()))
+        }
+        (HqpSemanticOperation::SetFilterNx, HqpEngineValue::Name(value)) => {
+            Some(HqpNativeSetting::FilterNx(value.clone()))
+        }
+        (HqpSemanticOperation::SetShaper, HqpEngineValue::Name(value)) => {
+            Some(HqpNativeSetting::Shaper(value.clone()))
+        }
+        (HqpSemanticOperation::SetRate, HqpEngineValue::Rate(value)) => {
+            Some(HqpNativeSetting::Rate(*value))
+        }
+        _ => None,
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct CompletionEvidence {
+    outcome: CommandOutcome,
+    write_attempt: WriteAttempt,
+    recovery: RecoveryState,
+    reason: Option<Reason>,
+}
+
+fn receipt_evidence(receipt: NativeSettingReceipt) -> CompletionEvidence {
+    match receipt {
+        NativeSettingReceipt::NotAttempted {
+            reason: detail,
+            readback: NativeSettingReadback::Noop | NativeSettingReadback::Verified,
+        } => CompletionEvidence {
+            outcome: CommandOutcome::Ignored,
+            write_attempt: WriteAttempt::NotAttempted,
+            recovery: RecoveryState::NotRequired,
+            reason: Some(reason(
+                ReasonCode::LockedByProducer,
+                ReasonScope::Observed,
+                detail,
+            )),
+        },
+        NativeSettingReceipt::NotAttempted {
+            reason: detail,
+            readback,
+        } => CompletionEvidence {
+            outcome: CommandOutcome::Superseded,
+            write_attempt: WriteAttempt::NotAttempted,
+            recovery: RecoveryState::ReplanRequired,
+            reason: Some(reason(
+                ReasonCode::Superseded,
+                ReasonScope::Observed,
+                format!("{detail}; native readback: {readback:?}"),
+            )),
+        },
+        NativeSettingReceipt::Suppressed { reason: detail } => CompletionEvidence {
+            outcome: CommandOutcome::Superseded,
+            write_attempt: WriteAttempt::NotAttempted,
+            recovery: RecoveryState::ReplanRequired,
+            reason: Some(reason(
+                ReasonCode::Superseded,
+                ReasonScope::Observed,
+                detail,
+            )),
+        },
+        NativeSettingReceipt::DaemonRejected(rejected) => CompletionEvidence {
+            outcome: CommandOutcome::Rejected,
+            write_attempt: WriteAttempt::AcknowledgedProvisional,
+            recovery: RecoveryState::NotRequired,
+            reason: Some(reason(
+                ReasonCode::LockedByProducer,
+                ReasonScope::Producer,
+                rejected.to_string(),
+            )),
+        },
+        NativeSettingReceipt::DaemonAcknowledged {
+            readback: NativeSettingReadback::Verified,
+        } => CompletionEvidence {
+            outcome: CommandOutcome::Applied,
+            write_attempt: WriteAttempt::Confirmed,
+            recovery: RecoveryState::NotRequired,
+            reason: None,
+        },
+        NativeSettingReceipt::DaemonAcknowledged {
+            readback: NativeSettingReadback::Noop,
+        } => CompletionEvidence {
+            outcome: CommandOutcome::Ignored,
+            write_attempt: WriteAttempt::Confirmed,
+            recovery: RecoveryState::NotRequired,
+            reason: None,
+        },
+        NativeSettingReceipt::DaemonAcknowledged {
+            readback:
+                NativeSettingReadback::Divergent {
+                    requested,
+                    observed,
+                },
+        } => divergent_evidence(WriteAttempt::AcknowledgedProvisional, requested, observed),
+        NativeSettingReceipt::DaemonAcknowledged {
+            readback: NativeSettingReadback::Unavailable { reason: detail },
+        } => indeterminate_evidence(
+            WriteAttempt::AcknowledgedProvisional,
+            RecoveryState::AwaitingReadback,
+            detail,
+        ),
+        NativeSettingReceipt::PossibleAttempt {
+            readback: NativeSettingReadback::Verified | NativeSettingReadback::Noop,
+            ..
+        } => CompletionEvidence {
+            outcome: CommandOutcome::Applied,
+            write_attempt: WriteAttempt::Confirmed,
+            recovery: RecoveryState::NotRequired,
+            reason: None,
+        },
+        NativeSettingReceipt::PossibleAttempt {
+            readback:
+                NativeSettingReadback::Divergent {
+                    requested,
+                    observed,
+                },
+            ..
+        } => divergent_evidence(WriteAttempt::Attempted, requested, observed),
+        NativeSettingReceipt::PossibleAttempt {
+            reason: delivery,
+            readback: NativeSettingReadback::Unavailable { reason: readback },
+        } => indeterminate_evidence(
+            WriteAttempt::Attempted,
+            RecoveryState::AwaitingReconnect,
+            format!("{delivery}; {readback}"),
+        ),
+    }
+}
+
+fn execution_error_evidence(error: anyhow::Error) -> CompletionEvidence {
+    // The manager's legacy `anyhow` boundary does not prove whether a write left. Preserve the
+    // ambiguity without parsing its display text or replaying the request.
+    indeterminate_evidence(
+        WriteAttempt::Attempted,
+        RecoveryState::AwaitingReconnect,
+        error.to_string(),
+    )
+}
+
+fn divergent_evidence(
+    write_attempt: WriteAttempt,
+    requested: String,
+    observed: String,
+) -> CompletionEvidence {
+    CompletionEvidence {
+        outcome: CommandOutcome::Divergent,
+        write_attempt,
+        recovery: RecoveryState::ReplanRequired,
+        reason: Some(reason(
+            ReasonCode::Unobservable,
+            ReasonScope::Observed,
+            format!("requested {requested}; authoritative readback reported {observed}"),
+        )),
+    }
+}
+
+fn indeterminate_evidence(
+    write_attempt: WriteAttempt,
+    recovery: RecoveryState,
+    detail: String,
+) -> CompletionEvidence {
+    CompletionEvidence {
+        outcome: CommandOutcome::Indeterminate,
+        write_attempt,
+        recovery,
+        reason: Some(reason(ReasonCode::Unobservable, ReasonScope::Lane, detail)),
+    }
+}
+
+fn completion(evidence: CompletionEvidence) -> HqpCommandCompletion {
+    HqpCommandCompletion::new(
+        evidence.outcome,
+        evidence.write_attempt,
+        now(),
+        Some(evidence.recovery),
+        evidence.reason,
+    )
+}
+
+fn reason(code: ReasonCode, scope: ReasonScope, detail: String) -> Reason {
+    Reason {
+        code,
+        scope,
+        display_text_key: None,
+        detail: Some(detail),
+    }
+}
+
+fn now() -> Timestamp {
+    Timestamp::new(chrono::Utc::now().to_rfc3339())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeMap, HashMap};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::Mutex as StdMutex;
+    use std::time::Duration;
+
+    use tokio::sync::{Notify, Semaphore};
+
+    use super::*;
+    use crate::adapters::hqplayer::HqpRejected;
+    use crate::adaptive::{
+        ApplyEffect, ApplyLane, ApplySemantics, Availability, Choice, ChoiceSet, Control,
+        ControlId, ControlKind, ControlValue, Disruption, DocumentRevisions, Extensions, Freshness,
+        LaneHealth, LaneState, OperationId, OperationRequest, ProducerDocument, ProducerEpoch,
+        ProducerIdentity, ProducerTarget, RevisionRef, RiskClass, TargetRole, TransportLane,
+        Verification, CONSUMER_SCHEMA_VERSION,
+    };
+    use crate::producers::hqplayer_command::{fingerprint, HqpCommandFingerprint};
+    use crate::producers::ProducerPresence;
+
+    const MODE: &str = "hqplayer.pipeline.mode";
+    const MODE_CHOICE: &str = "hqplayer.pipeline.mode.engine.50434d";
+    const FILTER_1X: &str = "hqplayer.pipeline.filter_1x";
+    const FILTER_1X_CHOICE: &str = "hqplayer.pipeline.filter_1x.engine.706f6c79";
+    const FILTER_NX: &str = "hqplayer.pipeline.filter_nx";
+    const FILTER_NX_CHOICE: &str = "hqplayer.pipeline.filter_nx.engine.73696e63";
+    const SHAPER: &str = "hqplayer.pipeline.shaper";
+    const SHAPER_CHOICE: &str = "hqplayer.pipeline.shaper.engine.4e5339";
+    const RATE: &str = "hqplayer.pipeline.rate";
+    const RATE_CHOICE: &str = "hqplayer.pipeline.rate.engine.313932303030";
+
+    struct FakeView {
+        snapshot: StdMutex<ProducerSnapshot>,
+    }
+
+    impl HqpCommandSnapshotView for FakeView {
+        fn snapshot(&self, key: &ProducerKey) -> Option<ProducerSnapshot> {
+            let snapshot = lock(&self.snapshot);
+            (snapshot.key == *key).then(|| snapshot.clone())
+        }
+    }
+
+    #[derive(Default)]
+    struct FakeCoordinator {
+        reserves: AtomicUsize,
+        validations: AtomicUsize,
+        completions: AtomicUsize,
+        supersessions: AtomicUsize,
+        lookups: AtomicUsize,
+        validation_fails: AtomicBool,
+        block_reserve: AtomicBool,
+        targetless_lease: AtomicBool,
+        reserve_started: Notify,
+        reserve_release: Notify,
+        correlations: StdMutex<HashMap<String, (HqpCommandFingerprint, HqpCommandReservation)>>,
+        sequence: Arc<StdMutex<Vec<&'static str>>>,
+    }
+
+    #[async_trait]
+    impl HqpCommandCoordinator for FakeCoordinator {
+        async fn lookup_correlation(
+            &self,
+            request: &HqpImmediateCommandRequest,
+        ) -> Result<Option<HqpCommandReservation>, HqpCoordinatorRefusal> {
+            self.lookups.fetch_add(1, Ordering::SeqCst);
+            let correlations = lock(&self.correlations);
+            let Some((reserved_fingerprint, reservation)) =
+                correlations.get(&request.correlation_id)
+            else {
+                return Ok(None);
+            };
+            if *reserved_fingerprint != fingerprint(request) {
+                return Err(HqpCoordinatorRefusal::CorrelationConflict);
+            }
+            Ok(Some(HqpCommandReservation::for_test(
+                reservation.lease().clone(),
+                reservation.operation().clone(),
+                true,
+            )))
+        }
+
+        async fn reserve(
+            &self,
+            command: HqpValidatedCommand,
+        ) -> Result<HqpCommandReservation, HqpCoordinatorRefusal> {
+            self.reserves.fetch_add(1, Ordering::SeqCst);
+            push(&self.sequence, "reserve");
+            if self.block_reserve.load(Ordering::SeqCst) {
+                self.reserve_started.notify_one();
+                self.reserve_release.notified().await;
+            }
+            let mut correlations = lock(&self.correlations);
+            if let Some((reserved_fingerprint, existing)) =
+                correlations.get(&command.request.correlation_id)
+            {
+                if *reserved_fingerprint != command.fingerprint {
+                    return Err(HqpCoordinatorRefusal::CorrelationConflict);
+                }
+                return Ok(HqpCommandReservation::for_test(
+                    existing.lease().clone(),
+                    existing.operation().clone(),
+                    true,
+                ));
+            }
+            let generation = self.reserves.load(Ordering::SeqCst) as u64;
+            let execution_target = HqpNativeExecutionTarget {
+                instance_name: command
+                    .request
+                    .key
+                    .producer_id
+                    .strip_prefix("hqplayer:")
+                    .unwrap_or_default()
+                    .to_string(),
+                producer_epoch: command.request.expected.epoch.0,
+                endpoint_generation: 17,
+                transport_generation: 23,
+            };
+            let lease = if self.targetless_lease.load(Ordering::SeqCst) {
+                HqpCommandLease::for_test(
+                    command.request.key.producer_id.clone(),
+                    command.request.expected.epoch.0,
+                    generation,
+                    command.request.correlation_id.clone(),
+                )
+            } else {
+                HqpCommandLease::for_test_with_execution_target(
+                    command.request.key.producer_id.clone(),
+                    command.request.expected.epoch.0,
+                    generation,
+                    command.request.correlation_id.clone(),
+                    execution_target,
+                )
+            };
+            let operation = pending_operation(&command, generation);
+            let reservation = HqpCommandReservation::for_test(lease, operation, false);
+            correlations.insert(
+                command.request.correlation_id,
+                (command.fingerprint, reservation.clone()),
+            );
+            Ok(reservation)
+        }
+
+        async fn validate(&self, _lease: &HqpCommandLease) -> Result<(), HqpCoordinatorRefusal> {
+            self.validations.fetch_add(1, Ordering::SeqCst);
+            push(&self.sequence, "validate");
+            if self.validation_fails.load(Ordering::SeqCst) {
+                Err(HqpCoordinatorRefusal::StaleLease)
+            } else {
+                Ok(())
+            }
+        }
+
+        async fn complete(
+            &self,
+            lease: &HqpCommandLease,
+            _completion: HqpCommandCompletion,
+        ) -> Result<OperationRecord, HqpCoordinatorRefusal> {
+            self.completions.fetch_add(1, Ordering::SeqCst);
+            push(&self.sequence, "complete");
+            lock(&self.correlations)
+                .values()
+                .find(|(_, reservation)| reservation.lease() == lease)
+                .map(|(_, reservation)| reservation.operation().clone())
+                .ok_or(HqpCoordinatorRefusal::StaleLease)
+        }
+
+        async fn supersede_stale_before_dispatch(
+            &self,
+            lease: &HqpCommandLease,
+            _at: Timestamp,
+        ) -> Result<OperationRecord, HqpCoordinatorRefusal> {
+            self.supersessions.fetch_add(1, Ordering::SeqCst);
+            push(&self.sequence, "supersede");
+            lock(&self.correlations)
+                .values()
+                .find(|(_, reservation)| reservation.lease() == lease)
+                .map(|(_, reservation)| reservation.operation().clone())
+                .ok_or(HqpCoordinatorRefusal::StaleLease)
+        }
+    }
+
+    struct FakeExecutor {
+        calls: AtomicUsize,
+        block: AtomicBool,
+        permits: Semaphore,
+        called: Notify,
+        last_target: StdMutex<Option<HqpNativeExecutionTarget>>,
+        receipt: StdMutex<NativeSettingReceipt>,
+        sequence: Arc<StdMutex<Vec<&'static str>>>,
+    }
+
+    impl FakeExecutor {
+        fn new(sequence: Arc<StdMutex<Vec<&'static str>>>) -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+                block: AtomicBool::new(false),
+                permits: Semaphore::new(0),
+                called: Notify::new(),
+                last_target: StdMutex::new(None),
+                receipt: StdMutex::new(NativeSettingReceipt::DaemonAcknowledged {
+                    readback: NativeSettingReadback::Verified,
+                }),
+                sequence,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl HqpNativeSettingExecutor for FakeExecutor {
+        async fn execute(
+            &self,
+            target: &HqpNativeExecutionTarget,
+            _setting: HqpNativeSetting,
+        ) -> anyhow::Result<NativeSettingReceipt> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            *lock(&self.last_target) = Some(target.clone());
+            push(&self.sequence, "execute");
+            self.called.notify_waiters();
+            if self.block.load(Ordering::SeqCst) {
+                let permit = self.permits.acquire().await;
+                if let Ok(permit) = permit {
+                    permit.forget();
+                }
+            }
+            Ok(lock(&self.receipt).clone())
+        }
+    }
+
+    fn build_test_service(
+        snapshot: ProducerSnapshot,
+        coordinator: Arc<FakeCoordinator>,
+        executor: Arc<FakeExecutor>,
+        capacity: usize,
+    ) -> (HqpImmediateCommandHandle, tokio::task::JoinHandle<()>) {
+        build_test_service_with_view(
+            Arc::new(FakeView {
+                snapshot: StdMutex::new(snapshot),
+            }),
+            coordinator,
+            executor,
+            capacity,
+        )
+    }
+
+    fn build_test_service_with_view(
+        view: Arc<FakeView>,
+        coordinator: Arc<FakeCoordinator>,
+        executor: Arc<FakeExecutor>,
+        capacity: usize,
+    ) -> (HqpImmediateCommandHandle, tokio::task::JoinHandle<()>) {
+        let (handle, actor) =
+            HqpImmediateCommandActor::build_with(view, coordinator, executor, capacity);
+        let task = tokio::spawn(actor.run());
+        (handle, task)
+    }
+
+    #[test]
+    fn verified_no_send_is_a_confirmed_noop_not_an_indeterminate_write() {
+        let evidence = receipt_evidence(NativeSettingReceipt::NotAttempted {
+            reason: "already selected".to_string(),
+            readback: NativeSettingReadback::Noop,
+        });
+
+        assert_eq!(evidence.outcome, CommandOutcome::Ignored);
+        assert_eq!(evidence.write_attempt, WriteAttempt::NotAttempted);
+        assert_eq!(evidence.recovery, RecoveryState::NotRequired);
+    }
+
+    #[test]
+    fn reserved_target_mismatch_is_terminal_no_write_evidence() {
+        let evidence = receipt_evidence(NativeSettingReceipt::NotAttempted {
+            reason: "reserved native producer identity moved before execution".to_string(),
+            readback: NativeSettingReadback::Unavailable {
+                reason: "reserved producer no longer exists".to_string(),
+            },
+        });
+
+        assert_eq!(evidence.outcome, CommandOutcome::Superseded);
+        assert_eq!(evidence.write_attempt, WriteAttempt::NotAttempted);
+        assert_eq!(evidence.recovery, RecoveryState::ReplanRequired);
+    }
+
+    #[test]
+    fn typed_native_receipts_keep_attempt_application_and_recovery_evidence_separate() {
+        let acknowledged = receipt_evidence(NativeSettingReceipt::DaemonAcknowledged {
+            readback: NativeSettingReadback::Verified,
+        });
+        assert_eq!(acknowledged.outcome, CommandOutcome::Applied);
+        assert_eq!(acknowledged.write_attempt, WriteAttempt::Confirmed);
+        assert_eq!(acknowledged.recovery, RecoveryState::NotRequired);
+
+        let rejected = receipt_evidence(NativeSettingReceipt::DaemonRejected(HqpRejected {
+            element: "SetMode".to_string(),
+            reason: Some("locked".to_string()),
+        }));
+        assert_eq!(rejected.outcome, CommandOutcome::Rejected);
+        assert_eq!(
+            rejected.write_attempt,
+            WriteAttempt::AcknowledgedProvisional
+        );
+        assert_eq!(rejected.recovery, RecoveryState::NotRequired);
+
+        let divergent = receipt_evidence(NativeSettingReceipt::DaemonAcknowledged {
+            readback: NativeSettingReadback::Divergent {
+                requested: "PCM".to_string(),
+                observed: "SDM".to_string(),
+            },
+        });
+        assert_eq!(divergent.outcome, CommandOutcome::Divergent);
+        assert_eq!(
+            divergent.write_attempt,
+            WriteAttempt::AcknowledgedProvisional
+        );
+        assert_eq!(divergent.recovery, RecoveryState::ReplanRequired);
+
+        let ambiguous = receipt_evidence(NativeSettingReceipt::PossibleAttempt {
+            reason: "reply was unavailable".to_string(),
+            readback: NativeSettingReadback::Unavailable {
+                reason: "session ended".to_string(),
+            },
+        });
+        assert_eq!(ambiguous.outcome, CommandOutcome::Indeterminate);
+        assert_eq!(ambiguous.write_attempt, WriteAttempt::Attempted);
+        assert_eq!(ambiguous.recovery, RecoveryState::AwaitingReconnect);
+    }
+
+    #[test]
+    fn all_five_validated_settings_have_one_owned_native_dispatch_arm() {
+        let snapshot = snapshot();
+        for (control, choice, expected) in [
+            (MODE, MODE_CHOICE, HqpNativeSetting::Mode("PCM".to_string())),
+            (
+                FILTER_1X,
+                FILTER_1X_CHOICE,
+                HqpNativeSetting::Filter1x("poly".to_string()),
+            ),
+            (
+                FILTER_NX,
+                FILTER_NX_CHOICE,
+                HqpNativeSetting::FilterNx("sinc".to_string()),
+            ),
+            (
+                SHAPER,
+                SHAPER_CHOICE,
+                HqpNativeSetting::Shaper("NS9".to_string()),
+            ),
+            (RATE, RATE_CHOICE, HqpNativeSetting::Rate(192_000)),
+        ] {
+            let request = request_for(&snapshot, "dispatch", control, choice);
+            let validated = preflight(&snapshot, &request);
+            assert!(
+                matches!(validated, Ok(ref command) if native_setting(command) == Some(expected)),
+                "{control} must dispatch only through its typed owned setting"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn stale_advisory_preflight_invokes_neither_reservation_nor_executor() {
+        let snapshot = snapshot();
+        let mut request = request(&snapshot, "stale");
+        request.expected.state.0 -= 1;
+        let sequence = Arc::new(StdMutex::new(Vec::new()));
+        let coordinator = Arc::new(FakeCoordinator {
+            sequence: sequence.clone(),
+            ..FakeCoordinator::default()
+        });
+        let executor = Arc::new(FakeExecutor::new(sequence));
+        let (handle, task) = build_test_service(snapshot, coordinator.clone(), executor.clone(), 4);
+
+        let result = handle.submit(request).await;
+        assert!(matches!(
+            result,
+            Err(HqpCommandServiceRefusal::Preflight(
+                HqpPreflightRefusal::RevisionMismatch { .. }
+            ))
+        ));
+        assert_eq!(coordinator.reserves.load(Ordering::SeqCst), 0);
+        assert_eq!(executor.calls.load(Ordering::SeqCst), 0);
+        assert!(handle.shutdown().await.is_ok());
+        assert!(task.await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn actor_owns_an_accepted_job_after_the_submitter_is_cancelled() {
+        let snapshot = snapshot();
+        let sequence = Arc::new(StdMutex::new(Vec::new()));
+        let coordinator = Arc::new(FakeCoordinator {
+            block_reserve: AtomicBool::new(true),
+            sequence: sequence.clone(),
+            ..FakeCoordinator::default()
+        });
+        let executor = Arc::new(FakeExecutor::new(sequence));
+        let (handle, task) =
+            build_test_service(snapshot.clone(), coordinator.clone(), executor.clone(), 4);
+
+        let submit = tokio::spawn({
+            let handle = handle.clone();
+            async move { handle.submit(request(&snapshot, "cancelled-caller")).await }
+        });
+        coordinator.reserve_started.notified().await;
+        submit.abort();
+        coordinator.reserve_release.notify_one();
+
+        let called = tokio::time::timeout(Duration::from_secs(1), executor.called.notified()).await;
+        assert!(
+            called.is_ok(),
+            "the actor must continue after the caller disappears"
+        );
+        assert!(
+            wait_for_count(&coordinator.completions, 1).await,
+            "the abandoned acknowledgement must still terminalize"
+        );
+        assert_eq!(executor.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(coordinator.completions.load(Ordering::SeqCst), 1);
+        assert!(handle.shutdown().await.is_ok());
+        assert!(task.await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn duplicate_correlation_is_acknowledged_without_a_second_send() {
+        let snapshot = snapshot();
+        let sequence = Arc::new(StdMutex::new(Vec::new()));
+        let coordinator = Arc::new(FakeCoordinator {
+            sequence: sequence.clone(),
+            ..FakeCoordinator::default()
+        });
+        let executor = Arc::new(FakeExecutor::new(sequence));
+        let (handle, task) =
+            build_test_service(snapshot.clone(), coordinator.clone(), executor.clone(), 4);
+        let command = request(&snapshot, "same-gesture");
+
+        let first = handle.submit(command.clone()).await;
+        assert!(matches!(first, Ok(ref acknowledgement) if !acknowledgement.duplicate));
+        assert!(wait_for_count(&coordinator.completions, 1).await);
+        let duplicate = handle.submit(command).await;
+        assert!(matches!(duplicate, Ok(ref acknowledgement) if acknowledgement.duplicate));
+        assert_eq!(executor.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(coordinator.reserves.load(Ordering::SeqCst), 1);
+        assert_eq!(coordinator.lookups.load(Ordering::SeqCst), 2);
+        assert!(handle.shutdown().await.is_ok());
+        assert!(task.await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn exact_retry_bypasses_stale_advisory_view_after_pending_advances_revision() {
+        let snapshot = snapshot();
+        let view = Arc::new(FakeView {
+            snapshot: StdMutex::new(snapshot.clone()),
+        });
+        let sequence = Arc::new(StdMutex::new(Vec::new()));
+        let coordinator = Arc::new(FakeCoordinator {
+            sequence: sequence.clone(),
+            ..FakeCoordinator::default()
+        });
+        let executor = Arc::new(FakeExecutor::new(sequence));
+        let (handle, task) =
+            build_test_service_with_view(view.clone(), coordinator.clone(), executor.clone(), 4);
+        let command = request(&snapshot, "pending-retry");
+
+        let first = handle.submit(command.clone()).await;
+        assert!(matches!(first, Ok(ref acknowledgement) if !acknowledgement.duplicate));
+        assert!(wait_for_count(&coordinator.completions, 1).await);
+        Arc::make_mut(&mut lock(&view.snapshot).document)
+            .revisions
+            .state
+            .0 += 1;
+
+        let retry = handle.submit(command).await;
+        assert!(matches!(retry, Ok(ref acknowledgement) if acknowledgement.duplicate));
+        assert_eq!(coordinator.reserves.load(Ordering::SeqCst), 1);
+        assert_eq!(executor.calls.load(Ordering::SeqCst), 1);
+        assert!(handle.shutdown().await.is_ok());
+        assert!(task.await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn correlation_reuse_with_changed_semantics_refuses_before_advisory_preflight() {
+        let snapshot = snapshot();
+        let sequence = Arc::new(StdMutex::new(Vec::new()));
+        let coordinator = Arc::new(FakeCoordinator {
+            sequence: sequence.clone(),
+            ..FakeCoordinator::default()
+        });
+        let executor = Arc::new(FakeExecutor::new(sequence));
+        let (handle, task) =
+            build_test_service(snapshot.clone(), coordinator.clone(), executor.clone(), 8);
+        let command = request(&snapshot, "conflicting-reuse");
+        assert!(handle.submit(command.clone()).await.is_ok());
+        assert!(wait_for_count(&coordinator.completions, 1).await);
+
+        let conflicts = vec![
+            HqpImmediateCommandRequest {
+                expected: RevisionRef {
+                    state: crate::adaptive::Revision(command.expected.state.0 + 1),
+                    ..command.expected
+                },
+                ..command.clone()
+            },
+            HqpImmediateCommandRequest {
+                key: ProducerKey {
+                    role: TargetRole::Instance,
+                    ..command.key.clone()
+                },
+                ..command.clone()
+            },
+            HqpImmediateCommandRequest {
+                lane: ApplyLane::Persistent,
+                ..command.clone()
+            },
+            HqpImmediateCommandRequest {
+                requested: ControlValue::choice("hqplayer.pipeline.mode.engine.53444d"),
+                ..command
+            },
+        ];
+        for conflict in conflicts {
+            assert_eq!(
+                handle.submit(conflict).await,
+                Err(HqpCommandServiceRefusal::Coordinator(
+                    HqpCoordinatorRefusal::CorrelationConflict,
+                ))
+            );
+        }
+
+        assert_eq!(coordinator.reserves.load(Ordering::SeqCst), 1);
+        assert_eq!(executor.calls.load(Ordering::SeqCst), 1);
+        assert!(handle.shutdown().await.is_ok());
+        assert!(task.await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn lease_validation_happens_immediately_before_native_dispatch() {
+        let snapshot = snapshot();
+        let sequence = Arc::new(StdMutex::new(Vec::new()));
+        let coordinator = Arc::new(FakeCoordinator {
+            sequence: sequence.clone(),
+            ..FakeCoordinator::default()
+        });
+        let executor = Arc::new(FakeExecutor::new(sequence.clone()));
+        let (handle, task) =
+            build_test_service(snapshot.clone(), coordinator.clone(), executor.clone(), 4);
+
+        assert!(handle.submit(request(&snapshot, "ordered")).await.is_ok());
+        assert!(wait_for_count(&coordinator.completions, 1).await);
+        assert_eq!(
+            *lock(&sequence),
+            vec!["reserve", "validate", "execute", "complete"]
+        );
+        assert_eq!(
+            *lock(&executor.last_target),
+            Some(HqpNativeExecutionTarget {
+                instance_name: "main".to_string(),
+                producer_epoch: 7,
+                endpoint_generation: 17,
+                transport_generation: 23,
+            }),
+            "the native executor must receive the exact identity retained by reservation"
+        );
+        assert!(handle.shutdown().await.is_ok());
+        assert!(task.await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn native_no_write_receipt_is_not_upgraded_to_attempted_before_execution() {
+        let snapshot = snapshot();
+        let sequence = Arc::new(StdMutex::new(Vec::new()));
+        let coordinator = Arc::new(FakeCoordinator {
+            sequence: sequence.clone(),
+            ..FakeCoordinator::default()
+        });
+        let executor = Arc::new(FakeExecutor::new(sequence.clone()));
+        *lock(&executor.receipt) = NativeSettingReceipt::NotAttempted {
+            reason: "the exact reserved endpoint moved before the native write path".to_string(),
+            readback: NativeSettingReadback::Unavailable {
+                reason: "the old native session is gone".to_string(),
+            },
+        };
+        let (handle, task) = build_test_service(snapshot.clone(), coordinator.clone(), executor, 4);
+
+        assert!(handle
+            .submit(request(&snapshot, "no-write-boundary"))
+            .await
+            .is_ok());
+        assert!(wait_for_count(&coordinator.completions, 1).await);
+        assert_eq!(
+            *lock(&sequence),
+            vec!["reserve", "validate", "execute", "complete"],
+            "attempt evidence must come from the executor receipt, not a pre-execution marker"
+        );
+        assert!(handle.shutdown().await.is_ok());
+        assert!(task.await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn failed_dispatch_validation_terminalizes_without_native_io() {
+        let snapshot = snapshot();
+        let sequence = Arc::new(StdMutex::new(Vec::new()));
+        let coordinator = Arc::new(FakeCoordinator {
+            validation_fails: AtomicBool::new(true),
+            sequence: sequence.clone(),
+            ..FakeCoordinator::default()
+        });
+        let executor = Arc::new(FakeExecutor::new(sequence.clone()));
+        let (handle, task) =
+            build_test_service(snapshot.clone(), coordinator.clone(), executor.clone(), 4);
+
+        assert!(handle
+            .submit(request(&snapshot, "stale-lease"))
+            .await
+            .is_ok());
+        assert!(wait_for_count(&coordinator.supersessions, 1).await);
+        assert_eq!(executor.calls.load(Ordering::SeqCst), 0);
+        assert_eq!(*lock(&sequence), vec!["reserve", "validate", "supersede"]);
+        assert!(handle.shutdown().await.is_ok());
+        assert!(task.await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn missing_reserved_target_terminalizes_without_native_io() {
+        let snapshot = snapshot();
+        let sequence = Arc::new(StdMutex::new(Vec::new()));
+        let coordinator = Arc::new(FakeCoordinator {
+            targetless_lease: AtomicBool::new(true),
+            sequence: sequence.clone(),
+            ..FakeCoordinator::default()
+        });
+        let executor = Arc::new(FakeExecutor::new(sequence.clone()));
+        let (handle, task) =
+            build_test_service(snapshot.clone(), coordinator.clone(), executor.clone(), 4);
+
+        assert!(handle
+            .submit(request(&snapshot, "targetless"))
+            .await
+            .is_ok());
+        assert!(wait_for_count(&coordinator.completions, 1).await);
+        assert_eq!(executor.calls.load(Ordering::SeqCst), 0);
+        assert_eq!(*lock(&sequence), vec!["reserve", "validate", "complete"]);
+        assert!(handle.shutdown().await.is_ok());
+        assert!(task.await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn graceful_shutdown_closes_ingress_and_drains_every_accepted_job() {
+        let snapshot = snapshot();
+        let sequence = Arc::new(StdMutex::new(Vec::new()));
+        let coordinator = Arc::new(FakeCoordinator {
+            sequence: sequence.clone(),
+            ..FakeCoordinator::default()
+        });
+        let executor = Arc::new(FakeExecutor::new(sequence));
+        executor.block.store(true, Ordering::SeqCst);
+        let (handle, task) =
+            build_test_service(snapshot.clone(), coordinator.clone(), executor.clone(), 4);
+
+        let first = tokio::spawn({
+            let handle = handle.clone();
+            let snapshot = snapshot.clone();
+            async move { handle.submit(request(&snapshot, "first")).await }
+        });
+        executor.called.notified().await;
+        let second = tokio::spawn({
+            let handle = handle.clone();
+            async move { handle.submit(request(&snapshot, "second")).await }
+        });
+        let shutdown = tokio::spawn({
+            let handle = handle.clone();
+            async move { handle.shutdown().await }
+        });
+        executor.permits.add_permits(2);
+
+        assert!(first.await.is_ok());
+        assert!(second.await.is_ok());
+        assert!(matches!(shutdown.await, Ok(Ok(()))));
+        assert!(task.await.is_ok());
+        assert_eq!(executor.calls.load(Ordering::SeqCst), 2);
+        assert_eq!(coordinator.completions.load(Ordering::SeqCst), 2);
+        assert!(matches!(
+            handle
+                .submit(request(&snapshot_for_closed(), "closed"))
+                .await,
+            Err(HqpCommandServiceRefusal::ServiceClosed)
+        ));
+    }
+
+    fn snapshot_for_closed() -> ProducerSnapshot {
+        snapshot()
+    }
+
+    fn snapshot() -> ProducerSnapshot {
+        let document = ProducerDocument {
+            schema_version: CONSUMER_SCHEMA_VERSION,
+            producer: ProducerIdentity {
+                producer_id: "hqplayer:main".to_string(),
+                producer_type: "hqplayer".to_string(),
+                instance_label: None,
+                product_version: None,
+                epoch: ProducerEpoch(7),
+                extensions: Extensions::default(),
+            },
+            target: ProducerTarget {
+                role: TargetRole::DspEngine,
+                zone_id: None,
+                extensions: Extensions::default(),
+            },
+            revisions: DocumentRevisions::new(3, 9),
+            lanes: vec![LaneHealth {
+                lane: TransportLane::Native,
+                state: LaneState::Connected,
+                last_success: None,
+                last_error: None,
+                freshness: Freshness::default(),
+                extensions: Extensions::default(),
+            }],
+            groups: Vec::new(),
+            controls: vec![
+                selection(MODE, MODE_CHOICE, "PCM"),
+                selection(FILTER_1X, FILTER_1X_CHOICE, "poly"),
+                selection(FILTER_NX, FILTER_NX_CHOICE, "sinc"),
+                selection(SHAPER, SHAPER_CHOICE, "NS9"),
+                selection(RATE, RATE_CHOICE, "192000"),
+            ],
+            constraints: Vec::new(),
+            draft_policy: None,
+            change_sets: Vec::new(),
+            operations: Vec::new(),
+            stale: false,
+            extensions: Extensions::default(),
+        };
+        ProducerSnapshot {
+            key: ProducerKey::of(&document),
+            document: Arc::new(document),
+            lanes: BTreeMap::new(),
+            presence: ProducerPresence::Live,
+            repairs: Vec::new(),
+            last_refusal: None,
+        }
+    }
+
+    fn request(snapshot: &ProducerSnapshot, correlation_id: &str) -> HqpImmediateCommandRequest {
+        request_for(snapshot, correlation_id, MODE, MODE_CHOICE)
+    }
+
+    fn request_for(
+        snapshot: &ProducerSnapshot,
+        correlation_id: &str,
+        control: &str,
+        choice: &str,
+    ) -> HqpImmediateCommandRequest {
+        HqpImmediateCommandRequest {
+            key: snapshot.key.clone(),
+            expected: snapshot.document.position(),
+            control: ControlId::new(control),
+            requested: ControlValue::choice(choice),
+            lane: ApplyLane::Immediate,
+            correlation_id: correlation_id.to_string(),
+        }
+    }
+
+    fn selection(control: &str, choice: &str, engine_name: &str) -> Control {
+        Control {
+            id: ControlId::new(control),
+            kind: ControlKind::Enumeration,
+            label_key: None,
+            description_key: None,
+            group: None,
+            order: None,
+            widget_hint: None,
+            unit: None,
+            values: Vec::new(),
+            choices: Some(ChoiceSet::runtime(vec![Choice::new(choice, engine_name)])),
+            range: None,
+            availability: Availability::available(),
+            apply: Some(ApplySemantics {
+                lane: ApplyLane::Immediate,
+                effect: ApplyEffect::LiveImmediate,
+                disruption: Disruption::NoDisruption,
+                risk: RiskClass::Safe,
+                verification: Verification::own_observed(),
+                invalidates: Vec::new(),
+                coupled_with: Vec::new(),
+            }),
+            divergences: Vec::new(),
+            members: Vec::new(),
+            extensions: Extensions::default(),
+        }
+    }
+
+    fn pending_operation(command: &HqpValidatedCommand, generation: u64) -> OperationRecord {
+        OperationRecord {
+            id: OperationId::new(format!(
+                "{}:operation:{generation}",
+                command.request.key.producer_id
+            )),
+            correlation_id: command.request.correlation_id.clone(),
+            request: Some(OperationRequest {
+                control: command.request.control.clone(),
+                requested: command.request.requested.clone(),
+                lane: command.request.lane.clone(),
+                base: command.request.expected,
+            }),
+            change_set: None,
+            generation: Some(generation),
+            write_attempt: WriteAttempt::NotAttempted,
+            outcome: CommandOutcome::Pending,
+            observed: Some(command.request.expected),
+            steps: Vec::new(),
+            revision_boundaries: Vec::new(),
+            history: Vec::new(),
+            recovery: None,
+            reason: None,
+            extensions: Extensions::default(),
+        }
+    }
+
+    fn lock<T>(mutex: &StdMutex<T>) -> std::sync::MutexGuard<'_, T> {
+        mutex
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn push(sequence: &StdMutex<Vec<&'static str>>, event: &'static str) {
+        lock(sequence).push(event);
+    }
+
+    async fn wait_for_count(counter: &AtomicUsize, expected: usize) -> bool {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while counter.load(Ordering::SeqCst) < expected {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .is_ok()
+    }
+}

--- a/src/producers/hqplayer_command_service.rs
+++ b/src/producers/hqplayer_command_service.rs
@@ -214,6 +214,17 @@ pub struct HqpImmediateCommandActor {
     executor: Arc<dyn HqpNativeSettingExecutor>,
 }
 
+fn send_submit_reply(
+    reply: oneshot::Sender<Result<HqpCommandAcknowledgement, HqpCommandServiceRefusal>>,
+    response: Result<HqpCommandAcknowledgement, HqpCommandServiceRefusal>,
+) {
+    if reply.send(response).is_err() {
+        // The actor owns an accepted reservation independently of caller lifetime. A dropped
+        // acknowledgement receiver is observable cancellation, not permission to abandon work.
+        tracing::debug!("HQPlayer command submitter disconnected before acknowledgement");
+    }
+}
+
 impl HqpImmediateCommandActor {
     /// Build a bounded service. Capacity must be non-zero (the same requirement as Tokio's
     /// bounded channel).
@@ -266,7 +277,11 @@ impl HqpImmediateCommandActor {
                         }
                     }
                     for waiter in shutdown_replies {
-                        let _ = waiter.send(());
+                        if waiter.send(()).is_err() {
+                            tracing::debug!(
+                                "HQPlayer command shutdown waiter disconnected before drain"
+                            );
+                        }
                     }
                     return;
                 }
@@ -280,43 +295,49 @@ impl HqpImmediateCommandActor {
         reply: oneshot::Sender<Result<HqpCommandAcknowledgement, HqpCommandServiceRefusal>>,
     ) {
         if let Err(refusal) = validate_correlation_id(&request.correlation_id) {
-            let _ = reply.send(Err(HqpCommandServiceRefusal::Preflight(refusal)));
+            send_submit_reply(reply, Err(HqpCommandServiceRefusal::Preflight(refusal)));
             return;
         }
         match self.coordinator.lookup_correlation(&request).await {
             Ok(Some(reservation)) => {
-                let _ = reply.send(Ok(HqpCommandAcknowledgement {
-                    operation: reservation.operation().clone(),
-                    duplicate: true,
-                }));
+                send_submit_reply(
+                    reply,
+                    Ok(HqpCommandAcknowledgement {
+                        operation: reservation.operation().clone(),
+                        duplicate: true,
+                    }),
+                );
                 return;
             }
             Ok(None) => {}
             Err(refusal) => {
-                let _ = reply.send(Err(HqpCommandServiceRefusal::Coordinator(refusal)));
+                send_submit_reply(reply, Err(HqpCommandServiceRefusal::Coordinator(refusal)));
                 return;
             }
         }
         let Some(snapshot) = self.view.snapshot(&request.key) else {
-            let _ = reply.send(Err(HqpCommandServiceRefusal::ProducerUnknown));
+            send_submit_reply(reply, Err(HqpCommandServiceRefusal::ProducerUnknown));
             return;
         };
         let validated = match preflight(&snapshot, &request) {
             Ok(validated) => validated,
             Err(refusal) => {
-                let _ = reply.send(Err(HqpCommandServiceRefusal::Preflight(refusal)));
+                send_submit_reply(reply, Err(HqpCommandServiceRefusal::Preflight(refusal)));
                 return;
             }
         };
         if instance_name(&validated).is_none() {
-            let _ = reply.send(Err(HqpCommandServiceRefusal::InvalidProducerIdentity));
+            send_submit_reply(
+                reply,
+                Err(HqpCommandServiceRefusal::InvalidProducerIdentity),
+            );
             return;
         }
         let setting = native_setting(&validated);
         let reservation = match self.coordinator.reserve(validated).await {
             Ok(reservation) => reservation,
             Err(refusal) => {
-                let _ = reply.send(Err(HqpCommandServiceRefusal::Coordinator(refusal)));
+                send_submit_reply(reply, Err(HqpCommandServiceRefusal::Coordinator(refusal)));
                 return;
             }
         };
@@ -329,7 +350,7 @@ impl HqpImmediateCommandActor {
         };
         // The accepted job no longer depends on this send succeeding. A disconnected submitter
         // drops only its acknowledgement receiver, never the actor-owned reservation.
-        let _ = reply.send(Ok(acknowledgement));
+        send_submit_reply(reply, Ok(acknowledgement));
         if duplicate {
             return;
         }

--- a/src/producers/hqplayer_command_service.rs
+++ b/src/producers/hqplayer_command_service.rs
@@ -70,7 +70,7 @@ trait HqpCommandCoordinator: Send + Sync {
         command: HqpValidatedCommand,
     ) -> Result<HqpCommandReservation, HqpCoordinatorRefusal>;
 
-    async fn validate(&self, lease: &HqpCommandLease) -> Result<(), HqpCoordinatorRefusal>;
+    async fn begin_dispatch(&self, lease: &HqpCommandLease) -> Result<(), HqpCoordinatorRefusal>;
 
     async fn complete(
         &self,
@@ -101,8 +101,8 @@ impl HqpCommandCoordinator for HqpAdaptivePublisher {
         HqpAdaptivePublisher::reserve(self, command).await
     }
 
-    async fn validate(&self, lease: &HqpCommandLease) -> Result<(), HqpCoordinatorRefusal> {
-        HqpAdaptivePublisher::validate(self, lease).await
+    async fn begin_dispatch(&self, lease: &HqpCommandLease) -> Result<(), HqpCoordinatorRefusal> {
+        HqpAdaptivePublisher::begin_dispatch(self, lease).await
     }
 
     async fn complete(
@@ -334,7 +334,7 @@ impl HqpImmediateCommandActor {
             return;
         }
 
-        if let Err(refusal) = self.coordinator.validate(&lease).await {
+        if let Err(refusal) = self.coordinator.begin_dispatch(&lease).await {
             if let Err(error) = self
                 .coordinator
                 .supersede_stale_before_dispatch(&lease, now())
@@ -371,11 +371,10 @@ impl HqpImmediateCommandActor {
             return;
         };
 
-        // The executor's typed receipt is the sole source of native-attempt evidence. In
-        // particular, do not publish `Attempted` merely because this actor is about to make the
-        // call: lifecycle stop between such a marker and the first native byte is a proven
-        // no-write case. The reserved target makes that stop race safe: a moved/removed instance
-        // returns `NativeSettingReceipt::NotAttempted` and no stale target is replayed.
+        // The coordinator fence says only that the executor call began; it remains deliberately
+        // outside the producer document. The executor's typed receipt is still the sole source of
+        // native-attempt evidence. A moved/removed reserved target returns `NotAttempted`, while
+        // observations and lifecycle teardown wait rather than guessing before this receipt.
         let evidence = match setting {
             Some(setting) => match self.executor.execute(&execution_target, setting).await {
                 Ok(receipt) => receipt_evidence(receipt),
@@ -750,9 +749,12 @@ mod tests {
             Ok(reservation)
         }
 
-        async fn validate(&self, _lease: &HqpCommandLease) -> Result<(), HqpCoordinatorRefusal> {
+        async fn begin_dispatch(
+            &self,
+            _lease: &HqpCommandLease,
+        ) -> Result<(), HqpCoordinatorRefusal> {
             self.validations.fetch_add(1, Ordering::SeqCst);
-            push(&self.sequence, "validate");
+            push(&self.sequence, "begin_dispatch");
             if self.validation_fails.load(Ordering::SeqCst) {
                 Err(HqpCoordinatorRefusal::StaleLease)
             } else {
@@ -1154,7 +1156,7 @@ mod tests {
         assert!(wait_for_count(&coordinator.completions, 1).await);
         assert_eq!(
             *lock(&sequence),
-            vec!["reserve", "validate", "execute", "complete"]
+            vec!["reserve", "begin_dispatch", "execute", "complete"]
         );
         assert_eq!(
             *lock(&executor.last_target),
@@ -1194,7 +1196,7 @@ mod tests {
         assert!(wait_for_count(&coordinator.completions, 1).await);
         assert_eq!(
             *lock(&sequence),
-            vec!["reserve", "validate", "execute", "complete"],
+            vec!["reserve", "begin_dispatch", "execute", "complete"],
             "attempt evidence must come from the executor receipt, not a pre-execution marker"
         );
         assert!(handle.shutdown().await.is_ok());
@@ -1220,7 +1222,10 @@ mod tests {
             .is_ok());
         assert!(wait_for_count(&coordinator.supersessions, 1).await);
         assert_eq!(executor.calls.load(Ordering::SeqCst), 0);
-        assert_eq!(*lock(&sequence), vec!["reserve", "validate", "supersede"]);
+        assert_eq!(
+            *lock(&sequence),
+            vec!["reserve", "begin_dispatch", "supersede"]
+        );
         assert!(handle.shutdown().await.is_ok());
         assert!(task.await.is_ok());
     }
@@ -1244,7 +1249,10 @@ mod tests {
             .is_ok());
         assert!(wait_for_count(&coordinator.completions, 1).await);
         assert_eq!(executor.calls.load(Ordering::SeqCst), 0);
-        assert_eq!(*lock(&sequence), vec!["reserve", "validate", "complete"]);
+        assert_eq!(
+            *lock(&sequence),
+            vec!["reserve", "begin_dispatch", "complete"]
+        );
         assert!(handle.shutdown().await.is_ok());
         assert!(task.await.is_ok());
     }

--- a/src/producers/mod.rs
+++ b/src/producers/mod.rs
@@ -49,6 +49,11 @@ pub mod admission;
 mod aggregator;
 pub mod event;
 pub mod hqplayer;
+pub(crate) mod hqplayer_command;
+// The command actor is composition infrastructure. It is public only so the binary composition
+// root can construct the one shared service; native command vocabulary remains release-internal.
+#[doc(hidden)]
+pub mod hqplayer_command_service;
 pub mod run;
 pub mod runtime;
 

--- a/tests/adaptive_contract.rs
+++ b/tests/adaptive_contract.rs
@@ -1392,6 +1392,8 @@ mod outcomes {
         for resolution in [
             CommandOutcome::Applied,
             CommandOutcome::Rejected,
+            CommandOutcome::TimedOut,
+            CommandOutcome::Indeterminate,
             CommandOutcome::Divergent,
             CommandOutcome::Unrecognized("later_terminal_outcome".to_string()),
         ] {

--- a/tests/adaptive_contract.rs
+++ b/tests/adaptive_contract.rs
@@ -1369,6 +1369,75 @@ mod outcomes {
     }
 
     #[test]
+    fn pending_is_unresolved_and_resolves_without_becoming_state_evidence() {
+        let pending = CommandOutcome::Pending;
+
+        assert!(!pending.is_terminal());
+        assert!(
+            !pending.is_state_evidence(),
+            "pending reports only that the operation has not yet converged"
+        );
+        assert!(pending.awaits_convergence());
+        assert_eq!(
+            serde_json::to_value(&pending).expect("pending serializes"),
+            serde_json::json!("pending"),
+            "pending has its own wire value rather than collapsing into another outcome"
+        );
+        assert_eq!(
+            serde_json::from_value::<CommandOutcome>(serde_json::json!("pending"))
+                .expect("pending deserializes"),
+            pending
+        );
+
+        for resolution in [
+            CommandOutcome::Applied,
+            CommandOutcome::Rejected,
+            CommandOutcome::Divergent,
+            CommandOutcome::Unrecognized("later_terminal_outcome".to_string()),
+        ] {
+            assert!(
+                pending.may_transition_to(&resolution),
+                "pending may resolve to {resolution}"
+            );
+        }
+
+        for terminal in [
+            CommandOutcome::Applied,
+            CommandOutcome::Ignored,
+            CommandOutcome::Rejected,
+            CommandOutcome::Superseded,
+            CommandOutcome::Compensated,
+            CommandOutcome::Expired,
+        ] {
+            assert!(
+                !terminal.may_transition_to(&pending),
+                "a terminal {terminal} cannot regress to pending"
+            );
+        }
+    }
+
+    #[test]
+    fn pending_records_the_exact_semantic_request_and_base_revision() {
+        let record = operation("op-pending-9000");
+        let request = record.request.expect("pending command request is explicit");
+
+        assert_eq!(request.control.as_str(), "hqplayer.pipeline.mode");
+        assert_eq!(
+            request.requested,
+            unified_hifi_control::adaptive::ControlValue::choice(
+                "hqplayer.pipeline.mode.engine.50434d"
+            )
+        );
+        assert_eq!(
+            request.lane,
+            unified_hifi_control::adaptive::ApplyLane::Immediate
+        );
+        assert_eq!(request.base.epoch.0, 7);
+        assert_eq!(request.base.control_plane.0, 12);
+        assert_eq!(request.base.state.0, 4211);
+    }
+
+    #[test]
     fn consumers_never_infer_state_from_whether_a_call_returned() {
         // The two facts are tracked separately, and only some combinations are
         // evidence of state.

--- a/tests/architecture_lint.rs
+++ b/tests/architecture_lint.rs
@@ -240,6 +240,69 @@ fn aggregator_exists_in_app_state() {
     );
 }
 
+/// The immediate HQPlayer command actor is the only production bridge from declarative intent to
+/// native `Set*` I/O. Socket conformance is an integration test, so debug builds intentionally
+/// expose a narrow test seam; a release build must keep the command vocabulary, receipt, reserved
+/// target and manager executor inside this crate.
+#[test]
+fn hqplayer_native_execution_is_release_internal() {
+    let adapter = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("src")
+        .join("adapters")
+        .join("hqplayer.rs");
+    let source = fs::read_to_string(adapter).expect("read HQPlayer adapter source");
+
+    for expected in [
+        "native_execution_test_seam!(pub(crate));",
+        "pub(crate) execution_target: HqpNativeExecutionTarget",
+        "pub(crate) async fn native_execution_target",
+        "pub(crate) async fn execute_reserved_native_setting",
+    ] {
+        assert!(
+            source.contains(expected),
+            "release HQPlayer native execution must remain internal; missing `{expected}`"
+        );
+    }
+
+    assert!(
+        source.contains("#[cfg(debug_assertions)]\n    #[doc(hidden)]\n    pub async fn execute_reserved_native_setting"),
+        "only the debug conformance seam may expose the manager executor"
+    );
+
+    let producers = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("src")
+        .join("producers")
+        .join("mod.rs");
+    let producer_source = fs::read_to_string(producers).expect("read producer module source");
+    assert!(
+        producer_source.contains("#[doc(hidden)]\npub mod hqplayer_command_service;"),
+        "the binary composition root needs the shared command actor, but it must not be an advertised API"
+    );
+
+    for relative in ["src/api", "src/mcp", "src/knobs"] {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join(relative);
+        for entry in WalkDir::new(root)
+            .into_iter()
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "rs"))
+        {
+            let content = fs::read_to_string(entry.path()).expect("read production surface");
+            for forbidden in [
+                "execute_reserved_native_setting",
+                "native_execution_target()",
+                "HqpNativeExecutionTarget",
+                "HqpNativeSetting",
+            ] {
+                assert!(
+                    !content.contains(forbidden),
+                    "{} bypasses the shared HQPlayer command service via `{forbidden}`",
+                    entry.path().display()
+                );
+            }
+        }
+    }
+}
+
 /// Adapter-to-prefix mapping for zone_id consistency check
 /// Format: (adapter_file, format_prefix, prefixed_zone_id_constructor)
 const ADAPTER_PREFIXES: &[(&str, &str, &str)] = &[

--- a/tests/fixtures/adaptive/command_outcomes.json
+++ b/tests/fixtures/adaptive/command_outcomes.json
@@ -76,6 +76,19 @@
   },
   "operations": [
     {
+      "id": "op-pending-9000",
+      "correlation_id": "corr-9000",
+      "request": {
+        "control": "hqplayer.pipeline.mode",
+        "requested": { "type": "choice", "value": "hqplayer.pipeline.mode.engine.50434d" },
+        "lane": "immediate",
+        "base": { "epoch": 7, "control_plane": 12, "state": 4211 }
+      },
+      "write_attempt": "not_attempted",
+      "outcome": "pending",
+      "recovery": "awaiting_readback"
+    },
+    {
       "id": "op-provisional-9001",
       "correlation_id": "corr-9001",
       "change_set": "cs-web-3f9a",

--- a/tests/hqplayer_conformance.rs
+++ b/tests/hqplayer_conformance.rs
@@ -34,9 +34,11 @@ mod mock_servers;
 use std::sync::Arc;
 use std::sync::Once;
 use std::time::Duration;
+use tokio::sync::Notify;
 
 use unified_hifi_control::adapters::hqplayer::{
-    framing, HqpAdapter, HqpRejected, HqpTimeouts, SettingOutcome,
+    framing, HqpAdapter, HqpInstanceManager, HqpNativeExecutionTarget, HqpNativeSetting,
+    HqpRejected, HqpTimeouts, NativeSettingReadback, NativeSettingReceipt, SettingOutcome,
 };
 use unified_hifi_control::bus::create_bus;
 
@@ -48,7 +50,9 @@ use mock_servers::hqplayer::model::{
     LoadedChain, Metadata,
 };
 use mock_servers::hqplayer::tier1;
-use mock_servers::hqplayer::wire::{Chunking, Disruption, Responder, WirePolicy, WireServer};
+use mock_servers::hqplayer::wire::{
+    Chunking, Disruption, ReplyGate, Responder, WirePolicy, WireServer,
+};
 
 // =============================================================================
 // Harness
@@ -144,6 +148,659 @@ impl Harness {
     fn stop(self) {
         self.server.stop();
     }
+}
+
+async fn manager_instance(
+    manager: &HqpInstanceManager,
+    name: &str,
+    server: &WireServer,
+) -> Arc<HqpAdapter> {
+    let adapter = manager.get_or_create(name).await;
+    adapter
+        .configure(
+            "127.0.0.1".to_string(),
+            Some(server.port()),
+            None,
+            None,
+            None,
+        )
+        .await;
+    adapter.set_timeouts(fast_timeouts()).await;
+    adapter.connect().await.expect("connect managed fake");
+    adapter
+}
+
+async fn native_target(manager: &HqpInstanceManager, name: &str) -> HqpNativeExecutionTarget {
+    manager
+        .get(name)
+        .await
+        .expect("managed instance exists")
+        .native_execution_target()
+        .await
+        .expect("managed instance has a coherent native producer session")
+}
+
+async fn wait_for_reply_gate(gate: &ReplyGate) {
+    tokio::time::timeout(Duration::from_secs(1), gate.wait_until_reached())
+        .await
+        .expect("fake daemon reaches gated native setting");
+}
+
+async fn assert_manager_mutation_waits(started: &Notify, task: &tokio::task::JoinHandle<()>) {
+    started.notified().await;
+    assert!(
+        !task.is_finished(),
+        "manager mutation must remain queued behind in-flight native execution"
+    );
+}
+
+fn assert_verified_receipt(receipt: NativeSettingReceipt) {
+    assert!(
+        matches!(
+            receipt,
+            NativeSettingReceipt::DaemonAcknowledged {
+                readback: NativeSettingReadback::Verified
+            } | NativeSettingReceipt::PossibleAttempt {
+                readback: NativeSettingReadback::Verified,
+                ..
+            }
+        ),
+        "semantic execution must retain verified native readback"
+    );
+}
+
+/// The native command seam must retain the daemon's explicit acknowledgement.  Reconstructing a
+/// receipt from `SettingOutcome::Applied` cannot satisfy this: that legacy outcome intentionally
+/// discards the wire-level `result="OK"` bit.
+#[tokio::test]
+async fn native_setting_receipts_keep_explicit_acknowledgement_for_all_five_semantic_controls() {
+    let cases = [
+        (
+            HqpNativeSetting::Mode("SDM (DSD)".to_string()),
+            "SetMode",
+            "GetModes",
+        ),
+        (
+            HqpNativeSetting::Filter1x("poly-sinc-gauss-long".to_string()),
+            "SetFilter",
+            "GetFilters",
+        ),
+        (
+            HqpNativeSetting::FilterNx("poly-sinc-gauss-long".to_string()),
+            "SetFilter",
+            "GetFilters",
+        ),
+        (
+            HqpNativeSetting::Shaper("NS5".to_string()),
+            "SetShaping",
+            "GetShapers",
+        ),
+        (HqpNativeSetting::Rate(705_600), "SetRate", "GetRates"),
+    ];
+
+    for (setting, element, enumeration) in cases {
+        isolate_config_dir();
+        let server = WireServer::start(
+            Arc::new(DaemonModel::with_profile(VERIFIED_PROFILE)),
+            WirePolicy::default(),
+        )
+        .await;
+        let manager = HqpInstanceManager::new(create_bus());
+        manager_instance(&manager, "rig", &server).await;
+
+        let receipt = manager
+            .execute_reserved_native_setting(&native_target(&manager, "rig").await, setting)
+            .await
+            .expect("semantic native execution");
+        assert!(
+            matches!(
+                receipt,
+                NativeSettingReceipt::DaemonAcknowledged {
+                    readback: NativeSettingReadback::Verified
+                }
+            ),
+            "{element} must retain its explicit acknowledgement and same-session proof"
+        );
+        assert_eq!(server.stats().element_count(element), 1);
+        assert!(
+            server.stats().element_count(enumeration) >= 2,
+            "{element} must be bracketed by a closing {enumeration} semantic-name proof"
+        );
+        server.stop();
+    }
+}
+
+#[tokio::test]
+async fn native_setting_receipt_reports_noop_without_sending_setmode() {
+    isolate_config_dir();
+    let server = WireServer::start(
+        Arc::new(DaemonModel::with_profile(VERIFIED_PROFILE)),
+        WirePolicy::default(),
+    )
+    .await;
+    let manager = HqpInstanceManager::new(create_bus());
+    manager_instance(&manager, "rig", &server).await;
+
+    let receipt = manager
+        .execute_reserved_native_setting(
+            &native_target(&manager, "rig").await,
+            HqpNativeSetting::Mode("PCM".to_string()),
+        )
+        .await
+        .expect("no-op is a receipt, not a transport error");
+    assert!(matches!(
+        receipt,
+        NativeSettingReceipt::NotAttempted {
+            readback: NativeSettingReadback::Noop,
+            ..
+        }
+    ));
+    assert_eq!(server.stats().element_count("SetMode"), 0);
+    server.stop();
+}
+
+#[tokio::test]
+async fn native_setting_receipt_reports_a_session_loss_before_send_as_not_attempted() {
+    isolate_config_dir();
+    let server = WireServer::start(
+        Arc::new(DaemonModel::with_profile(VERIFIED_PROFILE)),
+        WirePolicy::default(),
+    )
+    .await;
+    let manager = Arc::new(HqpInstanceManager::new(create_bus()));
+    let adapter = manager_instance(&manager, "rig", &server).await;
+    let gate = ReplyGate::new("State");
+    server.set_policy(WirePolicy {
+        reply_gate: Some(gate.clone()),
+        ..WirePolicy::default()
+    });
+
+    let execution = {
+        let manager = manager.clone();
+        tokio::spawn(async move {
+            manager
+                .execute_reserved_native_setting(
+                    &native_target(&manager, "rig").await,
+                    HqpNativeSetting::Shaper("NS5".to_string()),
+                )
+                .await
+        })
+    };
+    wait_for_reply_gate(&gate).await;
+    // The shaper list and preflight State are now in flight, but the SetShaping request has not
+    // entered the write path. Replace the native session before allowing State to return.
+    adapter.disconnect().await;
+    gate.release();
+
+    let receipt = execution
+        .await
+        .expect("execution task joins")
+        .expect("a proven pre-send loss is returned as native evidence");
+    assert!(matches!(
+        receipt,
+        NativeSettingReceipt::NotAttempted {
+            readback: NativeSettingReadback::Unavailable { .. },
+            ..
+        }
+    ));
+    assert_eq!(server.stats().element_count("SetShaping"), 0);
+    server.stop();
+}
+
+#[tokio::test]
+async fn native_setting_receipt_keeps_explicit_daemon_rejection_typed() {
+    isolate_config_dir();
+    let model = Arc::new(DaemonModel::with_profile(VERIFIED_PROFILE));
+    model.arm(|faults| {
+        faults
+            .reject_next
+            .push(("SetShaping".to_string(), "invalid shaper".to_string()));
+    });
+    let server = WireServer::start(model, WirePolicy::default()).await;
+    let manager = HqpInstanceManager::new(create_bus());
+    manager_instance(&manager, "rig", &server).await;
+
+    let receipt = manager
+        .execute_reserved_native_setting(
+            &native_target(&manager, "rig").await,
+            HqpNativeSetting::Shaper("NS5".to_string()),
+        )
+        .await
+        .expect("an explicit wire rejection is native evidence, not an adapter error");
+    assert!(matches!(
+        receipt,
+        NativeSettingReceipt::DaemonRejected(HqpRejected { .. })
+    ));
+    server.stop();
+}
+
+#[tokio::test]
+async fn native_setting_receipt_marks_a_lost_post_write_reply_as_possible_attempt() {
+    isolate_config_dir();
+    let server = WireServer::start(
+        Arc::new(DaemonModel::with_profile(VERIFIED_PROFILE)),
+        WirePolicy {
+            apply_then_drop_reply_for_element: Some("SetShaping".to_string()),
+            ..WirePolicy::default()
+        },
+    )
+    .await;
+    let manager = HqpInstanceManager::new(create_bus());
+    manager_instance(&manager, "rig", &server).await;
+
+    let receipt = manager
+        .execute_reserved_native_setting(
+            &native_target(&manager, "rig").await,
+            HqpNativeSetting::Shaper("NS5".to_string()),
+        )
+        .await
+        .expect("lost delivery is reported as evidence, not misclassified as a pre-send failure");
+    assert!(matches!(
+        receipt,
+        NativeSettingReceipt::PossibleAttempt {
+            readback: NativeSettingReadback::Unavailable { .. },
+            ..
+        }
+    ));
+    server.stop();
+}
+
+#[tokio::test]
+async fn native_setting_receipt_keeps_acknowledged_divergence_separate_from_delivery() {
+    isolate_config_dir();
+    let model = Arc::new(DaemonModel::with_profile(VERIFIED_PROFILE));
+    model.arm(|faults| faults.accept_but_ignore.push("SetShaping".to_string()));
+    let server = WireServer::start(model, WirePolicy::default()).await;
+    let manager = HqpInstanceManager::new(create_bus());
+    manager_instance(&manager, "rig", &server).await;
+
+    let receipt = manager
+        .execute_reserved_native_setting(
+            &native_target(&manager, "rig").await,
+            HqpNativeSetting::Shaper("NS5".to_string()),
+        )
+        .await
+        .expect("accepted-but-ignored setter returns a receipt");
+    assert!(matches!(
+        receipt,
+        NativeSettingReceipt::DaemonAcknowledged {
+            readback: NativeSettingReadback::Divergent { .. }
+        }
+    ));
+    server.stop();
+}
+
+#[tokio::test]
+async fn native_setting_receipt_keeps_acknowledgement_when_same_session_readback_fails() {
+    isolate_config_dir();
+    let gate = ReplyGate::new("SetShaping");
+    let server = WireServer::start(
+        Arc::new(DaemonModel::with_profile(VERIFIED_PROFILE)),
+        WirePolicy {
+            reply_gate: Some(gate.clone()),
+            ..WirePolicy::default()
+        },
+    )
+    .await;
+    let manager = Arc::new(HqpInstanceManager::new(create_bus()));
+    manager_instance(&manager, "rig", &server).await;
+
+    let execution = {
+        let manager = manager.clone();
+        tokio::spawn(async move {
+            manager
+                .execute_reserved_native_setting(
+                    &native_target(&manager, "rig").await,
+                    HqpNativeSetting::Shaper("NS5".to_string()),
+                )
+                .await
+        })
+    };
+    wait_for_reply_gate(&gate).await;
+    // The SetShaping reply has not been sent yet. Change only the subsequent State request so the
+    // receipt sees an explicit acknowledgement followed by a failed same-session verification.
+    server.set_policy(WirePolicy {
+        silent_for_element: Some("State".to_string()),
+        ..WirePolicy::default()
+    });
+    gate.release();
+
+    let receipt = execution
+        .await
+        .expect("execution task joins")
+        .expect("acknowledgement with failed readback is still a receipt");
+    assert!(matches!(
+        receipt,
+        NativeSettingReceipt::DaemonAcknowledged {
+            readback: NativeSettingReadback::Unavailable { .. }
+        }
+    ));
+    server.stop();
+}
+
+#[tokio::test]
+async fn manager_native_setting_dispatches_to_the_exact_named_instance() {
+    isolate_config_dir();
+    let left = WireServer::start(
+        Arc::new(DaemonModel::with_profile(VERIFIED_PROFILE)),
+        WirePolicy::default(),
+    )
+    .await;
+    let right = WireServer::start(
+        Arc::new(DaemonModel::with_profile(VERIFIED_PROFILE)),
+        WirePolicy::default(),
+    )
+    .await;
+    let manager = HqpInstanceManager::new(create_bus());
+    manager_instance(&manager, "left", &left).await;
+    manager_instance(&manager, "right", &right).await;
+
+    let receipt = manager
+        .execute_reserved_native_setting(
+            &native_target(&manager, "right").await,
+            HqpNativeSetting::Shaper("NS5".to_string()),
+        )
+        .await
+        .expect("execute on exact managed instance");
+    assert_verified_receipt(receipt);
+    assert_eq!(left.stats().element_count("SetShaping"), 0);
+    assert_eq!(right.stats().element_count("SetShaping"), 1);
+
+    left.stop();
+    right.stop();
+}
+
+#[tokio::test]
+async fn reserved_native_setting_is_not_attempted_after_instance_removal() {
+    isolate_config_dir();
+    let server = WireServer::start(
+        Arc::new(DaemonModel::with_profile(VERIFIED_PROFILE)),
+        WirePolicy::default(),
+    )
+    .await;
+    let manager = HqpInstanceManager::new(create_bus());
+    manager_instance(&manager, "rig", &server).await;
+    let target = native_target(&manager, "rig").await;
+
+    assert!(manager.remove_instance("rig").await);
+    let receipt = manager
+        .execute_reserved_native_setting(&target, HqpNativeSetting::Shaper("NS5".to_string()))
+        .await
+        .expect("stale reservation returns typed native evidence");
+
+    assert!(matches!(receipt, NativeSettingReceipt::NotAttempted { .. }));
+    assert_eq!(server.stats().element_count("SetShaping"), 0);
+    server.stop();
+}
+
+#[tokio::test]
+async fn reserved_native_setting_is_not_attempted_after_endpoint_reconfiguration() {
+    isolate_config_dir();
+    let first = WireServer::start(
+        Arc::new(DaemonModel::with_profile(VERIFIED_PROFILE)),
+        WirePolicy::default(),
+    )
+    .await;
+    let replacement = WireServer::start(
+        Arc::new(DaemonModel::with_profile(VERIFIED_PROFILE)),
+        WirePolicy::default(),
+    )
+    .await;
+    let manager = HqpInstanceManager::new(create_bus());
+    manager_instance(&manager, "rig", &first).await;
+    let target = native_target(&manager, "rig").await;
+
+    manager
+        .add_instance(
+            "rig".to_string(),
+            "127.0.0.1".to_string(),
+            Some(replacement.port()),
+            None,
+            None,
+            None,
+        )
+        .await;
+    let receipt = manager
+        .execute_reserved_native_setting(&target, HqpNativeSetting::Shaper("NS5".to_string()))
+        .await
+        .expect("stale endpoint reservation returns typed native evidence");
+
+    assert!(matches!(receipt, NativeSettingReceipt::NotAttempted { .. }));
+    assert_eq!(first.stats().element_count("SetShaping"), 0);
+    assert_eq!(replacement.stats().element_count("SetShaping"), 0);
+    first.stop();
+    replacement.stop();
+}
+
+#[tokio::test]
+async fn reserved_native_setting_is_not_attempted_after_same_endpoint_reconnect() {
+    isolate_config_dir();
+    let server = WireServer::start(
+        Arc::new(DaemonModel::with_profile(VERIFIED_PROFILE)),
+        WirePolicy::default(),
+    )
+    .await;
+    let manager = HqpInstanceManager::new(create_bus());
+    let adapter = manager_instance(&manager, "rig", &server).await;
+    let target = native_target(&manager, "rig").await;
+
+    adapter.disconnect().await;
+    adapter
+        .connect()
+        .await
+        .expect("replacement native handshake");
+    let receipt = manager
+        .execute_reserved_native_setting(&target, HqpNativeSetting::Shaper("NS5".to_string()))
+        .await
+        .expect("stale session reservation returns typed native evidence");
+
+    assert!(matches!(receipt, NativeSettingReceipt::NotAttempted { .. }));
+    assert_eq!(server.stats().element_count("SetShaping"), 0);
+    server.stop();
+}
+
+#[tokio::test]
+async fn typed_filter_receipt_does_not_verify_a_name_after_the_loaded_chain_moves() {
+    isolate_config_dir();
+    let model = Arc::new(DaemonModel::with_profile(SYNTHETIC_HAZARD_PROFILE));
+    let server = WireServer::start(model.clone(), WirePolicy::default()).await;
+    let manager = HqpInstanceManager::new(create_bus());
+    manager_instance(&manager, "rig", &server).await;
+    model.external_change(|state| {
+        state.mode_index = 0;
+        state.playback = 2;
+        state.filter_1x_index = 3;
+        state.filter_nx_index = 3;
+    });
+    model.switch_chain_after_request("GetFilters", LoadedChain::Sdm);
+    let target = native_target(&manager, "rig").await;
+
+    let receipt = manager
+        .execute_reserved_native_setting(
+            &target,
+            HqpNativeSetting::Filter1x("SYN-pcm-7".to_string()),
+        )
+        .await
+        .expect("chain movement is typed native evidence");
+
+    assert!(
+        !matches!(
+            receipt,
+            NativeSettingReceipt::DaemonAcknowledged {
+                readback: NativeSettingReadback::Verified
+            } | NativeSettingReceipt::PossibleAttempt {
+                readback: NativeSettingReadback::Verified,
+                ..
+            }
+        ),
+        "a numeric position applied after a chain move must not verify the requested filter name"
+    );
+    server.stop();
+}
+
+#[tokio::test]
+async fn typed_shaper_receipt_does_not_verify_a_name_after_the_loaded_chain_moves() {
+    isolate_config_dir();
+    let model = Arc::new(DaemonModel::with_profile(VERIFIED_PROFILE));
+    let server = WireServer::start(model.clone(), WirePolicy::default()).await;
+    let manager = HqpInstanceManager::new(create_bus());
+    manager_instance(&manager, "rig", &server).await;
+    model.external_change(|state| {
+        state.mode_index = 0;
+        state.playback = 2;
+        state.shaper_index = 1;
+    });
+    model.switch_chain_after_request("GetShapers", LoadedChain::Sdm);
+    let target = native_target(&manager, "rig").await;
+
+    let receipt = manager
+        .execute_reserved_native_setting(&target, HqpNativeSetting::Shaper("NS9".to_string()))
+        .await
+        .expect("chain movement is typed native evidence");
+
+    assert!(
+        !matches!(
+            receipt,
+            NativeSettingReceipt::DaemonAcknowledged {
+                readback: NativeSettingReadback::Verified
+            } | NativeSettingReceipt::PossibleAttempt {
+                readback: NativeSettingReadback::Verified,
+                ..
+            }
+        ),
+        "a numeric position applied after a chain move must not verify the requested shaper name"
+    );
+    server.stop();
+}
+
+#[tokio::test]
+async fn manager_removal_waits_for_in_flight_native_execution() {
+    isolate_config_dir();
+    let gate = ReplyGate::new("SetShaping");
+    let server = WireServer::start(
+        Arc::new(DaemonModel::with_profile(VERIFIED_PROFILE)),
+        WirePolicy {
+            reply_gate: Some(gate.clone()),
+            ..WirePolicy::default()
+        },
+    )
+    .await;
+    let manager = Arc::new(HqpInstanceManager::new(create_bus()));
+    manager_instance(&manager, "rig", &server).await;
+
+    let execution = {
+        let manager = manager.clone();
+        tokio::spawn(async move {
+            manager
+                .execute_reserved_native_setting(
+                    &native_target(&manager, "rig").await,
+                    HqpNativeSetting::Shaper("NS5".to_string()),
+                )
+                .await
+        })
+    };
+    wait_for_reply_gate(&gate).await;
+
+    let started = Arc::new(Notify::new());
+    let removal = {
+        let manager = manager.clone();
+        let started = started.clone();
+        tokio::spawn(async move {
+            started.notify_one();
+            assert!(manager.remove_instance("rig").await);
+        })
+    };
+    assert_manager_mutation_waits(&started, &removal).await;
+    gate.release();
+
+    let receipt = execution
+        .await
+        .expect("execution task joins")
+        .expect("execution completes before removal");
+    assert_verified_receipt(receipt);
+    removal.await.expect("removal follows execution");
+    assert!(manager.get("rig").await.is_none());
+    server.stop();
+}
+
+#[tokio::test]
+async fn manager_reconfiguration_waits_for_in_flight_native_execution() {
+    isolate_config_dir();
+    let gate = ReplyGate::new("SetShaping");
+    let first = WireServer::start(
+        Arc::new(DaemonModel::with_profile(VERIFIED_PROFILE)),
+        WirePolicy {
+            reply_gate: Some(gate.clone()),
+            ..WirePolicy::default()
+        },
+    )
+    .await;
+    let second = WireServer::start(
+        Arc::new(DaemonModel::with_profile(VERIFIED_PROFILE)),
+        WirePolicy::default(),
+    )
+    .await;
+    let manager = Arc::new(HqpInstanceManager::new(create_bus()));
+    manager_instance(&manager, "rig", &first).await;
+
+    let execution = {
+        let manager = manager.clone();
+        tokio::spawn(async move {
+            manager
+                .execute_reserved_native_setting(
+                    &native_target(&manager, "rig").await,
+                    HqpNativeSetting::Shaper("NS5".to_string()),
+                )
+                .await
+        })
+    };
+    wait_for_reply_gate(&gate).await;
+
+    let started = Arc::new(Notify::new());
+    let reconfigure = {
+        let manager = manager.clone();
+        let started = started.clone();
+        let second_port = second.port();
+        tokio::spawn(async move {
+            started.notify_one();
+            manager
+                .add_instance(
+                    "rig".to_string(),
+                    "127.0.0.1".to_string(),
+                    Some(second_port),
+                    None,
+                    None,
+                    None,
+                )
+                .await;
+        })
+    };
+    assert_manager_mutation_waits(&started, &reconfigure).await;
+    gate.release();
+
+    let receipt = execution
+        .await
+        .expect("execution task joins")
+        .expect("execution completes before reconfiguration");
+    assert_verified_receipt(receipt);
+    reconfigure
+        .await
+        .expect("reconfiguration follows execution");
+    assert_eq!(first.stats().element_count("SetShaping"), 1);
+    assert_eq!(second.stats().element_count("SetShaping"), 0);
+    assert_eq!(
+        manager
+            .get("rig")
+            .await
+            .expect("reconfigured instance remains")
+            .get_status()
+            .await
+            .port,
+        second.port()
+    );
+
+    first.stop();
+    second.stop();
 }
 
 // =============================================================================
@@ -1335,7 +1992,7 @@ async fn tier1_live_read_only_verification_when_opted_in() {
     adapter
         .connect()
         .await
-        .unwrap_or_else(|e| panic!("connect to HQPlayer at {host}:{port}: {e}"));
+        .unwrap_or_else(|e| panic!("connect to HQPlayer at {host}:{port}: {e:#}"));
 
     let capture = tier1::capture(&adapter)
         .await

--- a/tests/hqplayer_lifecycle.rs
+++ b/tests/hqplayer_lifecycle.rs
@@ -595,6 +595,89 @@ async fn failed_adaptive_retirement_rolls_back_instance_removal() {
 }
 
 #[tokio::test]
+async fn accepted_adaptive_retirement_retry_does_not_restore_the_removed_instance() {
+    isolate_config_dir();
+    let server = WireServer::start(
+        Arc::new(DaemonModel::with_profile(VERIFIED_PROFILE)),
+        WirePolicy::default(),
+    )
+    .await;
+    let bus = create_bus();
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    let (handle, actor, view) = AdaptiveRuntime::build(shutdown.clone(), 32);
+    let actor_task = tokio::spawn(async move { actor.run().await });
+    let publisher = Arc::new(HqpAdaptivePublisher::new(handle));
+    let manager = HqpInstanceManager::new_with_native_sink(bus, publisher.clone());
+    let adapter = manager
+        .add_instance(
+            "rig".to_string(),
+            "127.0.0.1".to_string(),
+            Some(server.port()),
+            None,
+            None,
+            None,
+        )
+        .await;
+    adapter.set_timeouts(fast_timeouts()).await;
+    adapter.set_recovery_config(fast_recovery()).await;
+    manager.start().await.expect("start managed instance");
+
+    for _ in 0..100 {
+        if view
+            .snapshots()
+            .iter()
+            .any(|snapshot| snapshot.key.producer_id == "hqplayer:rig")
+        {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(
+        view.snapshots()
+            .iter()
+            .any(|snapshot| snapshot.key.producer_id == "hqplayer:rig"),
+        "producer admitted before removal"
+    );
+
+    publisher
+        .debug_refuse_next_retirement()
+        .await
+        .expect("inject one retryable retirement refusal");
+    assert!(
+        manager.remove_instance("rig").await,
+        "coordinator-owned retirement retry is a committed removal"
+    );
+    assert!(
+        manager.get("rig").await.is_none(),
+        "committed removal never restores the adapter"
+    );
+    assert!(
+        !manager.worker_status("rig").await.supervisor_enabled,
+        "committed removal never restarts the worker"
+    );
+
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if view
+                .snapshots()
+                .iter()
+                .all(|snapshot| snapshot.key.producer_id != "hqplayer:rig")
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("coordinator retry eventually retires the producer");
+
+    manager.stop().await;
+    shutdown.cancel();
+    actor_task.await.expect("actor drains");
+    server.stop();
+}
+
+#[tokio::test]
 async fn managed_legacy_and_adaptive_projections_share_one_coherent_gather() {
     isolate_config_dir();
     let server = WireServer::start(

--- a/tests/hqplayer_lifecycle.rs
+++ b/tests/hqplayer_lifecycle.rs
@@ -18,6 +18,7 @@ use unified_hifi_control::adapters::hqplayer::{
     HqpRecoveryConfig, HqpTimeouts, HqpWorkerPhase, HqpWorkerStatus,
 };
 use unified_hifi_control::adapters::Startable;
+use unified_hifi_control::adaptive::TargetRole;
 use unified_hifi_control::aggregator::ZoneAggregator;
 use unified_hifi_control::bus::{create_bus, BusEvent, PlaybackState, Zone};
 use unified_hifi_control::producers::hqplayer::HqpAdaptivePublisher;
@@ -523,6 +524,101 @@ async fn removing_one_adaptive_instance_retires_only_its_producer() {
 }
 
 #[tokio::test]
+async fn stopped_manager_removal_retires_and_same_name_readd_advances_the_producer_epoch() {
+    isolate_config_dir();
+    let server = WireServer::start(
+        Arc::new(DaemonModel::with_profile(VERIFIED_PROFILE)),
+        WirePolicy::default(),
+    )
+    .await;
+    let bus = create_bus();
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    let (handle, actor, view) = AdaptiveRuntime::build(shutdown.clone(), 32);
+    let actor_task = tokio::spawn(async move { actor.run().await });
+    let manager = adaptive_manager(bus, handle);
+    let adapter = manager
+        .add_instance(
+            "rig".to_string(),
+            "127.0.0.1".to_string(),
+            Some(server.port()),
+            None,
+            None,
+            None,
+        )
+        .await;
+    adapter.set_timeouts(fast_timeouts()).await;
+    adapter.set_recovery_config(fast_recovery()).await;
+    manager.start().await.expect("start managed instance");
+
+    let key = ProducerKey {
+        producer_id: "hqplayer:rig".to_string(),
+        role: TargetRole::DspEngine,
+        zone_id: None,
+    };
+    let retired_epoch = tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if let Some(snapshot) = view.snapshot(&key) {
+                break snapshot.document.producer.epoch;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("initial producer admitted");
+
+    manager.stop().await;
+    assert!(
+        manager.remove_instance("rig").await,
+        "a configured instance can be definitively removed while its manager is stopped"
+    );
+    assert!(
+        view.snapshot(&key).is_none(),
+        "stopped-manager removal still applies adaptive retirement"
+    );
+
+    let replacement = manager
+        .add_instance(
+            "rig".to_string(),
+            "127.0.0.1".to_string(),
+            Some(server.port()),
+            None,
+            None,
+            None,
+        )
+        .await;
+    replacement.set_timeouts(fast_timeouts()).await;
+    replacement.set_recovery_config(fast_recovery()).await;
+    assert_eq!(
+        replacement.producer_epoch().await,
+        retired_epoch.0,
+        "replacement inherits the logical producer epoch floor before its first connection"
+    );
+    manager.start().await.expect("restart replacement instance");
+
+    let replacement_epoch = tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if let Some(snapshot) = view.snapshot(&key) {
+                if snapshot.presence == ProducerPresence::Live {
+                    break snapshot.document.producer.epoch;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("same-name replacement clears the retirement floor");
+    assert!(
+        replacement_epoch.0 == retired_epoch.0 + 1,
+        "same-name replacement's first coherent session advances exactly once past retirement"
+    );
+
+    manager.stop().await;
+    shutdown.cancel();
+    actor_task.await.expect("actor drains");
+    server.stop();
+}
+
+#[tokio::test]
 async fn failed_adaptive_retirement_rolls_back_instance_removal() {
     isolate_config_dir();
     let server = WireServer::start(
@@ -594,6 +690,7 @@ async fn failed_adaptive_retirement_rolls_back_instance_removal() {
     server.stop();
 }
 
+#[cfg(debug_assertions)]
 #[tokio::test]
 async fn accepted_adaptive_retirement_retry_does_not_restore_the_removed_instance() {
     isolate_config_dir();

--- a/tests/ignored_send_lint.rs
+++ b/tests/ignored_send_lint.rs
@@ -21,6 +21,7 @@
 //! tx.send(data).map_err(|_| anyhow!("Receiver dropped"))?;
 //! ```
 
+use proc_macro2::{TokenStream, TokenTree};
 use std::fs;
 use std::path::Path;
 use syn::visit::Visit;
@@ -50,6 +51,35 @@ impl IgnoredSendVisitor {
     fn is_wildcard_pattern(&self, pat: &Pat) -> bool {
         matches!(pat, Pat::Wild(_))
     }
+
+    fn inspect_macro_tokens(&mut self, tokens: TokenStream) {
+        let rendered = tokens.to_string();
+        for statement in rendered.split(';') {
+            let ignored_let = statement.contains("let _ =") && statement.contains(". send");
+            let trimmed = statement.trim();
+            let bare_send = trimmed.contains(". send")
+                && !trimmed.contains('=')
+                && !trimmed.starts_with("if ")
+                && !trimmed.starts_with("match ")
+                && !trimmed.contains(". is_err")
+                && !trimmed.contains(". is_ok")
+                && !trimmed.contains(". map_err")
+                && !trimmed.contains(". unwrap")
+                && !trimmed.contains(". expect")
+                && !trimmed.ends_with('?');
+            if ignored_let || bare_send {
+                self.violations.push((
+                    self.current_file.clone(),
+                    "ignored ...send(...) inside macro hides channel failure".to_string(),
+                ));
+            }
+        }
+        for token in tokens {
+            if let TokenTree::Group(group) = token {
+                self.inspect_macro_tokens(group.stream());
+            }
+        }
+    }
 }
 
 impl<'ast> Visit<'ast> for IgnoredSendVisitor {
@@ -59,16 +89,7 @@ impl<'ast> Visit<'ast> for IgnoredSendVisitor {
         // exact failure pattern this lint exists to prevent. Token rendering preserves statement
         // separators and punctuation with normalized whitespace, which is sufficient to identify
         // a wildcard binding whose expression contains a `.send(...)` call.
-        let rendered = mac.tokens.to_string();
-        for statement in rendered.split(';') {
-            if statement.contains("let _ =") && statement.contains(". send") {
-                self.violations.push((
-                    self.current_file.clone(),
-                    "let _ = ...send(...) inside macro - ignoring send result hides failures"
-                        .to_string(),
-                ));
-            }
-        }
+        self.inspect_macro_tokens(mac.tokens.clone());
         syn::visit::visit_macro(self, mac);
     }
 
@@ -208,6 +229,28 @@ fn detects_ignored_send_inside_macro_tokens() {
     assert!(
         !visitor.violations.is_empty(),
         "Should detect ignored send results hidden inside macro token streams"
+    );
+}
+
+#[test]
+fn detects_bare_send_inside_macro_tokens() {
+    let bad_code = r#"
+        async fn example(mut commands: Receiver<Command>) {
+            tokio::select! {
+                command = commands.recv() => {
+                    command.reply.send(Ok(()));
+                }
+            }
+        }
+    "#;
+
+    let syntax: File = syn::parse_file(bad_code).unwrap();
+    let mut visitor = IgnoredSendVisitor::new("test.rs".to_string());
+    visitor.visit_file(&syntax);
+
+    assert!(
+        !visitor.violations.is_empty(),
+        "Should detect bare send results hidden inside macro token streams"
     );
 }
 

--- a/tests/ignored_send_lint.rs
+++ b/tests/ignored_send_lint.rs
@@ -24,7 +24,7 @@
 use std::fs;
 use std::path::Path;
 use syn::visit::Visit;
-use syn::{Expr, File, Pat, Stmt};
+use syn::{Expr, File, Macro, Pat, Stmt};
 use walkdir::WalkDir;
 
 /// Visitor that detects `let _ = something.send(...)` patterns
@@ -53,6 +53,25 @@ impl IgnoredSendVisitor {
 }
 
 impl<'ast> Visit<'ast> for IgnoredSendVisitor {
+    fn visit_macro(&mut self, mac: &'ast Macro) {
+        // `syn::visit` deliberately treats macro bodies as opaque token streams. Channel actors
+        // commonly live inside `tokio::select!`, so an AST-only statement visitor would miss the
+        // exact failure pattern this lint exists to prevent. Token rendering preserves statement
+        // separators and punctuation with normalized whitespace, which is sufficient to identify
+        // a wildcard binding whose expression contains a `.send(...)` call.
+        let rendered = mac.tokens.to_string();
+        for statement in rendered.split(';') {
+            if statement.contains("let _ =") && statement.contains(". send") {
+                self.violations.push((
+                    self.current_file.clone(),
+                    "let _ = ...send(...) inside macro - ignoring send result hides failures"
+                        .to_string(),
+                ));
+            }
+        }
+        syn::visit::visit_macro(self, mac);
+    }
+
     fn visit_stmt(&mut self, stmt: &'ast Stmt) {
         // Look for `let _ = expr` statements
         if let Stmt::Local(local) = stmt {
@@ -167,6 +186,28 @@ fn detects_bare_send_statement() {
     assert!(
         !visitor.violations.is_empty(),
         "Should detect bare send statement"
+    );
+}
+
+#[test]
+fn detects_ignored_send_inside_macro_tokens() {
+    let bad_code = r#"
+        async fn example(mut commands: Receiver<Command>) {
+            tokio::select! {
+                command = commands.recv() => {
+                    let _ = command.reply.send(Ok(()));
+                }
+            }
+        }
+    "#;
+
+    let syntax: File = syn::parse_file(bad_code).unwrap();
+    let mut visitor = IgnoredSendVisitor::new("test.rs".to_string());
+    visitor.visit_file(&syntax);
+
+    assert!(
+        !visitor.violations.is_empty(),
+        "Should detect ignored send results hidden inside macro token streams"
     );
 }
 


### PR DESCRIPTION
Refs #329

OH: 80222d6d

## Outcome

Establish one internal, revision-fenced HQPlayer immediate-command path that later web, MCP, and device consumers can share without calling adapters directly or mistaking request delivery for native application.

This PR implements the command foundation for semantic pipeline controls: mode, filter 1x, filter Nx, shaper, and rate. Direct-zone transport, volume, now-playing, and consumer surfaces remain intentionally stacked in #328 and #331.

## What changed

- advisory preflight against one admitted adaptive snapshot
- producer-coordinator reservation with correlation/fingerprint idempotency
- explicit Pending publication before native I/O
- bounded command actor with graceful drain and caller-cancellation ownership
- exact producer/run/endpoint/transport/generation dispatch fencing
- contract-free typed native receipts and same-session readback evidence
- receipt precedence over racing observations and newer producer epochs
- append-only operation history merged into every observation
- bounded terminal, correlation, unresolved, and retired-instance retention
- explicit Expired/ReplanRequired publication before definitive retirement
- coordinator-owned retry after retirement intent commits; pre-accept failures still roll back
- stopped-manager retirement authority, including unresolved audit publication
- logical producer epoch continuity across same-name remove/re-add
- replacement isolation while an older lifetime is retiring
- explicitly handled coordinator replies plus macro-aware ignored-send enforcement
- ADR 004 updated with the final causality and lifecycle contract

No public route or payload contract changed.

## Review and dissent remediation

Successive independent review/dissent rounds identified and drove regressions for:

- observation erasing an in-flight native receipt
- unbounded retired identities and unresolved audit loss
- producer-epoch advancement racing an exact fenced receipt
- stop/start losing the active adaptive run
- expiration-frontier pruning behind newer terminal history
- manager rollback conflicting with coordinator-owned retirement retry
- stopped removal leaving an adaptive LastKnown ghost
- same-name replacement resetting its producer epoch
- replacement observations inheriting a retiring ledger
- admitted receipt truth being reported as unpublished
- ignored reply sends hidden inside macro bodies

Final review: PROCEED. Final dissent: PROCEED.

## Verification

- `cargo test --all-features`
- HQPlayer producer unit suite: 192 passing in the full library run
- HQPlayer lifecycle integration suite: 45 passing
- ignored-send lint: 6 passing
- API contract: 2 passing
- architecture/adaptive publication lints passing
- `cargo clippy --lib --all-features -- -D warnings`
- `cargo check --release --features server`
- release lifecycle-test compilation
- `dx build --release --platform web --features web` (server + WASM artifact)
- formatting and `git diff --check`

## Live HQPlayer status

The target HQPlayer Embedded 6.0.2 service is running and listening, but its native 4321 connection currently resets during the initial GetInfo exchange, including from the HQPlayer host itself. No live native mutation was attempted. Hermetic wire/conformance coverage is green; live handshake and mutation verification remain a beta gate once that daemon-side protocol path responds.

## Stack

Depends on #375 / PR #376 and the underlying protocol/lifecycle stack. Blocks the direct-zone/consumer work in #328, #331, #209, and #222.
