### PR TITLE
fix(synology): remove appdata on uninstall

### DIFF
--- a/build/synology/conf/privilege
+++ b/build/synology/conf/privilege
@@ -1,5 +1,11 @@
 {
   "defaults": {
     "run-as": "package"
-  }
+  },
+  "ctrl-script": [
+    {
+      "action": "postuninst",
+      "run-as": "root"
+    }
+  ]
 }

--- a/build/synology/scripts/postuninst
+++ b/build/synology/scripts/postuninst
@@ -2,7 +2,23 @@
 # Post-uninstallation script
 # Runs after package files are removed
 
-# DSM removes the package-owned FHS directories after this hook. Persistent
-# user data is intentionally left to the package framework.
+PACKAGE_NAME="unified-hifi-control"
+
+# DSM deliberately preserves SYNOPKG_PKGVAR across package removal. Resolve
+# its /var/packages symlink so the backing @appdata directory is removed on a
+# true uninstall, while retaining it when this hook runs during an upgrade.
+if [ "${SYNOPKG_PKG_STATUS:-}" = "UNINSTALL" ] && [ -n "${SYNOPKG_PKGVAR:-}" ]; then
+    PACKAGE_VAR=$(readlink -f "$SYNOPKG_PKGVAR")
+
+    case "$PACKAGE_VAR" in
+        */@appdata/"$PACKAGE_NAME")
+            rm -rf -- "$PACKAGE_VAR"
+            ;;
+        *)
+            echo "Refusing to remove unexpected package data path: $PACKAGE_VAR" >&2
+            exit 1
+            ;;
+    esac
+fi
 
 exit 0

--- a/build/synology/scripts/postuninst
+++ b/build/synology/scripts/postuninst
@@ -9,16 +9,32 @@ PACKAGE_NAME="unified-hifi-control"
 # true uninstall, while retaining it when this hook runs during an upgrade.
 if [ "${SYNOPKG_PKG_STATUS:-}" = "UNINSTALL" ] && [ -n "${SYNOPKG_PKGVAR:-}" ]; then
     PACKAGE_VAR=$(readlink -f "$SYNOPKG_PKGVAR")
+    PACKAGE_VOLUME=${SYNOPKG_PKGDEST_VOL:-}
+    VOLUME_NUMBER=${PACKAGE_VOLUME#/volume}
 
-    case "$PACKAGE_VAR" in
-        */@appdata/"$PACKAGE_NAME")
-            rm -rf -- "$PACKAGE_VAR"
+    case "$PACKAGE_VOLUME" in
+        /volume*)
             ;;
         *)
-            echo "Refusing to remove unexpected package data path: $PACKAGE_VAR" >&2
+            echo "Refusing to remove package data for unexpected volume: $PACKAGE_VOLUME" >&2
             exit 1
             ;;
     esac
+
+    case "$VOLUME_NUMBER" in
+        ""|0*|*[!0-9]*)
+            echo "Refusing to remove package data for unexpected volume: $PACKAGE_VOLUME" >&2
+            exit 1
+            ;;
+    esac
+
+    EXPECTED_PACKAGE_VAR="${PACKAGE_VOLUME}/@appdata/${PACKAGE_NAME}"
+    if [ "$PACKAGE_VAR" != "$EXPECTED_PACKAGE_VAR" ]; then
+        echo "Refusing to remove unexpected package data path: $PACKAGE_VAR" >&2
+        exit 1
+    fi
+
+    rm -rf -- "$PACKAGE_VAR"
 fi
 
 exit 0

--- a/tests/synology_package_contract.sh
+++ b/tests/synology_package_contract.sh
@@ -99,7 +99,15 @@ else
     fi
 fi
 
