### PR TITLE
docs: remove obsolete agent workflow guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ Use GitHub for all task tracking:
 **Purpose:** Propose implementations for review
 - Link to the issue being addressed: `Fixes #123`
 - Describe what changed and how to test
-- Request review from coderabbit and superego
+- Request review from coderabbit
 
 ### Merging PRs
 **TEST BEFORE MERGING.** Do not merge PRs without testing.
@@ -36,26 +36,7 @@ Use GitHub for all task tracking:
 - Merge without verifying the fix works
 - Auto-merge in a "merge party" without explicit approval for each PR
 
-### Git Workflow
-**DO NOT force push (`git push --force` or `git push -f`)**
-- This project uses squash merges, so commit history cleanup is unnecessary
-- Force pushing breaks checkouts for anyone tracking the branch
-- Force pushing loses SHA references (builds, comments, reviews)
-- Just push new commits - they all get squashed on merge anyway
-
----
-
 ## Code Review
-
-This project uses two complementary review tools:
-
-### superego (Metacognitive Advisor)
-**When to use:** Before commits, when choosing between approaches, when uncertain
-**Protocol:**
-- Mode: `pull` (reviews on request, not automatically)
-- Use `sg review` at decision points during development
-- Post superego reviews to PRs for visibility
-- Handle findings: P1-P3 fix immediately, P4 can discard with reason
 
 ### coderabbit (Automated Code Review)
 **When to use:** Automatically runs on all PRs
@@ -63,13 +44,6 @@ This project uses two complementary review tools:
 - Reviews code style, potential bugs, and best practices
 - Address feedback before merging
 - Use `@coderabbit` in PR comments to ask questions
-
-### wm (Working Memory)
-**When to use:** Automatic - captures learnings from sessions
-**Protocol:**
-- Runs automatically via hooks
-- Extracts tacit knowledge from completed work
-- No manual intervention needed
 
 ---
 


### PR DESCRIPTION
Fixes #384

## What changed

- removes superego and wm guidance
- removes the blanket force-push prohibition
- retains CodeRabbit review guidance
- retains test-before-merge and explicit maintainer approval rules

No `ba` guidance was present in the file.

## Test plan

- `rg -ni "\bba\b|superego|working memory|\bwm\b|force.push" AGENTS.md` returns no matches
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pull request review guidance to use automated CodeRabbit reviews.
  * Removed obsolete review-tool instructions and related Git Workflow guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->