### PR TITLE
feat(#328): make direct HQPlayer a truthful everyday UHC zone

### DIFF
--- a/.oh/hqplayer-direct-zone.md
+++ b/.oh/hqplayer-direct-zone.md
@@ -252,6 +252,22 @@ Deliberately **not** touched: `tests/fixtures/api_routes.txt`, `src/api/mod.rs`,
 9. **Mode-switch qualification during playback (issue's beta/dev criterion) is not addressed.**
    It is a #347/#375 setter concern, not a direct-zone projection concern, and nothing here
    changes it.
+10. **`is_muted` has a known false positive at the range floor, and it is inherent to the protocol.**
+    A user who deliberately turns the level down to `min_db` is reported as muted, because
+    `VolumeMute` *is* "set the level to `min_db`" and there is no mute flag to distinguish the two —
+    the two situations produce byte-identical observations. Reporting mute anyway is the better trade
+    (at the floor both readings agree no sound is coming out, and the alternative makes the mute
+    button's effect invisible), but it is a real mislabel for anyone who uses the bottom of the range.
+    Raised by the dissent pass; only a protocol-level mute flag could close it.
+11. **The root-`samplerate`-is-the-source-rate fallback rests on one agreeing sample.** The single
+    corpus `Status` document carries root `samplerate="44100"`, child `samplerate="44100"`,
+    `active_rate="352800"`. Agreement cannot distinguish *"the root is the source rate"* from *"the
+    root happens to equal it on this material"*, and no document shows them diverging. Kept, because
+    it is daemon-supplied data rather than an invention and dropping it loses a fact the daemon sent —
+    but if the root actually follows the output rate, this publishes an output rate as the track's,
+    which is a relocated instance of the defect this issue fixes. **Falsifiable cheaply:** play
+    upsampled material and compare root against child `samplerate`. Left to #332's live qualification;
+    the fallback must be deleted if the check goes the other way.
 
 ---
 

--- a/.oh/hqplayer-direct-zone.md
+++ b/.oh/hqplayer-direct-zone.md
@@ -1,0 +1,273 @@
+# HQPlayer direct zone: now-playing, transport, seek, safe volume (#328)
+
+**OH:** 80222d6d · **Issue:** [#328](https://github.com/open-horizon-labs/unified-hifi-control/issues/328) ·
+**Parent epic:** #313 · **Base branch:** `feat/issue-329-hqplayer-immediate-command` (PR #382)
+
+### Inputs read before choosing an approach
+
+`.oh/adaptive-interaction-plane.md` is the **program session** for epic #313 and is *not* tracked on
+this branch — it lives in the main checkout and `.oh/adaptive-producer-contract.md:5` names it
+"read-only for this session". It was read there. Recorded because a document that is absent from the
+branch it governs is easy to skip, and its constraints are the ones this work is judged against:
+
+* *"Aggregator owns authoritative state"* and *"Devices never call adapters directly"* — hard.
+* *"Existing API changes require explicit approval"* — hard: *"New protocols need approved additive
+  routes/contracts."*
+* *"Provider capabilities differ … Do not manufacture parity"* — hard, and its success criterion is
+  the sentence this issue turns on: **"unsupported operations are never advertised."**
+* *"Project all advertised capabilities into web, HTTP, device UI, and MCP through one semantic
+  execution path; surface-specific subsets are allowed, contradictory semantics are not."*
+* Its chosen Option D (unified adaptive interaction plane) sequences *"HQPlayer proving producer"*
+  ahead of the client-facing plane. #328 is that proving step for the **legacy zone projection**;
+  #331 is where the adaptive surface arrives. This is why Candidate D below is rejected as
+  sequencing rather than direction.
+
+Also read and unedited: [`.oh/adaptive-producer-contract.md`](adaptive-producer-contract.md) (#323
+producer document v1 + compatibility policy), [`.oh/adaptive-publication.md`](adaptive-publication.md)
+(#324 bus + aggregator publication), [`.oh/hqplayer-evidence-ledger.md`](hqplayer-evidence-ledger.md)
+(#341 protocol evidence authority), `docs/ARCHITECTURE.md`, `AGENTS.md`.
+
+---
+
+## Aim
+
+A direct HQPlayer user picks a `hqplayer:` zone on a knob, in the web UI, or through MCP and it
+behaves like every other everyday zone: it says what is playing, it says what it can do, transport
+and volume land on *that* daemon, and what it reports keeps up with the daemon even when somebody
+else is driving.
+
+The behaviour change to look for: a user stops keeping a Roon or LMS zone selected "because the
+HQPlayer one doesn't really work", and stops reaching for the relay PC to change the level.
+
+Not the aim: making HQPlayer a library browser, and not making a zone *look* complete when the
+daemon has not said enough to make it complete.
+
+---
+
+## Problem Statement
+
+**Reframed (from the issue):** direct HQPlayer users need a complete everyday playback zone on UHC
+surfaces. Today the zone exists but is not truthful, and the untruths are individually small and
+jointly disqualifying.
+
+What the code actually does, read before choosing an approach:
+
+| # | Defect | Location |
+|---|--------|----------|
+| 1 | **Every HQPlayer control command is executed against Roon.** `knob_control_handler` dispatches `lms:`, `openhome:`, `upnp:` explicitly and then *falls through* to `control_roon` for everything else — including `hqplayer:`. The Roon adapter is handed `hqplayer:Living Room` with the prefix stripped, and either fails or, worse, matches an unrelated Roon zone id. | `src/knobs/routes.rs:533-554` |
+| 2 | **The HQPlayer adapter toggle does not filter HQPlayer zones.** The zone filter tests the prefix `hqp:`; zones are published as `hqplayer:`. So the test never matches, HQPlayer zones land in the `_ => true` arm, and disabling the adapter in settings leaves its zones listed. | `src/knobs/routes.rs:165` |
+| 3 | **Transport capability is asserted, not observed.** `is_seekable`, `is_next_allowed`, `is_previous_allowed` are hard-coded `true` for every HQPlayer zone in every state, including stopped with nothing loaded. | `src/adapters/hqplayer.rs:7174-7179` |
+| 4 | **Output-domain facts are published as track metadata.** `TrackMetadata.bit_depth` is filled from `Status.active_bits` (the DAC's output depth) and `format` from `Status.active_mode` (the output mode, which under `[source]` reads back the literal string `[source]`). The source-domain depth the daemon *does* supply, on the `metadata` child, is dropped. | `src/adapters/hqplayer.rs:7146-7155` |
+| 5 | **A lost `VolumeRange` reply erases the volume capability.** `ensure_volume_range` answers a transient failure with `VolumeRange::default()`, whose `enabled` is `false`; `hqp_status_to_zone` maps `!enabled` to `volume_control: None`. One dropped reply and a zone that has a working −60…0 dB control reports as fixed-volume. | `src/adapters/hqplayer.rs:3255-3258`, `7120-7133` |
+| 6 | **Mute is published as a constant.** `is_muted: false`, with the comment "HQPlayer doesn't report mute separately". It does not report a *flag*; `VolumeMute` is a verified absolute move to the range floor (HQP, #322 live), so mute is observable — as the level sitting at `min_db`. | `src/adapters/hqplayer.rs:7127` |
+| 7 | **A direct zone can be linked to itself as a DSP enrichment target.** `link_zone` accepts any `zone_id` string, so `hqplayer:A` → instance `A` is storable, after which the zone carries a `dsp` block pointing at its own control path: two routes, one daemon, no disambiguation. | `src/adapters/hqplayer.rs:7783` |
+| 8 | **A missing volume value defaults to 50.** The `vol_abs` arm ends `.unwrap_or(50.0)`. For a dB zone +50 dB is above every possible maximum, and the existing safety lint does not see it — that lint scans `src/adapters` only, and matches the pattern `.value.unwrap_or(50.0)`, not `.as_f64()).unwrap_or(50.0)`. | `src/knobs/routes.rs:610`, `tests/architecture_lint.rs:787-829` |
+
+What is **already** right and must not be re-solved: the 2 s coherent-observation poll loop
+(#162/#369) republishes the zone continuously, so "changes made by another controller" is a
+*verification* obligation here, not an implementation one; `knob_now_playing_handler` already reads
+zone state from `ZoneAggregator` and no surface reads adapter state; `HqpStatus.volume_db` and
+`VolumeRange.{min,max,step}_db` already carry exact decimal dB internally (#322/#347).
+
+### Constraints treated as real
+
+* **No public HTTP/MCP endpoint, request schema, or response schema may change** without explicit
+  user approval, and `tests/fixtures/api_routes.txt` may not be edited. This is the binding
+  constraint on the design and it is what forces the `serde(skip)` internal-field approach below.
+* **No surface may query an adapter for state** (`docs/ARCHITECTURE.md`,
+  `tests/architecture_lint.rs`). Commands to adapters from `_control_handler` are the established
+  and allowed pattern; state reads are not.
+* **No unevidenced protocol claim.** `.oh/hqplayer-evidence-ledger.md` is the authority, and a
+  grep of the whole repository finds **no** evidence for `composer`, `performer`, `albumartist`,
+  `genre`, `date` or `uri` as `Status/metadata` attribute *spellings*. Only `artist`, `album`,
+  `song`, `samplerate`, `bits`, `channels`, `bitrate` are in the corpus.
+* **Hermetic only.** No connection to a live HQPlayer host from this branch.
+
+---
+
+## Solution Space
+
+### Candidate A — Band-aid: add a `hqplayer:` arm to the router
+
+Add the missing `else if req.zone_id.starts_with("hqplayer:")` branch, mapping actions onto the
+adapter methods that already exist.
+
+* Solves the stated problem: **the routing half only** (defect 1). Every other defect is in the
+  *projection* — the zone would still advertise seek on a stopped zone, still publish the DAC's bit
+  depth as the track's, still lose its volume control on a dropped reply.
+* Cost: very low. Second-order: the worst outcome available here, because commands start landing on
+  the right daemon while the capability flags stay false. A knob that now really does send `Seek` to
+  HQPlayer, told by the same server that seek is always allowed, is a *regression* in user-visible
+  correctness even though every individual change is an improvement.
+
+### Candidate B — Local optimum: fix the router and the projection together
+
+Add the `hqplayer:` arm **and** make `hqp_status_to_zone` derive every capability, level and
+metadata field from the observation instead of asserting it: capability from observed state,
+source-domain metadata from the `metadata` child, mute from the floor comparison, volume capability
+retained across a transient read failure.
+
+* Solves the stated problem: **yes**, for every acceptance criterion whose data has somewhere to go
+  in the existing schemas.
+* Cost: medium, concentrated in two files plus a link-service guard.
+* Second-order: the router and the projection have to agree about what "allowed" means, and nothing
+  structural makes them agree — they are two functions in two modules. Mitigated by deriving the
+  router's refusals from the *aggregator's published zone*, so the flag the client was given is
+  literally the flag the command is checked against. That is not a new abstraction; it is the
+  aggregator already being the single source of truth.
+
+### Candidate C — Reframe: a typed direct-zone projection module
+
+Extract an `hqplayer::direct_zone` module owning one function
+`observation -> (Zone, allowed_actions)`, with `AllowedActions` a type the router consumes, so
+"advertised" and "permitted" are one value by construction rather than by agreement.
+
+* Solves the stated problem: yes, and closes B's residual structurally.
+* Cost: high. `AllowedActions` has to cross from `src/adapters` to `src/knobs`, and the only way to
+  carry it is on the `Zone` the aggregator stores — which is `BusEvent::ZoneDiscovered`'s payload,
+  serialised verbatim into `GET /events`. **So the reframe requires a public response-schema change
+  and is therefore not available without approval.** A parallel side-channel keyed by zone id would
+  avoid the schema change and reintroduce exactly the drift the reframe exists to remove, on a path
+  the aggregator does not own.
+* Rejected on the constraint, not on the merits. Recorded as the shape to revisit if #331 opens the
+  adaptive surface, where a typed capability set has a legitimate home.
+
+### Candidate D — Redesign: route direct HQPlayer transport through the #329 immediate-command actor
+
+Model transport and volume as adaptive commands and submit them to
+`HqpImmediateCommandService`, gaining revision fencing, correlation-id dedup, operation records and
+supersession for free.
+
+* Solves the stated problem: yes, and it is where this ends up eventually.
+* Cost: highest. The #329 vocabulary is `Mode`/`Filter1x`/`FilterNx`/`Shaper`/`Rate` — declarative
+  *settings* with a `desired`/`observed` lane and a readback. Transport has no desired lane (there
+  is nothing to stage), and its "readback" is a state transition, not a value comparison. Adding
+  transport to that vocabulary means extending the producer document's control vocabulary, which is
+  the #323 v1 contract under `.oh/adaptive-producer-contract.md` and its compatibility policy.
+* Second-order: it also inherits #329's *pending* work. Doing it here couples a user-visible
+  everyday-zone fix to an unlanded contract extension on a stacked branch. **Rejected as
+  sequencing, not as direction** — #331 is where the adaptive surface arrives, and this is the note
+  to read then.
+
+### Chosen: **B**, with C's invariant enforced by test rather than by type
+
+Level: **local optimum**. The reframe is the better design and the constraint that blocks it is a
+real one, so the honest move is to take B and pay for C's guarantee in verification: the router
+resolves the zone from `ZoneAggregator` and refuses on the *published* flag, and a test asserts the
+two cannot disagree by driving both through the same daemon observation.
+
+Consequences accepted:
+
+1. `Status/metadata` is parsed **generically** — every attribute of the child is read into a map,
+   and known keys are mapped onto typed fields. This makes no claim that any given spelling exists:
+   an attribute is published when the daemon supplies it and absent otherwise. It is the only
+   parser shape that satisfies "parse composer/genre where present" without adding an unevidenced
+   protocol claim to a repository whose ledger lint exists to prevent exactly that.
+2. New metadata reaches surfaces only through fields that **already exist** on `NowPlaying` /
+   `TrackMetadata` (`composer`, `genre`, `sample_rate`, `bit_depth`, `bitrate`). New internal fields
+   on `HqpStatus` are `#[serde(skip)]`, following the precedent already set for `title`/`artist`/
+   `album` on that struct. No response payload changes shape.
+3. **URI cannot be published.** No existing field on any published type can carry it. See Known
+   limitations for the exact approved change it would need.
+
+---
+
+## Execute
+
+**Status:** complete (draft PR open, not merged) · **Updated:** 2026-07-31
+
+Test-first throughout: every behavioural change below has a client-expectation test that was run
+and observed to fail against the unmodified tree before the implementation existed. RED evidence is
+in [Verification evidence](#verification-evidence).
+
+### Client-first failing tests (new file `tests/hqplayer_direct_zone.rs`)
+
+The file is organised by the client whose expectation it encodes, not by the module it exercises.
+
+| Group | Client expectation |
+|-------|--------------------|
+| `routing` | A knob that posts `{zone_id: "hqplayer:…", action: …}` reaches *that* HQPlayer daemon and nothing else — asserted on the mock daemon's received-request log, and by a Roon adapter that would have to have been called and was not. An unknown *prefixed* zone id is refused rather than silently sent to Roon; a legacy unprefixed id still goes to Roon. |
+| `capability` | The flags the client is given match the state the daemon is in: no seek without a duration, no next/previous with nothing loaded, no pause when not playing. |
+| `metadata` | Title/artist/album/composer/genre appear when the daemon supplies them; source-domain rate and depth come from the source, not from the DAC; a malformed `metadata` child loses the metadata and keeps the transport state. |
+| `stale_state` | Stopping clears now-playing, seekability and next/previous; an observed fixed-volume transition clears the volume control; a *transient* read failure does not; zone identity survives a reconnect. |
+| `volume` | Decimal dB survives end to end; a missing or unparseable level is refused rather than defaulted; out-of-range levels clamp to the observed range; the daemon is never sent a volume command when it has no volume control. |
+| `reconciliation` | A change made by another controller is republished to the aggregator without any UHC command being issued. |
+| `dsp_boundary` | A direct zone carries no `dsp` block; linking a `hqplayer:` zone is refused; a linked Roon zone keeps its enrichment. |
+
+### Implementation boundary
+
+Four files. Nothing else is touched.
+
+* `src/adapters/hqplayer.rs` — generic `metadata`-child attribute parse; `HqpStatus` internal
+  fields; `hqp_status_to_zone` capability/metadata/volume derivation; `ensure_volume_range`
+  retains the last observed capability; `HqpZoneLinkService::link_zone` refuses `hqplayer:` ids.
+* `src/knobs/routes.rs` — `hqplayer:` routing arm; prefix-fallthrough closed; `hqp:` → `hqplayer:`
+  filter fix; no `dsp` block on direct zones.
+* `tests/hqplayer_direct_zone.rs` — new.
+* `tests/volume_safety.rs` — lint extension covering the direct-zone volume path.
+
+Deliberately **not** touched: `tests/fixtures/api_routes.txt`, `src/api/mod.rs`, `src/mcp/mod.rs`,
+`src/bus/events.rs`, `src/adaptive/**`, `src/producers/**`.
+
+---
+
+## Known limitations
+
+1. **URI is not published (AC1, partially not met).** Parsed from the `metadata` child when
+   supplied and used as a track-loaded signal for capability, but no published type has a field
+   for it. **Exact approved change required:** add
+   `#[serde(skip_serializing_if = "Option::is_none")] pub uri: Option<String>` to
+   `crate::bus::NowPlaying` (`src/bus/events.rs`). Reach: `ZoneDiscovered` / `ZoneUpdated` payloads
+   on the `GET /events` SSE stream only — no HTTP response body gains a field, and with
+   `skip_serializing_if` no payload changes at all unless HQPlayer supplies a URI. Not made.
+2. **Performer, album artist and date are not published (AC1 addendum, not met).** Same cause,
+   same shape of change; they would need `TrackMetadata` fields. Not made, and not parsed either,
+   because parsing a field nothing can publish is dead weight.
+3. **Album art is explicitly represented unavailable (AC9, met by the "explicitly unavailable"
+   arm).** `image_key` stays `None` for HQPlayer zones and `/knob/now_playing/image` returns its
+   placeholder. Native `LibraryPicture` needs binary framing on a connection this client treats as
+   XML-only, plus caps, auth and cache policy — the issue's own status-stream boundary says not to
+   issue picture commands before those are proven. Nothing here claims art is coming.
+4. **`play_pause` resolves against aggregator state, which can be up to one poll interval stale
+   (2 s default).** A `play_pause` issued inside that window can resolve to the direction the user
+   did not want. Bounded, and the alternative — a synchronous pre-read of daemon state on the
+   command path — is a surface reading adapter state, which the architecture forbids. Recorded
+   rather than mitigated.
+5. **`vol_up`/`vol_down` are absolute writes computed from the aggregator's last observed level**,
+   for the same staleness reason, so a rapid knob spin can compress. HQPlayer's own
+   `VolumeUp`/`VolumeDown` would avoid it but use the daemon's step, which the verified sample does
+   not even send — and it would ignore the user's `volume_step_override`. Traded deliberately.
+6. **Mute is one-way.** `VolumeMute` is a verified absolute move to the range floor with no mute
+   flag and no daemon-side unmute; `is_muted` is therefore derived as *level at floor*. Unmute is a
+   plain level write, so an "unmute" that restores a remembered level is not advertised, because
+   its result would not be observable as unmute. UHC stores no pre-mute level.
+7. **Adaptive-volume mode is reported but not modelled as a mode.** `VolumeRange.adaptive` is
+   observed and reaches the internal snapshot; the direct zone does not distinguish an
+   adaptive-mode level from a user-set one, so a level the daemon moved on its own reads as a
+   user's level. Making that distinction visible needs a field. Recorded against the issue's
+   "adaptive-volume mode may be stored as a mode, not a level" criterion, which is **not met**.
+8. **No live verification.** Hermetic wire/model fixtures only. The 6.0.2 rig
+   (`.oh/hqplayer-evidence-ledger.md`, and the rig-side faults recorded against #337) was not
+   touched from this branch, per the task constraint. Every claim below is a hermetic claim.
+9. **Mode-switch qualification during playback (issue's beta/dev criterion) is not addressed.**
+   It is a #347/#375 setter concern, not a direct-zone projection concern, and nothing here
+   changes it.
+
+---
+
+## Verification evidence
+
+Filled in as each gate runs; see the PR's Execute-checkpoint and Review comments for the transcript
+excerpts.
+
+| Gate | Command | Result |
+|------|---------|--------|
+| RED, targeted | `cargo test --test hqplayer_direct_zone` | recorded in the Execute checkpoint comment |
+| GREEN, targeted | `cargo test --test hqplayer_direct_zone` | recorded |
+| Client harness | `cargo test --test client_harness` | recorded |
+| Conformance | `cargo test --test hqplayer_conformance` | recorded |
+| Architecture / API / lints | `cargo test --test architecture_lint --test api_contract --test aggregator_lint --test adaptive_dependency_lint` | recorded |
+| Whole suite | `cargo test --all-features` | recorded |
+| Clippy | `cargo clippy --all-targets --all-features -- -D warnings` | recorded |
+| Format | `cargo fmt --check` | recorded |
+| UI build | `dx build --release --platform web --features web` | recorded / justified if skipped |

--- a/.oh/hqplayer-direct-zone.md
+++ b/.oh/hqplayer-direct-zone.md
@@ -262,12 +262,69 @@ excerpts.
 
 | Gate | Command | Result |
 |------|---------|--------|
-| RED, targeted | `cargo test --test hqplayer_direct_zone` | recorded in the Execute checkpoint comment |
-| GREEN, targeted | `cargo test --test hqplayer_direct_zone` | recorded |
-| Client harness | `cargo test --test client_harness` | recorded |
-| Conformance | `cargo test --test hqplayer_conformance` | recorded |
-| Architecture / API / lints | `cargo test --test architecture_lint --test api_contract --test aggregator_lint --test adaptive_dependency_lint` | recorded |
-| Whole suite | `cargo test --all-features` | recorded |
-| Clippy | `cargo clippy --all-targets --all-features -- -D warnings` | recorded |
-| Format | `cargo fmt --check` | recorded |
-| UI build | `dx build --release --platform web --features web` | recorded / justified if skipped |
+| **RED, targeted** | `cargo test --test hqplayer_direct_zone` @ `74b24d6` | **33 passed, 19 failed** — tests + seams only, no behaviour |
+| GREEN, targeted | `cargo test --test hqplayer_direct_zone` | **56 passed, 0 failed** |
+| Conformance | `cargo test --test hqplayer_conformance` | **290 passed, 0 failed** |
+| Volume safety | `cargo test --test volume_safety` | **16 passed** (2 new, both proven non-vacuous by mutation) |
+| API contract | `cargo test --test api_contract` | **2 passed**; `api_routes.txt` byte-identical |
+| Whole suite | `cargo test --all-features` | **1,250 passed, 0 failed, 13 ignored** across 32 targets |
+| Clippy | `cargo clippy --all-targets --all-features -- -D warnings` | **Not green, and not made green.** 397 pre-existing errors at base `a178b76` (the #338 backlog). One new finding introduced and fixed. Findings in `src/knobs/routes.rs`: **0**. In `src/adapters/hqplayer.rs`: **3**, all pre-existing in its `#[cfg(test)]` module, none on an edited line. |
+| Format | `cargo fmt --all --check` | **clean** |
+| Release UI | `dx build --release --platform web --features web` | **Client + Server build completed successfully** |
+| Live | — | **Not run.** Hermetic fixtures only, per constraint. |
+
+### Environment faults hit on the way (not code defects)
+
+* `public/tailwind.css` is a gitignored build artifact and absent from a fresh worktree; nothing
+  compiles until `make css` generates it.
+* `dx build` first failed with `Missing rust target wasm32-unknown-unknown`. Two causes stacked:
+  `sccache` (set as `rustc-wrapper` in `~/.cargo/config.toml`) corrupts `dx`'s rustc probe, and
+  `/opt/homebrew/bin/rustc` 1.93.1 — which has no wasm std — shadows the rustup `stable` toolchain
+  that does. Green with `RUSTC_WRAPPER=` and the rustup `stable` bin ahead on `PATH`. Same family as
+  the rig-side faults recorded against #337: the tree was fine and the host was not.
+
+---
+
+## Review pass — what falsification actually found
+
+Four defects, all in code written earlier in this same session. Each is now pinned by a named test.
+
+1. **The volume-step safety floor coarsened a finer reported step.** The floor was applied as
+   `.max(MIN_PUBLISHED_VOLUME_STEP_DB)` *over the reported value*, so a daemon offering 0.1 dB was
+   published as offering 0.5 dB. A fabrication in the opposite direction from the one the floor
+   exists to prevent, and the most embarrassing of the four: the fix for "never publish an unusable
+   step" quietly became "never publish an accurate one". Now the floor applies only when nothing
+   usable was reported. → `a_finer_reported_step_is_not_coarsened_by_the_safety_floor`
+2. **Float representation error reached the wire.** The published zone carries level and step as
+   `f32`; widening them back to `f64` to add turned `-23.5 + 0.1` into `-23.399999998509884`, and
+   `set_volume_db` formats with `{}`. Fixed by quantising to 0.01 dB — below audibility and below the
+   finest observed step, so it removes noise without quantising away a real distinction. →
+   `a_computed_level_reaches_the_wire_without_float_noise`
+3. **A raw `>` in an attribute value truncated the metadata scan.** XML forbids `<` and `&` in
+   attribute values but *permits a bare `>`*, so `song="a/>b"` is well-formed; the plain search for
+   the child's `/>` cut inside the value and silently lost the title, the album *and* the source bit
+   depth. The terminator search is now quote-aware. Note the direction of the miss: this was
+   introduced by the very bound added to stop a malformed child swallowing `</Status>`. →
+   `a_raw_terminator_inside_an_attribute_value_does_not_truncate_the_metadata_scan`
+4. **Transport was accepted for a withdrawn zone.** `play`/`pause`/`stop` did not consult the
+   published zone at all, so they answered `{"ok":true}` for a zone the aggregator had withdrawn,
+   purely because the instance remained in the manager's map. Now every arm requires the published
+   zone. → `transport_is_refused_for_a_zone_the_aggregator_has_withdrawn`
+
+Two hypotheses the pass **failed** to confirm, recorded because a review that only reports hits is
+not evidence of much:
+
+* That `trim_start_matches("hqplayer:")` mishandles an instance name containing a colon. It does
+  not — `hqplayer:a:b` yields `a:b`, which is the correct key. (It *would* strip a repeated prefix,
+  but an instance literally named `hqplayer:x` is not a reachable configuration.)
+* That an attribute value containing an encoded `&gt;` truncates the scan. It does not: the raw
+  document contains `&gt;`, not `>`. Only the *unencoded* form was a hazard, which is what sharpened
+  the probe into finding 3.
+
+### What the review did not close
+
+* The one-poll-interval staleness on `play_pause` and relative volume (Known limitations 4 and 5).
+  Confirmed reachable; not fixed, because both available fixes are forbidden — a surface reading
+  adapter state, or a daemon-side compare-and-set the protocol lacks.
+* Whether any real daemon populates `composer`/`genre`/`uri`. Unfalsifiable hermetically, and
+  deliberately not claimed either way: the parser reads what arrives.

--- a/src/adapters/hqplayer.rs
+++ b/src/adapters/hqplayer.rs
@@ -1813,6 +1813,20 @@ struct HqpAdapterState {
     /// been touched. Monotonic, bumped on every clear and every publication, and never reset.
     chain_generation: u64,
     volume_range: Option<VolumeRange>,
+    /// The last volume capability this endpoint was ever *observed* to have (#328).
+    ///
+    /// Distinct from `volume_range` above, and the distinction is the point. That one is
+    /// session-scoped and is cleared on every disconnect, because a session's values must not
+    /// outlive it. This one is **endpoint**-scoped: it answers "what did this daemon last tell us it
+    /// can do", which a dropped TCP reply is not evidence against.
+    ///
+    /// It exists because the transient-failure path used to answer with `VolumeRange::default()`,
+    /// whose `enabled` is `false`, and the zone projection maps `!enabled` to no volume control at
+    /// all. One lost `VolumeRange` reply therefore told every client that a working −60…0 dB zone
+    /// had become a fixed-volume device — a capability lie, and on a knob it removes the control the
+    /// user is turning. Cleared when the endpoint is reconfigured, since a different daemon's
+    /// capability is not this one's.
+    last_observed_volume_range: Option<VolumeRange>,
     // Web client state for profiles
     profiles: Vec<HqpProfile>,
     hidden_fields: HashMap<String, String>,
@@ -1860,6 +1874,7 @@ impl Default for HqpAdapterState {
             rates_fingerprint: None,
             chain_generation: 0,
             volume_range: None,
+            last_observed_volume_range: None,
             profiles: Vec::new(),
             hidden_fields: HashMap::new(),
             config_title: None,
@@ -1922,6 +1937,37 @@ impl HqpAdapter {
         };
         guard.take()
     }
+
+    /// Record an observed volume capability, keeping both scopes in step.
+    ///
+    /// `volume_range` is session-scoped and dies with the session; `last_observed_volume_range` is
+    /// endpoint-scoped and survives a reconnect so a dropped reply cannot be mistaken for a
+    /// fixed-volume daemon (#328). They are one fact in two lifetimes, and the reason this is a
+    /// helper rather than two assignments is that the first version of the #328 fix set only the
+    /// session-scoped one at three of its four sites: the fourth was `ensure_volume_range`'s
+    /// cache-hit early return, which is the path a healthy producer takes on *every poll after the
+    /// first*. The endpoint-scoped value was therefore still `None` at the moment the fault arrived,
+    /// and the retention it was added for never fired.
+    fn remember_volume_capability(state: &mut HqpAdapterState, range: &VolumeRange) {
+        state.volume_range = Some(range.clone());
+        state.last_observed_volume_range = Some(range.clone());
+    }
+
+    /// Comparison tolerance for a dB level that arrived as a double through two independent reads.
+    ///
+    /// Used only to decide whether the level is *at* the range floor, which is what mute is on this
+    /// protocol. An exact `==` on two separately-parsed doubles is the wrong test, and a wide
+    /// tolerance would report a genuinely low level as muted; 0.05 dB is far below the smallest step
+    /// any observed daemon offers and far above double-formatting noise.
+    const VOLUME_READBACK_TOLERANCE_DB: f64 = 0.05;
+
+    /// Floor for the volume step published to clients.
+    ///
+    /// The verified live sample sends no `step` attribute, so a step often has to be chosen rather
+    /// than read. Whatever is chosen must be *usable*: a published step of zero reaches a knob as a
+    /// control that visibly does nothing, and the user's conclusion is that the zone is broken.
+    /// 0.5 dB is the finest step any observed daemon reports, so it cannot overshoot a real one.
+    const MIN_PUBLISHED_VOLUME_STEP_DB: f64 = 0.5;
 
     pub fn new(bus: SharedBus) -> Self {
         #[allow(clippy::expect_used)] // HTTP client creation only fails if TLS setup fails
@@ -2063,6 +2109,9 @@ impl HqpAdapter {
                 // *another* daemon's chain had moved.
                 Self::clear_chain_cache(&mut state);
                 state.volume_range = None;
+                // Endpoint-scoped: a different daemon's volume capability is not this one's, so the
+                // retained last-observed value must not survive an endpoint change (#328).
+                state.last_observed_volume_range = None;
             }
             if persistent_changed {
                 // Hidden fields and profile values belong to one web endpoint and credential
@@ -2403,7 +2452,28 @@ impl HqpAdapter {
                             self.establish_transport_locked().await?;
                             (info, state, status) = self.read_required_handshake_fields().await?;
                         }
-                        VolumeRange::default()
+
+                        // Retain the capability this **endpoint** was last observed to have rather
+                        // than synthesising a disabled one (#328). `VolumeRange::default()` here has
+                        // `enabled: false`, which the direct-zone projection maps to no volume
+                        // control at all — so a daemon that stops answering one optional query was
+                        // reported to every client as having become a fixed-volume device, and a
+                        // knob lost the control the user was turning.
+                        //
+                        // This is the *handshake* copy of the same fallback in
+                        // `ensure_volume_range`, and it is the one that actually fires under a lost
+                        // reply: the timeout discards the socket, the reconnect above re-runs the
+                        // handshake, and the handshake — not the poll — is where the substitution
+                        // happened. Fixing only the poll's copy left the defect fully intact.
+                        //
+                        // An explicit `result="Error"` is still terminal (the arm above), because
+                        // there the daemon authoritatively answered.
+                        self.state
+                            .read()
+                            .await
+                            .last_observed_volume_range
+                            .clone()
+                            .unwrap_or_default()
                     }
                 },
             };
@@ -2434,7 +2504,7 @@ impl HqpAdapter {
             let mut state = self.state.write().await;
             state.info = Some(info.clone());
             state.last_state = Some(observed_state);
-            state.volume_range = Some(volume_range.clone());
+            Self::remember_volume_capability(&mut state, &volume_range);
             state.producer_epoch = state.producer_epoch.wrapping_add(1);
             // This is deliberately last: no observer may see reachable until the session has a
             // coherent initial snapshot ready to publish.
@@ -2523,7 +2593,7 @@ impl HqpAdapter {
                 ));
             }
             state.last_state = Some(snapshot.state.clone());
-            state.volume_range = Some(snapshot.volume_range.clone());
+            Self::remember_volume_capability(&mut state, &snapshot.volume_range);
         }
 
         let zone = Self::hqp_status_to_zone(
@@ -2584,7 +2654,7 @@ impl HqpAdapter {
                 return Ok(());
             }
             state.last_state = Some(observed_state);
-            state.volume_range = Some(volume_range.clone());
+            Self::remember_volume_capability(&mut state, &volume_range);
             (
                 state
                     .host
@@ -3279,12 +3349,13 @@ impl HqpAdapter {
     /// query rather than merely omitting the optional capability.
     async fn ensure_volume_range(&self) -> Result<PipelineVolumeRange> {
         {
-            let state = self.state.read().await;
+            let mut state = self.state.write().await;
             if let Some(range) = state.volume_range.clone() {
-                return Ok(PipelineVolumeRange::Observed {
-                    range,
-                    generation: state.transport_generation,
-                });
+                // The steady-state path: a healthy producer answers from cache on every poll after
+                // the first, so this is where the endpoint-scoped capability is kept alive.
+                let generation = state.transport_generation;
+                state.last_observed_volume_range = Some(range.clone());
+                return Ok(PipelineVolumeRange::Observed { range, generation });
             }
         }
         match self.get_volume_range_with_generation().await {
@@ -3292,14 +3363,34 @@ impl HqpAdapter {
                 let mut state = self.state.write().await;
                 // Do not date a value from the previous socket as if the replacement served it.
                 if state.transport_generation == generation {
-                    state.volume_range = Some(range.clone());
+                    Self::remember_volume_capability(&mut state, &range);
+                } else {
+                    // The value came from a socket this session replaced, so it must not be dated as
+                    // the current session's. It is still what this *endpoint* last reported it can
+                    // do, which is the only claim the endpoint-scoped field makes.
+                    state.last_observed_volume_range = Some(range.clone());
                 }
                 Ok(PipelineVolumeRange::Observed { range, generation })
             }
             Err(error) if error.downcast_ref::<HqpRejected>().is_some() => Err(error),
             Err(e) => {
-                tracing::debug!("HQPlayer volume range unavailable ({e}); reporting fixed volume");
-                Ok(PipelineVolumeRange::FixedFallback(VolumeRange::default()))
+                // A lost reply is not evidence that the daemon became fixed-volume, so the last
+                // capability it was observed to have is retained rather than replaced by a synthetic
+                // disabled one. Only a daemon that has *never* answered is reported as fixed —
+                // there, claiming a capability would be the opposite fabrication.
+                let retained = self
+                    .state
+                    .read()
+                    .await
+                    .last_observed_volume_range
+                    .clone()
+                    .unwrap_or_default();
+                tracing::debug!(
+                    "HQPlayer volume range unavailable ({e}); retaining last observed capability \
+                     (enabled={})",
+                    retained.enabled
+                );
+                Ok(PipelineVolumeRange::FixedFallback(retained))
             }
         }
     }
@@ -4150,15 +4241,85 @@ impl HqpAdapter {
         Ok(Self::parse_state_response(&response))
     }
 
-    /// Read an attribute from a child element without letting child attributes override the root.
-    fn parse_child_attr(response: &str, child: &str, attr: &str) -> Option<String> {
-        let marker = format!("<{child}");
-        let start = response.find(&marker)?;
-        Self::parse_attr(&response[start..], attr)
+    /// Every attribute of the `Status/metadata` child, keyed by name (#328).
+    ///
+    /// **Deliberately generic, and that is the whole design.** A per-attribute parser has to name
+    /// the attributes it expects, and naming one is a claim that a daemon sends it. The corpus
+    /// evidences exactly seven — `artist`, `album`, `song`, `samplerate`, `bits`, `channels`,
+    /// `bitrate` (`tests/fixtures/hqplayer/hqpd-6.0.4-opal/status_playing_with_metadata.xml`) — and
+    /// `.oh/hqplayer-evidence-ledger.md` exists because unevidenced protocol claims in this client
+    /// have repeatedly turned out to be wrong. Reading whatever the child carries makes no claim at
+    /// all: an attribute is published when it arrives and absent otherwise.
+    ///
+    /// Scoped to the child's own open tag, so a malformed or unterminated child costs the metadata
+    /// and nothing else — the root's `state`, `position`, `length` and `volume` are parsed from the
+    /// root tag by separate calls and are unaffected. That property is load-bearing: the `metadata`
+    /// child is the one part of a `Status` document this client has observed malformed in the wild
+    /// (see the framing note at the top of this file), and a status poll that lost the playback
+    /// state because a title was unreadable would be the worse failure by far.
+    fn parse_metadata_child(response: &str) -> HashMap<String, String> {
+        let mut attrs = HashMap::new();
+        let Some(start) = response.find("<metadata") else {
+            return attrs;
+        };
+        let rest = &response[start..];
+        // The child is self-closing in every observed document, but bound the scan at whichever
+        // terminator arrives first so a child missing its `/>` cannot swallow the closing `</Status>`
+        // and start reporting root attributes as source metadata.
+        let end = rest
+            .find("/>")
+            .or_else(|| rest.find('>'))
+            .unwrap_or(rest.len());
+        let scope = &rest[..end];
+
+        // Walk ` name="value"` pairs. An unterminated value ends the walk rather than the document:
+        // whatever was already collected stands, and the malformed tail is dropped.
+        let mut cursor = match scope.find(char::is_whitespace) {
+            Some(offset) => &scope[offset..],
+            None => return attrs,
+        };
+        while let Some(eq) = cursor.find('=') {
+            let name = cursor[..eq].trim();
+            let after_eq = cursor[eq + 1..].trim_start();
+            let Some(quoted) = after_eq.strip_prefix('"') else {
+                break;
+            };
+            // No closing quote: the child was cut mid-value. Stop, keeping what came before.
+            let Some(close) = quoted.find('"') else { break };
+            if !name.is_empty() && !name.contains(char::is_whitespace) {
+                attrs.insert(
+                    name.to_ascii_lowercase(),
+                    framing::decode_entities(&quoted[..close]),
+                );
+            }
+            cursor = &quoted[close + 1..];
+        }
+        attrs
+    }
+
+    /// Typed source-domain reading of one metadata attribute.
+    ///
+    /// A value the daemon sends but this client cannot parse becomes `None`, never `0`. Zero is a
+    /// meaningful sample rate and bit depth in exactly no context, and `#347`'s whole class of bug
+    /// was a parse failure defaulting to a plausible-looking number.
+    fn metadata_u32(attrs: &HashMap<String, String>, key: &str) -> Option<u32> {
+        attrs
+            .get(key)
+            .and_then(|raw| raw.trim().parse::<u32>().ok())
+            .filter(|value| *value > 0)
+    }
+
+    /// Non-empty text reading of one metadata attribute. An empty attribute is absent, not `""`.
+    fn metadata_text(attrs: &HashMap<String, String>, key: &str) -> Option<String> {
+        attrs
+            .get(key)
+            .map(|raw| raw.trim().to_string())
+            .filter(|value| !value.is_empty())
     }
 
     /// Parse the complete playback status, including its optional metadata child.
     fn parse_status_response(response: &str) -> HqpStatus {
+        let meta = Self::parse_metadata_child(response);
         HqpStatus {
             state: Self::parse_attr_u32(response, "state") as u8,
             track: Self::parse_attr_u32(response, "track"),
@@ -4175,16 +4336,20 @@ impl HqpAdapter {
             active_channels: Self::parse_attr_u32(response, "active_channels"),
             samplerate: Self::parse_attr_u32(response, "samplerate"),
             bitrate: Self::parse_attr_u32(response, "bitrate"),
-            title: Self::parse_child_attr(response, "metadata", "song"),
-            artist: Self::parse_child_attr(response, "metadata", "artist"),
-            album: Self::parse_child_attr(response, "metadata", "album"),
-            composer: None,
-            genre: None,
-            uri: None,
-            source_samplerate: None,
-            source_bits: None,
-            source_channels: None,
-            source_bitrate: None,
+            title: Self::metadata_text(&meta, "song"),
+            artist: Self::metadata_text(&meta, "artist"),
+            album: Self::metadata_text(&meta, "album"),
+            composer: Self::metadata_text(&meta, "composer"),
+            genre: Self::metadata_text(&meta, "genre"),
+            // `location` is the spelling UPnP/DIDL uses for the same idea; both are read because
+            // neither is evidenced for HQPlayer and reading a key the daemon never sends costs
+            // nothing, while guessing the wrong single spelling costs the field.
+            uri: Self::metadata_text(&meta, "uri")
+                .or_else(|| Self::metadata_text(&meta, "location")),
+            source_samplerate: Self::metadata_u32(&meta, "samplerate"),
+            source_bits: Self::metadata_u32(&meta, "bits"),
+            source_channels: Self::metadata_u32(&meta, "channels"),
+            source_bitrate: Self::metadata_u32(&meta, "bitrate"),
         }
     }
 
@@ -7196,13 +7361,35 @@ impl HqpAdapter {
         };
 
         let volume_control = if vol_range.enabled {
+            // The step the daemon actually sent, and only if it is usable. The verified live sample
+            // sends **no** `step` attribute at all, so `step_db` is routinely `None`; the integer
+            // sibling is already `.max(1)` at parse time. A zero or negative step would reach a knob
+            // as "turning me changes nothing", which is why this cannot be a bare `unwrap_or`.
+            let step = vol_range
+                .step_db
+                .filter(|db| *db > 0.0)
+                .unwrap_or(f64::from(vol_range.step))
+                .max(Self::MIN_PUBLISHED_VOLUME_STEP_DB);
+
+            // Clamped into the observed range before publication. An out-of-range level is a
+            // disagreement between two daemon reads (`Status.volume` and `VolumeRange`), and a client
+            // that draws a slider from these three numbers must not be handed a value outside its
+            // own track.
+            let value = status.volume_db.clamp(vol_range.min_db, vol_range.max_db);
+
             Some(BusVolumeControl {
                 // Exact dB, not the rounded payload projection.
-                value: status.volume_db as f32,
+                value: value as f32,
                 min: vol_range.min_db as f32,
                 max: vol_range.max_db as f32,
-                step: vol_range.step_db.unwrap_or(f64::from(vol_range.step)) as f32,
-                is_muted: false, // HQPlayer doesn't report mute separately
+                step: step as f32,
+                // Mute *is* observable, contrary to the comment this replaces. `VolumeMute` was
+                // verified live (#322, HQPlayer Embedded 6.0.2) to be an absolute, idempotent move
+                // to the range floor with no mute flag anywhere on the wire. So "muted" means the
+                // level is sitting at the floor, and that is a fact about the observation rather
+                // than a flag being invented. The tolerance is there because the floor arrives as a
+                // double through two independent reads.
+                is_muted: value <= vol_range.min_db + Self::VOLUME_READBACK_TOLERANCE_DB,
                 scale: VolumeScale::Decibel,
                 output_id: Some(zone_id.clone()),
             })
@@ -7210,25 +7397,53 @@ impl HqpAdapter {
             None
         };
 
-        // Build now_playing if we have track info
-        let has_metadata =
-            status.title.is_some() || status.artist.is_some() || status.album.is_some();
-        let now_playing = if !status.track_id.is_empty() || status.length > 0 || has_metadata {
+        // Is a track loaded? Every signal here is one the daemon supplied; none is inferred from
+        // another. `uri` participates because a location is a track identity even when the daemon
+        // sends no `song`/`track_id` — which is the one published use it has (see its field comment).
+        let has_metadata = status.title.is_some()
+            || status.artist.is_some()
+            || status.album.is_some()
+            || status.uri.is_some();
+        let track_loaded = !status.track_id.is_empty() || status.length > 0 || has_metadata;
+
+        let now_playing = if track_loaded {
             Some(BusNowPlaying {
                 title: status.title.clone().unwrap_or_default(),
                 artist: status.artist.clone().unwrap_or_default(),
                 album: status.album.clone().unwrap_or_default(),
+                // Album art is explicitly unavailable rather than promised. Native `LibraryPicture`
+                // needs binary framing on a connection this client treats as XML-only, plus caps,
+                // authentication and cache policy — none of which #328 establishes.
                 image_key: None,
                 seek_position: Some(status.position as f64),
                 duration: Some(status.length as f64),
                 metadata: Some(TrackMetadata {
-                    format: Some(status.active_mode.clone()),
-                    sample_rate: Some(status.samplerate),
-                    bit_depth: Some(status.active_bits as u8),
-                    bitrate: Some(status.bitrate),
-                    genre: None,
-                    composer: None,
-                    track_number: Some(status.track),
+                    // `TrackMetadata` is the **source** domain: it hangs off `NowPlaying` and
+                    // describes the track. HQPlayer's `active_*` attributes are the **output**
+                    // domain — what the DAC is being fed after upsampling and modulation — and
+                    // publishing them here is what made a 24-bit track read as 32-bit.
+                    //
+                    // `format` stays `None` on purpose. The daemon supplies no source container or
+                    // codec, and `active_mode` is not one: it is the output mode, and under
+                    // source-following it reads back the literal string `[source]`. Publishing it as
+                    // the track's format fabricates source metadata the daemon never sent.
+                    format: None,
+                    sample_rate: status.source_samplerate.or({
+                        // The root `samplerate` attribute is the source rate in every corpus
+                        // document (the child agrees with it), so it is a legitimate fallback —
+                        // unlike `active_rate`, which is the output rate and is never substituted.
+                        (status.samplerate > 0).then_some(status.samplerate)
+                    }),
+                    // No fallback to `active_bits`. There is no source-depth substitute for an
+                    // output depth: inferring one is exactly the "cannot fabricate PCM depth"
+                    // hazard, so an unsupplied source depth is absent.
+                    bit_depth: status.source_bits.and_then(|bits| u8::try_from(bits).ok()),
+                    bitrate: status
+                        .source_bitrate
+                        .or((status.bitrate > 0).then_some(status.bitrate)),
+                    genre: status.genre.clone(),
+                    composer: status.composer.clone(),
+                    track_number: (status.track > 0).then_some(status.track),
                     disc_number: None,
                 }),
             })
@@ -7249,12 +7464,23 @@ impl HqpAdapter {
             now_playing,
             source: "hqplayer".to_string(),
             is_controllable: true,
-            is_seekable: true,
+            // Every flag below is derived from the observation. They used to be hard-coded `true`,
+            // which made a stopped, empty zone advertise seek and skip — and the program session's
+            // hard constraint is that "unsupported operations are never advertised".
+            //
+            // A duration is what makes a position meaningful, so a live stream (`length == 0`) is
+            // playing and not seekable.
+            is_seekable: status.length > 0,
             last_updated,
+            // Play stays offered whenever the daemon is not already playing: HQPlayer can resume a
+            // loaded playlist the client cannot see, so refusing play on a stopped zone would deny
+            // a legitimate action rather than avoid an impossible one.
             is_play_allowed: state != PlaybackState::Playing,
             is_pause_allowed: state == PlaybackState::Playing,
-            is_next_allowed: true,
-            is_previous_allowed: true,
+            // Skip needs something to skip from. With nothing loaded these are the flags that had a
+            // knob drawing enabled buttons for a daemon that would answer `result="Error"`.
+            is_next_allowed: track_loaded,
+            is_previous_allowed: track_loaded,
         }
     }
 }
@@ -7859,6 +8085,19 @@ impl HqpZoneLinkService {
 
     /// Link a zone to an HQP instance
     pub async fn link_zone(&self, zone_id: String, instance_name: String) -> Result<()> {
+        // A direct HQPlayer zone is already an HQPlayer control path, so it cannot also be a
+        // DSP-*enrichment* target: linking one gives a client two routes to one daemon with no rule
+        // for which wins, which is the ambiguity #328's acceptance criteria forbid. Refused here
+        // rather than filtered at read time, so the ambiguous state is never storable in the first
+        // place — a link persisted to disk outlives whichever surface filtered it out.
+        if zone_id.starts_with("hqplayer:") {
+            return Err(anyhow!(
+                "{} is a direct HQPlayer zone and already controls its instance; DSP enrichment \
+                 links are for zones from another backend",
+                zone_id
+            ));
+        }
+
         // Verify instance exists
         if self.instances.get(&instance_name).await.is_none() {
             return Err(anyhow!("Unknown HQP instance: {}", instance_name));

--- a/src/adapters/hqplayer.rs
+++ b/src/adapters/hqplayer.rs
@@ -1163,6 +1163,51 @@ pub struct HqpStatus {
     /// Track album from the optional `Status/metadata` child.
     #[serde(skip)]
     pub album: Option<String>,
+
+    // -------------------------------------------------------------------------
+    // Remaining `Status/metadata` child attributes (#328).
+    //
+    // Every field below is `#[serde(skip)]`, following the precedent set by `title`/`artist`/`album`
+    // above: the public HQPlayer payload contract is unchanged, and the unified zone projection is
+    // what publishes these through the existing now-playing shape.
+    //
+    // **These are not protocol claims.** The parser reads the metadata child's attributes
+    // *generically* and fills whichever of these the daemon happened to send. Only `artist`,
+    // `album`, `song`, `samplerate`, `bits`, `channels` and `bitrate` have corpus evidence
+    // (`tests/fixtures/hqplayer/hqpd-6.0.4-opal/status_playing_with_metadata.xml`); the others are
+    // read opportunistically and are `None` on every daemon that does not send them. Nothing here
+    // asserts that any daemon does.
+    // -------------------------------------------------------------------------
+    /// Composer, when the metadata child supplies one.
+    #[serde(skip)]
+    pub composer: Option<String>,
+    /// Genre, when the metadata child supplies one.
+    #[serde(skip)]
+    pub genre: Option<String>,
+    /// Track URI/location, when the metadata child supplies one.
+    ///
+    /// Not published: no field on `crate::bus::NowPlaying` can carry it, and adding one is a
+    /// response-schema change to the `GET /events` payload requiring explicit approval (#328 Known
+    /// limitations). It is used as a *track-loaded* signal for transport capability, which is a real
+    /// consumer and the reason parsing it is not dead weight.
+    #[serde(skip)]
+    pub uri: Option<String>,
+
+    // Source-domain stream facts, kept deliberately separate from the `active_*` output-domain
+    // fields above. Conflating the two is the defect #328 records as its fourth: the DAC's output
+    // depth was being published as the track's.
+    /// Source sample rate from the metadata child.
+    #[serde(skip)]
+    pub source_samplerate: Option<u32>,
+    /// Source bit depth from the metadata child.
+    #[serde(skip)]
+    pub source_bits: Option<u32>,
+    /// Source channel count from the metadata child.
+    #[serde(skip)]
+    pub source_channels: Option<u32>,
+    /// Source bitrate from the metadata child.
+    #[serde(skip)]
+    pub source_bitrate: Option<u32>,
 }
 
 /// Volume range info
@@ -4133,6 +4178,13 @@ impl HqpAdapter {
             title: Self::parse_child_attr(response, "metadata", "song"),
             artist: Self::parse_child_attr(response, "metadata", "artist"),
             album: Self::parse_child_attr(response, "metadata", "album"),
+            composer: None,
+            genre: None,
+            uri: None,
+            source_samplerate: None,
+            source_bits: None,
+            source_channels: None,
+            source_bitrate: None,
         }
     }
 
@@ -7091,6 +7143,32 @@ impl HqpAdapter {
     pub async fn set_instance_name(&self, name: String) {
         let mut state = self.state.write().await;
         state.instance_name = Some(name);
+    }
+
+    /// Debug-only integration-test seam over the pure direct-zone projection.
+    ///
+    /// Exists because two of the projection's obligations are not expressible through the wire fake:
+    /// the source/output bit-depth split (the fake derives `Status.active_bits` from the same
+    /// metadata child it derives the source depth from, so the two can never disagree there), and
+    /// the exhaustive capability matrix, which would otherwise cost one TCP daemon per state. The
+    /// routing, clearing and reconciliation behaviour is tested through the real socket instead.
+    #[cfg(debug_assertions)]
+    #[doc(hidden)]
+    pub fn project_direct_zone(
+        host: &str,
+        instance_name: Option<&str>,
+        info: &HqpInfo,
+        status: &HqpStatus,
+        vol_range: &VolumeRange,
+    ) -> BusZone {
+        Self::hqp_status_to_zone(host, instance_name, info, status, vol_range)
+    }
+
+    /// Debug-only integration-test seam over the `Status` document parser.
+    #[cfg(debug_assertions)]
+    #[doc(hidden)]
+    pub fn parse_status_for_test(response: &str) -> HqpStatus {
+        Self::parse_status_response(response)
     }
 
     /// Convert HQPlayer status to a unified bus Zone

--- a/src/adapters/hqplayer.rs
+++ b/src/adapters/hqplayer.rs
@@ -4263,13 +4263,15 @@ impl HqpAdapter {
             return attrs;
         };
         let rest = &response[start..];
-        // The child is self-closing in every observed document, but bound the scan at whichever
-        // terminator arrives first so a child missing its `/>` cannot swallow the closing `</Status>`
-        // and start reporting root attributes as source metadata.
-        let end = rest
-            .find("/>")
-            .or_else(|| rest.find('>'))
-            .unwrap_or(rest.len());
+        // Bound the scan at the child's own terminator, so a child missing its `/>` cannot swallow
+        // the closing `</Status>` and start reporting root attributes as source metadata.
+        //
+        // The search is **quote-aware**, and that is not defensive padding: XML forbids `<` and `&`
+        // in an attribute value but *permits a bare `>`*, so `song="a/>b"` is well-formed. A plain
+        // `find("/>")` cuts inside that value and silently loses every attribute after it — verified
+        // by `probe_raw_terminator_inside_an_attribute_value`, which lost the title, the album and
+        // the source bit depth to a track name containing a slash before a bracket.
+        let end = Self::element_open_tag_end(rest);
         let scope = &rest[..end];
 
         // Walk ` name="value"` pairs. An unterminated value ends the walk rather than the document:
@@ -4295,6 +4297,22 @@ impl HqpAdapter {
             cursor = &quoted[close + 1..];
         }
         attrs
+    }
+
+    /// Byte offset just past an element's open tag, ignoring `>` inside quoted attribute values.
+    ///
+    /// Returns the slice length when the tag never terminates, so a truncated document yields
+    /// "everything present" rather than nothing.
+    fn element_open_tag_end(tag: &str) -> usize {
+        let mut in_quotes = false;
+        for (offset, ch) in tag.char_indices() {
+            match ch {
+                '"' => in_quotes = !in_quotes,
+                '>' if !in_quotes => return offset,
+                _ => {}
+            }
+        }
+        tag.len()
     }
 
     /// Typed source-domain reading of one metadata attribute.
@@ -7361,15 +7379,21 @@ impl HqpAdapter {
         };
 
         let volume_control = if vol_range.enabled {
-            // The step the daemon actually sent, and only if it is usable. The verified live sample
+            // The step the daemon actually sent, if it sent a usable one. The verified live sample
             // sends **no** `step` attribute at all, so `step_db` is routinely `None`; the integer
             // sibling is already `.max(1)` at parse time. A zero or negative step would reach a knob
             // as "turning me changes nothing", which is why this cannot be a bare `unwrap_or`.
-            let step = vol_range
-                .step_db
-                .filter(|db| *db > 0.0)
-                .unwrap_or(f64::from(vol_range.step))
-                .max(Self::MIN_PUBLISHED_VOLUME_STEP_DB);
+            //
+            // The floor applies **only when nothing usable was reported**. An earlier version of this
+            // took `.max(MIN_PUBLISHED_VOLUME_STEP_DB)` over the reported value, which silently
+            // coarsened a daemon's genuine 0.1 dB step to 0.5 dB — a fabrication in the opposite
+            // direction from the one the floor exists to prevent, and a fine-step user would have
+            // felt it immediately. Caught by review, pinned by
+            // `a_finer_reported_step_is_not_coarsened_by_the_safety_floor`.
+            let step = match vol_range.step_db.filter(|db| *db > 0.0) {
+                Some(reported) => reported,
+                None => f64::from(vol_range.step).max(Self::MIN_PUBLISHED_VOLUME_STEP_DB),
+            };
 
             // Clamped into the observed range before publication. An out-of-range level is a
             // disagreement between two daemon reads (`Status.volume` and `VolumeRange`), and a client

--- a/src/adapters/hqplayer.rs
+++ b/src/adapters/hqplayer.rs
@@ -7413,6 +7413,14 @@ impl HqpAdapter {
                 // level is sitting at the floor, and that is a fact about the observation rather
                 // than a flag being invented. The tolerance is there because the floor arrives as a
                 // double through two independent reads.
+                //
+                // **Known false positive, inherent to the protocol rather than to this code.** A user
+                // who deliberately turns the level down to the floor is reported as muted, because
+                // "muted" and "turned all the way down" produce byte-identical observations — there
+                // is no mute flag to disambiguate them. The alternative is to never report mute,
+                // which makes the mute button's effect invisible and is the worse trade: at the floor
+                // both readings agree that no sound is coming out. Recorded in
+                // `.oh/hqplayer-direct-zone.md` rather than papered over.
                 is_muted: value <= vol_range.min_db + Self::VOLUME_READBACK_TOLERANCE_DB,
                 scale: VolumeScale::Decibel,
                 output_id: Some(zone_id.clone()),
@@ -7453,9 +7461,29 @@ impl HqpAdapter {
                     // the track's format fabricates source metadata the daemon never sent.
                     format: None,
                     sample_rate: status.source_samplerate.or({
-                        // The root `samplerate` attribute is the source rate in every corpus
-                        // document (the child agrees with it), so it is a legitimate fallback —
-                        // unlike `active_rate`, which is the output rate and is never substituted.
+                        // Fallback to the root `samplerate` attribute, and the strength of this is
+                        // worth stating exactly rather than generously.
+                        //
+                        // **What is evidenced:** the one corpus `Status` document carries root
+                        // `samplerate="44100"`, child `samplerate="44100"` and
+                        // `active_rate="352800"`. So the root tracks the *child* and not the output
+                        // rate in that sample.
+                        //
+                        // **What is not:** the root and the child *agree* there, which cannot
+                        // distinguish "the root is the source rate" from "the root happens to equal
+                        // the source rate on this material". One agreeing sample is not proof of
+                        // identity, and no corpus document shows them diverging.
+                        //
+                        // Kept anyway, because this is HQPlayer-supplied data rather than an
+                        // invention, and the alternative — publishing no rate when the child omits
+                        // one — loses a fact the daemon did send. `active_rate` is never substituted,
+                        // which is the substitution that would actually misattribute the domain.
+                        //
+                        // Falsifiable, and the check is cheap: play upsampled material and compare
+                        // root `samplerate` against child `samplerate`. If the root follows the
+                        // output, this fallback is publishing an output rate as the track's and must
+                        // be deleted. Recorded in `.oh/hqplayer-direct-zone.md` and left to #332's
+                        // live qualification.
                         (status.samplerate > 0).then_some(status.samplerate)
                     }),
                     // No fallback to `active_bits`. There is no source-depth substitute for an

--- a/src/adapters/hqplayer.rs
+++ b/src/adapters/hqplayer.rs
@@ -1953,6 +1953,26 @@ impl HqpAdapter {
         state.last_observed_volume_range = Some(range.clone());
     }
 
+    /// Can this observed dB range bound a level?
+    ///
+    /// Both bounds are `parse_attr_f64(...).unwrap_or_default()`, so nothing upstream guarantees
+    /// they are ordered or even finite. A daemon that reports `max` and omits `min` yields
+    /// `min_db = 0.0` against a negative `max_db`; `"nan".parse::<f64>()` is a parse *success*, so
+    /// `min="nan"` arrives as NaN. `f64::clamp` is specified to panic on either shape — via
+    /// `assert!`, so in release builds too — and the clamps that consume this range sit in
+    /// `hqp_status_to_zone`, which runs on the handshake and on every status poll. Such a daemon
+    /// therefore panicked the managed worker before it ever published, and the zone simply never
+    /// appeared.
+    ///
+    /// The answer is not a safer clamp but no capability. A slider whose track runs backwards, or
+    /// whose ends are not numbers, is the same class of claim as reporting a working −60…0 dB zone
+    /// as fixed-volume. A zero-width range is refused for the adjacent reason: nothing can be
+    /// moved within it, and `is_muted` below would be unconditionally true, so the zone would
+    /// report itself permanently muted.
+    fn volume_range_is_usable(range: &VolumeRange) -> bool {
+        range.min_db.is_finite() && range.max_db.is_finite() && range.min_db < range.max_db
+    }
+
     /// Comparison tolerance for a dB level that arrived as a double through two independent reads.
     ///
     /// Used only to decide whether the level is *at* the range floor, which is what mute is on this
@@ -7378,7 +7398,9 @@ impl HqpAdapter {
             _ => PlaybackState::Unknown,
         };
 
-        let volume_control = if vol_range.enabled {
+        // `enabled` is the daemon's own claim; usability is whether the bounds it sent can actually
+        // bound a level. Both have to hold — see `volume_range_is_usable`.
+        let volume_control = if vol_range.enabled && Self::volume_range_is_usable(vol_range) {
             // The step the daemon actually sent, if it sent a usable one. The verified live sample
             // sends **no** `step` attribute at all, so `step_db` is routinely `None`; the integer
             // sibling is already `.max(1)` at parse time. A zero or negative step would reach a knob

--- a/src/knobs/routes.rs
+++ b/src/knobs/routes.rs
@@ -133,8 +133,16 @@ pub async fn get_all_zones_internal(state: &AppState) -> Vec<ZoneInfo> {
         .map(|l| (l.zone_id, l.instance))
         .collect();
 
-    // Helper to create DspInfo if zone is linked to HQPlayer
+    // Helper to create DspInfo if zone is linked to HQPlayer.
+    //
+    // A direct `hqplayer:` zone never gets one. It already *is* an HQPlayer control path, so a `dsp`
+    // block pointing at an instance would give the client two routes to one daemon with no rule for
+    // which wins (#328). `HqpZoneLinkService::link_zone` refuses such a link at the source, and this
+    // is the second half of that guard: links persisted by an older build must not resurface here.
     let get_dsp = |zone_id: &str| -> Option<DspInfo> {
+        if zone_id.starts_with("hqplayer:") {
+            return None;
+        }
         hqp_links.get(zone_id).map(|instance| DspInfo {
             r#type: "hqplayer".to_string(),
             instance: Some(instance.clone()),
@@ -162,7 +170,11 @@ pub async fn get_all_zones_internal(state: &AppState) -> Vec<ZoneInfo> {
                 adapters.openhome
             } else if z.zone_id.starts_with("upnp:") {
                 adapters.upnp
-            } else if z.zone_id.starts_with("hqp:") {
+            } else if z.zone_id.starts_with("hqplayer:") {
+                // `hqplayer:` is the prefix `PrefixedZoneId::hqplayer` emits and the only one
+                // HQPlayer zones ever carry. This tested `hqp:` until #328, so it never matched, and
+                // HQPlayer zones fell into the include-by-default arm below — the adapter toggle in
+                // settings silently did nothing for them.
                 adapters.hqplayer
             } else {
                 true // Unknown prefix, include by default
@@ -542,9 +554,43 @@ pub async fn knob_control_handler(
         // UPnP zone control
         let udn = req.zone_id.trim_start_matches("upnp:");
         return control_upnp(&state, udn, &req.action).await;
+    } else if req.zone_id.starts_with("hqplayer:") {
+        // Direct HQPlayer instance control (#328). Before this arm existed, a `hqplayer:` zone id
+        // fell through to the Roon branch below and every HQPlayer command was executed against
+        // Roon with the prefix stripped.
+        let instance = req.zone_id.trim_start_matches("hqplayer:");
+        return control_hqplayer(
+            &state,
+            &req.zone_id,
+            instance,
+            &req.action,
+            req.value.as_ref(),
+        )
+        .await;
     }
 
-    // Roon zone (or legacy zone_id without prefix)
+    // Roon zone, or a legacy zone_id with no prefix at all.
+    //
+    // A *prefixed* id that reached here names a backend this server does not route, and offering it
+    // to Roon is how a command for one zone silently became a command for another (or for none).
+    // Only the legacy unprefixed shape — which the Node.js server and older knob firmware still
+    // send — may mean Roon implicitly.
+    if !req.zone_id.starts_with("roon:") && req.zone_id.contains(':') {
+        let prefix = req
+            .zone_id
+            .split(':')
+            .next()
+            .unwrap_or_default()
+            .to_string();
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": format!("Unsupported zone source: {}", prefix),
+                "error_code": "UNSUPPORTED_ZONE_SOURCE",
+            })),
+        ));
+    }
+
     let roon_zone_id = if req.zone_id.starts_with("roon:") {
         req.zone_id.trim_start_matches("roon:").to_string()
     } else {
@@ -552,6 +598,204 @@ pub async fn knob_control_handler(
     };
 
     control_roon(&state, &roon_zone_id, &req.action, req.value.as_ref()).await
+}
+
+/// Control a direct HQPlayer instance (#328).
+///
+/// **Every refusal below is checked against the zone the aggregator published**, not against a fresh
+/// adapter read. That is deliberate and it is the invariant that keeps this function honest: the
+/// capability flag a client was handed in `GET /knob/now_playing` is literally the flag its command
+/// is judged by, so "advertised" and "permitted" cannot drift apart. It is also required — a surface
+/// may not query an adapter for state (`docs/ARCHITECTURE.md`, `tests/architecture_lint.rs`).
+///
+/// The cost is that the flags can be up to one poll interval (2 s by default) stale. That bound is
+/// accepted and recorded in `.oh/hqplayer-direct-zone.md`; closing it would need either a
+/// forbidden adapter state read on the command path or daemon-side compare-and-set, which the
+/// protocol does not offer.
+async fn control_hqplayer(
+    state: &AppState,
+    zone_id: &str,
+    instance: &str,
+    action: &str,
+    value: Option<&serde_json::Value>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let bad_request = |message: String, code: &str| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": message, "error_code": code})),
+        )
+    };
+
+    // Resolve the instance explicitly. A missing instance is a 404 rather than a fallback: the
+    // client named a specific daemon, and quietly using a different one is the failure mode this
+    // whole function exists to remove.
+    let Some(adapter) = state.hqp_instances.get(instance).await else {
+        return Err((
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({
+                "error": format!("Unknown HQPlayer instance: {}", instance),
+                "error_code": "ZONE_NOT_FOUND",
+            })),
+        ));
+    };
+
+    // The aggregator is the only state source consulted here.
+    let zone = state.aggregator.get_zone(zone_id).await;
+
+    let result = match action {
+        "play" => adapter.play().await,
+        "pause" => adapter.pause().await,
+        "stop" => adapter.stop().await,
+        "next" | "previous" | "prev" => {
+            let allowed = zone
+                .as_ref()
+                .map(|z| {
+                    if action == "next" {
+                        z.is_next_allowed
+                    } else {
+                        z.is_previous_allowed
+                    }
+                })
+                .unwrap_or(false);
+            if !allowed {
+                return Err(bad_request(
+                    format!("{} is not available in the zone's current state", action),
+                    "ACTION_NOT_ALLOWED",
+                ));
+            }
+            if action == "next" {
+                adapter.next().await
+            } else {
+                adapter.previous().await
+            }
+        }
+        "play_pause" | "playpause" => {
+            // Resolved from the published state rather than sent as a toggle, because HQPlayer has
+            // no toggle command: `Pause` pauses and `Play` plays. With no published state there is
+            // nothing to resolve against, and guessing would be a coin flip on an audible action.
+            match zone.as_ref().map(|z| z.state) {
+                Some(crate::bus::PlaybackState::Playing) => adapter.pause().await,
+                Some(_) => adapter.play().await,
+                None => {
+                    return Err(bad_request(
+                        "play_pause needs a known playback state; none has been observed yet"
+                            .to_string(),
+                        "STATE_UNKNOWN",
+                    ))
+                }
+            }
+        }
+        "seek" => {
+            if !zone.as_ref().map(|z| z.is_seekable).unwrap_or(false) {
+                return Err(bad_request(
+                    "this zone is not seekable in its current state".to_string(),
+                    "ACTION_NOT_ALLOWED",
+                ));
+            }
+            // No default position. A seek with no usable target is a client bug, and inventing 0
+            // would restart the track.
+            let Some(position) = value.and_then(|v| v.as_f64()) else {
+                return Err(bad_request(
+                    "seek requires a numeric position in seconds".to_string(),
+                    "INVALID_VALUE",
+                ));
+            };
+            if !position.is_finite() || position < 0.0 {
+                return Err(bad_request(
+                    "seek position must be a non-negative number of seconds".to_string(),
+                    "INVALID_VALUE",
+                ));
+            }
+            // Clamped to the observed duration so a slider released past the end lands on the end
+            // rather than drawing `result="Error"` from the daemon. Kept as an `Option` with no
+            // numeric default: an absent duration means "nothing observed to clamp against", which
+            // is a different fact from "the track is zero seconds long", and collapsing the two
+            // through `unwrap_or(0.0)` is the shape `tests/volume_safety.rs` refuses on this path.
+            let ceiling = zone
+                .as_ref()
+                .and_then(|z| z.now_playing.as_ref())
+                .and_then(|np| np.duration)
+                .filter(|d| *d > 0.0);
+            let target = match ceiling {
+                Some(duration) => position.min(duration),
+                None => position,
+            };
+            adapter.seek(target.round().max(0.0) as u32).await
+        }
+        "vol_up" | "volume_up" | "vol_down" | "volume_down" => {
+            let vc = require_volume_control(zone.as_ref())?;
+            let down = action.contains("down");
+            // The step the client asked for, else the step this zone published. Both are decimal dB.
+            let step = value
+                .and_then(|v| v.as_f64())
+                .map(|v| v.abs())
+                .filter(|v| v.is_finite() && *v > 0.0)
+                .unwrap_or(f64::from(vc.step));
+            let delta = if down { -step } else { step };
+            // Relative movement is applied as an absolute write computed from the last observed
+            // level. HQPlayer's own `VolumeUp`/`VolumeDown` would avoid the staleness window but use
+            // the daemon's step — which the verified live sample does not even send — and would
+            // ignore the user's configured `volume_step_override`.
+            let target = (f64::from(vc.value) + delta).clamp(f64::from(vc.min), f64::from(vc.max));
+            adapter.set_volume_db(target).await
+        }
+        "vol_abs" | "volume" => {
+            let vc = require_volume_control(zone.as_ref())?;
+            // SAFETY: no numeric default, in either direction. `unwrap_or(50.0)` on a dB zone means
+            // +50 dB, which is above every possible maximum; `unwrap_or(0.0)` means full scale. A
+            // level nobody supplied is a refusal, never a number.
+            let Some(requested) = value.and_then(|v| v.as_f64()).filter(|v| v.is_finite()) else {
+                return Err(bad_request(
+                    "an absolute volume requires a finite numeric level in dB".to_string(),
+                    "INVALID_VALUE",
+                ));
+            };
+            adapter
+                .set_volume_db(requested.clamp(f64::from(vc.min), f64::from(vc.max)))
+                .await
+        }
+        "mute" => {
+            require_volume_control(zone.as_ref())?;
+            // `VolumeMute` is a verified absolute, idempotent move to the range floor (#322, live
+            // 6.0.2). There is no daemon-side unmute and UHC stores no pre-mute level, so no
+            // toggle is advertised — an "unmute" whose result is not observable as unmute would be
+            // exactly the kind of claim this issue exists to remove.
+            adapter.volume_mute().await
+        }
+        _ => {
+            return Err(bad_request(
+                format!("Unknown action: {}", action),
+                "UNKNOWN_ACTION",
+            ))
+        }
+    };
+
+    match result {
+        Ok(()) => Ok(Json(serde_json::json!({"ok": true}))),
+        Err(e) => Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": e.to_string()})),
+        )),
+    }
+}
+
+/// The zone's published volume control, or a refusal.
+///
+/// A zone with no volume control is a zone whose daemon answers `Volume` with a bare
+/// `result="Error"`. Sending one anyway is a request with no safe interpretation on a
+/// hardware-attenuated setup, so it is refused before it reaches the wire.
+fn require_volume_control(
+    zone: Option<&crate::bus::Zone>,
+) -> Result<crate::bus::VolumeControl, (StatusCode, Json<serde_json::Value>)> {
+    zone.and_then(|z| z.volume_control.clone()).ok_or_else(|| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": "this zone has no volume control",
+                "error_code": "VOLUME_NOT_AVAILABLE",
+            })),
+        )
+    })
 }
 
 /// Control Roon zone

--- a/src/knobs/routes.rs
+++ b/src/knobs/routes.rs
@@ -819,18 +819,32 @@ fn quantise_db(db: f64) -> f64 {
 /// A zone with no volume control is a zone whose daemon answers `Volume` with a bare
 /// `result="Error"`. Sending one anyway is a request with no safe interpretation on a
 /// hardware-attenuated setup, so it is refused before it reaches the wire.
+///
+/// The bounds are re-checked here even though the projection already refuses an unorderable range
+/// (`HqpAdapter::volume_range_is_usable`). Both `.clamp` calls below panic on `min > max` or a NaN
+/// bound, and a panic in an HTTP or MCP handler is a worse failure than a 400: this function is the
+/// only gate in front of them, so it owns the precondition rather than trusting its caller's caller.
 fn require_volume_control(
     zone: Option<&crate::bus::Zone>,
 ) -> Result<crate::bus::VolumeControl, (StatusCode, Json<serde_json::Value>)> {
-    zone.and_then(|z| z.volume_control.clone()).ok_or_else(|| {
+    let refuse = |message: &str| {
         (
             StatusCode::BAD_REQUEST,
             Json(serde_json::json!({
-                "error": "this zone has no volume control",
+                "error": message,
                 "error_code": "VOLUME_NOT_AVAILABLE",
             })),
         )
-    })
+    };
+    let control = zone
+        .and_then(|z| z.volume_control.clone())
+        .ok_or_else(|| refuse("this zone has no volume control"))?;
+    if !(control.min.is_finite() && control.max.is_finite() && control.min < control.max) {
+        return Err(refuse(
+            "this zone's published volume range cannot bound a level",
+        ));
+    }
+    Ok(control)
 }
 
 /// Control Roon zone

--- a/src/knobs/routes.rs
+++ b/src/knobs/routes.rs
@@ -640,7 +640,24 @@ async fn control_hqplayer(
     };
 
     // The aggregator is the only state source consulted here.
-    let zone = state.aggregator.get_zone(zone_id).await;
+    //
+    // Its absence is decisive rather than merely inconvenient: the aggregator withdraws the zone when
+    // the producer stops, so a zone it does not hold is one no surface will show and none of this
+    // function's capability checks can be evaluated against. The transport arms below consulted the
+    // zone only for `next`/`previous`, so `play`, `pause` and `stop` were accepted — and answered
+    // `{"ok":true}` — for a withdrawn zone whose instance still happened to exist in the manager's
+    // map. Found by the review pass, pinned by
+    // `transport_is_refused_for_a_zone_the_aggregator_has_withdrawn`.
+    let Some(zone) = state.aggregator.get_zone(zone_id).await else {
+        return Err((
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({
+                "error": format!("zone {} is not currently published", zone_id),
+                "error_code": "ZONE_NOT_FOUND",
+            })),
+        ));
+    };
+    let zone = Some(zone);
 
     let result = match action {
         "play" => adapter.play().await,
@@ -737,7 +754,7 @@ async fn control_hqplayer(
             // the daemon's step — which the verified live sample does not even send — and would
             // ignore the user's configured `volume_step_override`.
             let target = (f64::from(vc.value) + delta).clamp(f64::from(vc.min), f64::from(vc.max));
-            adapter.set_volume_db(target).await
+            adapter.set_volume_db(quantise_db(target)).await
         }
         "vol_abs" | "volume" => {
             let vc = require_volume_control(zone.as_ref())?;
@@ -751,7 +768,9 @@ async fn control_hqplayer(
                 ));
             };
             adapter
-                .set_volume_db(requested.clamp(f64::from(vc.min), f64::from(vc.max)))
+                .set_volume_db(quantise_db(
+                    requested.clamp(f64::from(vc.min), f64::from(vc.max)),
+                ))
                 .await
         }
         "mute" => {
@@ -777,6 +796,22 @@ async fn control_hqplayer(
             Json(serde_json::json!({"error": e.to_string()})),
         )),
     }
+}
+
+/// Round a computed dB level to a hundredth of a decibel before it reaches the wire.
+///
+/// The published zone carries `value`, `min`, `max` and `step` as `f32` (`crate::bus::VolumeControl`),
+/// so widening them back to `f64` to do arithmetic reintroduces the representation error as trailing
+/// digits. A daemon reporting a 0.1 dB step turned `-23.5 + 0.1` into `-23.399999998509884`, and
+/// `set_volume_db` formats with `{}` — so that is what would have gone out on the wire, where the
+/// reference client sends `-23.4`.
+///
+/// A hundredth of a dB is far below audibility and below the finest step any observed daemon reports,
+/// so this cannot quantise away a real distinction; it only removes float noise. It is deliberately
+/// **not** a clamp and does not decide any bound — the clamp against the zone's observed range has
+/// already happened by the time this is called.
+fn quantise_db(db: f64) -> f64 {
+    (db * 100.0).round() / 100.0
 }
 
 /// The zone's published volume control, or a refusal.

--- a/tests/hqplayer_conformance.rs
+++ b/tests/hqplayer_conformance.rs
@@ -8384,15 +8384,75 @@ async fn a_lost_volume_range_reply_does_not_publish_the_cache_its_reconnect_empt
     h.stop();
 }
 
-/// A daemon may serve its complete setting universe while never answering `VolumeRange`. The
+/// A daemon may serve its complete setting universe while **never** answering `VolumeRange`. The
 /// pipeline contract treats that missing, non-chain-scoped capability as fixed volume; reconnecting
 /// after its timeout must not make the transport-generation fence reject an otherwise coherent
 /// settings read.
 ///
 /// **Label: client-red.** CodeRabbit found that the fallback was dated to the failed transport, so
 /// the replacement transport deterministically made both pipeline attempts fail.
+///
+/// **Amended by #328, and the amendment is a scenario fix rather than a weakening.** This test's
+/// setup used `connected_then_policy`, which connects successfully *first* and only then silences
+/// `VolumeRange` — so it was never exercising its own stated premise. It observed a working
+/// −60…0 dB control and then asserted that losing one reply about it proves the daemon became a
+/// fixed-volume device. #328 rejects that inference (see the retention test below); the
+/// never-answered premise this docstring actually describes is unaffected and is what is pinned
+/// here, using a policy that is silent from the very first request.
 #[tokio::test]
-async fn an_unresponsive_volume_range_still_yields_a_fixed_volume_pipeline() {
+async fn a_never_answered_volume_range_still_yields_a_fixed_volume_pipeline() {
+    let h = Harness::start(
+        VERIFIED_PROFILE,
+        WirePolicy {
+            silent_for_element: Some("VolumeRange".to_string()),
+            ..WirePolicy::default()
+        },
+        fast_timeouts(),
+    )
+    .await;
+    h.adapter
+        .connect()
+        .await
+        .expect("missing VolumeRange remains an optional fixed-volume capability");
+    h.adapter.disconnect().await;
+
+    let pipeline = h
+        .adapter
+        .get_pipeline_status()
+        .await
+        .expect("missing VolumeRange degrades to a fixed-volume pipeline");
+
+    assert!(
+        pipeline.volume.is_fixed,
+        "with no volume capability ever observed, the fallback must advertise fixed volume rather \
+         than invent variable-volume bounds"
+    );
+    assert_eq!(
+        published_families(&pipeline).len(),
+        4,
+        "the non-chain-scoped fallback must not discard coherent setting families"
+    );
+    h.stop();
+}
+
+/// Once a volume capability **has** been observed on an endpoint, losing a later `VolumeRange` reply
+/// must not downgrade the pipeline to fixed volume (#328).
+///
+/// This is the scenario the test above used to run, with the opposite expectation. The reasoning
+/// changed because the old assertion conflated two different facts: *"this daemon has no volume
+/// control"* and *"one query about the volume control went unanswered"*. Only the first is a
+/// capability claim; the second is a transport event, and answering it with `enabled: false` made
+/// the direct-zone projection drop `volume_control` entirely — so a knob lost the control the user
+/// was turning because a reply was dropped.
+///
+/// The retained bounds are **observed**, never synthesised, which is what the original assertion's
+/// stated concern ("rather than invent variable-volume bounds") was actually protecting against.
+/// An explicit `result="Error"` is still terminal and is covered separately: there the daemon
+/// authoritatively answered.
+///
+/// **Label: client-red.** Verified failing against the pre-#328 tree.
+#[tokio::test]
+async fn an_observed_volume_capability_survives_a_later_unanswered_volume_range() {
     let h = Harness::connected_then_policy(
         WirePolicy {
             silent_for_element: Some("VolumeRange".to_string()),
@@ -8407,16 +8467,19 @@ async fn an_unresponsive_volume_range_still_yields_a_fixed_volume_pipeline() {
         .adapter
         .get_pipeline_status()
         .await
-        .expect("missing VolumeRange degrades to a fixed-volume pipeline");
+        .expect("a lost optional reply must not fail the whole pipeline read");
 
     assert!(
-        pipeline.volume.is_fixed,
-        "the fallback must advertise fixed volume rather than invent variable-volume bounds"
+        !pipeline.volume.is_fixed,
+        "the -60..0 dB capability was observed on this endpoint; a dropped reply is a transport \
+         event, not evidence the daemon became fixed-volume"
     );
+    assert_eq!(pipeline.volume.min, -60);
+    assert_eq!(pipeline.volume.max, 0);
     assert_eq!(
         published_families(&pipeline).len(),
         4,
-        "the non-chain-scoped fallback must not discard coherent setting families"
+        "retaining the capability must still not discard coherent setting families"
     );
     h.stop();
 }

--- a/tests/hqplayer_direct_zone.rs
+++ b/tests/hqplayer_direct_zone.rs
@@ -62,7 +62,19 @@ fn isolate_config_dir() {
     static ONCE: Once = Once::new();
     ONCE.call_once(|| {
         let dir = std::env::temp_dir().join(format!("uhc-hqp-direct-{}", std::process::id()));
-        std::fs::create_dir_all(&dir).expect("create isolated direct-zone config dir");
+        let subdir = dir.join("unified-hifi");
+        std::fs::create_dir_all(&subdir).expect("create isolated direct-zone config dir");
+
+        // The HQPlayer adapter defaults to **off**, and a zone whose adapter is disabled is a 404 by
+        // design. Every test here is about a user who has turned it on, so the setting is written
+        // rather than assumed — and writing it is also what makes the adapter-filter test meaningful:
+        // with the toggle off, a filter bug and a correct filter are indistinguishable.
+        std::fs::write(
+            subdir.join("app-settings.json"),
+            r#"{"adapters":{"roon":true,"upnp":false,"openhome":false,"lms":false,"hqplayer":true}}"#,
+        )
+        .expect("write isolated app settings");
+
         std::env::set_var("UHC_CONFIG_DIR", dir);
     });
 }
@@ -292,7 +304,9 @@ async fn transport_reaches_the_selected_hqplayer_instance_and_not_roon() {
     rig.zone_when(|z| z.state == PlaybackState::Playing).await;
 
     let before = model.request_count("Pause");
-    let (status, body) = rig.post_control(json!({"zone_id":"hqplayer:rig","action":"pause"})).await;
+    let (status, body) = rig
+        .post_control(json!({"zone_id":"hqplayer:rig","action":"pause"}))
+        .await;
 
     assert_eq!(
         status,
@@ -488,16 +502,16 @@ async fn a_stopped_empty_zone_advertises_no_seek_next_or_previous() {
     rig.attach(&server).await;
     let zone = rig.zone_when(|z| z.state == PlaybackState::Stopped).await;
 
-    assert!(!zone.is_seekable, "nothing is loaded, so nothing is seekable");
+    assert!(
+        !zone.is_seekable,
+        "nothing is loaded, so nothing is seekable"
+    );
     assert!(
         !zone.is_next_allowed,
         "no loaded track means no next to skip to"
     );
     assert!(!zone.is_previous_allowed);
-    assert!(
-        !zone.is_pause_allowed,
-        "a stopped zone cannot be paused"
-    );
+    assert!(!zone.is_pause_allowed, "a stopped zone cannot be paused");
 
     let (status, body) = rig
         .get_json("/knob/now_playing?zone_id=hqplayer%3Arig")
@@ -528,7 +542,9 @@ async fn a_loaded_playing_zone_advertises_the_transport_it_really_has() {
     assert!(!zone.is_play_allowed, "already playing");
     assert!(zone.is_controllable);
 
-    let np = zone.now_playing.expect("a loaded track publishes now_playing");
+    let np = zone
+        .now_playing
+        .expect("a loaded track publishes now_playing");
     assert_eq!(np.duration, Some(215.0));
     assert_eq!(np.seek_position, Some(42.0));
 

--- a/tests/hqplayer_direct_zone.rs
+++ b/tests/hqplayer_direct_zone.rs
@@ -1301,3 +1301,187 @@ fn the_zone_filter_matches_the_prefix_hqplayer_zones_are_actually_published_with
 // axum versions, so name it once rather than conditionally importing it.
 #[allow(dead_code)]
 fn _addr_type_is_used(_: Option<SocketAddr>) {}
+
+// =============================================================================
+// review — defects found by the falsification pass, pinned so they stay fixed
+// =============================================================================
+
+/// **Found by review.** The safety floor on the published volume step must not coarsen a *finer*
+/// step the daemon actually reported.
+///
+/// The first version of the #328 projection took `.max(MIN_PUBLISHED_VOLUME_STEP_DB)` over the
+/// reported value, so a daemon offering 0.1 dB was published as offering 0.5 dB. That is a
+/// fabrication in the opposite direction from the one the floor exists to prevent, and a
+/// fine-step user would feel it on the first turn of the knob. The floor is for a step that was
+/// never reported, not for one that was.
+#[tokio::test]
+async fn a_finer_reported_step_is_not_coarsened_by_the_safety_floor() {
+    let model = playing_daemon();
+    model.external_change(|s| {
+        s.volume_db = -23.5;
+        s.volume_range.min_db = -60.0;
+        s.volume_range.max_db = 0.0;
+        s.volume_range.step_db = Some(0.1);
+    });
+    let server = start_daemon(&model).await;
+    let rig = Rig::new().await;
+    rig.attach(&server).await;
+    let zone = rig.zone_when(|z| z.volume_control.is_some()).await;
+
+    assert_eq!(
+        zone.volume_control.expect("control").step,
+        0.1,
+        "the daemon reported 0.1 dB; publishing 0.5 dB overstates its granularity"
+    );
+
+    let (status, _) = rig
+        .post_control(json!({"zone_id":"hqplayer:rig","action":"vol_up"}))
+        .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        mock_servers::hqplayer::model::request_attr(
+            &model.last_request("Volume").expect("a Volume write"),
+            "value"
+        )
+        .as_deref(),
+        Some("-23.4"),
+        "one 0.1 dB step up from -23.5 dB is -23.4 dB"
+    );
+
+    rig.shutdown().await;
+    server.stop();
+}
+
+/// **Found by review.** A computed level must reach the wire as a clean decimal, not as the
+/// `f32`→`f64` representation error of the arithmetic that produced it.
+///
+/// The published zone carries the level and step as `f32`. Widening them back to `f64` and adding
+/// turned `-23.5 + 0.1` into `-23.399999998509884`, and `set_volume_db` formats with `{}` — so that
+/// is the string the daemon would have received, where the reference client sends `-23.4`.
+#[tokio::test]
+async fn a_computed_level_reaches_the_wire_without_float_noise() {
+    let model = playing_daemon();
+    model.external_change(|s| {
+        s.volume_db = -23.5;
+        s.volume_range.min_db = -60.0;
+        s.volume_range.max_db = 0.0;
+        s.volume_range.step_db = Some(0.1);
+    });
+    let server = start_daemon(&model).await;
+    let rig = Rig::new().await;
+    rig.attach(&server).await;
+    rig.zone_when(|z| z.volume_control.is_some()).await;
+
+    for action in ["vol_up", "vol_down"] {
+        let (status, _) = rig
+            .post_control(json!({"zone_id":"hqplayer:rig","action":action}))
+            .await;
+        assert_eq!(status, StatusCode::OK);
+        let value = mock_servers::hqplayer::model::request_attr(
+            &model.last_request("Volume").expect("a Volume write"),
+            "value",
+        )
+        .expect("a value attribute");
+        let decimals = value.split_once('.').map(|(_, d)| d.len()).unwrap_or(0);
+        assert!(
+            decimals <= 2,
+            "`{action}` put {decimals} decimal places on the wire ({value}); a dB level is not a \
+             place to leak float representation error"
+        );
+    }
+
+    rig.shutdown().await;
+    server.stop();
+}
+
+/// **Found by review.** A raw `>` inside an attribute value must not truncate the metadata scan.
+///
+/// XML forbids `<` and `&` in attribute values but **permits a bare `>`**, so `song="a/>b"` is
+/// well-formed. A plain search for the child's `/>` terminator cut inside that value and silently
+/// lost every attribute after it — here the title, the album *and* the source bit depth, to a track
+/// name containing a slash before a bracket.
+#[test]
+fn a_raw_terminator_inside_an_attribute_value_does_not_truncate_the_metadata_scan() {
+    let doc = concat!(
+        r#"<?xml version="1.0"?>"#,
+        r#"<Status state="2" track="1" track_id="x" position="5" length="60" volume="-12.5" "#,
+        r#"samplerate="44100" bitrate="1411">"#,
+        "\n",
+        r#"<metadata artist="Nine Inch Nails" song="a/>b" album="Broken" bits="24"/>"#,
+        "\n</Status>",
+    );
+
+    let status = HqpAdapter::parse_status_for_test(doc);
+    assert_eq!(status.artist.as_deref(), Some("Nine Inch Nails"));
+    assert_eq!(status.title.as_deref(), Some("a/>b"));
+    assert_eq!(
+        status.album.as_deref(),
+        Some("Broken"),
+        "attributes after a value containing `/>` must still be read"
+    );
+    assert_eq!(status.source_bits, Some(24));
+
+    // And the bound still holds in the direction it was added for: a child that never terminates
+    // must not start reporting the root's own attributes as source metadata.
+    let unterminated = concat!(
+        r#"<?xml version="1.0"?>"#,
+        r#"<Status state="2" track="1" track_id="x" position="5" length="60" volume="-12.5" "#,
+        r#"active_bits="32" samplerate="44100">"#,
+        "\n",
+        r#"<metadata artist="Bill Evans"#,
+        "\n</Status>",
+    );
+    let status = HqpAdapter::parse_status_for_test(unterminated);
+    assert_eq!(status.state, 2, "the root survives");
+    assert_eq!(status.volume_db, -12.5);
+    assert_eq!(
+        status.source_bits, None,
+        "the root's output active_bits must never be read as the source depth"
+    );
+}
+
+/// **Found by review.** A command for a zone the aggregator has withdrawn must be refused.
+///
+/// The capability checks are evaluated against the published zone, so with no published zone there
+/// is nothing to evaluate — but the `play`/`pause`/`stop` arms did not consult it at all and
+/// answered `{"ok":true}` for a zone that had already been withdrawn, purely because the instance
+/// still existed in the manager's map. A client that shows no such zone should not be able to
+/// command it.
+#[tokio::test]
+async fn transport_is_refused_for_a_zone_the_aggregator_has_withdrawn() {
+    let model = playing_daemon();
+    let server = start_daemon(&model).await;
+    let rig = Rig::new().await;
+    rig.attach(&server).await;
+    rig.zone_when(|z| z.state == PlaybackState::Playing).await;
+
+    // Stopping the producer withdraws the zone; the instance itself remains configured.
+    rig.manager.stop().await;
+    for _ in 0..200 {
+        if rig.aggregator.get_zone("hqplayer:rig").await.is_none() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(
+        rig.aggregator.get_zone("hqplayer:rig").await.is_none(),
+        "the RED needs the zone actually withdrawn"
+    );
+
+    for action in ["play", "pause", "stop", "next", "seek", "vol_up", "mute"] {
+        let mut body = json!({"zone_id":"hqplayer:rig","action":action});
+        if action == "seek" {
+            body["value"] = json!(10);
+        }
+        let (status, response) = rig.post_control(body).await;
+        assert_eq!(
+            status,
+            StatusCode::NOT_FOUND,
+            "`{action}` on a withdrawn zone must be refused; got {response}"
+        );
+    }
+
+    rig.bus.publish(BusEvent::ShuttingDown { reason: None });
+    let _ = rig.aggregator_task.await;
+    server.stop();
+}

--- a/tests/hqplayer_direct_zone.rs
+++ b/tests/hqplayer_direct_zone.rs
@@ -1485,3 +1485,135 @@ async fn transport_is_refused_for_a_zone_the_aggregator_has_withdrawn() {
     let _ = rig.aggregator_task.await;
     server.stop();
 }
+
+/// **Found by the Opus stacked review.** A `VolumeRange` reply whose bounds cannot be ordered must
+/// leave the zone without a volume control — it must not take the polling task down.
+///
+/// `min_db` and `max_db` are both `parse_attr_f64(...).unwrap_or_default()`, so a daemon that
+/// reports `max` but omits `min` yields `min_db = 0.0` against a negative `max_db`. `f64::clamp`
+/// is specified to **panic** when `min > max` or either bound is NaN, and the panic is an
+/// `assert!`, so it fires in release builds too.
+///
+/// #328 added `status.volume_db.clamp(vol_range.min_db, vol_range.max_db)` to
+/// `hqp_status_to_zone`, which runs on the initial handshake and on every subsequent status poll.
+/// A daemon in this shape therefore panics the managed worker before it ever publishes, and the
+/// zone simply never appears — the surface has no zone to show and no error to explain it.
+///
+/// An unorderable range is also not a capability. Publishing a slider whose track runs backwards
+/// is the same class of lie as reporting a working −60…0 dB zone as fixed-volume, so the honest
+/// projection is the one `enabled="0"` already produces: no control at all.
+///
+/// **RED before this fix:** the worker panics with `min > max, or either was NaN`, and
+/// `zone_when` times out because no zone is ever published.
+#[tokio::test]
+async fn an_unorderable_volume_range_is_refused_rather_than_panicking_the_poll() {
+    let model = playing_daemon();
+    model.external_change(|s| {
+        // The daemon answered `VolumeRange` with a negative `max` and no `min` at all.
+        s.volume_range.min_db = 0.0;
+        s.volume_range.max_db = -10.0;
+        s.volume_range.step_db = None;
+        s.volume_range.enabled = true;
+    });
+    let server = start_daemon(&model).await;
+    let rig = Rig::new().await;
+    rig.attach(&server).await;
+
+    // The zone must still be published — everything except the volume capability is observable.
+    let zone = rig.zone_when(|z| z.state == PlaybackState::Playing).await;
+    assert!(
+        zone.volume_control.is_none(),
+        "an unorderable dB range is not a volume capability; got {:?}",
+        zone.volume_control
+    );
+
+    // And the command path refuses rather than computing against those bounds.
+    for action in ["vol_up", "vol_down", "mute"] {
+        let (status, body) = rig
+            .post_control(json!({"zone_id":"hqplayer:rig","action":action}))
+            .await;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "`{action}` must be refused when no usable range was observed; got {body}"
+        );
+        assert_eq!(body["error_code"], "VOLUME_NOT_AVAILABLE");
+    }
+    let (status, _) = rig
+        .post_control(json!({"zone_id":"hqplayer:rig","action":"vol_abs","value":-5.0}))
+        .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    assert!(
+        model.last_request("Volume").is_none(),
+        "no level may reach the wire when the observed range cannot bound one"
+    );
+
+    rig.shutdown().await;
+    server.stop();
+}
+
+/// **Found by the Opus stacked review.** The same bound, exercised directly on the projection for
+/// the shapes the wire fake cannot express.
+///
+/// NaN reaches `min_db`/`max_db` because `"nan".parse::<f64>()` succeeds, so a daemon or a garbled
+/// frame carrying `min="nan"` is a parse *success* that panics `f64::clamp`. A zero-width range is
+/// the third shape: it never panics, but it is not a control either — nothing can be moved, and
+/// `is_muted` (`value <= min + tolerance`) is unconditionally true, so the zone would report
+/// itself permanently muted.
+#[test]
+fn a_nan_or_zero_width_volume_range_publishes_no_control() {
+    let status = HqpStatus {
+        state: 2,
+        track: 1,
+        track_id: "t".to_string(),
+        position: 5,
+        length: 100,
+        volume: -24,
+        volume_db: -23.5,
+        ..HqpStatus::default()
+    };
+    let range = |min_db: f64, max_db: f64| VolumeRange {
+        min: min_db as i32,
+        max: max_db as i32,
+        step: 1,
+        enabled: true,
+        adaptive: false,
+        min_db,
+        max_db,
+        step_db: Some(0.5),
+    };
+
+    for (label, min_db, max_db) in [
+        ("NaN floor", f64::NAN, 0.0),
+        ("NaN ceiling", -60.0, f64::NAN),
+        ("infinite floor", f64::NEG_INFINITY, 0.0),
+        ("reversed", 0.0, -60.0),
+        ("zero width", -60.0, -60.0),
+    ] {
+        let zone = HqpAdapter::project_direct_zone(
+            "127.0.0.1",
+            Some("rig"),
+            &Default::default(),
+            &status,
+            &range(min_db, max_db),
+        );
+        assert!(
+            zone.volume_control.is_none(),
+            "{label}: a range that cannot bound a level is not a volume control"
+        );
+    }
+
+    // The ordinary range is untouched.
+    let zone = HqpAdapter::project_direct_zone(
+        "127.0.0.1",
+        Some("rig"),
+        &Default::default(),
+        &status,
+        &range(-60.0, 0.0),
+    );
+    let control = zone.volume_control.expect("a usable range still publishes");
+    assert_eq!(control.value, -23.5);
+    assert_eq!(control.min, -60.0);
+    assert_eq!(control.max, 0.0);
+}

--- a/tests/hqplayer_direct_zone.rs
+++ b/tests/hqplayer_direct_zone.rs
@@ -1,0 +1,1287 @@
+//! Direct HQPlayer zone conformance (issue #328).
+//!
+//! **These tests are written from the client's expectation, not from the implementation.** The
+//! clients are the ESP32 knob firmware (`roon-knob`, which posts `{zone_id, action, value}` to
+//! `POST /control` and renders `GET /knob/now_playing`) and the iOS/watch app (same two shapes).
+//! Each test names the expectation in its doc comment; none of them was written by reading the
+//! projection and asserting what it already does.
+//!
+//! No live HQPlayer is contacted. The daemon is the stateful wire/model fake from
+//! `tests/mock_servers/hqplayer`, which is the same fake the native-protocol conformance suite
+//! (#322) and the lifecycle suite (#162) drive.
+//!
+//! Two acceptance criteria of #328 were **already** satisfied before this issue and are deliberately
+//! not re-tested here: continuous republication of external changes, and the stopped/fixed-volume
+//! clear, both pinned by
+//! `hqplayer_lifecycle::external_changes_converge_into_the_aggregator_without_a_surface_read`. What
+//! this file adds is everything that observation is *projected into*: capability truthfulness,
+//! source-vs-output metadata domains, explicit routing, and volume safety.
+
+#[allow(dead_code, unused_imports, unused_variables)]
+mod mock_servers;
+
+use std::net::SocketAddr;
+use std::sync::{Arc, Once};
+use std::time::{Duration, Instant};
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use axum::routing::{get, post};
+use axum::Router;
+use serde_json::{json, Value};
+use tokio_util::sync::CancellationToken;
+use tower::ServiceExt;
+
+use mock_servers::hqplayer::corpus::VERIFIED_PROFILE;
+use mock_servers::hqplayer::model::{DaemonModel, Metadata};
+use mock_servers::hqplayer::wire::{WirePolicy, WireServer};
+
+use unified_hifi_control::adapters::hqplayer::{
+    HqpAdapter, HqpInstanceManager, HqpRecoveryConfig, HqpStatus, HqpTimeouts, HqpZoneLinkService,
+    VolumeRange,
+};
+use unified_hifi_control::adapters::lms::LmsAdapter;
+use unified_hifi_control::adapters::openhome::OpenHomeAdapter;
+use unified_hifi_control::adapters::roon::RoonAdapter;
+use unified_hifi_control::adapters::upnp::UPnPAdapter;
+use unified_hifi_control::adapters::Startable;
+use unified_hifi_control::aggregator::ZoneAggregator;
+use unified_hifi_control::api::AppState;
+use unified_hifi_control::bus::{create_bus, BusEvent, PlaybackState, SharedBus, Zone};
+use unified_hifi_control::coordinator::AdapterCoordinator;
+use unified_hifi_control::knobs::{self, KnobStore};
+
+// =============================================================================
+// Harness
+// =============================================================================
+
+/// Every test in this file writes zone links and instance config through the same process-wide
+/// config path. Isolating it keeps the suite from reading the developer's real configuration and
+/// keeps concurrent tests from linking each other's zones.
+fn isolate_config_dir() {
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        let dir = std::env::temp_dir().join(format!("uhc-hqp-direct-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create isolated direct-zone config dir");
+        std::env::set_var("UHC_CONFIG_DIR", dir);
+    });
+}
+
+fn fast_timeouts() -> HqpTimeouts {
+    HqpTimeouts {
+        connect: Duration::from_millis(100),
+        response: Duration::from_millis(500),
+        reconnect_delay: Duration::from_millis(10),
+        max_attempts: 1,
+    }
+}
+
+fn fast_recovery() -> HqpRecoveryConfig {
+    HqpRecoveryConfig {
+        poll_interval: Duration::from_millis(10),
+        short_retry_delay: Duration::from_millis(10),
+        restart_window: Duration::from_millis(40),
+        backoff_initial: Duration::from_millis(20),
+        backoff_cap: Duration::from_millis(40),
+        stable_threshold: Duration::from_millis(20),
+    }
+}
+
+/// The two client-facing routes under test, wired exactly as `main.rs` wires them.
+///
+/// `/control` and `/knob/now_playing` are the knob's whole world; `/zones` is what both clients read
+/// to populate their picker. Nothing else is mounted, so a test cannot accidentally pass through a
+/// route the client does not use.
+fn client_router(state: AppState) -> Router {
+    Router::new()
+        .route("/control", post(knobs::knob_control_handler))
+        .route("/knob/control", post(knobs::knob_control_handler))
+        .route("/knob/now_playing", get(knobs::knob_now_playing_handler))
+        .route("/zones", get(knobs::knob_zones_handler))
+        .with_state(state)
+}
+
+struct Rig {
+    app: Router,
+    state: AppState,
+    manager: Arc<HqpInstanceManager>,
+    aggregator: Arc<ZoneAggregator>,
+    bus: SharedBus,
+    aggregator_task: tokio::task::JoinHandle<()>,
+}
+
+impl Rig {
+    /// Build the surface stack over a disconnected Roon adapter.
+    ///
+    /// Roon being *disconnected* is load-bearing for the routing tests: a command that reaches Roon
+    /// cannot silently succeed, so "did not fall through to Roon" is observable from the response
+    /// as well as from the daemon's request log.
+    async fn new() -> Self {
+        isolate_config_dir();
+        let bus = create_bus();
+        let aggregator = Arc::new(ZoneAggregator::new(bus.clone()));
+        let aggregator_task = {
+            let aggregator = aggregator.clone();
+            tokio::spawn(async move { aggregator.run().await })
+        };
+        tokio::task::yield_now().await;
+
+        let coordinator = Arc::new(AdapterCoordinator::new(bus.clone()));
+        let roon = Arc::new(RoonAdapter::new_disconnected(bus.clone()));
+        let manager = Arc::new(HqpInstanceManager::new(bus.clone()));
+        let hqplayer = manager.get_default().await;
+        let hqp_zone_links = Arc::new(HqpZoneLinkService::new(manager.clone()));
+        let lms = Arc::new(LmsAdapter::new(bus.clone()));
+        let openhome = Arc::new(OpenHomeAdapter::new(bus.clone()));
+        let upnp = Arc::new(UPnPAdapter::new(bus.clone()));
+
+        let startable: Vec<Arc<dyn Startable>> = vec![];
+        let state = AppState::new(
+            roon,
+            hqplayer,
+            manager.clone(),
+            hqp_zone_links,
+            lms,
+            openhome,
+            upnp,
+            KnobStore::new(),
+            bus.clone(),
+            aggregator.clone(),
+            coordinator,
+            startable,
+            Instant::now(),
+            CancellationToken::new(),
+        );
+
+        Self {
+            app: client_router(state.clone()),
+            state,
+            manager,
+            aggregator,
+            bus,
+            aggregator_task,
+        }
+    }
+
+    /// Attach a managed instance named `rig` to a wire daemon and run it to a published zone.
+    async fn attach(&self, server: &WireServer) -> Arc<HqpAdapter> {
+        let adapter = self
+            .manager
+            .add_instance(
+                "rig".to_string(),
+                "127.0.0.1".to_string(),
+                Some(server.port()),
+                None,
+                None,
+                None,
+            )
+            .await;
+        adapter.set_timeouts(fast_timeouts()).await;
+        adapter.set_recovery_config(fast_recovery()).await;
+        self.manager.start().await.expect("start managed lifecycle");
+        adapter
+    }
+
+    async fn zone_when(&self, mut condition: impl FnMut(&Zone) -> bool) -> Zone {
+        for _ in 0..200 {
+            if let Some(zone) = self.aggregator.get_zone("hqplayer:rig").await {
+                if condition(&zone) {
+                    return zone;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        panic!(
+            "zone never satisfied the condition inside the bounded budget; zones={:?}",
+            self.aggregator.get_zones().await
+        );
+    }
+
+    async fn post_control(&self, body: Value) -> (StatusCode, Value) {
+        let request = Request::builder()
+            .method("POST")
+            .uri("/control")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .expect("build control request");
+        let response = self
+            .app
+            .clone()
+            .oneshot(request)
+            .await
+            .expect("control response");
+        let status = response.status();
+        let bytes = axum::body::to_bytes(response.into_body(), 64 * 1024)
+            .await
+            .expect("read control body");
+        let value = serde_json::from_slice(&bytes).unwrap_or_else(|e| {
+            panic!(
+                "control response was not JSON ({e}): {}",
+                String::from_utf8_lossy(&bytes)
+            )
+        });
+        (status, value)
+    }
+
+    async fn get_json(&self, uri: &str) -> (StatusCode, Value) {
+        let request = Request::builder()
+            .uri(uri)
+            .body(Body::empty())
+            .expect("build get request");
+        let response = self
+            .app
+            .clone()
+            .oneshot(request)
+            .await
+            .expect("get response");
+        let status = response.status();
+        let bytes = axum::body::to_bytes(response.into_body(), 512 * 1024)
+            .await
+            .expect("read body");
+        let value = serde_json::from_slice(&bytes).unwrap_or_else(|e| {
+            panic!(
+                "{uri} response was not JSON ({e}): {}",
+                String::from_utf8_lossy(&bytes)
+            )
+        });
+        (status, value)
+    }
+
+    async fn shutdown(self) {
+        self.manager.stop().await;
+        self.bus.publish(BusEvent::ShuttingDown { reason: None });
+        let _ = self.aggregator_task.await;
+    }
+}
+
+/// A daemon mid-playback with a loaded, seekable track and a working decimal-dB control.
+fn playing_daemon() -> DaemonModel {
+    let model = DaemonModel::with_profile(VERIFIED_PROFILE);
+    model.external_change(|s| {
+        s.playback = 2;
+        s.track = 3;
+        s.track_id = "t-3".to_string();
+        s.position = 42;
+        s.length = 215;
+        s.volume_db = -23.5;
+        s.metadata = Some(Metadata::sample());
+    });
+    model
+}
+
+async fn start_daemon(model: &DaemonModel) -> WireServer {
+    WireServer::start(Arc::new(model.clone()), WirePolicy::default()).await
+}
+
+// =============================================================================
+// routing — AC2, and the "no fallback to Roon" constraint
+// =============================================================================
+
+/// **Client expectation.** A knob whose selected zone is `hqplayer:rig` posts
+/// `{"zone_id":"hqplayer:rig","action":"pause"}` and expects that daemon to pause.
+///
+/// **RED before #328:** `knob_control_handler` dispatches `lms:`, `openhome:` and `upnp:` and then
+/// *falls through* to `control_roon` for everything else. The command was executed against Roon
+/// with the prefix stripped, so the daemon saw nothing and a disconnected Roon returned 500.
+#[tokio::test]
+async fn transport_reaches_the_selected_hqplayer_instance_and_not_roon() {
+    let model = playing_daemon();
+    let server = start_daemon(&model).await;
+    let rig = Rig::new().await;
+    rig.attach(&server).await;
+    rig.zone_when(|z| z.state == PlaybackState::Playing).await;
+
+    let before = model.request_count("Pause");
+    let (status, body) = rig.post_control(json!({"zone_id":"hqplayer:rig","action":"pause"})).await;
+
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "pause on a direct HQPlayer zone must succeed; body={body}"
+    );
+    assert_eq!(
+        model.request_count("Pause"),
+        before + 1,
+        "the selected daemon must have received exactly one Pause"
+    );
+    rig.zone_when(|z| z.state == PlaybackState::Paused).await;
+
+    rig.shutdown().await;
+    server.stop();
+}
+
+/// **Client expectation.** Every transport verb the zone advertises is routed, not just play/pause.
+///
+/// **RED before #328:** all of them reached Roon. `stop` and `seek` additionally had no route at
+/// all — `control_roon` maps `stop`, but `seek` is not in any adapter's action vocabulary.
+#[tokio::test]
+async fn stop_next_previous_and_seek_all_route_to_the_daemon() {
+    let model = playing_daemon();
+    let server = start_daemon(&model).await;
+    let rig = Rig::new().await;
+    rig.attach(&server).await;
+    rig.zone_when(|z| z.state == PlaybackState::Playing).await;
+
+    for (action, element, value) in [
+        ("next", "Next", None),
+        ("previous", "Previous", None),
+        ("seek", "Seek", Some(json!(90))),
+        ("stop", "Stop", None),
+    ] {
+        let before = model.request_count(element);
+        let mut body = json!({"zone_id":"hqplayer:rig","action":action});
+        if let Some(v) = value {
+            body["value"] = v;
+        }
+        let (status, response) = rig.post_control(body).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "action `{action}` must route to HQPlayer; body={response}"
+        );
+        assert_eq!(
+            model.request_count(element),
+            before + 1,
+            "action `{action}` must send exactly one `{element}`"
+        );
+    }
+
+    let seek = model
+        .last_request("Seek")
+        .expect("the daemon recorded the Seek");
+    assert_eq!(
+        mock_servers::hqplayer::model::request_attr(&seek, "position").as_deref(),
+        Some("90"),
+        "the requested position must reach the wire unmodified: {seek}"
+    );
+
+    rig.shutdown().await;
+    server.stop();
+}
+
+/// **Client expectation.** `play_pause` — the knob's single-press verb — resolves against the state
+/// the server most recently published to that knob, not against a guess.
+///
+/// **RED before #328:** routed to Roon.
+#[tokio::test]
+async fn play_pause_resolves_against_the_published_state() {
+    let model = playing_daemon();
+    let server = start_daemon(&model).await;
+    let rig = Rig::new().await;
+    rig.attach(&server).await;
+    rig.zone_when(|z| z.state == PlaybackState::Playing).await;
+
+    let (status, _) = rig
+        .post_control(json!({"zone_id":"hqplayer:rig","action":"play_pause"}))
+        .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        model.request_count("Pause"),
+        1,
+        "playing + play_pause must pause"
+    );
+    assert_eq!(model.request_count("Play"), 0);
+
+    rig.zone_when(|z| z.state == PlaybackState::Paused).await;
+    let (status, _) = rig
+        .post_control(json!({"zone_id":"hqplayer:rig","action":"play_pause"}))
+        .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        model.request_count("Play"),
+        1,
+        "paused + play_pause must play"
+    );
+
+    rig.shutdown().await;
+    server.stop();
+}
+
+/// **Client expectation.** A command naming an instance that does not exist is refused. It is never
+/// quietly redirected to whichever backend happens to be the fallback.
+///
+/// **RED before #328:** `hqplayer:ghost` fell through to `control_roon`, which asked Roon for a zone
+/// called `ghost`.
+#[tokio::test]
+async fn an_unknown_instance_is_refused_rather_than_redirected() {
+    let model = playing_daemon();
+    let server = start_daemon(&model).await;
+    let rig = Rig::new().await;
+    rig.attach(&server).await;
+    rig.zone_when(|z| z.state == PlaybackState::Playing).await;
+
+    let before = model.request_count("Play");
+    let (status, body) = rig
+        .post_control(json!({"zone_id":"hqplayer:ghost","action":"play"}))
+        .await;
+
+    assert_eq!(
+        status,
+        StatusCode::NOT_FOUND,
+        "an unknown HQPlayer instance must be a 404, not a fallback; body={body}"
+    );
+    assert_eq!(
+        model.request_count("Play"),
+        before,
+        "the configured instance must not receive another instance's command"
+    );
+
+    rig.shutdown().await;
+    server.stop();
+}
+
+/// **Client expectation.** An unrecognised *prefixed* zone id is an error. Only a legacy
+/// **unprefixed** id may mean Roon — that is the documented Node.js compatibility behaviour and the
+/// knob still sends it after an upgrade.
+///
+/// **RED before #328:** any unrecognised prefix was handed to Roon with nothing stripped.
+#[tokio::test]
+async fn an_unknown_prefix_is_refused_but_a_legacy_unprefixed_id_still_means_roon() {
+    let rig = Rig::new().await;
+
+    let (status, body) = rig
+        .post_control(json!({"zone_id":"spotify:abc","action":"play"}))
+        .await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "an unknown prefix must be refused, not routed to Roon; body={body}"
+    );
+
+    // Legacy shape: no colon at all. Roon is disconnected here, so the contract being pinned is
+    // "it was offered to Roon", which a 5xx from the Roon adapter demonstrates and a 400 from the
+    // router's own prefix check would not.
+    let (status, _) = rig
+        .post_control(json!({"zone_id":"1601bb42ed14351b99c2926214f6cbb80724","action":"play"}))
+        .await;
+    assert_ne!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "a legacy unprefixed zone id must still be offered to Roon"
+    );
+
+    rig.shutdown().await;
+}
+
+// =============================================================================
+// capability — allowed controls must reflect observed state
+// =============================================================================
+
+/// **Client expectation.** The knob greys out what it cannot do. `GET /knob/now_playing` on a
+/// stopped HQPlayer zone with nothing loaded must not claim seek, next and previous are available.
+///
+/// **RED before #328:** `hqp_status_to_zone` hard-coded `is_seekable: true`, `is_next_allowed: true`
+/// and `is_previous_allowed: true` for every HQPlayer zone in every state.
+#[tokio::test]
+async fn a_stopped_empty_zone_advertises_no_seek_next_or_previous() {
+    let model = DaemonModel::with_profile(VERIFIED_PROFILE);
+    model.external_change(|s| {
+        s.playback = 0;
+        s.track = 0;
+        s.track_id.clear();
+        s.position = 0;
+        s.length = 0;
+        s.metadata = None;
+    });
+    let server = start_daemon(&model).await;
+    let rig = Rig::new().await;
+    rig.attach(&server).await;
+    let zone = rig.zone_when(|z| z.state == PlaybackState::Stopped).await;
+
+    assert!(!zone.is_seekable, "nothing is loaded, so nothing is seekable");
+    assert!(
+        !zone.is_next_allowed,
+        "no loaded track means no next to skip to"
+    );
+    assert!(!zone.is_previous_allowed);
+    assert!(
+        !zone.is_pause_allowed,
+        "a stopped zone cannot be paused"
+    );
+
+    let (status, body) = rig
+        .get_json("/knob/now_playing?zone_id=hqplayer%3Arig")
+        .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["is_next_allowed"], json!(false));
+    assert_eq!(body["is_previous_allowed"], json!(false));
+    assert_eq!(body["is_pause_allowed"], json!(false));
+
+    rig.shutdown().await;
+    server.stop();
+}
+
+/// **Client expectation.** With a track loaded and a known duration, seek and skip *are* offered,
+/// and the duration the knob draws its progress bar from is the daemon's.
+#[tokio::test]
+async fn a_loaded_playing_zone_advertises_the_transport_it_really_has() {
+    let model = playing_daemon();
+    let server = start_daemon(&model).await;
+    let rig = Rig::new().await;
+    rig.attach(&server).await;
+    let zone = rig.zone_when(|z| z.state == PlaybackState::Playing).await;
+
+    assert!(zone.is_seekable, "a 215 s track is seekable");
+    assert!(zone.is_next_allowed);
+    assert!(zone.is_previous_allowed);
+    assert!(zone.is_pause_allowed);
+    assert!(!zone.is_play_allowed, "already playing");
+    assert!(zone.is_controllable);
+
+    let np = zone.now_playing.expect("a loaded track publishes now_playing");
+    assert_eq!(np.duration, Some(215.0));
+    assert_eq!(np.seek_position, Some(42.0));
+
+    rig.shutdown().await;
+    server.stop();
+}
+
+/// **Client expectation.** A seek on a zone the server told the client was not seekable is refused
+/// locally. The router must not send a command the same server advertised as unavailable.
+///
+/// **RED before #328:** seek routed to Roon, and there was no capability check anywhere.
+#[tokio::test]
+async fn seek_is_refused_when_the_published_zone_is_not_seekable() {
+    let model = DaemonModel::with_profile(VERIFIED_PROFILE);
+    model.external_change(|s| {
+        s.playback = 2;
+        s.track = 1;
+        s.track_id = "stream".to_string();
+        // A live stream: playing, but with no duration, so there is no position to seek to.
+        s.length = 0;
+        s.metadata = Some(Metadata::sample());
+    });
+    let server = start_daemon(&model).await;
+    let rig = Rig::new().await;
+    rig.attach(&server).await;
+    let zone = rig.zone_when(|z| z.state == PlaybackState::Playing).await;
+    assert!(!zone.is_seekable, "the RED needs an unseekable zone");
+
+    let before = model.request_count("Seek");
+    let (status, body) = rig
+        .post_control(json!({"zone_id":"hqplayer:rig","action":"seek","value":30}))
+        .await;
+
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "seek on an unseekable zone must be refused; body={body}"
+    );
+    assert_eq!(
+        model.request_count("Seek"),
+        before,
+        "no Seek may reach a daemon whose zone advertises no seek"
+    );
+
+    rig.shutdown().await;
+    server.stop();
+}
+
+// =============================================================================
+// metadata — AC1 and the source/output domain split
+// =============================================================================
+
+/// **Client expectation.** The knob's three text lines come from the track, and the format badge it
+/// draws must describe the *source* material — not the DAC's output stage.
+///
+/// **RED before #328:** `TrackMetadata.bit_depth` was filled from `Status.active_bits`, which is the
+/// **output** depth. With a 24-bit source upsampled to a 32-bit output stage the client was told the
+/// track was 32-bit. `format` was filled from `Status.active_mode`, the output mode, which reads
+/// back the literal string `[source]` under source-following.
+#[tokio::test]
+async fn track_metadata_is_the_source_domain_never_the_output_stage() {
+    let model = DaemonModel::with_profile(VERIFIED_PROFILE);
+    model.external_change(|s| {
+        s.playback = 2;
+        s.track = 1;
+        s.track_id = "domain".to_string();
+        s.length = 100;
+        // Source: 24/44.1. The fake derives Status.active_bits/samplerate/bitrate from this child,
+        // and active_rate separately, which is exactly the daemon's own split.
+        s.metadata = Some(Metadata {
+            artist: "Bill Evans".to_string(),
+            album: "Sunday at the Village Vanguard".to_string(),
+            song: "Gloria's Step".to_string(),
+            samplerate: 44_100,
+            bits: 24,
+            channels: 2,
+            bitrate: 1411,
+        });
+        // Output: upsampled to 352.8 kHz.
+        s.active_rate_hz = 352_800;
+    });
+    let server = start_daemon(&model).await;
+    let rig = Rig::new().await;
+    rig.attach(&server).await;
+    let zone = rig.zone_when(|z| z.state == PlaybackState::Playing).await;
+
+    let np = zone.now_playing.expect("now_playing");
+    assert_eq!(np.title, "Gloria's Step");
+    assert_eq!(np.artist, "Bill Evans");
+    assert_eq!(np.album, "Sunday at the Village Vanguard");
+
+    let meta = np.metadata.expect("track metadata");
+    assert_eq!(
+        meta.sample_rate,
+        Some(44_100),
+        "the track's rate is the source rate, not the 352800 Hz output rate"
+    );
+    assert_eq!(
+        meta.bit_depth,
+        Some(24),
+        "the track's depth is the source depth, not Status.active_bits"
+    );
+    assert_eq!(meta.bitrate, Some(1411));
+    assert_eq!(
+        meta.format, None,
+        "HQPlayer supplies no source container/codec, and active_mode is an output fact; \
+         publishing it as the track's format fabricates source metadata"
+    );
+
+    rig.shutdown().await;
+    server.stop();
+}
+
+/// **Client expectation.** With the source at 24 bit and the output stage at 32 bit, the client is
+/// told the *track* is 24 bit.
+///
+/// This one goes through the pure projection rather than the wire fake, because the fake derives
+/// `Status.active_bits` from the very metadata child it derives the source depth from, so on that
+/// wire the two values can never disagree and the defect is unexpressible. The wire test above
+/// covers the rate half of the same split, where the fake does keep the domains apart.
+///
+/// **RED before #328:** `bit_depth` was `Some(status.active_bits as u8)` — the output stage.
+#[test]
+fn the_published_track_depth_is_the_source_depth_not_the_output_stage() {
+    let mut status = HqpStatus {
+        state: 2,
+        track: 1,
+        track_id: "domain".to_string(),
+        position: 5,
+        length: 100,
+        volume: -24,
+        volume_db: -23.5,
+        active_mode: "PCM".to_string(),
+        active_rate: 352_800,
+        // The DAC is being fed 32-bit words.
+        active_bits: 32,
+        active_channels: 2,
+        samplerate: 44_100,
+        bitrate: 1411,
+        title: Some("Gloria's Step".to_string()),
+        artist: Some("Bill Evans".to_string()),
+        album: Some("Sunday at the Village Vanguard".to_string()),
+        ..HqpStatus::default()
+    };
+    // The source is 24/44.1.
+    status.source_bits = Some(24);
+    status.source_samplerate = Some(44_100);
+    status.source_bitrate = Some(1411);
+
+    let zone = HqpAdapter::project_direct_zone(
+        "127.0.0.1",
+        Some("rig"),
+        &Default::default(),
+        &status,
+        &VolumeRange {
+            min: -60,
+            max: 0,
+            step: 1,
+            enabled: true,
+            adaptive: false,
+            min_db: -60.0,
+            max_db: 0.0,
+            step_db: Some(0.5),
+        },
+    );
+
+    let meta = zone
+        .now_playing
+        .expect("a loaded track")
+        .metadata
+        .expect("track metadata");
+    assert_eq!(
+        meta.bit_depth,
+        Some(24),
+        "32 is the output stage's depth; publishing it as the track's fabricates the source"
+    );
+    assert_eq!(meta.sample_rate, Some(44_100));
+}
+
+/// **Client expectation.** Fields the daemon supplies are published; fields it does not supply are
+/// absent rather than invented.
+///
+/// **RED before #328:** the parser read exactly three attributes — `song`, `artist`, `album` — and
+/// hard-coded `composer: None` and `genre: None` in the projection, so a daemon that supplies them
+/// could not surface them.
+///
+/// The attribute *spellings* `composer` and `genre` have no evidence anywhere in this repository.
+/// This test does not assert that a real daemon sends them; it asserts that the parser is generic
+/// over the child's attributes, so whatever is supplied is published and nothing is claimed.
+#[test]
+fn supplied_metadata_attributes_are_published_and_absent_ones_are_not_invented() {
+    let with_extras = concat!(
+        r#"<?xml version="1.0"?>"#,
+        r#"<Status state="2" track="1" track_id="x" position="5" length="60" volume="-12.5" "#,
+        r#"active_mode="PCM" active_rate="352800" active_bits="32" active_channels="2" "#,
+        r#"samplerate="96000" bitrate="4608">"#,
+        "\n",
+        r#"<metadata artist="Miles Davis" album="Kind of Blue" song="So What" "#,
+        r#"composer="Miles Davis" genre="Jazz" uri="file:///m/so-what.flac" "#,
+        r#"samplerate="96000" bits="24" channels="2" bitrate="4608"/>"#,
+        "\n</Status>",
+    );
+
+    let status = HqpAdapter::parse_status_for_test(with_extras);
+    assert_eq!(status.composer.as_deref(), Some("Miles Davis"));
+    assert_eq!(status.genre.as_deref(), Some("Jazz"));
+    assert_eq!(status.uri.as_deref(), Some("file:///m/so-what.flac"));
+    assert_eq!(status.source_bits, Some(24));
+    assert_eq!(status.source_samplerate, Some(96_000));
+
+    let without_extras = concat!(
+        r#"<?xml version="1.0"?>"#,
+        r#"<Status state="2" track="1" track_id="x" position="5" length="60" volume="-12.5" "#,
+        r#"samplerate="44100" bitrate="1411">"#,
+        "\n",
+        r#"<metadata artist="Bill Evans" album="Vanguard" song="Gloria&apos;s Step"/>"#,
+        "\n</Status>",
+    );
+    let status = HqpAdapter::parse_status_for_test(without_extras);
+    assert_eq!(status.title.as_deref(), Some("Gloria's Step"));
+    assert_eq!(
+        status.composer, None,
+        "an absent attribute must stay absent, never a placeholder"
+    );
+    assert_eq!(status.genre, None);
+    assert_eq!(status.uri, None);
+    assert_eq!(
+        status.source_bits, None,
+        "the child sent no bits; the root's output active_bits must not stand in for it"
+    );
+}
+
+/// **Client expectation.** A malformed `metadata` child costs the metadata and nothing else. The
+/// knob keeps showing the right play state and level even when the title is unreadable.
+///
+/// The `metadata` child is the one part of a `Status` document observed to be malformed in the wild
+/// (`src/adapters/hqplayer.rs:310`, and the framing note on the corpus fixture).
+#[test]
+fn a_malformed_metadata_child_cannot_wedge_the_transport_state() {
+    // Unterminated child: the attribute value's closing quote and the element's `/>` are both gone.
+    let wedged = concat!(
+        r#"<?xml version="1.0"?>"#,
+        r#"<Status state="2" track="7" track_id="ok" position="11" length="60" volume="-18.5" "#,
+        r#"samplerate="44100" bitrate="1411">"#,
+        "\n",
+        r#"<metadata artist="Bill Evans" album="Vanguard" song="Gloria"#,
+        "\n</Status>",
+    );
+
+    let status = HqpAdapter::parse_status_for_test(wedged);
+    assert_eq!(status.state, 2, "playback state survives a bad child");
+    assert_eq!(status.position, 11);
+    assert_eq!(status.length, 60);
+    assert_eq!(
+        status.volume_db, -18.5,
+        "the level survives, and is not defaulted to 0 dB / full scale"
+    );
+    assert_eq!(status.track, 7);
+}
+
+// =============================================================================
+// stale_state — capability and identity transitions
+// =============================================================================
+
+/// **Client expectation.** Stopping clears the track *and* the capabilities that only made sense
+/// while it was loaded. A knob must not be left offering seek on a zone that stopped.
+///
+/// The now-playing clear itself is already pinned by the #162 lifecycle suite; what is new here is
+/// that `is_seekable` / `is_next_allowed` transition with it.
+#[tokio::test]
+async fn stopping_clears_the_track_and_the_capabilities_that_depended_on_it() {
+    let model = playing_daemon();
+    let server = start_daemon(&model).await;
+    let rig = Rig::new().await;
+    rig.attach(&server).await;
+    let playing = rig.zone_when(|z| z.state == PlaybackState::Playing).await;
+    assert!(playing.is_seekable && playing.is_next_allowed);
+
+    model.external_change(|s| {
+        s.playback = 0;
+        s.track = 0;
+        s.track_id.clear();
+        s.position = 0;
+        s.length = 0;
+        s.metadata = None;
+    });
+
+    let stopped = rig.zone_when(|z| z.state == PlaybackState::Stopped).await;
+    assert!(stopped.now_playing.is_none(), "stale track must clear");
+    assert!(
+        !stopped.is_seekable,
+        "seekability must clear with the track, not persist as a stale capability"
+    );
+    assert!(!stopped.is_next_allowed);
+    assert!(!stopped.is_previous_allowed);
+
+    rig.shutdown().await;
+    server.stop();
+}
+
+/// **Client expectation.** A transient failure to read the volume capability must not tell the
+/// client the zone has become a fixed-volume device. That is a capability *lie*, and on a knob it
+/// removes the control the user is actively turning.
+///
+/// **RED before #328:** `ensure_volume_range` answered any transient failure with
+/// `VolumeRange::default()`, whose `enabled` is `false`, and `hqp_status_to_zone` maps `!enabled` to
+/// `volume_control: None`. One dropped `VolumeRange` reply erased a working −60…0 dB control.
+///
+/// Distinct from an *observed* transition to fixed volume, which must clear — pinned by the #162
+/// suite and left alone here.
+#[tokio::test]
+async fn a_transient_volume_read_failure_retains_the_last_observed_capability() {
+    let model = playing_daemon();
+    model.external_change(|s| {
+        s.volume_db = -23.5;
+        s.volume_range.min_db = -60.0;
+        s.volume_range.max_db = 0.0;
+        s.volume_range.step_db = Some(0.5);
+    });
+    let server = start_daemon(&model).await;
+    let rig = Rig::new().await;
+    rig.attach(&server).await;
+    let observed = rig.zone_when(|z| z.volume_control.is_some()).await;
+    assert_eq!(
+        observed.volume_control.as_ref().map(|v| v.min),
+        Some(-60.0),
+        "the RED needs a capability that was genuinely observed first"
+    );
+
+    // The daemon stops answering `VolumeRange` — a lost reply, not a refusal. A refusal
+    // (`result="Error"`) is `HqpRejected` and already aborts the whole read; this is the path that
+    // instead substituted a synthetic fixed-volume capability and published it.
+    let polls_before = server.stats().element_count("Status");
+    server.set_policy(WirePolicy {
+        silent_for_element: Some("VolumeRange".to_string()),
+        ..WirePolicy::default()
+    });
+
+    // Let the worker complete several coherent-observation cycles under the fault.
+    for _ in 0..200 {
+        if server.stats().element_count("Status") > polls_before + 2 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+
+    let zone = rig
+        .aggregator
+        .get_zone("hqplayer:rig")
+        .await
+        .expect("the zone must not disappear because one optional read timed out");
+    let vc = zone.volume_control.as_ref().unwrap_or_else(|| {
+        panic!(
+            "a dropped VolumeRange reply is not evidence that the daemon became fixed-volume; \
+             the last observed -60..0 dB capability must be retained. zone={zone:?}"
+        )
+    });
+    assert_eq!(vc.min, -60.0, "the retained bounds are the observed ones");
+    assert_eq!(vc.max, 0.0);
+    assert_eq!(vc.step, 0.5);
+
+    rig.shutdown().await;
+    server.stop();
+}
+
+/// **Client expectation.** The zone id a knob has stored survives a daemon restart. A knob that
+/// reconnects to a renamed zone silently controls nothing.
+#[tokio::test]
+async fn the_direct_zone_id_is_stable_across_a_reconnect() {
+    let model = playing_daemon();
+    let server = start_daemon(&model).await;
+    let rig = Rig::new().await;
+    let adapter = rig.attach(&server).await;
+    rig.zone_when(|z| z.state == PlaybackState::Playing).await;
+
+    adapter.disconnect().await;
+    let recovered = rig.zone_when(|z| z.state == PlaybackState::Playing).await;
+    assert_eq!(
+        recovered.zone_id, "hqplayer:rig",
+        "the id is the instance name, and a reconnect must not renumber it to the host"
+    );
+    assert_eq!(recovered.source, "hqplayer");
+
+    rig.shutdown().await;
+    server.stop();
+}
+
+// =============================================================================
+// volume — decimal dB, clamping, and refusing to guess
+// =============================================================================
+
+/// **Client expectation.** A knob configured for 0.5 dB steps moves the level by 0.5 dB. Decimal dB
+/// must survive from the daemon's `VolumeRange`, through the published zone, into the level written
+/// back — with no rounding step anywhere in between.
+#[tokio::test]
+async fn decimal_db_survives_the_whole_round_trip() {
+    let model = playing_daemon();
+    model.external_change(|s| {
+        s.volume_db = -23.5;
+        s.volume_range.min_db = -60.0;
+        s.volume_range.max_db = 0.0;
+        s.volume_range.step_db = Some(0.5);
+    });
+    let server = start_daemon(&model).await;
+    let rig = Rig::new().await;
+    rig.attach(&server).await;
+    let zone = rig.zone_when(|z| z.state == PlaybackState::Playing).await;
+
+    let vc = zone.volume_control.expect("a decimal-dB control");
+    assert_eq!(vc.value, -23.5);
+    assert_eq!(vc.min, -60.0);
+    assert_eq!(vc.max, 0.0);
+    assert_eq!(vc.step, 0.5, "the daemon's own step, not a rounded 1 dB");
+
+    let (status, body) = rig
+        .post_control(json!({"zone_id":"hqplayer:rig","action":"vol_up"}))
+        .await;
+    assert_eq!(status, StatusCode::OK, "body={body}");
+
+    rig.zone_when(|z| {
+        z.volume_control
+            .as_ref()
+            .map(|v| (v.value - (-23.0)).abs() < 1e-6)
+            .unwrap_or(false)
+    })
+    .await;
+
+    let (status, _) = rig
+        .post_control(json!({"zone_id":"hqplayer:rig","action":"vol_abs","value":-31.5}))
+        .await;
+    assert_eq!(status, StatusCode::OK);
+    let written = model
+        .last_request("Volume")
+        .expect("the daemon recorded the level write");
+    assert_eq!(
+        mock_servers::hqplayer::model::request_attr(&written, "value").as_deref(),
+        Some("-31.5"),
+        "the fractional level must reach the wire unrounded: {written}"
+    );
+
+    rig.shutdown().await;
+    server.stop();
+}
+
+/// **Client expectation, and the safety-critical one.** A volume command whose level is missing or
+/// unparseable is **refused**. It is never turned into a number.
+///
+/// **RED before #328:** the `vol_abs` arm ended `.unwrap_or(50.0)`. For a dB zone +50 dB is above
+/// every possible maximum, and the existing safety lint does not see it — that lint scans
+/// `src/adapters` only, and matches `.value.unwrap_or(50.0)`, not `.as_f64()).unwrap_or(50.0)`.
+#[tokio::test]
+async fn a_missing_or_unparseable_level_is_refused_never_defaulted() {
+    let model = playing_daemon();
+    let server = start_daemon(&model).await;
+    let rig = Rig::new().await;
+    rig.attach(&server).await;
+    rig.zone_when(|z| z.state == PlaybackState::Playing).await;
+
+    for body in [
+        json!({"zone_id":"hqplayer:rig","action":"vol_abs"}),
+        json!({"zone_id":"hqplayer:rig","action":"vol_abs","value":null}),
+        json!({"zone_id":"hqplayer:rig","action":"vol_abs","value":"loud"}),
+    ] {
+        let before = model.request_count("Volume");
+        let (status, response) = rig.post_control(body.clone()).await;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "an absolute volume with no usable level must be refused: {body} -> {response}"
+        );
+        assert_eq!(
+            model.request_count("Volume"),
+            before,
+            "no level may be written when none was supplied: {body}"
+        );
+    }
+
+    rig.shutdown().await;
+    server.stop();
+}
+
+/// **Client expectation.** A level outside the daemon's range is clamped into it, not rejected and
+/// not passed through. A knob spun to its stop should land on the daemon's maximum.
+#[tokio::test]
+async fn out_of_range_levels_clamp_to_the_observed_range() {
+    let model = playing_daemon();
+    model.external_change(|s| {
+        s.volume_range.min_db = -60.0;
+        s.volume_range.max_db = 0.0;
+    });
+    let server = start_daemon(&model).await;
+    let rig = Rig::new().await;
+    rig.attach(&server).await;
+    rig.zone_when(|z| z.volume_control.is_some()).await;
+
+    let (status, _) = rig
+        .post_control(json!({"zone_id":"hqplayer:rig","action":"vol_abs","value":12.0}))
+        .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        mock_servers::hqplayer::model::request_attr(
+            &model.last_request("Volume").expect("a Volume write"),
+            "value"
+        )
+        .as_deref(),
+        Some("0"),
+        "+12 dB must clamp to the observed maximum of 0 dB"
+    );
+
+    let (status, _) = rig
+        .post_control(json!({"zone_id":"hqplayer:rig","action":"vol_abs","value":-400.0}))
+        .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        mock_servers::hqplayer::model::request_attr(
+            &model.last_request("Volume").expect("a Volume write"),
+            "value"
+        )
+        .as_deref(),
+        Some("-60"),
+        "-400 dB must clamp to the observed minimum"
+    );
+
+    rig.shutdown().await;
+    server.stop();
+}
+
+/// **Client expectation.** A zone the server published without a volume control gets no volume
+/// commands. Sending one to a fixed-volume daemon produces a bare `result="Error"` and, on a
+/// hardware-attenuated setup, is the request that has no safe interpretation.
+#[tokio::test]
+async fn volume_commands_are_refused_when_the_zone_advertises_no_control() {
+    let model = playing_daemon();
+    model.external_change(|s| s.volume_range.enabled = false);
+    let server = start_daemon(&model).await;
+    let rig = Rig::new().await;
+    rig.attach(&server).await;
+    let zone = rig.zone_when(|z| z.state == PlaybackState::Playing).await;
+    assert!(
+        zone.volume_control.is_none(),
+        "the RED needs an observed fixed-volume zone"
+    );
+
+    for action in ["vol_up", "vol_down", "mute"] {
+        let (status, body) = rig
+            .post_control(json!({"zone_id":"hqplayer:rig","action":action}))
+            .await;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "`{action}` must be refused on a fixed-volume zone; body={body}"
+        );
+    }
+    let (status, _) = rig
+        .post_control(json!({"zone_id":"hqplayer:rig","action":"vol_abs","value":-20.0}))
+        .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    assert_eq!(
+        model.request_count("Volume")
+            + model.request_count("VolumeUp")
+            + model.request_count("VolumeDown")
+            + model.request_count("VolumeMute"),
+        0,
+        "not one volume command may reach a daemon with no volume control"
+    );
+
+    rig.shutdown().await;
+    server.stop();
+}
+
+/// **Client expectation.** Mute is reported only because it is observable. `VolumeMute` is a
+/// verified absolute move to the range floor with no mute flag on the wire (#322, live 6.0.2), so
+/// "muted" means the level is at the floor — and that is what the client is told.
+///
+/// **RED before #328:** `is_muted` was the literal `false`, with the comment "HQPlayer doesn't
+/// report mute separately".
+#[tokio::test]
+async fn mute_is_routed_and_reported_from_the_observable_floor() {
+    let model = playing_daemon();
+    model.external_change(|s| {
+        s.volume_db = -23.5;
+        s.volume_range.min_db = -60.0;
+        s.volume_range.max_db = 0.0;
+    });
+    let server = start_daemon(&model).await;
+    let rig = Rig::new().await;
+    rig.attach(&server).await;
+    let zone = rig.zone_when(|z| z.volume_control.is_some()).await;
+    assert!(
+        !zone.volume_control.expect("control").is_muted,
+        "-23.5 dB is not muted"
+    );
+
+    let (status, body) = rig
+        .post_control(json!({"zone_id":"hqplayer:rig","action":"mute"}))
+        .await;
+    assert_eq!(status, StatusCode::OK, "body={body}");
+    assert_eq!(model.request_count("VolumeMute"), 1);
+
+    let muted = rig
+        .zone_when(|z| {
+            z.volume_control
+                .as_ref()
+                .map(|v| v.is_muted)
+                .unwrap_or(false)
+        })
+        .await;
+    let vc = muted.volume_control.expect("control");
+    assert_eq!(vc.value, -60.0, "the floor is where VolumeMute leaves it");
+    assert!(vc.is_muted);
+
+    rig.shutdown().await;
+    server.stop();
+}
+
+// =============================================================================
+// dsp_boundary — AC7, no ambiguous double routing
+// =============================================================================
+
+/// **Client expectation.** A direct HQPlayer zone is one zone with one control path. It must not
+/// also advertise itself as a DSP-enrichment target, which would give the client two ways to reach
+/// the same daemon with no rule for which wins.
+///
+/// **RED before #328:** `link_zone` accepted any `zone_id`, so `hqplayer:rig` → `rig` was storable,
+/// after which `get_all_zones_internal` attached a `dsp` block to the direct zone.
+#[tokio::test]
+async fn a_direct_zone_cannot_be_its_own_dsp_enrichment_target() {
+    let model = playing_daemon();
+    let server = start_daemon(&model).await;
+    let rig = Rig::new().await;
+    rig.attach(&server).await;
+    rig.zone_when(|z| z.state == PlaybackState::Playing).await;
+
+    let refused = rig
+        .state
+        .hqp_zone_links
+        .link_zone("hqplayer:rig".to_string(), "rig".to_string())
+        .await;
+    assert!(
+        refused.is_err(),
+        "linking a direct HQPlayer zone as a DSP target must be refused"
+    );
+    assert!(
+        rig.state
+            .hqp_zone_links
+            .get_instance_for_zone("hqplayer:rig")
+            .await
+            .is_none(),
+        "the refused link must not have been stored"
+    );
+
+    let (status, body) = rig.get_json("/zones").await;
+    assert_eq!(status, StatusCode::OK);
+    let direct = body["zones"]
+        .as_array()
+        .expect("zones array")
+        .iter()
+        .find(|z| z["zone_id"] == "hqplayer:rig")
+        .expect("the direct zone is listed");
+    assert!(
+        direct.get("dsp").is_none(),
+        "a direct zone carries no dsp block: {direct}"
+    );
+
+    rig.shutdown().await;
+    server.stop();
+}
+
+/// **Client expectation.** Making the direct zone truthful must not cost the existing feature:
+/// a Roon or LMS zone linked to an HQPlayer instance keeps its DSP enrichment.
+#[tokio::test]
+async fn a_linked_roon_zone_keeps_its_dsp_enrichment() {
+    let model = playing_daemon();
+    let server = start_daemon(&model).await;
+    let rig = Rig::new().await;
+    rig.attach(&server).await;
+    rig.zone_when(|z| z.state == PlaybackState::Playing).await;
+
+    // A Roon zone published the ordinary way, then linked for DSP enrichment.
+    rig.bus.publish(BusEvent::ZoneDiscovered {
+        zone: Zone {
+            zone_id: "roon:living".to_string(),
+            zone_name: "Living Room".to_string(),
+            state: PlaybackState::Playing,
+            volume_control: None,
+            now_playing: None,
+            source: "roon".to_string(),
+            is_controllable: true,
+            is_seekable: true,
+            last_updated: 0,
+            is_play_allowed: false,
+            is_pause_allowed: true,
+            is_next_allowed: true,
+            is_previous_allowed: true,
+        },
+    });
+    for _ in 0..50 {
+        if rig.aggregator.get_zone("roon:living").await.is_some() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    rig.state
+        .hqp_zone_links
+        .link_zone("roon:living".to_string(), "rig".to_string())
+        .await
+        .expect("a Roon zone may be linked for DSP enrichment");
+
+    let (_, body) = rig.get_json("/zones").await;
+    let linked = body["zones"]
+        .as_array()
+        .expect("zones array")
+        .iter()
+        .find(|z| z["zone_id"] == "roon:living")
+        .expect("the Roon zone is listed");
+    assert_eq!(
+        linked["dsp"]["type"], "hqplayer",
+        "the linked Roon zone keeps its enrichment: {linked}"
+    );
+    assert_eq!(linked["dsp"]["instance"], "rig");
+
+    rig.state.hqp_zone_links.unlink_zone("roon:living").await;
+    rig.shutdown().await;
+    server.stop();
+}
+
+/// **Client expectation.** Turning the HQPlayer adapter off in settings hides HQPlayer zones, the
+/// same way it does for every other backend.
+///
+/// **RED before #328:** the zone filter tested the prefix `hqp:` while zones are published as
+/// `hqplayer:`, so the test never matched and HQPlayer zones fell into the "unknown prefix, include
+/// by default" arm. The toggle did nothing.
+#[test]
+fn the_zone_filter_matches_the_prefix_hqplayer_zones_are_actually_published_with() {
+    let source = std::fs::read_to_string(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/knobs/routes.rs"),
+    )
+    .expect("read the routing surface");
+
+    assert!(
+        !source.contains(r#"starts_with("hqp:")"#),
+        "the adapter filter must test `hqplayer:` — the prefix PrefixedZoneId::hqplayer emits — \
+         not `hqp:`, which no zone id ever carries"
+    );
+    assert!(
+        source.contains(r#"starts_with("hqplayer:")"#),
+        "the routing surface must recognise the `hqplayer:` prefix"
+    );
+}
+
+// Keep the unused-import guard honest: `SocketAddr` is referenced only by the router type in some
+// axum versions, so name it once rather than conditionally importing it.
+#[allow(dead_code)]
+fn _addr_type_is_used(_: Option<SocketAddr>) {}

--- a/tests/volume_safety.rs
+++ b/tests/volume_safety.rs
@@ -159,3 +159,114 @@ fn relative_step_clamped_prevents_wild_jumps() {
     assert_eq!(clamp(50.0, -max_step, max_step), max_step);
     assert_eq!(clamp(-50.0, -max_step, max_step), -max_step);
 }
+
+// =============================================================================
+// Direct HQPlayer volume path (issue #328)
+// =============================================================================
+//
+// `tests/architecture_lint.rs::volume_values_use_safe_defaults` is the existing guard, and it could
+// not see the defect #328 found. Two reasons, both structural rather than accidental:
+//
+//   1. It walks `src/adapters` only. The routing surface that decides what level to write lives in
+//      `src/knobs/routes.rs`.
+//   2. It matches the literal `.value.unwrap_or(50.0)`. The real line read
+//      `value.and_then(|v| v.as_f64()).unwrap_or(50.0)` — same hazard, different spelling, no match.
+//
+// So this is deliberately not "the same lint with another directory added". It asserts a property of
+// the HQPlayer control path — *no numeric literal is ever substituted for a missing level* — which
+// holds regardless of how the substitution is spelled.
+//
+// The behavioural counterpart is
+// `hqplayer_direct_zone::a_missing_or_unparseable_level_is_refused_never_defaulted`, which proves the
+// daemon receives nothing. This lint exists because that test can only cover the paths it calls,
+// while a future edit could add a fifth volume arm with a default and break no existing test.
+
+/// The body of `control_hqplayer`, from its signature to the sibling that follows it.
+fn control_hqplayer_body() -> String {
+    let source = std::fs::read_to_string(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/knobs/routes.rs"),
+    )
+    .expect("read the routing surface");
+
+    let start = source
+        .find("async fn control_hqplayer(")
+        .expect("control_hqplayer must exist: the direct HQPlayer zone routes through it");
+    let rest = &source[start..];
+    let end = rest
+        .find("\nfn require_volume_control(")
+        .expect("the function that follows control_hqplayer must still follow it");
+    rest[..end].to_string()
+}
+
+#[test]
+fn the_hqplayer_volume_path_never_substitutes_a_numeric_level() {
+    let body = control_hqplayer_body();
+
+    // Non-vacuity: the arms this is a claim about have to be present, or the lint passes by
+    // describing a function that no longer does the thing.
+    for marker in ["set_volume_db", "vol_abs", "vol_up"] {
+        assert!(
+            body.contains(marker),
+            "`{marker}` is gone from control_hqplayer; this lint is now vacuous and must be updated \
+             alongside whatever replaced it"
+        );
+    }
+
+    // A numeric default anywhere in this function is a level nobody asked for. For a dB zone the
+    // familiar constants are the dangerous ones — `0.0` is full scale and `50.0` is above every
+    // possible maximum — so no `unwrap_or` with a numeric argument is permitted at all. The safe
+    // shapes are `filter(...)` + an early return, or `clamp` between two *observed* bounds.
+    let mut offenders = Vec::new();
+    for (index, line) in body.lines().enumerate() {
+        // Comments discuss the hazard by name — including the two constants above — and a lint that
+        // cannot tell an explanation from an occurrence trains people to delete the explanation.
+        if line.trim_start().starts_with("//") {
+            continue;
+        }
+        let Some(after) = line.split("unwrap_or(").nth(1) else {
+            continue;
+        };
+        let argument = after.trim_start();
+        let starts_numeric = argument
+            .chars()
+            .next()
+            .map(|c| c.is_ascii_digit() || c == '-' || c == '+')
+            .unwrap_or(false);
+        if starts_numeric {
+            offenders.push(format!("  line +{}: {}", index + 1, line.trim()));
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "\n\nSAFETY: control_hqplayer substitutes a numeric volume level.\n\n\
+         A level the client did not supply must be REFUSED, not invented. On a dB zone 0.0 is full \
+         scale and 50.0 is above every possible maximum, and this path writes straight to a DAC.\n\n\
+         Offending lines:\n{}\n\n\
+         Safe shapes: `.filter(|v| v.is_finite())` with an early return for `None`, or `clamp` \
+         between the zone's own observed `min`/`max`.\n",
+        offenders.join("\n")
+    );
+}
+
+#[test]
+fn the_hqplayer_volume_path_clamps_to_the_zones_observed_bounds() {
+    let body = control_hqplayer_body();
+
+    // Both the absolute and the relative arm must clamp, and must clamp to values read off the
+    // published zone rather than to constants. `vc` is that zone's volume control.
+    let clamps: Vec<&str> = body.lines().filter(|l| l.contains(".clamp(")).collect();
+    assert!(
+        clamps.len() >= 2,
+        "both the absolute and the relative volume arms must clamp; found {} clamp(s) in \
+         control_hqplayer",
+        clamps.len()
+    );
+    for line in &clamps {
+        assert!(
+            line.contains("vc.min") && line.contains("vc.max"),
+            "a volume clamp must use the zone's observed bounds, not constants: {}",
+            line.trim()
+        );
+    }
+}


### PR DESCRIPTION
## What this is

Makes a direct HQPlayer instance a truthful everyday UHC zone: observed now-playing metadata,
observed playback state, transport + seek, safe decimal-dB volume, and explicit backend routing —
with **no fallback to Roon or LMS**.

Stacked on #382 (`feat/issue-329-hqplayer-immediate-command`). **Do not merge.**

Refs #328 · OH: 80222d6d · Parent epic #313
Session record: [`.oh/hqplayer-direct-zone.md`](../blob/feat/issue-328-direct-hqplayer-zone/.oh/hqplayer-direct-zone.md)

## The defects this closes

Found by reading the code before choosing an approach; each is a specific line, not a category:

1. **Every HQPlayer control command was executed against Roon.** `knob_control_handler` dispatches
   `lms:`/`openhome:`/`upnp:` explicitly then *falls through* to `control_roon` — including for
   `hqplayer:` zone ids, prefix stripped.
2. **The HQPlayer adapter toggle did not filter HQPlayer zones** — the filter tested the prefix
   `hqp:`, zones are published as `hqplayer:`.
3. **Transport capability was asserted, not observed** — `is_seekable`, `is_next_allowed`,
   `is_previous_allowed` hard-coded `true` in every state.
4. **Output-domain facts were published as track metadata** — `TrackMetadata.bit_depth` from
   `Status.active_bits` (the DAC), `format` from `Status.active_mode` (which reads back the literal
   `[source]` under source-following), while the source-domain depth on the `metadata` child was
   dropped.
5. **A lost `VolumeRange` reply erased the volume capability** — the transient-failure fallback has
   `enabled: false`, which the zone projection maps to `volume_control: None`.
6. **Mute was a constant `false`**, though `VolumeMute` is a verified absolute move to the range
   floor and is therefore observable.
7. **A direct zone could be linked to itself as a DSP-enrichment target**, producing two control
   routes to one daemon.
8. **A missing volume value defaulted to `50.0`** — above every possible dB maximum, and invisible
   to the existing safety lint (which scans `src/adapters` only, for a different pattern).

## API contract impact

**None.** No route added, removed or changed; `tests/fixtures/api_routes.txt` untouched; no request
or response payload changes shape. New metadata reaches surfaces only through fields that already
exist on `NowPlaying`/`TrackMetadata`; new internal fields on `HqpStatus` are `#[serde(skip)]`,
following the precedent already set there for `title`/`artist`/`album`.

One acceptance criterion is **blocked** by that constraint rather than silently worked around — see
the Known limitations section of the session record for the exact additive change URI publication
would need, and why it was not made.

## Verification

Hermetic only — the live HQPlayer host was not touched from this branch. Wire/model fixtures from
the existing `tests/mock_servers/hqplayer` harness. Full gate transcript in the Execute-checkpoint
and Review comments below.