-python3 -S -m json.tool "${SYNOLOGY_DIR}/conf/privilege" >/dev/null || fail "conf/privilege is invalid JSON"
+privilege_file="${SYNOLOGY_DIR}/conf/privilege"
+python3 -S -m json.tool "$privilege_file" >/dev/null || fail "conf/privilege is invalid JSON"
+postuninst_run_as=$(python3 -S -c '
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as source:
+    privilege = json.load(source)
+print(next((entry.get("run-as", "") for entry in privilege.get("ctrl-script", []) if entry.get("action") == "postuninst"), ""))
+' "$privilege_file")
+[[ "$postuninst_run_as" == root ]] || fail "postuninst must run as root so it can remove the package @appdata directory"
 python3 -S -m json.tool "${SYNOLOGY_DIR}/conf/resource" >/dev/null || fail "conf/resource is invalid JSON"
 assert_contains "${SYNOLOGY_DIR}/conf/resource" '"port-config"' "conf/resource must register the package firewall protocol file"
 

--- a/tests/synology_package_lifecycle.sh
+++ b/tests/synology_package_lifecycle.sh
@@ -13,7 +13,7 @@ cp "${ROOT_DIR}"/build/synology/scripts/* "${TEST_ROOT}/scripts/"
 # DSM exposes persistent package data through /var/packages/<name>/var, which
 # points to a volume's @appdata directory.
 rmdir "${TEST_ROOT}/var"
-ln -s /volume1/@appdata/unified-hifi-control "${TEST_ROOT}/var"
+ln -s /volume2/@appdata/unified-hifi-control "${TEST_ROOT}/var"
 
 cat > "${TEST_ROOT}/target/unified-hifi-control" <<'DAEMON'
 #!/bin/sh
@@ -35,9 +35,9 @@ docker run --rm \
     "$IMAGE" \
     bash -euo pipefail -c '
         useradd --system --home-dir /var/packages/unified-hifi-control/home unified-hifi-control
-        mkdir -p /volume1/@appdata/unified-hifi-control/firmware
+        mkdir -p /volume2/@appdata/unified-hifi-control/firmware
         chown -R unified-hifi-control:unified-hifi-control /var/packages/unified-hifi-control
-        chown -R unified-hifi-control:unified-hifi-control /volume1/@appdata/unified-hifi-control
+        chown -R unified-hifi-control:unified-hifi-control /volume2/@appdata/unified-hifi-control
 
         run_as_package() {
             su -s /bin/sh unified-hifi-control -c "$1"
@@ -53,9 +53,10 @@ docker run --rm \
         run_as_package "/var/packages/unified-hifi-control/scripts/preuninst"
         printf "preserve during upgrade\n" > /var/packages/unified-hifi-control/var/firmware/version.json
         SYNOPKG_PKG_STATUS=UPGRADE \
+            SYNOPKG_PKGDEST_VOL=/volume2 \
             SYNOPKG_PKGVAR=/var/packages/unified-hifi-control/var \
             /var/packages/unified-hifi-control/scripts/postuninst
-        test -f /volume1/@appdata/unified-hifi-control/firmware/version.json
+        test -f /volume2/@appdata/unified-hifi-control/firmware/version.json
         run_as_package "/var/packages/unified-hifi-control/scripts/preinst"
         run_as_package "/var/packages/unified-hifi-control/scripts/postinst"
         run_as_package "/var/packages/unified-hifi-control/scripts/postupgrade"
@@ -85,10 +86,26 @@ docker run --rm \
         rm /var/packages/unified-hifi-control/var/unified-hifi-control.pid
 
         run_as_package "/var/packages/unified-hifi-control/scripts/preuninst"
+
+        # A lookalike @appdata path outside DSM's selected package volume must
+        # never be removed by the root-running uninstall hook.
+        mkdir -p /tmp/@appdata/unified-hifi-control
+        printf "preserve unexpected path\n" > /tmp/@appdata/unified-hifi-control/sentinel
+        set +e
         SYNOPKG_PKG_STATUS=UNINSTALL \
+            SYNOPKG_PKGDEST_VOL=/volume2 \
+            SYNOPKG_PKGVAR=/tmp/@appdata/unified-hifi-control \
+            /var/packages/unified-hifi-control/scripts/postuninst
+        unexpected_path_rc=$?
+        set -e
+        test "$unexpected_path_rc" -ne 0
+        test -f /tmp/@appdata/unified-hifi-control/sentinel
+
+        SYNOPKG_PKG_STATUS=UNINSTALL \
+            SYNOPKG_PKGDEST_VOL=/volume2 \
             SYNOPKG_PKGVAR=/var/packages/unified-hifi-control/var \
             /var/packages/unified-hifi-control/scripts/postuninst
-        test ! -e /volume1/@appdata/unified-hifi-control
+        test ! -e /volume2/@appdata/unified-hifi-control
 
         # Restore bind-mount ownership so the host-side cleanup trap works on
         # Linux runners where container UID ownership is preserved.

--- a/tests/synology_package_lifecycle.sh
+++ b/tests/synology_package_lifecycle.sh
@@ -10,6 +10,11 @@ trap 'rm -rf "$TEST_ROOT"' EXIT
 mkdir -p "${TEST_ROOT}/target" "${TEST_ROOT}/scripts" "${TEST_ROOT}/var" "${TEST_ROOT}/home"
 cp "${ROOT_DIR}"/build/synology/scripts/* "${TEST_ROOT}/scripts/"
 
+# DSM exposes persistent package data through /var/packages/<name>/var, which
+# points to a volume's @appdata directory.
+rmdir "${TEST_ROOT}/var"
+ln -s /volume1/@appdata/unified-hifi-control "${TEST_ROOT}/var"
+
 cat > "${TEST_ROOT}/target/unified-hifi-control" <<'DAEMON'
 #!/bin/sh
 
@@ -30,7 +35,9 @@ docker run --rm \
     "$IMAGE" \
     bash -euo pipefail -c '
         useradd --system --home-dir /var/packages/unified-hifi-control/home unified-hifi-control
+        mkdir -p /volume1/@appdata/unified-hifi-control/firmware
         chown -R unified-hifi-control:unified-hifi-control /var/packages/unified-hifi-control
+        chown -R unified-hifi-control:unified-hifi-control /volume1/@appdata/unified-hifi-control
 
         run_as_package() {
             su -s /bin/sh unified-hifi-control -c "$1"
@@ -44,7 +51,11 @@ docker run --rm \
         run_as_package "/var/packages/unified-hifi-control/scripts/postinst"
         run_as_package "/var/packages/unified-hifi-control/scripts/preupgrade"
         run_as_package "/var/packages/unified-hifi-control/scripts/preuninst"
-        run_as_package "/var/packages/unified-hifi-control/scripts/postuninst"
+        printf "preserve during upgrade\n" > /var/packages/unified-hifi-control/var/firmware/version.json
+        SYNOPKG_PKG_STATUS=UPGRADE \
+            SYNOPKG_PKGVAR=/var/packages/unified-hifi-control/var \
+            /var/packages/unified-hifi-control/scripts/postuninst
+        test -f /volume1/@appdata/unified-hifi-control/firmware/version.json
         run_as_package "/var/packages/unified-hifi-control/scripts/preinst"
         run_as_package "/var/packages/unified-hifi-control/scripts/postinst"
         run_as_package "/var/packages/unified-hifi-control/scripts/postupgrade"
@@ -74,7 +85,10 @@ docker run --rm \
         rm /var/packages/unified-hifi-control/var/unified-hifi-control.pid
 
         run_as_package "/var/packages/unified-hifi-control/scripts/preuninst"
-        run_as_package "/var/packages/unified-hifi-control/scripts/postuninst"
+        SYNOPKG_PKG_STATUS=UNINSTALL \
+            SYNOPKG_PKGVAR=/var/packages/unified-hifi-control/var \
+            /var/packages/unified-hifi-control/scripts/postuninst
+        test ! -e /volume1/@appdata/unified-hifi-control
 
         # Restore bind-mount ownership so the host-side cleanup trap works on
         # Linux runners where container UID ownership is preserved.

--- a/tests/synology_package_lifecycle.sh
+++ b/tests/synology_package_lifecycle.sh
@@ -87,7 +87,7 @@ docker run --rm \
 
         run_as_package "/var/packages/unified-hifi-control/scripts/preuninst"
 
-        # A lookalike @appdata path outside DSM's selected package volume must
+        # A lookalike @appdata path outside the DSM-selected package volume must
         # never be removed by the root-running uninstall hook.
         mkdir -p /tmp/@appdata/unified-hifi-control
         printf "preserve unexpected path\n" > /tmp/@appdata/unified-hifi-control/sentinel


### PR DESCRIPTION
## Summary

- remove the package-owned `@appdata/unified-hifi-control` directory on a true DSM uninstall
- preserve persistent package data when `postuninst` runs during an upgrade
- elevate only the `postuninst` hook so it can remove the directory from the root-owned `@appdata` parent
- extend the Synology contract and lifecycle tests to cover the real DSM symlink layout

## Root cause

DSM deliberately preserves `SYNOPKG_PKGVAR`; it has no automatic removal lifecycle. The existing `postuninst` hook incorrectly assumed DSM removed all package-owned FHS directories, leaving logs, firmware, and other runtime files behind after package removal.

## User impact

Removing the package now performs a complete cleanup. Upgrades continue to preserve package data.

## Validation

- `make synology-test`
  - Synology SPK contract passed
  - unprivileged Docker lifecycle passed
  - upgrade data preservation verified
  - uninstall appdata removal verified

The `build:synology` label will produce x86_64 and ARM64 SPK artifacts for testing on DSM hardware.

Fixes #389

OH: 80222d6d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Uninstallation now removes package data only during genuine uninstall operations.
  * Upgrade operations preserve existing firmware and user data.
  * Unexpected package data paths are rejected safely.

* **Tests**
  * Added coverage for privileged uninstall execution.
  * Expanded lifecycle checks for upgrade preservation and uninstall cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->