### PR TITLE
Adaptive control: one producer model, surface-appropriate projections (#331)

### DIFF
--- a/.oh/adaptive-control-plane.md
+++ b/.oh/adaptive-control-plane.md
@@ -207,10 +207,35 @@ knob, which is the acceptance criterion the issue actually turns on.
 
 ### TDD evidence — RED before GREEN
 
-`tests/adaptive_control_plane.rs` was written first, against a deliberately naive stub
-(`src/producers/surface.rs` returning an empty projection and `control_plane.rs` routing by
-first-match). The RED transcript is recorded in the Execute PR comment and reproduced in
-"Verification" below.
+`tests/adaptive_control_plane.rs` was written first, against a deliberately naive stub:
+`surface.rs` returned an empty projection and `control_plane.rs::route` returned the *first*
+admitted snapshot — the fallthrough this issue exists to remove, written down so a test could kill
+it.
+
+```
+$ cargo test --all-features --test adaptive_control_plane
+test result: FAILED. 8 passed; 31 failed; 0 ignored
+```
+
+Two of the RED failures are the ones worth citing, because they are the issue's hard constraints
+failing exactly as predicted:
+
+```
+two_producers_claiming_one_zone_refuse_rather_than_pick
+  picking one silently is how a command lands on the wrong role:
+  Ok(ProducerKey { producer_id: "hqplayer:living-room", role: Playback, ... })
+
+a_producer_family_with_no_executor_is_refused_not_defaulted
+  expected a refusal naming the family, got Err(ServiceClosed)
+```
+
+Of the 8 that passed at RED, 6 passed vacuously over an empty control list (`no_two_surfaces_…`,
+`a_surface_that_offers_less_…`, `every_control_in_one_projection_…`,
+`a_verified_product_version_…`, `an_older_projection_…`, `routing_reads_only_admitted_state`) and 2
+were genuine (`a_projection_carries_exactly_one_producer_position`,
+`every_apply_effect_has_its_own_timing_key`). All 6 became non-vacuous at GREEN.
+
+GREEN: **44 passed, 0 failed**, plus 2 new unit tests in the HQPlayer command service.
 
 ### What landed
 
@@ -227,6 +252,28 @@ first-match). The RED transcript is recorded in the Execute PR comment and repro
 | Version fallback | An unsupported major yields `SurfaceProjection::Fallback` carrying the legible identity and the refusal. An untested *product* version yields a notice and keeps every discovered control. A newer minor yields `UnknownAdditions` and renders. |
 | `ControlPlaneService::route()` | Resolves a prefixed zone id to a `ProducerKey` from admitted state only. An unknown `hqplayer:` identity returns `RouteRefusal::UnknownProducer`; it can never resolve to another family's key. |
 | `ControlPlaneService::submit()` | Surface-neutral semantic command → routed producer → #375's registry → #329's actor. A producer family with no registered executor is refused, not defaulted. |
+
+### What the review pass changed
+
+Three defects in my own first cut, all of the same shape — a decision that looked deterministic and
+was not, or a field that promised something it did not deliver:
+
+| Finding | Fix |
+|---|---|
+| Two outstanding writes invalidating one enumeration picked whichever came first in `operations`, a `Vec` order the producer never promised | `Invalidation::of` sorts by operation id first — the same reasoning #324 used when it refused to keep "the first" C2 claimant |
+| `narrow()` ended with a `truncate` that could never fire, so the retention rule read as if it had a bound it did not | rewritten as membership-then-position over a `BTreeSet`; the budget is deliberately exceeded when a control holds more selections than the surface asked for, and that is now stated |
+| `SurfaceCapabilities::reason_text` was declared, documented, and read by nothing | removed. A capability that changes no projection is a promise to a future reader that this layer honours something it does not |
+
+### What the dissent pass changed
+
+Four more, and the first two are the ones that would have shipped a false claim:
+
+| Finding | Fix |
+|---|---|
+| `every_operation_mcp_may_invoke_is_fully_described_without_guessing` asserted `timing_key != unknown`, but nothing enforced it: an `ApplyEffect` from a newer minor would be advertised as invokable with `apply.timing.unknown` — a tool description that is an admission rather than a description | unrecognized `lane`/`effect`/`disruption` now withhold mutation under `WITHHELD_UNDESCRIBABLE_APPLY`, with a test |
+| `SurfaceProjection` had a `Fallback` arm nothing could construct: an admitted snapshot cannot carry an unsupported major, because `admit_document` refused it upstream. An enum modelling a union that only exists on a wire nobody has approved yet | removed. `project` returns `RenderedProjection`; `admit_for_surface` returns the fallback as its error. The proposed HTTP contract below describes the union honestly, without an in-tree type that lies about being reachable |
+| `SurfaceProfile::mcp()` capped risk at `Caution`, which would have silently removed a capability `hifi_hqplayer_set_pipeline` ships today (mode is `playback_interruption`) the moment MCP adopted the profile | ceiling raised to `Disruptive`, `Destructive` still excluded, and the decision is pinned by `mcp_keeps_the_capability_the_shipped_tool_already_has` |
+| A bounded surface could not disclose staged edits it was not shown, which is exactly the case the issue's immediate-tuning criterion names | `RenderedProjection::staged_elsewhere`, disclosure only — it never applies, discards or blocks |
 
 ### Drift check
 
@@ -278,6 +325,9 @@ request type. Notes that matter for the approval decision:
 
 1. **No surface consumes this yet.** Web rendering, MCP discovery/execution and device manifests all
    require the contract above. The layer is complete and tested; the last hop is an approval.
+   Concretely: `ControlPlaneService` is constructed by nothing in `src/main.rs`, because the only
+   place it could be held is `AppState`, which lives in `src/api/` and may not name
+   `crate::producers`.
 2. **ESP32 manifests are doubly blocked.** Beyond the API freeze, #326 (matcher-to-manifest
    composition) does not exist on this branch. The `device` profile and its bounded, priority-ordered
    projection are delivered and tested, but there is no manifest composer to feed.
@@ -291,14 +341,44 @@ request type. Notes that matter for the approval decision:
 5. **Continuous-control interaction rules are not implemented.** Transient drag state, coalesced
    pointer intent and latest-wins settlement are surface-side behaviours; the projector supplies the
    range, step, unit and reset provenance they need, and #342/#329 own the interaction itself.
-6. **`SurfaceProjection` is not itself version-negotiated across processes.** It carries a `schema`
-   field and a compatibility rule, but with no out-of-process consumer the rule has never been
-   exercised against a real mismatch.
+6. **`RenderedProjection` is not itself version-negotiated across processes.** It carries a `schema`
+   field, but with no out-of-process consumer the compatibility rule has never been exercised
+   against a real mismatch.
 7. **No live validation.** Hermetic fixtures only, as instructed. #375 already records that the
    6.0.2 rig is in an About-only Trial state that prevents native/config observation.
+8. **The routing rule is a second router, not the one in the live path.** #328 already fixed the
+   `hqplayer:`-falls-through-to-Roon defect in `src/knobs/routes.rs`. `ControlPlaneService::route`
+   governs the *producer-addressed* path a future surface would use, so the acceptance criterion
+   "no route defaults unknown HQPlayer identity to Roon" is now satisfied twice rather than once
+   here.
+9. **Projection tests construct `ProducerSnapshot` directly.** Its fields are `pub`, so the pure
+   projection tests exercise only the contract-layer `admit_document`, not #324's admission gate.
+   The routing and command tests do go through the real gate. The gap is narrow — canonical fixtures
+   pass both — but `snapshot.repairs` has no coverage from a demotion the aggregator actually
+   performed, so `ProjectionNotice::IntentRepaired` is reachable in code and unproven end to end.
 
 ---
 
 ## Verification
 
-Recorded at the exact head in the Execute PR comment.
+**Updated:** 2026-07-31 · exact head recorded in the Execute PR comment.
+
+| Gate | Result |
+|---|---|
+| `cargo test --all-features --test adaptive_control_plane` | 44 passed, 0 failed |
+| `cargo test --all-features --lib producers::hqplayer_command_service` | 16 passed, 0 failed (2 new) |
+| `cargo test --all-features --test adaptive_publication_lint` | 57 passed — the surface boundary holds |
+| `cargo test --all-features --test architecture_lint` | 9 passed |
+| `cargo test --all-features --test api_contract` | 2 passed; route fixture unchanged |
+| `cargo test --all-features --test adaptive_dependency_lint` / `aggregator_lint` | 7 / 2 passed |
+| `cargo test --all-features --no-fail-fast` (whole suite) | **1296 passed, 0 failed, 13 ignored** (environment-gated) |
+| `cargo fmt --all -- --check` | clean |
+| `cargo clippy --lib --all-features -- -D warnings` | clean |
+| `cargo check --release --all-features` | clean |
+| `dx build --release --platform web --features web` | recorded in the Execute comment |
+
+**Drift, verified rather than asserted.** Against the base `212f555` the only files touched are
+`.oh/adaptive-control-plane.md`, `src/producers/{surface,control_plane,mod,hqplayer,hqplayer_command_service}.rs`
+and `tests/adaptive_control_plane.rs`. `src/api/`, `src/mcp/`, `src/app/`, `src/knobs/`, `src/mqtt/`
+and `src/main.rs` are untouched. `tests/fixtures/api_routes.txt` is byte-identical to `origin/v3`.
+`src/main.rs` carries 88 `.route(` lines on the base and 88 here. No label applied to the PR.

--- a/.oh/adaptive-control-plane.md
+++ b/.oh/adaptive-control-plane.md
@@ -1,0 +1,304 @@
+# Adaptive control plane: one producer model, surface-appropriate projections (#331)
+
+**OH:** 80222d6d · **Issue:** [#331](https://github.com/open-horizon-labs/unified-hifi-control/issues/331) ·
+**Parent epic:** #313 · **Base branch:** `feat/issue-328-direct-hqplayer-zone` at `212f555`
+
+### Inputs read before choosing an approach
+
+* [`.oh/adaptive-interaction-plane.md`](../../unified-hifi-control/.oh/adaptive-interaction-plane.md)
+  — the **program session** for epic #313. It is not tracked on this branch; it lives in the main
+  checkout and `.oh/adaptive-producer-contract.md:5` names it "read-only for this session". Read
+  there. Its Option D (unified adaptive interaction plane) is the direction this issue implements,
+  and its implementation note 4 is the sentence #331 is judged against: *"Project all advertised
+  capabilities into web, HTTP, device UI, and MCP through one semantic execution path;
+  surface-specific subsets are allowed, contradictory semantics are not."*
+* [`.oh/adaptive-producer-contract.md`](adaptive-producer-contract.md) (#323) — the v1 document,
+  five value lanes, fifteen-plus command outcomes, reason-carrying availability, two revisions.
+* [`.oh/adaptive-publication.md`](adaptive-publication.md) (#324) — the admission gate, the
+  actor-owned aggregator, `AdaptiveView`, and **the boundary lint that governs this issue's shape**
+  (`tests/adaptive_publication_lint.rs`, boundary 2: no file under `src/` other than
+  `src/adaptive/`, `src/producers/`, `src/lib.rs` and `src/main.rs` may name `crate::adaptive` or
+  `crate::producers`).
+* [`.oh/issue-375-hqplayer-adaptive-producer.md`](issue-375-hqplayer-adaptive-producer.md) (#375) —
+  the first truthful producer, and its explicit hand-off: *"The generic command preflight, typed
+  attempt receipts, and public consumer dispatch remain in #331. That issue must consume the
+  registry added here rather than create a second control-to-operation mapping."*
+* [`.oh/issue-329-hqplayer-immediate-command.md`](issue-329-hqplayer-immediate-command.md) (#329) —
+  `HqpImmediateCommandActor`, whose `Submit` variant carries
+  `// The first public consumer lands in #331`.
+* [`.oh/hqplayer-direct-zone.md`](hqplayer-direct-zone.md) (#328) — the immediate base, and the
+  source of the "no unknown HQPlayer identity falls through to Roon" defect class.
+* `AGENTS.md`, `docs/ARCHITECTURE.md`, `tests/architecture_lint.rs`, `tests/api_contract.rs`,
+  `tests/fixtures/adaptive/*.json`, and the five #331 issue comments recording the HQPTuner audits.
+
+---
+
+## Aim
+
+A control that exists once in the producer document appears — or is honestly withheld — the same
+way everywhere. The web page, an MCP client and a knob read the *same* advertised id, the same
+option set, the same constraint, the same reason for unavailability, and the same apply cost; when
+one of them acts, all three follow one correlation id to one observed result.
+
+The behaviour change to look for: adding an HQPlayer control stops meaning "and now write it three
+more times", and a user stops discovering that the web page offers something the MCP tool denies.
+
+Not the aim: an identical UI on every device, a producer that knows what a knob looks like, or
+parity manufactured where the engine has none.
+
+---
+
+## Problem Statement
+
+**Reframed (from the issue):** users need consistent capabilities and outcomes across surfaces, but
+bespoke integrations cause each surface to advertise different choices, routing, constraints and
+success semantics.
+
+**The shift:** from feature parity by duplicated code to *surface-appropriate projections of one
+aggregator-owned producer document and one command execution path*.
+
+### What the code actually does today, read before choosing
+
+| # | Fact | Location |
+|---|------|----------|
+| 1 | MCP's HQPlayer write tool calls the **adapter** directly — `self.state.hqplayer.set_mode(...)` — bypassing the aggregator, the admitted document, preflight, correlation and outcome recording entirely. | `src/mcp/mod.rs:600-611` |
+| 2 | The web HQPlayer page fetches `/hqp/*` JSON and renders hand-wired dropdowns whose option lists come from the legacy `PipelineStatus` projection, not from a producer document. | `src/app/pages/hqplayer.rs`, `src/app/components/hqp_controls.rs` |
+| 3 | There is **no device manifest surface at all** on this branch. #326 (matcher-to-manifest composition) is unstarted, so the ESP32 criterion has no composition layer to project into. | absent |
+| 4 | `AdaptiveView` — the only legal read path — is *moved* into `HqpImmediateCommandActor::build` at the composition root and is held by nothing else. | `src/main.rs:221-240` |
+| 5 | `HqpImmediateCommandHandle::submit` and `HqpCommandServiceRefusal::ServiceClosed` are `#[cfg_attr(not(test), allow(dead_code))]`, waiting for this issue. | `src/producers/hqplayer_command_service.rs:47,148,166` |
+| 6 | `hqp_semantic_operation_registry()` is the single 11-entry control-id → semantic-operation bijection, and `preflight()` is a complete pure admission check over a snapshot. | `src/producers/hqplayer.rs:100-160`, `src/producers/hqplayer_command.rs` |
+
+### The constraint that decides this issue's shape
+
+`tests/adaptive_publication_lint.rs::lint_only_the_composition_root_names_the_contract_or_the_publication_layer`
+sweeps **all** of `src/` and forbids every file outside `src/adaptive/`, `src/producers/`,
+`src/lib.rs` and `src/main.rs` from naming `crate::adaptive` or `crate::producers`. That lint is
+#324's mechanical form of the API freeze: `ProducerDocument` derives `Serialize`, so one
+`Json(snapshot)` in `src/api/` re-exports the whole v1 contract outside this repository.
+
+The consequence is not a detail, it is the boundary of this issue:
+
+* `src/api/`, `src/mcp/`, `src/app/`, `src/knobs/`, `src/mqtt/` **cannot legally see a projection**
+  today.
+* The Dioxus web client is SSR + WASM and reads its data over HTTP (`src/app/api.rs:306`), so even
+  ignoring the lint, a producer-driven web page needs a route.
+* Therefore **every surface hop in #331's acceptance criteria is gated behind exactly one API
+  approval**, and the issue's `protocol:additive` label is not that approval.
+
+What remains, and is delivered here, is the whole of the part that does not need it: the one
+projection model, the one command execution path, the routing rule, and the contract tests that
+falsify drift between the projections the surfaces will consume.
+
+### Constraints treated as real
+
+* **Hard.** No new/changed HTTP route, request or response schema; no MCP tool or schema change;
+  `tests/fixtures/api_routes.txt` untouched; `api-change-approved` never self-applied.
+* **Hard.** All command execution stays aggregator/application-service owned. No surface reaches an
+  adapter. No unknown HQPlayer identity may fall through to Roon or any other adapter.
+* **Hard.** Clients use semantic ids and values; no adapter internals, no native indices, no
+  backend prose.
+* **Hard.** One control-to-operation mapping — #375's registry — never a second.
+* **Hard.** Hermetic fixtures only. The live HQPlayer host is not contacted.
+* **Soft.** MCP tool granularity, web grouping, which device screens ship first, exact fallback UX.
+
+---
+
+## Solution Space
+
+**Updated:** 2026-07-31
+
+**Problem:** three surfaces need consistent, surface-appropriate views of one producer document and
+one command path, while no surface is currently permitted to see the document at all.
+
+### Candidates Considered
+
+| Option | Level | Approach | Trade-off |
+|--------|-------|----------|-----------|
+| A | Band-Aid | Each surface consumes `ProducerDocument` directly; the contract types are already `pub`. | Zero new model; three renderers reproduce lane resolution, availability, budget and truncation independently — the drift this issue exists to remove — and it is illegal under boundary 2. |
+| B | Local Optimum | One projector with a `SurfaceKind { Web, Mcp, Device }` enum and a `match` per behaviour. | One code path, but surface knowledge moves *into* the producer layer; every new client is a new arm in the core, and a device that can render per-choice reasons is indistinguishable from one that cannot. |
+| C | Reframe | **Capability-declared `SurfaceProfile` + one pure projector owned by `src/producers/`, emitting a closed `SurfaceProjection`; one `ControlPlaneService` owns routing and command submission.** | One more model layer, and profiles must be honest about what they can render. Surfaces become data, not code. |
+| D | Redesign | Server-authored screens/widgets per surface (the v4 manifest approach). | Pixels become the domain model; explicitly excluded by the interaction plane's "what this framing excludes". |
+| E | Reframe | Producers emit per-surface document variants. | Pushes surface knowledge into every adapter, N×M, and destroys producer neutrality — the exact coupling #312/#313 exist to remove. |
+
+### Evaluation
+
+**A — surfaces read the document.**
+Solves stated problem: no. Cost: low. Burden: high.
+Second-order: the failure is not hypothetical. Lane resolution alone has five lanes plus an
+editor-effective projection; `EffectiveView` exists in the contract precisely because #323 judged
+per-surface resolution unsafe. Truncation for a device, per-choice availability, and "which reason
+do I show" would each be re-decided three times. Also disqualified mechanically: boundary 2 fails
+the moment `src/mcp/mod.rs` names `crate::adaptive`. Rejected.
+
+**B — surface-kind enum inside the projector.**
+Solves stated problem: partially. Cost: low-medium. Burden: medium-high.
+Second-order: it works until the second device class. The interaction plane's hard constraint is
+*"Device resources and peripherals vary … Negotiate capabilities; do not infer from board names"* —
+a `SurfaceKind` enum is a board name. The HQPTuner renderer audit on this issue makes the same point
+from the other end: the mismatch it found was a *widget capability* mismatch (segmented controls
+cannot express per-choice disabled-with-reason), not a device-class mismatch. Rejected, but its
+single-code-path instinct is exactly right and is what C keeps.
+
+**C — capability-declared profiles, one pure projector, one command service.**
+Solves stated problem: yes. Cost: medium. Burden: low.
+Second-order: the profile is *data*, so a new surface is a new profile literal, and "can this
+surface express what the producer advertised?" becomes a checkable question rather than an
+assumption. Because the projector is pure over `(ProducerSnapshot, SurfaceProfile)`, cross-surface
+drift becomes a property two projections of one fixture either have or do not — i.e. a test rather
+than a review comment. Costs: one more layer between document and pixel, and a dishonest profile
+produces a dishonest projection (mitigated: capability loss is *declared* in the projection, never
+silent). Selected.
+
+**D — server-authored screens.**
+Solves stated problem: superficially, then worse. Cost: high. Burden: high.
+Second-order: it is the v4 approach the program session already evaluated and rejected — *"Do not
+port pixels as the domain contract"*. It also makes every layout change a server release and leaves
+MCP, which has no pixels, outside the model. Rejected.
+
+**E — per-surface producer documents.**
+Solves stated problem: no. Cost: high. Burden: very high.
+Second-order: every adapter would need to know every client class; adding a knob variant would
+touch HQPlayer. It also breaks #324's single-admission-gate property, because "the document" stops
+being one object. Rejected.
+
+### Recommendation
+
+**Selected:** Option C — capability-declared surface profiles over one aggregator-owned projector
+and one command service.
+**Level:** Reframe.
+
+**Rationale.** The reframe is *what a surface is*. Read as a class of device, a surface is code and
+every one of them is a fork. Read as a **declaration of what it can faithfully render and how much
+of it**, a surface is data, and the projector's job becomes a single question asked uniformly: can
+this profile express what the producer advertised, and if not, what must be said out loud? That
+question is answerable, testable, and — crucially — produces the same answer for the web, MCP and a
+knob, which is the acceptance criterion the issue actually turns on.
+
+**Accepted trade-offs.**
+* One more model between document and pixel. Justified because the alternative is three.
+* Capability loss is handled by *declaration*, not by silent substitution: a control a surface
+  cannot render faithfully is withheld with a reason, and a truncated list reports what it dropped.
+  Surfaces get less, never something untrue.
+* Priority for a bounded device (transport/volume/metadata first) is **profile policy**, expressed
+  as a list of group ids the profile ranks. The projector holds no HQPlayer-specific knowledge.
+* The delivered layer has **no production consumer** until the API contract below is approved. It is
+  exercised by contract tests against canonical fixtures. This is stated as a limitation rather than
+  disguised by wiring something into `main.rs` that nothing reads.
+
+### Implementation Notes
+
+1. `src/producers/surface.rs` — pure projection. No tokio, no locks, no clock, no adapter, no
+   `crate::api`. `project(&ProducerSnapshot, &SurfaceProfile) -> SurfaceProjection`.
+2. `src/producers/control_plane.rs` — the application service over `AdaptiveView`: capability
+   routing, projection, and command submission delegated to #329's actor via #375's registry.
+3. Both live under `src/producers/` because boundary 2 exempts exactly `src/adaptive/` and
+   `src/producers/`. Widening `EXEMPT_DIRS` would weaken the lint that encodes the API freeze; it is
+   not touched.
+4. Contract tests in `tests/adaptive_control_plane.rs`, driven by the canonical `#323/#324`
+   fixtures, comparing web / MCP / device projections of **the same** fixture.
+5. No route changes. `tests/fixtures/api_routes.txt` untouched; no label applied.
+
+---
+
+## Execute
+
+**Updated:** 2026-07-31
+**Status:** complete
+
+### TDD evidence — RED before GREEN
+
+`tests/adaptive_control_plane.rs` was written first, against a deliberately naive stub
+(`src/producers/surface.rs` returning an empty projection and `control_plane.rs` routing by
+first-match). The RED transcript is recorded in the Execute PR comment and reproduced in
+"Verification" below.
+
+### What landed
+
+| Unit | Behaviour |
+|---|---|
+| `SurfaceProfile` / `SurfaceCapabilities` / `SurfaceBudget` | A surface declares which control kinds it can render, whether it can show per-choice availability reasons and reason text, the highest risk class it may advertise as invokable, its control/choice budgets and its group priority. Nothing is inferred from a device name. |
+| `project()` | One pure function. Same snapshot in, surface-appropriate projection out, one `RevisionRef` stamped on the whole result so no consumer can mix two revisions. |
+| Lane separation | `observed` is projected separately from `editor_effective`, `desired`, `held` and `persisted`. The observed lane never carries staged intent. |
+| Capability honesty | A control whose kind the profile cannot render, or whose per-choice availability the profile cannot express, is `Withheld` with a `Reason` — never silently flattened. |
+| Declared truncation | Budget overflow produces `omitted: Vec<OmittedControl>` carrying the id and the reason. A projection never silently claims completeness. |
+| Dependency invalidation | A non-terminal operation on a control whose `apply.invalidates` names `Y` puts `Y`'s choices in `Reloading { invalidated_by, operation }` and **withholds the stale list**. |
+| Unknown ≠ empty | `ChoiceProjection::Unknown { reason }` is distinct from an enumerated set that happens to be empty. |
+| Operation scoping | Pending markers are per `(control, operation_id)`; one control's completion cannot clear another's. |
+| Version fallback | An unsupported major yields `SurfaceProjection::Fallback` carrying the legible identity and the refusal. An untested *product* version yields a notice and keeps every discovered control. A newer minor yields `UnknownAdditions` and renders. |
+| `ControlPlaneService::route()` | Resolves a prefixed zone id to a `ProducerKey` from admitted state only. An unknown `hqplayer:` identity returns `RouteRefusal::UnknownProducer`; it can never resolve to another family's key. |
+| `ControlPlaneService::submit()` | Surface-neutral semantic command → routed producer → #375's registry → #329's actor. A producer family with no registered executor is refused, not defaulted. |
+
+### Drift check
+
+* Original scope: surfaces consume projections of one producer model over one command path.
+* Current work: the projection model, the command path, the routing rule, and their falsification
+  tests. No surface wired.
+* Gap: the three surface-rendering acceptance criteria and the ESP32 criterion. Cause: the API
+  freeze (and, for ESP32, #326 is unstarted). Reported, not worked around.
+* Verdict: aligned, and deliberately short of the issue's full acceptance set.
+
+---
+
+## API impact
+
+**None.** `tests/fixtures/api_routes.txt` is byte-identical to `origin/v3`. No `.route(` line added
+or removed. `src/api/`, `src/mcp/`, `src/app/`, `src/knobs/` and `src/mqtt/` are untouched. No label
+applied to the PR.
+
+### The smallest exact contract that would unblock the surface criteria
+
+Submitted for explicit approval; **not implemented on this branch**.
+
+```
+GET  /adaptive/producers                     -> { producers: [ProducerRef] }
+GET  /adaptive/projection?producer=<id>&role=<role>&zone=<zone>&surface=<profile-id>
+                                             -> SurfaceProjection
+POST /adaptive/command                       -> CommandAcknowledgement
+       { producer, role, zone?, surface, control, value, lane, correlation_id,
+         expected: { epoch, control_plane, state } }
+```
+
+Three routes, one new response type (`SurfaceProjection`, already defined and tested here), one new
+request type. Notes that matter for the approval decision:
+
+* `GET /adaptive/projection` returns the **projection**, never `ProducerDocument`. The v1 contract
+  stays inside the repository; what leaves is the surface-shaped view, which is versioned by
+  `SurfaceProjection.schema` independently of the producer contract.
+* `POST /adaptive/command` carries `expected` (epoch + both revisions), so #329's revision fence
+  applies to every surface identically, and `correlation_id`, so a retried tap is one operation.
+* `tests/adaptive_publication_lint.rs::lint_publication_layer_adds_no_routes` currently forbids the
+  strings `/adaptive` and `/producer` in `api_routes.txt`. Approving these routes means amending
+  that lint deliberately, in the same change, with a rationale — not deleting it.
+* Nothing else needs to change: MCP tools would call the same `ControlPlaneService` in-process once
+  the boundary-2 exemption is widened to name it, which is a smaller and separately reviewable step.
+
+---
+
+## Limitations
+
+1. **No surface consumes this yet.** Web rendering, MCP discovery/execution and device manifests all
+   require the contract above. The layer is complete and tested; the last hop is an approval.
+2. **ESP32 manifests are doubly blocked.** Beyond the API freeze, #326 (matcher-to-manifest
+   composition) does not exist on this branch. The `device` profile and its bounded, priority-ordered
+   projection are delivered and tested, but there is no manifest composer to feed.
+3. **One producer family has an executor.** `submit()` routes HQPlayer to #329's actor. Roon, LMS,
+   OpenHome and UPnP publish no producer documents yet, so they are refused with
+   `NoExecutorForProducer` rather than defaulted — correct, but it means "all surfaces use the same
+   command path" is currently true of one family.
+4. **Catalog text is keys only.** `label_key` / `description_key` / `display_text_key` pass through
+   unresolved. #343 owns the provenance-governed catalog; resolving keys here would have invented
+   the provenance rules that issue exists to decide.
+5. **Continuous-control interaction rules are not implemented.** Transient drag state, coalesced
+   pointer intent and latest-wins settlement are surface-side behaviours; the projector supplies the
+   range, step, unit and reset provenance they need, and #342/#329 own the interaction itself.
+6. **`SurfaceProjection` is not itself version-negotiated across processes.** It carries a `schema`
+   field and a compatibility rule, but with no out-of-process consumer the rule has never been
+   exercised against a real mismatch.
+7. **No live validation.** Hermetic fixtures only, as instructed. #375 already records that the
+   6.0.2 rig is in an About-only Trial state that prevents native/config observation.
+
+---
+
+## Verification
+
+Recorded at the exact head in the Execute PR comment.

--- a/src/producers/control_plane.rs
+++ b/src/producers/control_plane.rs
@@ -31,7 +31,7 @@ use async_trait::async_trait;
 use crate::adaptive::{ApplyLane, ControlId, ControlValue, OperationRecord, RevisionRef};
 use crate::bus::events::PrefixedZoneId;
 
-use super::surface::{project_with, SurfaceProfile, SurfaceProjection, VerifiedSeries};
+use super::surface::{project_with, RenderedProjection, SurfaceProfile, VerifiedSeries};
 use super::{AdaptiveView, ProducerKey, ProducerSnapshot};
 
 /// Why a zone id did not resolve to a producer.
@@ -229,7 +229,7 @@ impl ControlPlaneService {
         &self,
         key: &ProducerKey,
         profile: &SurfaceProfile,
-    ) -> Option<SurfaceProjection> {
+    ) -> Option<RenderedProjection> {
         self.view
             .snapshot(key)
             .map(|snapshot| project_with(&snapshot, profile, &self.verified))

--- a/src/producers/control_plane.rs
+++ b/src/producers/control_plane.rs
@@ -1,0 +1,213 @@
+//! The one application service every surface goes through (#331).
+//!
+//! Three jobs, and the reason they are one type is that separating them is what lets them disagree:
+//!
+//! 1. **Routing.** A prefixed zone id resolves to a [`ProducerKey`] *only* from admitted aggregator
+//!    state. There is no fallthrough arm. #328 records what a fallthrough costs: `hqplayer:Living
+//!    Room` reached the Roon adapter with its prefix stripped, where it either failed or matched an
+//!    unrelated Roon zone.
+//! 2. **Projection.** [`super::surface::project`] over the snapshot the aggregator serves, for the
+//!    profile the surface declared.
+//! 3. **Submission.** A surface-neutral semantic command, executed by the registered executor for
+//!    the routed producer's family — HQPlayer's being #329's bounded actor, reached through #375's
+//!    single control-to-operation registry. A family with no executor is refused, never defaulted.
+//!
+//! ## Why the surface never sees the internals
+//!
+//! [`SemanticRefusal`] is a public, surface-neutral vocabulary. The HQPlayer preflight has
+//! twenty-odd typed refusals naming lanes, chains and rate spellings; a browser and an MCP client
+//! need to know *what to do next*, and the answer is one of ten things. The mapping is an
+//! exhaustive `match`, so a new internal refusal cannot silently become an existing surface verdict.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::adaptive::{ApplyLane, ControlId, ControlValue, RevisionRef};
+use crate::bus::events::PrefixedZoneId;
+
+use super::surface::{project, SurfaceProfile, SurfaceProjection};
+use super::{AdaptiveView, ProducerKey, ProducerSnapshot};
+
+/// Why a zone id did not resolve to a producer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RouteRefusal {
+    /// The string carries no recognized zone prefix.
+    UnknownZonePrefix {
+        /// The id the surface supplied.
+        zone_id: String,
+    },
+    /// No admitted producer is bound to that zone.
+    ///
+    /// The refusal a fallthrough would have hidden. An unknown `hqplayer:` identity ends here.
+    UnknownProducer {
+        /// The id the surface supplied.
+        zone_id: String,
+    },
+    /// More than one admitted producer claims that zone, so the surface must name a role.
+    AmbiguousProducer {
+        /// The id the surface supplied.
+        zone_id: String,
+        /// Every producer claiming it.
+        candidates: Vec<ProducerKey>,
+    },
+}
+
+/// A surface-neutral reason a semantic command was not admitted.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SemanticRefusal {
+    /// The correlation id is empty or too long to retain.
+    CorrelationUnusable,
+    /// The addressed producer is not the one the aggregator holds.
+    ProducerMismatch,
+    /// The caller's position is not current. Re-read the projection and retry.
+    PositionStale {
+        /// The position the caller cited.
+        expected: RevisionRef,
+        /// The position the aggregator serves.
+        actual: RevisionRef,
+    },
+    /// The producer is last-known, or declares itself stale. Last-known data is not a write target.
+    ProducerNotWritable,
+    /// The transport lane that would carry the write is missing, down or too stale to mutate from.
+    LaneUnusable,
+    /// The control is unknown to the exact document, read-only, or not available for mutation.
+    ControlNotWritable,
+    /// The request contradicts the descriptor: wrong apply lane, wrong kind, wrong value shape.
+    RequestMismatch,
+    /// The value is not a currently selectable, sendable choice.
+    ValueNotSelectable,
+    /// The control has no verified semantic operation yet, so no truthful receipt is possible.
+    NoVerifiedOperation,
+    /// The coordinator would not reserve the operation: a conflicting correlation, a superseding
+    /// operation, or a closed producer.
+    NotReserved,
+}
+
+/// Why a command did not reach an executor, or was not admitted by one.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CommandRefusal {
+    /// The zone did not resolve.
+    Route(RouteRefusal),
+    /// The routed producer's family has no registered semantic executor.
+    ///
+    /// The alternative — trying the executor we happen to have — is the #328 defect with a
+    /// different prefix.
+    NoExecutorForProducer {
+        /// The family that has none.
+        producer_type: String,
+    },
+    /// The executor refused before writing anything.
+    Refused(SemanticRefusal),
+    /// The executor is shutting down and accepted nothing.
+    ServiceClosed,
+}
+
+/// One surface's proposed semantic mutation, in producer terms only.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SemanticCommand {
+    /// The producer to address.
+    pub key: ProducerKey,
+    /// The position the surface projected. The executor fences against it.
+    pub expected: RevisionRef,
+    /// The semantic control.
+    pub control: ControlId,
+    /// The semantic value. Never a native index.
+    pub requested: ControlValue,
+    /// The apply lane the descriptor declared.
+    pub lane: ApplyLane,
+    /// Idempotency correlation, shared by every surface following this operation.
+    pub correlation_id: String,
+    /// Which surface submitted it.
+    pub surface_id: String,
+}
+
+/// An admitted command, before its outcome converges.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CommandAcceptance {
+    /// The operation the producer will report against.
+    pub operation: crate::adaptive::OperationRecord,
+    /// True when this correlation matched an operation already reserved: a retry, not a new write.
+    pub duplicate: bool,
+}
+
+/// Executes semantic commands for one producer family.
+#[async_trait]
+pub trait SemanticCommandExecutor: Send + Sync {
+    /// The `producer_type` this executor owns.
+    fn producer_type(&self) -> &str;
+
+    /// Submit one command.
+    async fn submit(&self, command: SemanticCommand) -> Result<CommandAcceptance, CommandRefusal>;
+}
+
+/// The single surface-facing entry point to aggregator-owned producer state.
+#[derive(Clone)]
+pub struct ControlPlaneService {
+    view: AdaptiveView,
+    executors: BTreeMap<String, Arc<dyn SemanticCommandExecutor>>,
+}
+
+impl ControlPlaneService {
+    /// Build a service over the aggregator's read-only view.
+    pub fn new(view: AdaptiveView) -> Self {
+        Self {
+            view,
+            executors: BTreeMap::new(),
+        }
+    }
+
+    /// Register the executor for one producer family.
+    pub fn with_executor(mut self, executor: Arc<dyn SemanticCommandExecutor>) -> Self {
+        self.executors
+            .insert(executor.producer_type().to_string(), executor);
+        self
+    }
+
+    /// Every producer the aggregator currently holds.
+    pub fn producers(&self) -> Vec<ProducerKey> {
+        // RED stub.
+        Vec::new()
+    }
+
+    /// Resolve a prefixed zone id to the producer bound to it.
+    pub fn route(&self, zone_id: &str) -> Result<ProducerKey, RouteRefusal> {
+        // RED stub: the naive first-match a fallthrough would have written.
+        let _ = zone_id;
+        self.view
+            .snapshots()
+            .first()
+            .map(|snapshot| snapshot.key.clone())
+            .ok_or_else(|| RouteRefusal::UnknownProducer {
+                zone_id: zone_id.to_string(),
+            })
+    }
+
+    /// The aggregator's snapshot for one producer.
+    pub fn snapshot(&self, key: &ProducerKey) -> Option<ProducerSnapshot> {
+        self.view.snapshot(key)
+    }
+
+    /// Project one producer for one surface.
+    pub fn project(&self, key: &ProducerKey, profile: &SurfaceProfile) -> Option<SurfaceProjection> {
+        self.view
+            .snapshot(key)
+            .map(|snapshot| project(&snapshot, profile))
+    }
+
+    /// Submit one semantic command through the executor that owns the routed producer's family.
+    pub async fn submit(
+        &self,
+        command: SemanticCommand,
+    ) -> Result<CommandAcceptance, CommandRefusal> {
+        // RED stub.
+        let _ = &command;
+        Err(CommandRefusal::ServiceClosed)
+    }
+}
+
+#[allow(dead_code)]
+fn stub_unused(zone_id: &str) -> Option<PrefixedZoneId> {
+    PrefixedZoneId::parse(zone_id)
+}

--- a/src/producers/control_plane.rs
+++ b/src/producers/control_plane.rs
@@ -6,28 +6,32 @@
 //!    state. There is no fallthrough arm. #328 records what a fallthrough costs: `hqplayer:Living
 //!    Room` reached the Roon adapter with its prefix stripped, where it either failed or matched an
 //!    unrelated Roon zone.
-//! 2. **Projection.** [`super::surface::project`] over the snapshot the aggregator serves, for the
-//!    profile the surface declared.
+//! 2. **Projection.** [`super::surface::project_with`] over the snapshot the aggregator serves, for
+//!    the profile the surface declared.
 //! 3. **Submission.** A surface-neutral semantic command, executed by the registered executor for
-//!    the routed producer's family — HQPlayer's being #329's bounded actor, reached through #375's
-//!    single control-to-operation registry. A family with no executor is refused, never defaulted.
+//!    the routed producer's family. A family with no executor is refused, never defaulted.
 //!
 //! ## Why the surface never sees the internals
 //!
-//! [`SemanticRefusal`] is a public, surface-neutral vocabulary. The HQPlayer preflight has
-//! twenty-odd typed refusals naming lanes, chains and rate spellings; a browser and an MCP client
-//! need to know *what to do next*, and the answer is one of ten things. The mapping is an
-//! exhaustive `match`, so a new internal refusal cannot silently become an existing surface verdict.
+//! [`SemanticRefusal`] is a public, surface-neutral vocabulary. HQPlayer's preflight has twenty-odd
+//! typed refusals naming lanes, chains and rate spellings; a browser and an MCP client need to know
+//! *what to do next*, and the answer is one of ten things. The mapping is an exhaustive `match` in
+//! the executor, so a new internal refusal cannot silently become an existing surface verdict.
+//!
+//! ## What this module does not know
+//!
+//! Any producer family. `hqplayer` appears nowhere here; the HQPlayer executor is registered by the
+//! composition root and lives beside the HQPlayer command service.
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use crate::adaptive::{ApplyLane, ControlId, ControlValue, RevisionRef};
+use crate::adaptive::{ApplyLane, ControlId, ControlValue, OperationRecord, RevisionRef};
 use crate::bus::events::PrefixedZoneId;
 
-use super::surface::{project, SurfaceProfile, SurfaceProjection};
+use super::surface::{project_with, SurfaceProfile, SurfaceProjection, VerifiedSeries};
 use super::{AdaptiveView, ProducerKey, ProducerSnapshot};
 
 /// Why a zone id did not resolve to a producer.
@@ -81,18 +85,18 @@ pub enum SemanticRefusal {
     /// The control has no verified semantic operation yet, so no truthful receipt is possible.
     NoVerifiedOperation,
     /// The coordinator would not reserve the operation: a conflicting correlation, a superseding
-    /// operation, or a closed producer.
+    /// operation, a busy producer, or one that is shutting down.
     NotReserved,
 }
 
 /// Why a command did not reach an executor, or was not admitted by one.
 #[derive(Debug, Clone, PartialEq)]
 pub enum CommandRefusal {
-    /// The zone did not resolve.
+    /// The zone or producer did not resolve.
     Route(RouteRefusal),
     /// The routed producer's family has no registered semantic executor.
     ///
-    /// The alternative — trying the executor we happen to have — is the #328 defect with a
+    /// The alternative — trying the executor we happen to have — is the #328 fallthrough with a
     /// different prefix.
     NoExecutorForProducer {
         /// The family that has none.
@@ -118,6 +122,9 @@ pub struct SemanticCommand {
     /// The apply lane the descriptor declared.
     pub lane: ApplyLane,
     /// Idempotency correlation, shared by every surface following this operation.
+    ///
+    /// One physical gesture is one correlation, so a duplicated tap — the iPad Safari
+    /// compatibility-click case recorded on #331 — is one operation rather than two audible writes.
     pub correlation_id: String,
     /// Which surface submitted it.
     pub surface_id: String,
@@ -127,7 +134,7 @@ pub struct SemanticCommand {
 #[derive(Debug, Clone, PartialEq)]
 pub struct CommandAcceptance {
     /// The operation the producer will report against.
-    pub operation: crate::adaptive::OperationRecord,
+    pub operation: OperationRecord,
     /// True when this correlation matched an operation already reserved: a retry, not a new write.
     pub duplicate: bool,
 }
@@ -147,6 +154,7 @@ pub trait SemanticCommandExecutor: Send + Sync {
 pub struct ControlPlaneService {
     view: AdaptiveView,
     executors: BTreeMap<String, Arc<dyn SemanticCommandExecutor>>,
+    verified: VerifiedSeries,
 }
 
 impl ControlPlaneService {
@@ -155,6 +163,7 @@ impl ControlPlaneService {
         Self {
             view,
             executors: BTreeMap::new(),
+            verified: VerifiedSeries::default(),
         }
     }
 
@@ -165,23 +174,49 @@ impl ControlPlaneService {
         self
     }
 
+    /// Declare which backend release series this build has verified.
+    pub fn with_verified_series(mut self, verified: VerifiedSeries) -> Self {
+        self.verified = verified;
+        self
+    }
+
     /// Every producer the aggregator currently holds.
     pub fn producers(&self) -> Vec<ProducerKey> {
-        // RED stub.
-        Vec::new()
+        self.view
+            .snapshots()
+            .into_iter()
+            .map(|snapshot| snapshot.key)
+            .collect()
     }
 
     /// Resolve a prefixed zone id to the producer bound to it.
+    ///
+    /// Reads admitted state only, and has no default arm. Both properties matter: an adapter cannot
+    /// be consulted, and an id that matches nothing produces a refusal rather than whichever
+    /// producer happened to be first.
     pub fn route(&self, zone_id: &str) -> Result<ProducerKey, RouteRefusal> {
-        // RED stub: the naive first-match a fallthrough would have written.
-        let _ = zone_id;
-        self.view
-            .snapshots()
-            .first()
-            .map(|snapshot| snapshot.key.clone())
-            .ok_or_else(|| RouteRefusal::UnknownProducer {
+        if PrefixedZoneId::parse(zone_id).is_none() {
+            return Err(RouteRefusal::UnknownZonePrefix {
                 zone_id: zone_id.to_string(),
-            })
+            });
+        }
+        let mut candidates: Vec<ProducerKey> = self
+            .view
+            .snapshots()
+            .into_iter()
+            .filter(|snapshot| snapshot.key.zone_id.as_deref() == Some(zone_id))
+            .map(|snapshot| snapshot.key)
+            .collect();
+        match candidates.len() {
+            0 => Err(RouteRefusal::UnknownProducer {
+                zone_id: zone_id.to_string(),
+            }),
+            1 => Ok(candidates.remove(0)),
+            _ => Err(RouteRefusal::AmbiguousProducer {
+                zone_id: zone_id.to_string(),
+                candidates,
+            }),
+        }
     }
 
     /// The aggregator's snapshot for one producer.
@@ -190,24 +225,37 @@ impl ControlPlaneService {
     }
 
     /// Project one producer for one surface.
-    pub fn project(&self, key: &ProducerKey, profile: &SurfaceProfile) -> Option<SurfaceProjection> {
+    pub fn project(
+        &self,
+        key: &ProducerKey,
+        profile: &SurfaceProfile,
+    ) -> Option<SurfaceProjection> {
         self.view
             .snapshot(key)
-            .map(|snapshot| project(&snapshot, profile))
+            .map(|snapshot| project_with(&snapshot, profile, &self.verified))
     }
 
-    /// Submit one semantic command through the executor that owns the routed producer's family.
+    /// Submit one semantic command through the executor that owns the addressed producer's family.
+    ///
+    /// The family is read from the *admitted document*, never from the caller's request, so a
+    /// surface cannot name a family to choose an executor.
     pub async fn submit(
         &self,
         command: SemanticCommand,
     ) -> Result<CommandAcceptance, CommandRefusal> {
-        // RED stub.
-        let _ = &command;
-        Err(CommandRefusal::ServiceClosed)
+        let Some(snapshot) = self.view.snapshot(&command.key) else {
+            return Err(CommandRefusal::Route(RouteRefusal::UnknownProducer {
+                zone_id: command
+                    .key
+                    .zone_id
+                    .clone()
+                    .unwrap_or_else(|| command.key.producer_id.clone()),
+            }));
+        };
+        let producer_type = snapshot.document.producer.producer_type.clone();
+        let Some(executor) = self.executors.get(&producer_type) else {
+            return Err(CommandRefusal::NoExecutorForProducer { producer_type });
+        };
+        executor.submit(command).await
     }
-}
-
-#[allow(dead_code)]
-fn stub_unused(zone_id: &str) -> Option<PrefixedZoneId> {
-    PrefixedZoneId::parse(zone_id)
 }

--- a/src/producers/hqplayer.rs
+++ b/src/producers/hqplayer.rs
@@ -33,6 +33,15 @@ use crate::producers::{
     ProducerSnapshot, RetirementOutcome,
 };
 
+/// HQPlayer `product_version` prefixes this build has actually verified against captured protocol
+/// evidence.
+///
+/// The authority is the corpus under `tests/fixtures/hqplayer/` and the ledger in
+/// `.oh/hqplayer-evidence-ledger.md`: a 5.x legacy daemon and two 6.0.4 captures. Anything outside
+/// those series still renders every runtime-enumerated control — the engine remains the authority
+/// on what it accepts — but a surface is told the series is unverified (#331).
+pub const HQP_VERIFIED_PRODUCT_SERIES: &[&str] = &["5.", "6.0."];
+
 const CONTROL_TRANSPORT_STATE: &str = "hqplayer.transport.state";
 const CONTROL_TRANSPORT_PLAY: &str = "hqplayer.transport.play";
 const CONTROL_TRANSPORT_PAUSE: &str = "hqplayer.transport.pause";

--- a/src/producers/hqplayer_command_service.rs
+++ b/src/producers/hqplayer_command_service.rs
@@ -18,6 +18,9 @@ use crate::adaptive::{
     WriteAttempt,
 };
 
+use super::control_plane::{
+    CommandAcceptance, CommandRefusal, SemanticCommand, SemanticCommandExecutor, SemanticRefusal,
+};
 use super::hqplayer::{
     HqpAdaptivePublisher, HqpCommandCompletion, HqpCommandLease, HqpCommandReservation,
     HqpCoordinatorRefusal, HqpSemanticOperation,
@@ -42,9 +45,7 @@ pub(crate) enum HqpCommandServiceRefusal {
     InvalidProducerIdentity,
     Preflight(HqpPreflightRefusal),
     Coordinator(HqpCoordinatorRefusal),
-    // #329 intentionally adds no public consumer. #331 will construct this refusal when its
-    // adaptive surface submits after shutdown.
-    #[cfg_attr(not(test), allow(dead_code))]
+    /// The actor closed before accepting the message. Reached by `HqpSemanticExecutor` (#331).
     ServiceClosed,
 }
 
@@ -143,9 +144,7 @@ impl HqpNativeSettingExecutor for HqpInstanceManager {
 }
 
 enum HqpCommandActorMessage {
-    // The first public consumer lands in #331; keeping the variant in the production actor now is
-    // what lets that issue remain a thin projection instead of redesigning accepted-job lifetime.
-    #[cfg_attr(not(test), allow(dead_code))]
+    // The public consumer landed in #331: `HqpSemanticExecutor` below is the only sender.
     Submit {
         request: Box<HqpImmediateCommandRequest>,
         reply: oneshot::Sender<Result<HqpCommandAcknowledgement, HqpCommandServiceRefusal>>,
@@ -163,7 +162,6 @@ pub struct HqpImmediateCommandHandle {
 }
 
 impl HqpImmediateCommandHandle {
-    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) async fn submit(
         &self,
         request: HqpImmediateCommandRequest,
@@ -627,6 +625,126 @@ fn now() -> Timestamp {
     Timestamp::new(chrono::Utc::now().to_rfc3339())
 }
 
+// =============================================================================
+// #331: the surface-facing executor
+// =============================================================================
+
+/// The HQPlayer implementation of the control plane's producer-neutral executor (#331).
+///
+/// It exists so `ControlPlaneService` never names a producer family, and so the twenty-two typed
+/// refusals this module can produce are translated once, here, into the ten a surface can act on.
+/// The translation is an exhaustive `match`: a refusal added later fails to compile rather than
+/// silently inheriting an existing surface verdict.
+pub struct HqpSemanticExecutor {
+    commands: HqpImmediateCommandHandle,
+}
+
+impl HqpSemanticExecutor {
+    /// The `producer_type` this executor owns, as published by the HQPlayer producer document.
+    pub const PRODUCER_TYPE: &'static str = "hqplayer";
+
+    /// Wrap the bounded immediate-command actor's ingress.
+    pub fn new(commands: HqpImmediateCommandHandle) -> Self {
+        Self { commands }
+    }
+}
+
+#[async_trait]
+impl SemanticCommandExecutor for HqpSemanticExecutor {
+    fn producer_type(&self) -> &str {
+        Self::PRODUCER_TYPE
+    }
+
+    async fn submit(&self, command: SemanticCommand) -> Result<CommandAcceptance, CommandRefusal> {
+        let request = HqpImmediateCommandRequest {
+            key: command.key,
+            expected: command.expected,
+            control: command.control,
+            requested: command.requested,
+            lane: command.lane,
+            correlation_id: command.correlation_id,
+        };
+        match self.commands.submit(request).await {
+            Ok(acknowledgement) => Ok(CommandAcceptance {
+                operation: acknowledgement.operation,
+                duplicate: acknowledgement.duplicate,
+            }),
+            Err(refusal) => Err(surface_refusal(refusal)),
+        }
+    }
+}
+
+fn surface_refusal(refusal: HqpCommandServiceRefusal) -> CommandRefusal {
+    match refusal {
+        HqpCommandServiceRefusal::ServiceClosed => CommandRefusal::ServiceClosed,
+        HqpCommandServiceRefusal::ProducerUnknown
+        | HqpCommandServiceRefusal::InvalidProducerIdentity => {
+            CommandRefusal::Refused(SemanticRefusal::ProducerMismatch)
+        }
+        HqpCommandServiceRefusal::Preflight(preflight) => {
+            CommandRefusal::Refused(semantic_preflight(preflight))
+        }
+        HqpCommandServiceRefusal::Coordinator(coordinator) => match coordinator {
+            HqpCoordinatorRefusal::Preflight(preflight) => {
+                CommandRefusal::Refused(semantic_preflight(preflight))
+            }
+            HqpCoordinatorRefusal::CoordinatorClosed
+            | HqpCoordinatorRefusal::LifecycleNotRunning => CommandRefusal::ServiceClosed,
+            HqpCoordinatorRefusal::ProducerUnknown => {
+                CommandRefusal::Refused(SemanticRefusal::ProducerMismatch)
+            }
+            HqpCoordinatorRefusal::InvalidCorrelation => {
+                CommandRefusal::Refused(SemanticRefusal::CorrelationUnusable)
+            }
+            // Everything remaining is one fact for a surface: nothing was written, and the reason
+            // is contention or bookkeeping rather than the request. A surface re-reads and retries.
+            HqpCoordinatorRefusal::CorrelationConflict
+            | HqpCoordinatorRefusal::ConflictBusy
+            | HqpCoordinatorRefusal::UnresolvedRetentionFull
+            | HqpCoordinatorRefusal::StaleLease
+            | HqpCoordinatorRefusal::LeaseStillCurrent
+            | HqpCoordinatorRefusal::IllegalTransition
+            | HqpCoordinatorRefusal::RevisionFailed(_)
+            | HqpCoordinatorRefusal::PublicationFailed(_)
+            | HqpCoordinatorRefusal::RetirementFailed(_) => {
+                CommandRefusal::Refused(SemanticRefusal::NotReserved)
+            }
+        },
+    }
+}
+
+fn semantic_preflight(refusal: HqpPreflightRefusal) -> SemanticRefusal {
+    match refusal {
+        HqpPreflightRefusal::CorrelationIdEmpty
+        | HqpPreflightRefusal::CorrelationIdTooLong { .. } => SemanticRefusal::CorrelationUnusable,
+        HqpPreflightRefusal::ProducerMismatch => SemanticRefusal::ProducerMismatch,
+        HqpPreflightRefusal::RevisionMismatch { expected, actual } => {
+            SemanticRefusal::PositionStale { expected, actual }
+        }
+        HqpPreflightRefusal::ProducerNotLive | HqpPreflightRefusal::ProducerStale => {
+            SemanticRefusal::ProducerNotWritable
+        }
+        HqpPreflightRefusal::NativeLaneMissing
+        | HqpPreflightRefusal::NativeLaneUnavailable
+        | HqpPreflightRefusal::NativeLaneStale => SemanticRefusal::LaneUnusable,
+        HqpPreflightRefusal::ControlUnknown
+        | HqpPreflightRefusal::ControlUnavailable
+        | HqpPreflightRefusal::ControlReadOnly => SemanticRefusal::ControlNotWritable,
+        HqpPreflightRefusal::WrongApplyLane
+        | HqpPreflightRefusal::NonImmediateRequest
+        | HqpPreflightRefusal::WrongControlKind
+        | HqpPreflightRefusal::WrongValueKind => SemanticRefusal::RequestMismatch,
+        HqpPreflightRefusal::UnknownChoice
+        | HqpPreflightRefusal::ChoiceUnavailable
+        | HqpPreflightRefusal::ChoiceMissingEngineName
+        | HqpPreflightRefusal::InvalidRateEngineName => SemanticRefusal::ValueNotSelectable,
+        // #375 registered these descriptors; #347 owes them a verified receipt. Advertising them as
+        // invokable before that is how a tool description stops being true.
+        HqpPreflightRefusal::DeferredToIssue328 { .. }
+        | HqpPreflightRefusal::UnsupportedControl => SemanticRefusal::NoVerifiedOperation,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::{BTreeMap, HashMap};
@@ -885,6 +1003,118 @@ mod tests {
             HqpImmediateCommandActor::build_with(view, coordinator, executor, capacity);
         let task = tokio::spawn(actor.run());
         (handle, task)
+    }
+
+    // =========================================================================
+    // #331: the surface-facing executor
+    // =========================================================================
+
+    /// The `ServiceClosed` case #329 predicted for this issue, now reachable.
+    ///
+    /// It matters because a surface must be able to distinguish "the request was wrong" from "the
+    /// server is going away": the first is worth showing the user, the second is worth retrying.
+    #[tokio::test]
+    async fn a_command_submitted_after_shutdown_is_service_closed_rather_than_a_refusal() {
+        let live = snapshot();
+        let key = live.key.clone();
+        let expected = live.document.position();
+        let (handle, task) = build_test_service(
+            live,
+            Arc::new(FakeCoordinator::default()),
+            Arc::new(FakeExecutor::new(Arc::new(StdMutex::new(Vec::new())))),
+            4,
+        );
+        handle.shutdown().await.expect("the actor drains");
+        task.await.expect("the actor task ends");
+
+        let executor = HqpSemanticExecutor::new(handle);
+        assert_eq!(executor.producer_type(), "hqplayer");
+        let refused = executor
+            .submit(SemanticCommand {
+                key,
+                expected,
+                control: ControlId::new(MODE),
+                requested: ControlValue::Choice(MODE_CHOICE.to_string()),
+                lane: ApplyLane::Immediate,
+                correlation_id: "corr-after-shutdown".to_string(),
+                surface_id: "web".to_string(),
+            })
+            .await
+            .expect_err("a closed actor accepts nothing");
+        assert_eq!(refused, CommandRefusal::ServiceClosed);
+    }
+
+    /// Every internal refusal has to land on exactly one surface verdict, and the collapse must not
+    /// erase the distinction a surface acts on. Revision staleness in particular must survive:
+    /// "re-read and retry" is a different instruction from "your request was wrong".
+    #[test]
+    fn internal_refusals_collapse_onto_surface_verdicts_without_losing_what_to_do_next() {
+        assert_eq!(
+            surface_refusal(HqpCommandServiceRefusal::Preflight(
+                HqpPreflightRefusal::RevisionMismatch {
+                    expected: stale_position(),
+                    actual: current_position(),
+                }
+            )),
+            CommandRefusal::Refused(SemanticRefusal::PositionStale {
+                expected: stale_position(),
+                actual: current_position(),
+            })
+        );
+        assert_eq!(
+            surface_refusal(HqpCommandServiceRefusal::Preflight(
+                HqpPreflightRefusal::UnknownChoice
+            )),
+            CommandRefusal::Refused(SemanticRefusal::ValueNotSelectable)
+        );
+        assert_eq!(
+            surface_refusal(HqpCommandServiceRefusal::Preflight(
+                HqpPreflightRefusal::ControlReadOnly
+            )),
+            CommandRefusal::Refused(SemanticRefusal::ControlNotWritable)
+        );
+        assert_eq!(
+            surface_refusal(HqpCommandServiceRefusal::Preflight(
+                HqpPreflightRefusal::UnsupportedControl
+            )),
+            CommandRefusal::Refused(SemanticRefusal::NoVerifiedOperation)
+        );
+        assert_eq!(
+            surface_refusal(HqpCommandServiceRefusal::Coordinator(
+                HqpCoordinatorRefusal::CoordinatorClosed
+            )),
+            CommandRefusal::ServiceClosed,
+            "a closing coordinator is a retry, not a rejected request"
+        );
+        assert_eq!(
+            surface_refusal(HqpCommandServiceRefusal::Coordinator(
+                HqpCoordinatorRefusal::ConflictBusy
+            )),
+            CommandRefusal::Refused(SemanticRefusal::NotReserved)
+        );
+        assert_eq!(
+            surface_refusal(HqpCommandServiceRefusal::Coordinator(
+                HqpCoordinatorRefusal::Preflight(HqpPreflightRefusal::ProducerNotLive)
+            )),
+            CommandRefusal::Refused(SemanticRefusal::ProducerNotWritable),
+            "a preflight refusal repeated by the coordinator must read the same to a surface"
+        );
+    }
+
+    fn stale_position() -> RevisionRef {
+        RevisionRef {
+            epoch: ProducerEpoch(7),
+            control_plane: crate::adaptive::Revision(3),
+            state: crate::adaptive::Revision(8),
+        }
+    }
+
+    fn current_position() -> RevisionRef {
+        RevisionRef {
+            epoch: ProducerEpoch(7),
+            control_plane: crate::adaptive::Revision(3),
+            state: crate::adaptive::Revision(9),
+        }
     }
 
     #[test]

--- a/src/producers/mod.rs
+++ b/src/producers/mod.rs
@@ -47,6 +47,7 @@
 
 pub mod admission;
 mod aggregator;
+pub mod control_plane;
 pub mod event;
 pub mod hqplayer;
 pub(crate) mod hqplayer_command;
@@ -56,6 +57,7 @@ pub(crate) mod hqplayer_command;
 pub mod hqplayer_command_service;
 pub mod run;
 pub mod runtime;
+pub mod surface;
 
 pub use admission::{
     admit, Admission, AdmissionKind, AdmissionRefusal, AdmittedDocument, IntentRepair, LaneDefect,

--- a/src/producers/surface.rs
+++ b/src/producers/surface.rs
@@ -91,8 +91,6 @@ pub struct SurfaceCapabilities {
     /// disable the whole control. Swapping one for the other silently deletes a published
     /// constraint.
     pub per_choice_reasons: bool,
-    /// Whether the surface can display reason text at all, as opposed to a bare state.
-    pub reason_text: bool,
     /// The highest risk class this surface may advertise as invokable.
     ///
     /// [`RiskClass::Unrecognized`] sorts above every recognized member, so a risk class from a
@@ -102,12 +100,11 @@ pub struct SurfaceCapabilities {
 }
 
 impl SurfaceCapabilities {
-    /// A surface that can render every primitive this build knows, with full reason text.
+    /// A surface that can render every primitive this build knows, including per-choice reasons.
     pub fn unrestricted() -> Self {
         Self {
             renders_kinds: ControlKind::known().into_iter().collect(),
             per_choice_reasons: true,
-            reason_text: true,
             max_risk: RiskClass::Destructive,
         }
     }
@@ -178,7 +175,6 @@ impl SurfaceProfile {
                 .into_iter()
                 .collect(),
                 per_choice_reasons: false,
-                reason_text: false,
                 max_risk: RiskClass::Caution,
             },
             budget: SurfaceBudget {
@@ -973,7 +969,13 @@ struct Invalidation {
 impl Invalidation {
     fn of(document: &ProducerDocument) -> Self {
         let mut by_control = BTreeMap::new();
-        for operation in &document.operations {
+        // Two outstanding writes can invalidate the same enumeration, and the surface is shown one
+        // of them. Choosing by operation id rather than by position in `operations` keeps that
+        // choice independent of a `Vec` order the producer never promised — the same arbitrariness
+        // #324 refused to depend on when it demoted every C2 claimant instead of keeping the first.
+        let mut operations: Vec<&OperationRecord> = document.operations.iter().collect();
+        operations.sort_by(|left, right| left.id.as_str().cmp(right.id.as_str()));
+        for operation in operations {
             if operation.outcome.is_state_evidence() {
                 continue;
             }
@@ -1118,27 +1120,27 @@ fn narrow(
         })
         .collect();
 
-    let mut kept: Vec<Choice> = choices
+    // Membership first: every held selection, then fill to the budget from the top of the
+    // authority's list. The budget can be exceeded when a control holds more selections than the
+    // surface asked for — deliberately, because a control whose own value is missing from its
+    // options is a state the user cannot reason about, and a list one item too long is not.
+    let mut kept: BTreeSet<&str> = choices
         .iter()
-        .filter(|choice| selected.contains(&choice.id))
-        .cloned()
+        .map(|choice| choice.id.as_str())
+        .filter(|id| selected.contains(*id))
         .collect();
     for choice in choices {
         if kept.len() >= budget {
             break;
         }
-        if selected.contains(&choice.id) {
-            continue;
-        }
-        kept.push(choice.clone());
+        kept.insert(choice.id.as_str());
     }
-    // Restore the authority's own order; keeping the selection is about membership, not position.
-    let mut ordered: Vec<Choice> = choices
+    // Then position: the authority's own order, which the contract says is meaningful.
+    let ordered: Vec<Choice> = choices
         .iter()
-        .filter(|choice| kept.iter().any(|keeper| keeper.id == choice.id))
+        .filter(|choice| kept.contains(choice.id.as_str()))
         .cloned()
         .collect();
-    ordered.truncate(kept.len().max(selected.len()));
     let dropped = choices.len() - ordered.len();
     (ordered, (dropped > 0).then_some(dropped))
 }

--- a/src/producers/surface.rs
+++ b/src/producers/surface.rs
@@ -68,6 +68,8 @@ pub const WITHHELD_UNRENDERABLE_KIND: &str = "surface.withheld.unrenderable_kind
 pub const WITHHELD_PER_CHOICE_REASON: &str = "surface.withheld.per_choice_reason";
 /// Catalog key for a control whose risk class exceeds what this surface may offer.
 pub const WITHHELD_RISK_EXCEEDS_SURFACE: &str = "surface.withheld.risk_exceeds_surface";
+/// Catalog key for a control whose apply semantics this build cannot describe.
+pub const WITHHELD_UNDESCRIBABLE_APPLY: &str = "surface.withheld.undescribable_apply";
 /// Catalog key for a control dropped because the surface's control budget was exhausted.
 pub const OMITTED_BUDGET_EXHAUSTED: &str = "surface.omitted.budget_exhausted";
 /// Catalog key for a control dropped because the container it belongs to was dropped.
@@ -146,13 +148,19 @@ impl SurfaceProfile {
         }
     }
 
-    /// An AI tool client: every primitive is expressible as data, but nothing confirms at invoke
-    /// time, so a destructive operation is not advertised as invokable.
+    /// An AI tool client: every primitive is expressible as data, and nothing confirms at invoke
+    /// time.
+    ///
+    /// The ceiling is `Disruptive` rather than `Caution` deliberately. `hifi_hqplayer_set_pipeline`
+    /// already lets an assistant change mode today, and mode is `playback_interruption`; a stricter
+    /// default would look like a projection detail while silently removing a shipped capability the
+    /// moment MCP adopted this profile. `Destructive` stays out: losing retained configuration is
+    /// not recoverable by re-issuing the opposite command.
     pub fn mcp() -> Self {
         Self {
             surface_id: "mcp".to_string(),
             capabilities: SurfaceCapabilities {
-                max_risk: RiskClass::Caution,
+                max_risk: RiskClass::Disruptive,
                 ..SurfaceCapabilities::unrestricted()
             },
             budget: SurfaceBudget::default(),
@@ -255,33 +263,6 @@ pub struct FallbackProjection {
     pub declared_schema: Option<String>,
     /// Why the document was not admitted.
     pub refusal: Refusal,
-}
-
-/// What a surface receives.
-#[derive(Debug, Clone, PartialEq)]
-pub enum SurfaceProjection {
-    /// The document was admitted and projected.
-    Rendered(Box<RenderedProjection>),
-    /// The document could not be admitted at this schema generation.
-    Fallback(FallbackProjection),
-}
-
-impl SurfaceProjection {
-    /// The rendered projection, if this is one.
-    pub fn rendered(&self) -> Option<&RenderedProjection> {
-        match self {
-            Self::Rendered(rendered) => Some(rendered),
-            Self::Fallback(_) => None,
-        }
-    }
-
-    /// The surface this projection was produced for.
-    pub fn surface_id(&self) -> &str {
-        match self {
-            Self::Rendered(rendered) => &rendered.surface_id,
-            Self::Fallback(fallback) => &fallback.surface_id,
-        }
-    }
 }
 
 /// Producer identity, as a surface needs it.
@@ -627,6 +608,11 @@ pub struct RenderedProjection {
     pub controls: Vec<ProjectedControl>,
     /// Controls this surface did not receive, and why.
     pub omitted: Vec<OmittedControl>,
+    /// Controls with unapplied intent that this surface did not receive.
+    ///
+    /// Disclosure, not an instruction: a bounded surface must be able to say that edits are waiting
+    /// where the user cannot see them, without applying, discarding or blocking on them.
+    pub staged_elsewhere: Vec<ControlId>,
     /// What the surface must tell the user about the projection as a whole.
     pub notices: Vec<ProjectionNotice>,
 }
@@ -691,7 +677,7 @@ fn legible_string(raw: &serde_json::Value, path: &[&str]) -> Option<String> {
 // =============================================================================
 
 /// Project one admitted snapshot for one surface, with no opinion about backend releases.
-pub fn project(snapshot: &ProducerSnapshot, profile: &SurfaceProfile) -> SurfaceProjection {
+pub fn project(snapshot: &ProducerSnapshot, profile: &SurfaceProfile) -> RenderedProjection {
     project_with(snapshot, profile, &VerifiedSeries::default())
 }
 
@@ -700,7 +686,7 @@ pub fn project_with(
     snapshot: &ProducerSnapshot,
     profile: &SurfaceProfile,
     verified: &VerifiedSeries,
-) -> SurfaceProjection {
+) -> RenderedProjection {
     let document = snapshot.document.as_ref();
     let mut notices = document_notices(snapshot, document, verified);
 
@@ -708,12 +694,14 @@ pub fn project_with(
     let ranked = rank_controls(document, profile);
     let (kept, omitted) = apply_budget(document, ranked, profile, &mut notices);
 
+    let staged_elsewhere = staged_outside(document, &kept);
+
     let controls: Vec<ProjectedControl> = kept
         .iter()
         .map(|control| project_control(control, document, profile, &invalidation, &mut notices))
         .collect();
 
-    SurfaceProjection::Rendered(Box::new(RenderedProjection {
+    RenderedProjection {
         schema: SURFACE_PROJECTION_SCHEMA,
         surface_id: profile.surface_id.clone(),
         producer: projected_producer(document),
@@ -723,8 +711,41 @@ pub fn project_with(
         groups: project_groups(document, profile),
         controls,
         omitted,
+        staged_elsewhere,
         notices,
-    }))
+    }
+}
+
+/// Controls holding unapplied intent that this surface did not receive.
+///
+/// A surface that shows a subset must still be able to say "there are edits waiting somewhere you
+/// cannot see" — the alternative is a user who applies what is in front of them and silently ships
+/// changes they forgot about, or who cannot find the change the system says is pending. Disclosure
+/// only: this is not an instruction to apply, discard, or block on them.
+fn staged_outside(document: &ProducerDocument, kept: &[&Control]) -> Vec<ControlId> {
+    let present: BTreeSet<&ControlId> = kept.iter().map(|control| &control.id).collect();
+    let mut waiting: BTreeSet<ControlId> = document
+        .controls
+        .iter()
+        .filter(|control| !present.contains(&control.id))
+        .filter(|control| {
+            [ValueLane::Desired, ValueLane::Held].iter().any(|lane| {
+                control
+                    .lane(lane)
+                    .and_then(LaneValue::grounded_value)
+                    .is_some()
+            })
+        })
+        .map(|control| control.id.clone())
+        .collect();
+    for change_set in &document.change_sets {
+        for entry in &change_set.entries {
+            if !present.contains(&entry.control) {
+                waiting.insert(entry.control.clone());
+            }
+        }
+    }
+    waiting.into_iter().collect()
 }
 
 fn projected_producer(document: &ProducerDocument) -> ProjectedProducer {
@@ -1183,10 +1204,34 @@ fn project_mutability(control: &Control, profile: &SurfaceProfile) -> Mutability
         return withheld(WITHHELD_RISK_EXCEEDS_SURFACE, apply.risk.as_str());
     }
 
+    // A newer minor can add an apply lane, effect or disruption this build has never heard of. The
+    // value still round-trips and the control still renders — but "where does this write go", "when
+    // does it become true" and "what will I hear" are the three things every surface tells the user
+    // before it offers a write, and an unrecognized member answers none of them. Offering it anyway
+    // is how a tool description stops being true; `timing_key` would fall back to
+    // [`TIMING_UNKNOWN`], which is an admission, not a description.
+    if let Some(unknown) = undescribable(apply) {
+        return withheld(WITHHELD_UNDESCRIBABLE_APPLY, unknown);
+    }
+
     Mutability::Mutable {
         apply: Box::new(apply.clone()),
         description: describe(apply),
     }
+}
+
+/// The first apply-semantics member this build does not recognize, if any.
+fn undescribable(apply: &ApplySemantics) -> Option<&str> {
+    if !apply.lane.is_recognized() {
+        return Some(apply.lane.as_str());
+    }
+    if !apply.effect.is_recognized() {
+        return Some(apply.effect.as_str());
+    }
+    if !apply.disruption.is_recognized() {
+        return Some(apply.disruption.as_str());
+    }
+    None
 }
 
 fn withheld(display_text_key: &str, detail: &str) -> Mutability {

--- a/src/producers/surface.rs
+++ b/src/producers/surface.rs
@@ -1,0 +1,670 @@
+//! Surface-appropriate projections of one aggregator-owned producer document (#331).
+//!
+//! ## Why a projection layer exists at all
+//!
+//! #323 defines what a producer may say; #324 makes the aggregator the only thing that holds an
+//! admitted document. Neither answers the question three surfaces have to answer identically:
+//! *given this document, what may I show, what may I offer, and what must I say out loud when I
+//! cannot do either faithfully?*
+//!
+//! Left to each surface, that question is answered three times. Lane resolution alone has five
+//! lanes; availability is reason-carrying; enumerations can be unknown, stale, invalidated or
+//! merely long. Each of those has a wrong answer that looks right, and three independent wrong
+//! answers is exactly the drift #331 exists to remove.
+//!
+//! ## Surfaces are data, not code
+//!
+//! A [`SurfaceProfile`] *declares* what a consumer can faithfully render — which control
+//! primitives, whether it can show a per-choice availability reason, how much it can hold, how
+//! risky an operation it may offer. Nothing here branches on a device class or a board name; the
+//! program session's hard constraint is "negotiate capabilities; do not infer from board names",
+//! and a `SurfaceKind` enum is a board name.
+//!
+//! ## The rule that makes a subset safe
+//!
+//! Surface-specific subsets are allowed; contradictory semantics are not. So every reduction this
+//! module performs is **declared**:
+//!
+//! * a control this surface cannot render faithfully is still *displayed*, with its mutation
+//!   [`Mutability::WithheldFromSurface`] and a reason — never silently flattened into a primitive
+//!   that loses per-choice availability;
+//! * a budget that drops controls reports them in [`RenderedProjection::omitted`];
+//! * a truncated enumeration says so, and never truncates away the current selection;
+//! * an enumeration invalidated by an in-flight write withholds the stale list and says which
+//!   operation invalidated it, rather than serving choices that are about to be wrong.
+//!
+//! Nothing here resolves catalog text (#343 owns that), invents a value, or reorders a producer's
+//! own enumeration.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::adaptive::{
+    ApplyEffect, ApplyLane, ApplySemantics, Authority, Availability, AvailabilityState, Choice,
+    CommandOutcome, Constraint, ControlGroup, ControlId, ControlKind, ControlValue, Disruption,
+    Divergence, LaneHealth, LaneValue, NumericRange, OperationId, ProducerDocument, ProducerEpoch,
+    Reason, ReasonCode, ReasonScope, RecoveryState, Refusal, RevisionRef, RiskClass, SchemaVersion,
+    SourceClass, TargetRole, ValueLane, WriteAttempt, CONSUMER_SCHEMA_VERSION,
+};
+
+use super::aggregator::{ProducerPresence, ProducerSnapshot};
+
+/// The version of the *projection* contract, deliberately independent of the producer contract's.
+///
+/// A surface negotiates what it can render; the producer negotiates what it can say. Tying the two
+/// together would mean a new producer minor forced every client to re-qualify.
+pub const SURFACE_PROJECTION_SCHEMA: SchemaVersion = SchemaVersion::new(1, 0);
+
+/// Catalog keys this module attaches to reasons it originates.
+///
+/// Keys, never prose: #343 owns the catalog and its provenance. A surface that has no catalog entry
+/// still has the [`ReasonCode`] to branch on.
+pub const WITHHELD_UNRENDERABLE_KIND: &str = "surface.withheld.unrenderable_kind";
+/// A control whose per-choice availability this surface cannot express.
+pub const WITHHELD_PER_CHOICE_REASON: &str = "surface.withheld.per_choice_reason";
+/// A control whose risk class exceeds what this surface may offer.
+pub const WITHHELD_RISK_EXCEEDS_SURFACE: &str = "surface.withheld.risk_exceeds_surface";
+/// A control dropped because the surface's control budget was exhausted.
+pub const OMITTED_BUDGET_EXHAUSTED: &str = "surface.omitted.budget_exhausted";
+/// A control dropped because the container it belongs to was dropped.
+pub const OMITTED_CONTAINER_DROPPED: &str = "surface.omitted.container_dropped";
+
+// =============================================================================
+// Profile
+// =============================================================================
+
+/// What a surface can faithfully render, declared rather than inferred.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SurfaceCapabilities {
+    /// Control primitives this surface can render without losing a published semantic.
+    pub renders_kinds: BTreeSet<ControlKind>,
+    /// Whether the surface can show *per-choice* availability and its reason.
+    ///
+    /// The HQPTuner renderer audit on #331 is the reason this is a capability rather than an
+    /// assumption: a dropdown can disable one option and explain it; a segmented control can only
+    /// disable the whole control. Swapping one for the other silently deletes a published
+    /// constraint.
+    pub per_choice_reasons: bool,
+    /// Whether the surface can display reason text at all, as opposed to a bare state.
+    pub reason_text: bool,
+    /// The highest risk class this surface may advertise as invokable.
+    ///
+    /// [`RiskClass::Unrecognized`] sorts above every recognized member, so a risk class from a
+    /// newer minor is never advertised as invokable by an older surface. That is the safe
+    /// direction: the control stays visible, the mutation does not.
+    pub max_risk: RiskClass,
+}
+
+impl SurfaceCapabilities {
+    /// A surface that can render every primitive this build knows, with full reason text.
+    pub fn unrestricted() -> Self {
+        Self {
+            renders_kinds: ControlKind::known().into_iter().collect(),
+            per_choice_reasons: true,
+            reason_text: true,
+            max_risk: RiskClass::Destructive,
+        }
+    }
+}
+
+/// How much of a document a surface can hold, and what it wants first.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct SurfaceBudget {
+    /// Maximum number of controls the surface can present.
+    pub max_controls: Option<usize>,
+    /// Maximum number of choices the surface can present for one control.
+    pub max_choices: Option<usize>,
+    /// Group ids in the order this surface wants them, most important first.
+    ///
+    /// Deliberately surface policy rather than producer truth. "Transport and volume before
+    /// tuning" is a statement about a knob, not about HQPlayer, and putting it in the producer
+    /// would make every adapter know what a knob is.
+    pub priority_groups: Vec<String>,
+}
+
+/// One consumer's declared capabilities and limits.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SurfaceProfile {
+    /// Stable identifier for this surface, echoed into every projection it receives.
+    pub surface_id: String,
+    /// What it can render.
+    pub capabilities: SurfaceCapabilities,
+    /// How much, and in what order.
+    pub budget: SurfaceBudget,
+}
+
+impl SurfaceProfile {
+    /// A browser: renders every primitive, no budget.
+    pub fn web() -> Self {
+        Self {
+            surface_id: "web".to_string(),
+            capabilities: SurfaceCapabilities::unrestricted(),
+            budget: SurfaceBudget::default(),
+        }
+    }
+
+    /// An AI tool client: no pixels, so every primitive is expressible as data, but it cannot ask a
+    /// human to confirm, so it may not be offered a disruptive or destructive operation unattended.
+    pub fn mcp() -> Self {
+        Self {
+            surface_id: "mcp".to_string(),
+            capabilities: SurfaceCapabilities {
+                max_risk: RiskClass::Caution,
+                ..SurfaceCapabilities::unrestricted()
+            },
+            budget: SurfaceBudget::default(),
+        }
+    }
+
+    /// A small control device: bounded, transport and volume first, and no primitive that needs a
+    /// per-option explanation.
+    pub fn compact_device(surface_id: impl Into<String>, max_controls: usize) -> Self {
+        Self {
+            surface_id: surface_id.into(),
+            capabilities: SurfaceCapabilities {
+                renders_kinds: [
+                    ControlKind::Action,
+                    ControlKind::Boolean,
+                    ControlKind::Enumeration,
+                    ControlKind::NumericRange,
+                    ControlKind::Text,
+                ]
+                .into_iter()
+                .collect(),
+                per_choice_reasons: false,
+                reason_text: false,
+                max_risk: RiskClass::Safe,
+            },
+            budget: SurfaceBudget {
+                max_controls: Some(max_controls),
+                max_choices: Some(8),
+                priority_groups: vec![
+                    "transport".to_string(),
+                    "volume".to_string(),
+                    "metadata".to_string(),
+                ],
+            },
+        }
+    }
+}
+
+// =============================================================================
+// Projection
+// =============================================================================
+
+/// What a surface receives.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SurfaceProjection {
+    /// The document was admitted and projected.
+    Rendered(Box<RenderedProjection>),
+    /// The document could not be admitted at this schema generation.
+    Fallback(FallbackProjection),
+}
+
+impl SurfaceProjection {
+    /// The rendered projection, if this is one.
+    pub fn rendered(&self) -> Option<&RenderedProjection> {
+        match self {
+            Self::Rendered(rendered) => Some(rendered),
+            Self::Fallback(_) => None,
+        }
+    }
+
+    /// The surface this projection was produced for.
+    pub fn surface_id(&self) -> &str {
+        match self {
+            Self::Rendered(rendered) => &rendered.surface_id,
+            Self::Fallback(fallback) => &fallback.surface_id,
+        }
+    }
+}
+
+/// A safe, informative degradation for a document this build cannot admit.
+///
+/// It carries whatever identity was legible *without* trusting the body, so a surface can say "this
+/// producer speaks a generation UHC does not" instead of showing an empty panel with no explanation.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FallbackProjection {
+    /// Projection contract version.
+    pub schema: SchemaVersion,
+    /// The surface this was produced for.
+    pub surface_id: String,
+    /// The producer id, when the raw value carried a legible one.
+    pub producer_id: Option<String>,
+    /// The producer family, when the raw value carried a legible one.
+    pub producer_type: Option<String>,
+    /// The `schema_version` string exactly as the producer stamped it.
+    pub declared_schema: Option<String>,
+    /// Why the document was not admitted.
+    pub refusal: Refusal,
+}
+
+/// Producer identity, as a surface needs it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectedProducer {
+    /// Stable semantic producer id.
+    pub producer_id: String,
+    /// Producer family.
+    pub producer_type: String,
+    /// Operator-visible label, if any.
+    pub instance_label: Option<String>,
+    /// Backend product version, informational.
+    pub product_version: Option<String>,
+    /// The producer's restart counter.
+    pub epoch: ProducerEpoch,
+    /// The role these controls act in.
+    pub role: TargetRole,
+    /// The prefixed zone id this producer is bound to, if any.
+    pub zone_id: Option<String>,
+}
+
+/// Something a surface must tell the user about the projection as a whole.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProjectionNotice {
+    /// The document declares a newer minor. Unknown members were preserved, not rendered.
+    UnknownSchemaAdditions {
+        /// The document's declared version.
+        document: SchemaVersion,
+        /// The version this build implements.
+        consumer: SchemaVersion,
+    },
+    /// The producer's own product version is outside the series this build has verified.
+    ///
+    /// Deliberately *not* a reason to withhold controls: the runtime enumeration is still the
+    /// authority on what the engine accepts, and blanking a working control because a version
+    /// string is unfamiliar removes the user's way out of the state.
+    UntestedProducerVersion {
+        /// The version the producer reported.
+        product_version: String,
+    },
+    /// The whole document is last-known rather than current.
+    LastKnown,
+    /// The producer declares itself stale.
+    ProducerStale,
+    /// A transport lane is not healthy. Values sourced from it may be last-good.
+    LaneNotHealthy {
+        /// Which lane.
+        lane: crate::adaptive::TransportLane,
+        /// Its state.
+        state: crate::adaptive::LaneState,
+    },
+    /// The aggregator demoted published intent before serving this snapshot.
+    IntentRepaired {
+        /// How many change-set entries were demoted.
+        count: usize,
+    },
+    /// The surface budget dropped controls. See [`RenderedProjection::omitted`].
+    Truncated {
+        /// How many the surface can hold.
+        budget: usize,
+        /// How many the document advertised.
+        advertised: usize,
+    },
+    /// A control uses a primitive this build does not recognize.
+    UnrecognizedControlKind {
+        /// The control.
+        control: ControlId,
+        /// The unrecognized wire spelling.
+        kind: String,
+    },
+}
+
+/// A control dropped from this surface, with the reason it was dropped.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OmittedControl {
+    /// Which control.
+    pub id: ControlId,
+    /// Machine-readable reason code.
+    pub code: ReasonCode,
+    /// Catalog key for display text.
+    pub display_text_key: &'static str,
+}
+
+/// A presentation container, projected verbatim.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectedGroup {
+    /// Stable group id.
+    pub id: String,
+    /// Catalog key for the label.
+    pub label_key: Option<String>,
+    /// The surface's rank for this group, lower first.
+    pub rank: usize,
+    /// The group's own ordering hint.
+    pub order: Option<i32>,
+}
+
+/// Transport-lane health, projected verbatim plus the aggregator's own witness.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProjectedLaneHealth {
+    /// The producer's published health for this lane.
+    pub health: LaneHealth,
+    /// When the aggregator last saw this lane succeed, across admissions.
+    pub last_success_seen: Option<crate::adaptive::Timestamp>,
+}
+
+/// Whether, and how, a surface may offer mutation.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Mutability {
+    /// Writable, with the cost of writing spelled out.
+    Mutable {
+        /// The producer's apply semantics, verbatim.
+        apply: Box<ApplySemantics>,
+        /// The surface-neutral description derived from them.
+        description: ApplyDescription,
+    },
+    /// The producer publishes no apply semantics: this control is observation only.
+    ObservationOnly,
+    /// The producer says the control is not writable now, and why.
+    Blocked {
+        /// The producer's reasons, verbatim. Never empty for a non-available state.
+        reasons: Vec<Reason>,
+    },
+    /// The producer would allow it; this surface cannot offer it faithfully.
+    ///
+    /// A different verdict from [`Mutability::Blocked`], and the distinction matters: a surface
+    /// that reports its own limitation as the producer's is how a user concludes the engine is
+    /// broken.
+    WithheldFromSurface {
+        /// Why this surface withheld it.
+        reason: Reason,
+    },
+}
+
+/// The surface-neutral answer to "when does this become true, and what does it cost".
+///
+/// An MCP tool description, a web apply button and a device confirmation prompt are all derived
+/// from this one value, which is why the timing key is a closed set rather than a sentence.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApplyDescription {
+    /// Where the write is routed.
+    pub lane: ApplyLane,
+    /// When it becomes true.
+    pub effect: ApplyEffect,
+    /// What the user notices.
+    pub disruption: Disruption,
+    /// How much care it deserves.
+    pub risk: RiskClass,
+    /// Closed catalog key naming the timing class. Distinct per [`ApplyEffect`].
+    pub timing_key: &'static str,
+    /// Whether a returned call is evidence the value changed.
+    ///
+    /// False when the producer marks the acknowledgement provisional: the write is confirmed by
+    /// readback, and a dropped connection after it is indeterminate rather than failed.
+    pub acknowledgement_is_evidence: bool,
+    /// Controls whose enumerations this write invalidates.
+    pub invalidates: Vec<ControlId>,
+    /// Controls the producer writes together with this one, as one plan.
+    pub coupled_with: Vec<ControlId>,
+}
+
+/// Catalog key for a control that takes effect on the running engine at once.
+pub const TIMING_LIVE_IMMEDIATE: &str = "apply.timing.live_immediate";
+/// Catalog key for a control whose write is confirmed by readback.
+pub const TIMING_VERIFIED_PENDING: &str = "apply.timing.verified_pending";
+/// Catalog key for a control that is stored now and audible after a restart.
+pub const TIMING_RESTART_REQUIRED: &str = "apply.timing.restart_required";
+/// Catalog key for a control that changes only the persisted baseline.
+pub const TIMING_PERSISTENT_ONLY: &str = "apply.timing.persistent_only";
+/// Catalog key for a control retained for a chain that is not loaded.
+pub const TIMING_HELD_UNTIL_CHAIN_LOADED: &str = "apply.timing.held_until_chain_loaded";
+/// Catalog key for an apply effect this build does not recognize.
+pub const TIMING_UNKNOWN: &str = "apply.timing.unknown";
+
+/// The timing key for one apply effect.
+///
+/// Total, including the unrecognized arm: a newer minor's effect must not silently borrow the
+/// wording of a recognized one, because "live" and "after restart" are the two answers a user acts
+/// on differently.
+pub fn timing_key(effect: &ApplyEffect) -> &'static str {
+    match effect {
+        ApplyEffect::LiveImmediate => TIMING_LIVE_IMMEDIATE,
+        ApplyEffect::VerifiedPending => TIMING_VERIFIED_PENDING,
+        ApplyEffect::RestartRequired => TIMING_RESTART_REQUIRED,
+        ApplyEffect::PersistentOnly => TIMING_PERSISTENT_ONLY,
+        ApplyEffect::HeldUntilChainLoaded => TIMING_HELD_UNTIL_CHAIN_LOADED,
+        ApplyEffect::Unrecognized(_) => TIMING_UNKNOWN,
+    }
+}
+
+/// What a surface may offer as selectable options.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ChoiceProjection {
+    /// This control is not an enumeration.
+    NotApplicable,
+    /// The producer published a set.
+    Enumerated {
+        /// Whose enumeration this is.
+        authority: Authority,
+        /// How it was obtained.
+        source: SourceClass,
+        /// The options, in the authority's own order.
+        choices: Vec<Choice>,
+        /// How many the surface budget dropped, when it dropped any.
+        truncated: Option<usize>,
+    },
+    /// A write in flight invalidates this enumeration. The stale list is deliberately withheld.
+    Reloading {
+        /// The control whose pending write invalidates this one.
+        invalidated_by: ControlId,
+        /// The operation doing the invalidating.
+        operation: OperationId,
+    },
+    /// The producer could not read the set.
+    ///
+    /// Distinct from `Enumerated { choices: [] }`, which is a *successful* read of an empty
+    /// collection. Collapsing the two is how "the engine offers nothing" and "we do not know what
+    /// the engine offers" become the same blank dropdown.
+    Unknown {
+        /// Why it is unknown.
+        reason: Reason,
+    },
+}
+
+/// One operation the document still publishes for this control.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProjectedOperation {
+    /// Stable operation identity. Busy state is scoped to this, never to the surface.
+    pub id: OperationId,
+    /// The correlation the submitting surface supplied. Every surface follows the same one.
+    pub correlation_id: String,
+    /// How far the write got.
+    pub write_attempt: WriteAttempt,
+    /// The current outcome.
+    pub outcome: CommandOutcome,
+    /// Whether this outcome is evidence about the producer's observed state.
+    pub is_state_evidence: bool,
+    /// Whether the outcome may still change.
+    pub awaits_convergence: bool,
+    /// The last producer position this operation observed, so a surface can order results.
+    pub observed: Option<RevisionRef>,
+    /// What is needed to reach a coherent state.
+    pub recovery: Option<RecoveryState>,
+    /// Why, when the outcome needs one.
+    pub reason: Option<Reason>,
+    /// The value that was requested, when the record carries one.
+    pub requested: Option<ControlValue>,
+}
+
+/// A constraint the producer published about this control.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProjectedConstraint {
+    /// Stable constraint id, so a surface can suppress a duplicate without matching a message.
+    pub id: String,
+    /// What holds when the condition holds.
+    pub effect: crate::adaptive::ConstraintEffect,
+    /// Machine-readable reason with a catalog key.
+    pub reason: Reason,
+}
+
+/// One control, as one surface sees it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProjectedControl {
+    /// Stable semantic identity. Identical across every surface.
+    pub id: ControlId,
+    /// The producer's primitive, never substituted.
+    pub kind: ControlKind,
+    /// Catalog key for the label.
+    pub label_key: Option<String>,
+    /// Catalog key for help text.
+    pub description_key: Option<String>,
+    /// Group this control belongs to.
+    pub group: Option<String>,
+    /// Ordering hint within the group.
+    pub order: Option<i32>,
+    /// Unit symbol for scalar controls.
+    pub unit: Option<String>,
+    /// Availability, reason-carrying, verbatim from the producer.
+    pub availability: Availability,
+    /// The running value.
+    ///
+    /// Held separately from every other lane on purpose: the signal path must never preview intent
+    /// the engine has not adopted.
+    pub observed: Option<LaneValue>,
+    /// Every other published lane, kept distinct rather than collapsed into "the value".
+    pub intent: Vec<LaneValue>,
+    /// Selectable options, or the reason there are none to offer.
+    pub choices: ChoiceProjection,
+    /// Numeric domain, for ranges.
+    pub range: Option<NumericRange>,
+    /// Whether and how this surface may offer mutation.
+    pub mutability: Mutability,
+    /// Operations the document still publishes for this control, scoped per operation.
+    pub operations: Vec<ProjectedOperation>,
+    /// Recorded lane disagreements.
+    pub divergences: Vec<Divergence>,
+    /// Constraints that name this control.
+    pub constraints: Vec<ProjectedConstraint>,
+}
+
+impl ProjectedControl {
+    /// The choice ids a surface may offer, empty for anything that is not an enumerated set.
+    pub fn offered_choice_ids(&self) -> Vec<&str> {
+        match &self.choices {
+            ChoiceProjection::Enumerated { choices, .. } => {
+                choices.iter().map(|choice| choice.id.as_str()).collect()
+            }
+            _ => Vec::new(),
+        }
+    }
+
+    /// Whether this surface may offer mutation.
+    pub fn is_mutable_here(&self) -> bool {
+        matches!(self.mutability, Mutability::Mutable { .. })
+    }
+}
+
+/// One surface's whole view of one producer, at one revision.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RenderedProjection {
+    /// Projection contract version.
+    pub schema: SchemaVersion,
+    /// The surface this was produced for.
+    pub surface_id: String,
+    /// Who is producing.
+    pub producer: ProjectedProducer,
+    /// The exact producer position this whole projection was taken at.
+    ///
+    /// One position for the whole value: a surface can never combine a mode read at one revision
+    /// with an enumeration read at another, because it never receives two.
+    pub position: RevisionRef,
+    /// Whether the aggregator considers this current or last-known.
+    pub presence: ProducerPresence,
+    /// Per-lane health.
+    pub lanes: Vec<ProjectedLaneHealth>,
+    /// Presentation containers, in this surface's priority order.
+    pub groups: Vec<ProjectedGroup>,
+    /// The controls, in this surface's order.
+    pub controls: Vec<ProjectedControl>,
+    /// Controls this surface did not receive, and why.
+    pub omitted: Vec<OmittedControl>,
+    /// What the surface must tell the user about the projection as a whole.
+    pub notices: Vec<ProjectionNotice>,
+}
+
+impl RenderedProjection {
+    /// One control by id.
+    pub fn control(&self, id: &str) -> Option<&ProjectedControl> {
+        self.controls
+            .iter()
+            .find(|control| control.id.as_str() == id)
+    }
+
+    /// Whether a control was omitted from this surface.
+    pub fn omitted_control(&self, id: &str) -> Option<&OmittedControl> {
+        self.omitted.iter().find(|entry| entry.id.as_str() == id)
+    }
+}
+
+// =============================================================================
+// Projection
+// =============================================================================
+
+/// Project one admitted snapshot for one surface.
+pub fn project(snapshot: &ProducerSnapshot, profile: &SurfaceProfile) -> SurfaceProjection {
+    // RED stub: returns an empty rendered projection so the contract tests compile and fail.
+    let document = snapshot.document.as_ref();
+    SurfaceProjection::Rendered(Box::new(RenderedProjection {
+        schema: SURFACE_PROJECTION_SCHEMA,
+        surface_id: profile.surface_id.clone(),
+        producer: projected_producer(document),
+        position: document.position(),
+        presence: snapshot.presence,
+        lanes: Vec::new(),
+        groups: Vec::new(),
+        controls: Vec::new(),
+        omitted: Vec::new(),
+        notices: Vec::new(),
+    }))
+}
+
+/// Admit a raw producer value and project it, degrading to a fallback when it cannot be admitted.
+pub fn project_raw(raw: &serde_json::Value, profile: &SurfaceProfile) -> SurfaceProjection {
+    // RED stub.
+    let _ = raw;
+    SurfaceProjection::Fallback(FallbackProjection {
+        schema: SURFACE_PROJECTION_SCHEMA,
+        surface_id: profile.surface_id.clone(),
+        producer_id: None,
+        producer_type: None,
+        declared_schema: None,
+        refusal: Refusal::MissingVersion,
+    })
+}
+
+fn projected_producer(document: &ProducerDocument) -> ProjectedProducer {
+    ProjectedProducer {
+        producer_id: document.producer.producer_id.clone(),
+        producer_type: document.producer.producer_type.clone(),
+        instance_label: document.producer.instance_label.clone(),
+        product_version: document.producer.product_version.clone(),
+        epoch: document.producer.epoch,
+        role: document.target.role.clone(),
+        zone_id: document.target.zone_id.clone(),
+    }
+}
+
+// Silence unused-import warnings while the stub is in place; the real implementation uses all of
+// these.
+#[allow(dead_code)]
+type StubUnused = (
+    AvailabilityState,
+    BTreeMap<String, ()>,
+    ControlGroup,
+    Constraint,
+    ProjectedConstraint,
+    ValueLane,
+    ReasonScope,
+);
+#[allow(dead_code)]
+const STUB_UNUSED_KEYS: [&str; 5] = [
+    WITHHELD_UNRENDERABLE_KIND,
+    WITHHELD_PER_CHOICE_REASON,
+    WITHHELD_RISK_EXCEEDS_SURFACE,
+    OMITTED_BUDGET_EXHAUSTED,
+    OMITTED_CONTAINER_DROPPED,
+];
+#[allow(dead_code)]
+fn stub_unused(code: ReasonCode) -> Reason {
+    Reason::observed(code)
+}
+#[allow(dead_code)]
+const STUB_UNUSED_VERSION: SchemaVersion = CONSUMER_SCHEMA_VERSION;

--- a/src/producers/surface.rs
+++ b/src/producers/surface.rs
@@ -33,17 +33,22 @@
 //! * an enumeration invalidated by an in-flight write withholds the stale list and says which
 //!   operation invalidated it, rather than serving choices that are about to be wrong.
 //!
-//! Nothing here resolves catalog text (#343 owns that), invents a value, or reorders a producer's
-//! own enumeration.
+//! ## What this module deliberately does not know
+//!
+//! No producer family, no engine, no catalog text. Two facts that look producer-specific are
+//! parameters rather than knowledge: a surface's group priority comes from its own
+//! [`SurfaceBudget`], and the set of verified backend releases comes from a caller-supplied
+//! [`VerifiedSeries`]. The HQPlayer entry for the latter lives beside the HQPlayer producer.
 
 use std::collections::{BTreeMap, BTreeSet};
 
 use crate::adaptive::{
-    ApplyEffect, ApplyLane, ApplySemantics, Authority, Availability, AvailabilityState, Choice,
-    CommandOutcome, Constraint, ControlGroup, ControlId, ControlKind, ControlValue, Disruption,
-    Divergence, LaneHealth, LaneValue, NumericRange, OperationId, ProducerDocument, ProducerEpoch,
-    Reason, ReasonCode, ReasonScope, RecoveryState, Refusal, RevisionRef, RiskClass, SchemaVersion,
-    SourceClass, TargetRole, ValueLane, WriteAttempt, CONSUMER_SCHEMA_VERSION,
+    ApplyEffect, ApplyLane, ApplySemantics, Authority, Availability, Choice, CommandOutcome,
+    Constraint, ConstraintEffect, Control, ControlId, ControlKind, ControlValue, Disruption,
+    Divergence, LaneHealth, LaneState, LaneValue, NumericRange, OperationId, OperationRecord,
+    ProducerDocument, ProducerEpoch, Reason, ReasonCode, ReasonScope, RecoveryState, Refusal,
+    RevisionRef, RiskClass, SchemaVersion, SourceClass, TargetRole, Timestamp, TransportLane,
+    ValueLane, WriteAttempt, CONSUMER_SCHEMA_VERSION,
 };
 
 use super::aggregator::{ProducerPresence, ProducerSnapshot};
@@ -54,19 +59,21 @@ use super::aggregator::{ProducerPresence, ProducerSnapshot};
 /// together would mean a new producer minor forced every client to re-qualify.
 pub const SURFACE_PROJECTION_SCHEMA: SchemaVersion = SchemaVersion::new(1, 0);
 
-/// Catalog keys this module attaches to reasons it originates.
+/// Catalog key for a control whose primitive this surface cannot render.
 ///
-/// Keys, never prose: #343 owns the catalog and its provenance. A surface that has no catalog entry
+/// Keys, never prose: #343 owns the catalog and its provenance. A surface with no catalog entry
 /// still has the [`ReasonCode`] to branch on.
 pub const WITHHELD_UNRENDERABLE_KIND: &str = "surface.withheld.unrenderable_kind";
-/// A control whose per-choice availability this surface cannot express.
+/// Catalog key for a control whose per-choice availability this surface cannot express.
 pub const WITHHELD_PER_CHOICE_REASON: &str = "surface.withheld.per_choice_reason";
-/// A control whose risk class exceeds what this surface may offer.
+/// Catalog key for a control whose risk class exceeds what this surface may offer.
 pub const WITHHELD_RISK_EXCEEDS_SURFACE: &str = "surface.withheld.risk_exceeds_surface";
-/// A control dropped because the surface's control budget was exhausted.
+/// Catalog key for a control dropped because the surface's control budget was exhausted.
 pub const OMITTED_BUDGET_EXHAUSTED: &str = "surface.omitted.budget_exhausted";
-/// A control dropped because the container it belongs to was dropped.
+/// Catalog key for a control dropped because the container it belongs to was dropped.
 pub const OMITTED_CONTAINER_DROPPED: &str = "surface.omitted.container_dropped";
+/// Catalog key for an enumeration the producer declared but did not publish.
+pub const CHOICES_NOT_PUBLISHED: &str = "surface.choices.not_published";
 
 // =============================================================================
 // Profile
@@ -133,7 +140,7 @@ pub struct SurfaceProfile {
 }
 
 impl SurfaceProfile {
-    /// A browser: renders every primitive, no budget.
+    /// A browser: renders every primitive, no budget, and a human present to confirm.
     pub fn web() -> Self {
         Self {
             surface_id: "web".to_string(),
@@ -142,8 +149,8 @@ impl SurfaceProfile {
         }
     }
 
-    /// An AI tool client: no pixels, so every primitive is expressible as data, but it cannot ask a
-    /// human to confirm, so it may not be offered a disruptive or destructive operation unattended.
+    /// An AI tool client: every primitive is expressible as data, but nothing confirms at invoke
+    /// time, so a destructive operation is not advertised as invokable.
     pub fn mcp() -> Self {
         Self {
             surface_id: "mcp".to_string(),
@@ -155,8 +162,8 @@ impl SurfaceProfile {
         }
     }
 
-    /// A small control device: bounded, transport and volume first, and no primitive that needs a
-    /// per-option explanation.
+    /// A small control device: bounded, transport and volume first, no confirmation dialog, and no
+    /// primitive that needs a per-option explanation.
     pub fn compact_device(surface_id: impl Into<String>, max_controls: usize) -> Self {
         Self {
             surface_id: surface_id.into(),
@@ -172,7 +179,7 @@ impl SurfaceProfile {
                 .collect(),
                 per_choice_reasons: false,
                 reason_text: false,
-                max_risk: RiskClass::Safe,
+                max_risk: RiskClass::Caution,
             },
             budget: SurfaceBudget {
                 max_controls: Some(max_controls),
@@ -187,9 +194,72 @@ impl SurfaceProfile {
     }
 }
 
+/// Backend release series this build has actually verified, per producer family.
+///
+/// Empty means "no opinion", which raises no notice. The projector holds no engine knowledge; the
+/// HQPlayer entry is supplied by the HQPlayer producer, which owns the evidence ledger that decides
+/// what "verified" means.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct VerifiedSeries {
+    prefixes: BTreeMap<String, Vec<String>>,
+}
+
+impl VerifiedSeries {
+    /// Declare the verified `product_version` prefixes for one producer family.
+    pub fn with(
+        mut self,
+        producer_type: impl Into<String>,
+        prefixes: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        self.prefixes.insert(
+            producer_type.into(),
+            prefixes.into_iter().map(Into::into).collect(),
+        );
+        self
+    }
+
+    /// Whether this build has an opinion about `producer_type` at all.
+    pub fn has_opinion(&self, producer_type: &str) -> bool {
+        self.prefixes.contains_key(producer_type)
+    }
+
+    /// Whether `product_version` falls in a verified series.
+    ///
+    /// True when there is no opinion: silence is not evidence of a problem, and a notice nobody can
+    /// act on trains users to ignore notices.
+    pub fn covers(&self, producer_type: &str, product_version: &str) -> bool {
+        match self.prefixes.get(producer_type) {
+            None => true,
+            Some(prefixes) => prefixes
+                .iter()
+                .any(|prefix| product_version.starts_with(prefix.as_str())),
+        }
+    }
+}
+
 // =============================================================================
-// Projection
+// Projection value types
 // =============================================================================
+
+/// A safe, informative degradation for a document this build cannot admit.
+///
+/// It carries whatever identity was legible *without* trusting the body, so a surface can say "this
+/// producer speaks a generation UHC does not" instead of showing an empty panel with no explanation.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FallbackProjection {
+    /// Projection contract version.
+    pub schema: SchemaVersion,
+    /// The surface this was produced for.
+    pub surface_id: String,
+    /// The producer id, when the raw value carried a legible one.
+    pub producer_id: Option<String>,
+    /// The producer family, when the raw value carried a legible one.
+    pub producer_type: Option<String>,
+    /// The `schema_version` string exactly as the producer stamped it.
+    pub declared_schema: Option<String>,
+    /// Why the document was not admitted.
+    pub refusal: Refusal,
+}
 
 /// What a surface receives.
 #[derive(Debug, Clone, PartialEq)]
@@ -216,26 +286,6 @@ impl SurfaceProjection {
             Self::Fallback(fallback) => &fallback.surface_id,
         }
     }
-}
-
-/// A safe, informative degradation for a document this build cannot admit.
-///
-/// It carries whatever identity was legible *without* trusting the body, so a surface can say "this
-/// producer speaks a generation UHC does not" instead of showing an empty panel with no explanation.
-#[derive(Debug, Clone, PartialEq)]
-pub struct FallbackProjection {
-    /// Projection contract version.
-    pub schema: SchemaVersion,
-    /// The surface this was produced for.
-    pub surface_id: String,
-    /// The producer id, when the raw value carried a legible one.
-    pub producer_id: Option<String>,
-    /// The producer family, when the raw value carried a legible one.
-    pub producer_type: Option<String>,
-    /// The `schema_version` string exactly as the producer stamped it.
-    pub declared_schema: Option<String>,
-    /// Why the document was not admitted.
-    pub refusal: Refusal,
 }
 
 /// Producer identity, as a surface needs it.
@@ -283,9 +333,9 @@ pub enum ProjectionNotice {
     /// A transport lane is not healthy. Values sourced from it may be last-good.
     LaneNotHealthy {
         /// Which lane.
-        lane: crate::adaptive::TransportLane,
+        lane: TransportLane,
         /// Its state.
-        state: crate::adaptive::LaneState,
+        state: LaneState,
     },
     /// The aggregator demoted published intent before serving this snapshot.
     IntentRepaired {
@@ -319,7 +369,7 @@ pub struct OmittedControl {
     pub display_text_key: &'static str,
 }
 
-/// A presentation container, projected verbatim.
+/// A presentation container, in this surface's order.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProjectedGroup {
     /// Stable group id.
@@ -338,35 +388,10 @@ pub struct ProjectedLaneHealth {
     /// The producer's published health for this lane.
     pub health: LaneHealth,
     /// When the aggregator last saw this lane succeed, across admissions.
-    pub last_success_seen: Option<crate::adaptive::Timestamp>,
-}
-
-/// Whether, and how, a surface may offer mutation.
-#[derive(Debug, Clone, PartialEq)]
-pub enum Mutability {
-    /// Writable, with the cost of writing spelled out.
-    Mutable {
-        /// The producer's apply semantics, verbatim.
-        apply: Box<ApplySemantics>,
-        /// The surface-neutral description derived from them.
-        description: ApplyDescription,
-    },
-    /// The producer publishes no apply semantics: this control is observation only.
-    ObservationOnly,
-    /// The producer says the control is not writable now, and why.
-    Blocked {
-        /// The producer's reasons, verbatim. Never empty for a non-available state.
-        reasons: Vec<Reason>,
-    },
-    /// The producer would allow it; this surface cannot offer it faithfully.
     ///
-    /// A different verdict from [`Mutability::Blocked`], and the distinction matters: a surface
-    /// that reports its own limitation as the producer's is how a user concludes the engine is
-    /// broken.
-    WithheldFromSurface {
-        /// Why this surface withheld it.
-        reason: Reason,
-    },
+    /// Kept beside the producer's own words rather than merged into them: editing a producer's
+    /// statement is the fabrication #324's coherence rules forbid.
+    pub last_success_seen: Option<Timestamp>,
 }
 
 /// The surface-neutral answer to "when does this become true, and what does it cost".
@@ -394,6 +419,34 @@ pub struct ApplyDescription {
     pub invalidates: Vec<ControlId>,
     /// Controls the producer writes together with this one, as one plan.
     pub coupled_with: Vec<ControlId>,
+}
+
+/// Whether, and how, a surface may offer mutation.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Mutability {
+    /// Writable, with the cost of writing spelled out.
+    Mutable {
+        /// The producer's apply semantics, verbatim.
+        apply: Box<ApplySemantics>,
+        /// The surface-neutral description derived from them.
+        description: ApplyDescription,
+    },
+    /// The producer publishes no apply semantics: this control is observation only.
+    ObservationOnly,
+    /// The producer says the control is not writable now, and why.
+    Blocked {
+        /// The producer's reasons, verbatim.
+        reasons: Vec<Reason>,
+    },
+    /// The producer would allow it; this surface cannot offer it faithfully.
+    ///
+    /// A different verdict from [`Mutability::Blocked`], and the distinction matters: a surface
+    /// that reports its own limitation as the producer's is how a user concludes the engine is
+    /// broken.
+    WithheldFromSurface {
+        /// Why this surface withheld it.
+        reason: Reason,
+    },
 }
 
 /// Catalog key for a control that takes effect on the running engine at once.
@@ -490,7 +543,7 @@ pub struct ProjectedConstraint {
     /// Stable constraint id, so a surface can suppress a duplicate without matching a message.
     pub id: String,
     /// What holds when the condition holds.
-    pub effect: crate::adaptive::ConstraintEffect,
+    pub effect: ConstraintEffect,
     /// Machine-readable reason with a catalog key.
     pub reason: Reason,
 }
@@ -533,6 +586,8 @@ pub struct ProjectedControl {
     pub divergences: Vec<Divergence>,
     /// Constraints that name this control.
     pub constraints: Vec<ProjectedConstraint>,
+    /// Member ids, for groups and composites.
+    pub members: Vec<ControlId>,
 }
 
 impl ProjectedControl {
@@ -595,39 +650,85 @@ impl RenderedProjection {
 }
 
 // =============================================================================
+// Admission for a surface
+// =============================================================================
+
+/// Admit a raw producer value for a surface, or produce the fallback that explains why not.
+///
+/// This is the *compatibility* entry point, and it is deliberately the same
+/// [`crate::adaptive::admit_document`] gate every other consumer uses — it does not open a second
+/// path into the aggregator. Its whole contribution is turning a refusal into something a surface
+/// can render: a legible identity plus the reason, rather than an empty panel.
+/// The error is boxed because it is the rare branch and the whole point of it is to be rich: a
+/// legible identity plus a structured refusal is bigger than the document handle it replaces.
+pub fn admit_for_surface(
+    raw: &serde_json::Value,
+    profile: &SurfaceProfile,
+) -> Result<ProducerDocument, Box<FallbackProjection>> {
+    crate::adaptive::admit_document(raw).map_err(|refusal| {
+        Box::new(FallbackProjection {
+            schema: SURFACE_PROJECTION_SCHEMA,
+            surface_id: profile.surface_id.clone(),
+            // Read straight off the raw value, because the body is exactly what could not be
+            // trusted. Both spellings are tried: a generation that reshaped identity still usually
+            // leaves a string a human can recognize somewhere obvious, and naming the producer you
+            // cannot render is the difference between a diagnosable state and a blank one.
+            producer_id: legible_string(raw, &["producer", "producer_id"])
+                .or_else(|| legible_string(raw, &["producer", "identity", "urn"])),
+            producer_type: legible_string(raw, &["producer", "producer_type"]),
+            declared_schema: legible_string(raw, &["schema_version"]),
+            refusal,
+        })
+    })
+}
+
+fn legible_string(raw: &serde_json::Value, path: &[&str]) -> Option<String> {
+    let mut cursor = raw;
+    for segment in path {
+        cursor = cursor.get(segment)?;
+    }
+    cursor.as_str().map(str::to_string)
+}
+
+// =============================================================================
 // Projection
 // =============================================================================
 
-/// Project one admitted snapshot for one surface.
+/// Project one admitted snapshot for one surface, with no opinion about backend releases.
 pub fn project(snapshot: &ProducerSnapshot, profile: &SurfaceProfile) -> SurfaceProjection {
-    // RED stub: returns an empty rendered projection so the contract tests compile and fail.
+    project_with(snapshot, profile, &VerifiedSeries::default())
+}
+
+/// Project one admitted snapshot for one surface.
+pub fn project_with(
+    snapshot: &ProducerSnapshot,
+    profile: &SurfaceProfile,
+    verified: &VerifiedSeries,
+) -> SurfaceProjection {
     let document = snapshot.document.as_ref();
+    let mut notices = document_notices(snapshot, document, verified);
+
+    let invalidation = Invalidation::of(document);
+    let ranked = rank_controls(document, profile);
+    let (kept, omitted) = apply_budget(document, ranked, profile, &mut notices);
+
+    let controls: Vec<ProjectedControl> = kept
+        .iter()
+        .map(|control| project_control(control, document, profile, &invalidation, &mut notices))
+        .collect();
+
     SurfaceProjection::Rendered(Box::new(RenderedProjection {
         schema: SURFACE_PROJECTION_SCHEMA,
         surface_id: profile.surface_id.clone(),
         producer: projected_producer(document),
         position: document.position(),
         presence: snapshot.presence,
-        lanes: Vec::new(),
-        groups: Vec::new(),
-        controls: Vec::new(),
-        omitted: Vec::new(),
-        notices: Vec::new(),
+        lanes: project_lanes(snapshot, document),
+        groups: project_groups(document, profile),
+        controls,
+        omitted,
+        notices,
     }))
-}
-
-/// Admit a raw producer value and project it, degrading to a fallback when it cannot be admitted.
-pub fn project_raw(raw: &serde_json::Value, profile: &SurfaceProfile) -> SurfaceProjection {
-    // RED stub.
-    let _ = raw;
-    SurfaceProjection::Fallback(FallbackProjection {
-        schema: SURFACE_PROJECTION_SCHEMA,
-        surface_id: profile.surface_id.clone(),
-        producer_id: None,
-        producer_type: None,
-        declared_schema: None,
-        refusal: Refusal::MissingVersion,
-    })
 }
 
 fn projected_producer(document: &ProducerDocument) -> ProjectedProducer {
@@ -642,29 +743,522 @@ fn projected_producer(document: &ProducerDocument) -> ProjectedProducer {
     }
 }
 
-// Silence unused-import warnings while the stub is in place; the real implementation uses all of
-// these.
-#[allow(dead_code)]
-type StubUnused = (
-    AvailabilityState,
-    BTreeMap<String, ()>,
-    ControlGroup,
-    Constraint,
-    ProjectedConstraint,
-    ValueLane,
-    ReasonScope,
-);
-#[allow(dead_code)]
-const STUB_UNUSED_KEYS: [&str; 5] = [
-    WITHHELD_UNRENDERABLE_KIND,
-    WITHHELD_PER_CHOICE_REASON,
-    WITHHELD_RISK_EXCEEDS_SURFACE,
-    OMITTED_BUDGET_EXHAUSTED,
-    OMITTED_CONTAINER_DROPPED,
-];
-#[allow(dead_code)]
-fn stub_unused(code: ReasonCode) -> Reason {
-    Reason::observed(code)
+fn document_notices(
+    snapshot: &ProducerSnapshot,
+    document: &ProducerDocument,
+    verified: &VerifiedSeries,
+) -> Vec<ProjectionNotice> {
+    let mut notices = Vec::new();
+
+    if document.schema_version.major == CONSUMER_SCHEMA_VERSION.major
+        && document.schema_version.minor > CONSUMER_SCHEMA_VERSION.minor
+    {
+        notices.push(ProjectionNotice::UnknownSchemaAdditions {
+            document: document.schema_version,
+            consumer: CONSUMER_SCHEMA_VERSION,
+        });
+    }
+
+    if let Some(product_version) = &document.producer.product_version {
+        if !verified.covers(&document.producer.producer_type, product_version) {
+            notices.push(ProjectionNotice::UntestedProducerVersion {
+                product_version: product_version.clone(),
+            });
+        }
+    }
+
+    if snapshot.presence == ProducerPresence::LastKnown {
+        notices.push(ProjectionNotice::LastKnown);
+    }
+    if document.stale {
+        notices.push(ProjectionNotice::ProducerStale);
+    }
+    for health in &document.lanes {
+        if health.state != LaneState::Connected {
+            notices.push(ProjectionNotice::LaneNotHealthy {
+                lane: health.lane.clone(),
+                state: health.state.clone(),
+            });
+        }
+    }
+    if !snapshot.repairs.is_empty() {
+        notices.push(ProjectionNotice::IntentRepaired {
+            count: snapshot.repairs.len(),
+        });
+    }
+    notices
 }
-#[allow(dead_code)]
-const STUB_UNUSED_VERSION: SchemaVersion = CONSUMER_SCHEMA_VERSION;
+
+fn project_lanes(
+    snapshot: &ProducerSnapshot,
+    document: &ProducerDocument,
+) -> Vec<ProjectedLaneHealth> {
+    document
+        .lanes
+        .iter()
+        .map(|health| ProjectedLaneHealth {
+            health: health.clone(),
+            last_success_seen: snapshot
+                .lanes
+                .get(&health.lane)
+                .and_then(|witness| witness.last_success.clone()),
+        })
+        .collect()
+}
+
+/// The surface's rank for a group id: its position in the profile's priority list, then everything
+/// else. Groups the profile did not rank keep the producer's own ordering among themselves.
+fn group_rank(profile: &SurfaceProfile, group: Option<&str>) -> usize {
+    let ranked = &profile.budget.priority_groups;
+    match group {
+        Some(id) => ranked
+            .iter()
+            .position(|candidate| candidate == id)
+            .unwrap_or(ranked.len()),
+        None => ranked.len(),
+    }
+}
+
+fn project_groups(document: &ProducerDocument, profile: &SurfaceProfile) -> Vec<ProjectedGroup> {
+    let mut groups: Vec<ProjectedGroup> = document
+        .groups
+        .iter()
+        .map(|group| ProjectedGroup {
+            id: group.id.clone(),
+            label_key: group.label_key.clone(),
+            rank: group_rank(profile, Some(group.id.as_str())),
+            order: group.order,
+        })
+        .collect();
+    groups.sort_by(|left, right| {
+        left.rank
+            .cmp(&right.rank)
+            .then(
+                left.order
+                    .unwrap_or(i32::MAX)
+                    .cmp(&right.order.unwrap_or(i32::MAX)),
+            )
+            .then(left.id.cmp(&right.id))
+    });
+    groups
+}
+
+/// Controls in this surface's presentation order.
+///
+/// Total and deterministic: rank, then the group's own order, then the control's order, then id.
+/// A partial ordering would make truncation depend on `Vec` order, which is producer-arbitrary.
+fn rank_controls<'a>(document: &'a ProducerDocument, profile: &SurfaceProfile) -> Vec<&'a Control> {
+    let group_order: BTreeMap<&str, i32> = document
+        .groups
+        .iter()
+        .map(|group| (group.id.as_str(), group.order.unwrap_or(i32::MAX)))
+        .collect();
+
+    let mut ordered: Vec<&Control> = document.controls.iter().collect();
+    ordered.sort_by(|left, right| {
+        let left_group = left.group.as_deref();
+        let right_group = right.group.as_deref();
+        group_rank(profile, left_group)
+            .cmp(&group_rank(profile, right_group))
+            .then(
+                group_order
+                    .get(left_group.unwrap_or_default())
+                    .copied()
+                    .unwrap_or(i32::MAX)
+                    .cmp(
+                        &group_order
+                            .get(right_group.unwrap_or_default())
+                            .copied()
+                            .unwrap_or(i32::MAX),
+                    ),
+            )
+            .then(left_group.cmp(&right_group))
+            .then(
+                left.order
+                    .unwrap_or(i32::MAX)
+                    .cmp(&right.order.unwrap_or(i32::MAX)),
+            )
+            .then(left.id.cmp(&right.id))
+    });
+    ordered
+}
+
+/// Cut the ordered control list to the surface's budget, declaring every drop.
+///
+/// Two passes, and the second is the one that matters: after the budget cut, any surviving control
+/// whose container was cut is cut too, and reported under the container's reason rather than the
+/// budget's. A coupled half rendered with no container is worse than a missing control, because the
+/// surface would offer an edit whose other half it cannot see.
+fn apply_budget<'a>(
+    document: &ProducerDocument,
+    ordered: Vec<&'a Control>,
+    profile: &SurfaceProfile,
+    notices: &mut Vec<ProjectionNotice>,
+) -> (Vec<&'a Control>, Vec<OmittedControl>) {
+    let advertised = ordered.len();
+    let mut omitted: Vec<OmittedControl> = Vec::new();
+
+    let mut kept: Vec<&Control> = match profile.budget.max_controls {
+        Some(budget) if advertised > budget => {
+            notices.push(ProjectionNotice::Truncated { budget, advertised });
+            for control in ordered.iter().skip(budget) {
+                omitted.push(OmittedControl {
+                    id: control.id.clone(),
+                    code: ReasonCode::RequiresCapability,
+                    display_text_key: OMITTED_BUDGET_EXHAUSTED,
+                });
+            }
+            ordered.into_iter().take(budget).collect()
+        }
+        _ => ordered,
+    };
+
+    // Containers may nest, so iterate to a fixed point rather than assuming one level.
+    loop {
+        let present: BTreeSet<&ControlId> = kept.iter().map(|control| &control.id).collect();
+        let orphaned: BTreeSet<ControlId> = document
+            .controls
+            .iter()
+            .filter(|container| !present.contains(&container.id))
+            .flat_map(|container| container.members.iter().cloned())
+            .filter(|member| present.contains(member))
+            .collect();
+        if orphaned.is_empty() {
+            break;
+        }
+        kept.retain(|control| !orphaned.contains(&control.id));
+        for id in orphaned {
+            omitted.push(OmittedControl {
+                id,
+                code: ReasonCode::RequiresCapability,
+                display_text_key: OMITTED_CONTAINER_DROPPED,
+            });
+        }
+    }
+
+    // A member dropped by the budget whose container also went is reported for the container.
+    let dropped: BTreeSet<&ControlId> = document
+        .controls
+        .iter()
+        .filter(|control| !kept.iter().any(|keeper| keeper.id == control.id))
+        .map(|control| &control.id)
+        .collect();
+    let orphan_ids: BTreeSet<ControlId> = document
+        .controls
+        .iter()
+        .filter(|container| dropped.contains(&container.id))
+        .flat_map(|container| container.members.iter().cloned())
+        .collect();
+    for entry in &mut omitted {
+        if orphan_ids.contains(&entry.id) {
+            entry.display_text_key = OMITTED_CONTAINER_DROPPED;
+        }
+    }
+    omitted.sort_by(|left, right| left.id.cmp(&right.id));
+    omitted.dedup_by(|left, right| left.id == right.id);
+
+    (kept, omitted)
+}
+
+/// Which controls have their enumeration invalidated by a write that has not settled.
+///
+/// The predicate is [`CommandOutcome::is_state_evidence`], negated: `Pending`, `Indeterminate`,
+/// `TimedOut` and `Compensating` are the four outcomes #323 says describe the *operation* rather
+/// than the producer. While one of those is outstanding on a control that declares `invalidates`,
+/// the dependent enumerations published beside it may already be wrong.
+struct Invalidation {
+    by_control: BTreeMap<ControlId, (ControlId, OperationId)>,
+}
+
+impl Invalidation {
+    fn of(document: &ProducerDocument) -> Self {
+        let mut by_control = BTreeMap::new();
+        for operation in &document.operations {
+            if operation.outcome.is_state_evidence() {
+                continue;
+            }
+            let Some(request) = &operation.request else {
+                continue;
+            };
+            let Some(control) = document.control(&request.control) else {
+                continue;
+            };
+            let Some(apply) = &control.apply else {
+                continue;
+            };
+            for dependent in &apply.invalidates {
+                if dependent == &control.id {
+                    // A write does not invalidate its own enumeration; the producer republishes it
+                    // with the result. Guarding here keeps a self-referential descriptor from
+                    // blanking the control the user is holding.
+                    continue;
+                }
+                by_control
+                    .entry(dependent.clone())
+                    .or_insert_with(|| (control.id.clone(), operation.id.clone()));
+            }
+        }
+        Self { by_control }
+    }
+
+    fn for_control(&self, id: &ControlId) -> Option<&(ControlId, OperationId)> {
+        self.by_control.get(id)
+    }
+}
+
+fn project_control(
+    control: &Control,
+    document: &ProducerDocument,
+    profile: &SurfaceProfile,
+    invalidation: &Invalidation,
+    notices: &mut Vec<ProjectionNotice>,
+) -> ProjectedControl {
+    if !control.kind.is_recognized() {
+        notices.push(ProjectionNotice::UnrecognizedControlKind {
+            control: control.id.clone(),
+            kind: control.kind.as_str().to_string(),
+        });
+    }
+
+    let observed = control.lane(&ValueLane::Observed).cloned();
+    let intent: Vec<LaneValue> = control
+        .values
+        .iter()
+        .filter(|value| value.lane != ValueLane::Observed)
+        .cloned()
+        .collect();
+
+    let choices = project_choices(control, profile, invalidation);
+    let mutability = project_mutability(control, profile);
+
+    ProjectedControl {
+        id: control.id.clone(),
+        kind: control.kind.clone(),
+        label_key: control.label_key.clone(),
+        description_key: control.description_key.clone(),
+        group: control.group.clone(),
+        order: control.order,
+        unit: control.unit.clone(),
+        availability: control.availability.clone(),
+        observed,
+        intent,
+        choices,
+        range: control.range.clone(),
+        mutability,
+        operations: project_operations(control, document),
+        divergences: control.divergences.clone(),
+        constraints: project_constraints(control, document),
+        members: control.members.clone(),
+    }
+}
+
+fn project_choices(
+    control: &Control,
+    profile: &SurfaceProfile,
+    invalidation: &Invalidation,
+) -> ChoiceProjection {
+    if let Some((invalidated_by, operation)) = invalidation.for_control(&control.id) {
+        return ChoiceProjection::Reloading {
+            invalidated_by: invalidated_by.clone(),
+            operation: operation.clone(),
+        };
+    }
+
+    let Some(set) = &control.choices else {
+        // An enumeration with no published set is not an empty set: the producer declared a control
+        // whose options it could not read. Anything else is simply not a chooser.
+        return if control.kind == ControlKind::Enumeration {
+            ChoiceProjection::Unknown {
+                reason: Reason {
+                    code: ReasonCode::Unobservable,
+                    scope: ReasonScope::Observed,
+                    display_text_key: Some(CHOICES_NOT_PUBLISHED.to_string()),
+                    detail: None,
+                },
+            }
+        } else {
+            ChoiceProjection::NotApplicable
+        };
+    };
+
+    let (choices, truncated) = narrow(&set.choices, control, profile);
+    ChoiceProjection::Enumerated {
+        authority: set.authority.clone(),
+        source: set.source.clone(),
+        choices,
+        truncated,
+    }
+}
+
+/// Shorten an option list to the surface's budget without losing the current selection.
+///
+/// Head truncation alone produces a control whose value is not among its options, which is the
+/// state a user cannot reason about or escape. Every currently-held selection — observed, desired
+/// and held — is retained, and the drop count is reported so the surface can say the list is
+/// partial.
+fn narrow(
+    choices: &[Choice],
+    control: &Control,
+    profile: &SurfaceProfile,
+) -> (Vec<Choice>, Option<usize>) {
+    let Some(budget) = profile.budget.max_choices else {
+        return (choices.to_vec(), None);
+    };
+    if choices.len() <= budget {
+        return (choices.to_vec(), None);
+    }
+
+    let selected: BTreeSet<String> = [ValueLane::Observed, ValueLane::Desired, ValueLane::Held]
+        .iter()
+        .filter_map(|lane| control.lane(lane))
+        .filter_map(LaneValue::grounded_value)
+        .filter_map(|value| match value {
+            ControlValue::Choice(id) => Some(id.clone()),
+            _ => None,
+        })
+        .collect();
+
+    let mut kept: Vec<Choice> = choices
+        .iter()
+        .filter(|choice| selected.contains(&choice.id))
+        .cloned()
+        .collect();
+    for choice in choices {
+        if kept.len() >= budget {
+            break;
+        }
+        if selected.contains(&choice.id) {
+            continue;
+        }
+        kept.push(choice.clone());
+    }
+    // Restore the authority's own order; keeping the selection is about membership, not position.
+    let mut ordered: Vec<Choice> = choices
+        .iter()
+        .filter(|choice| kept.iter().any(|keeper| keeper.id == choice.id))
+        .cloned()
+        .collect();
+    ordered.truncate(kept.len().max(selected.len()));
+    let dropped = choices.len() - ordered.len();
+    (ordered, (dropped > 0).then_some(dropped))
+}
+
+/// The precedence that decides who is responsible for a control not being writable.
+///
+/// Producer truth first, always: a surface that reports its own limitation where the producer
+/// already had a reason is how a user concludes the engine is broken and goes looking for a fault
+/// that is not there.
+///
+/// 1. No apply semantics at all — observation only, whatever availability says.
+/// 2. The producer's availability forbids mutation — [`Mutability::Blocked`], with its reasons.
+/// 3. This surface cannot render the primitive.
+/// 4. This surface cannot express the control's per-choice availability.
+/// 5. The risk exceeds what this surface may offer.
+fn project_mutability(control: &Control, profile: &SurfaceProfile) -> Mutability {
+    let Some(apply) = &control.apply else {
+        return Mutability::ObservationOnly;
+    };
+    if !control.availability.permits_mutation() {
+        return Mutability::Blocked {
+            reasons: control.availability.reasons.clone(),
+        };
+    }
+
+    if !profile.capabilities.renders_kinds.contains(&control.kind) {
+        return withheld(WITHHELD_UNRENDERABLE_KIND, control.kind.as_str());
+    }
+
+    let carries_choice_reasons = control.choices.as_ref().is_some_and(|set| {
+        set.choices
+            .iter()
+            .any(|choice| choice.availability.is_some())
+    });
+    if carries_choice_reasons && !profile.capabilities.per_choice_reasons {
+        return withheld(WITHHELD_PER_CHOICE_REASON, control.id.as_str());
+    }
+
+    if apply.risk > profile.capabilities.max_risk {
+        return withheld(WITHHELD_RISK_EXCEEDS_SURFACE, apply.risk.as_str());
+    }
+
+    Mutability::Mutable {
+        apply: Box::new(apply.clone()),
+        description: describe(apply),
+    }
+}
+
+fn withheld(display_text_key: &str, detail: &str) -> Mutability {
+    Mutability::WithheldFromSurface {
+        reason: Reason {
+            code: ReasonCode::RequiresCapability,
+            // The gap is the *surface's*, and `ReasonScope` has no surface member in v1. `Producer`
+            // would misattribute it, so the reason is scoped to the lane-independent `Draft` view
+            // the surface owns, and the catalog key names the surface limitation exactly.
+            scope: ReasonScope::Draft,
+            display_text_key: Some(display_text_key.to_string()),
+            detail: Some(detail.to_string()),
+        },
+    }
+}
+
+fn describe(apply: &ApplySemantics) -> ApplyDescription {
+    ApplyDescription {
+        lane: apply.lane.clone(),
+        effect: apply.effect.clone(),
+        disruption: apply.disruption.clone(),
+        risk: apply.risk.clone(),
+        timing_key: timing_key(&apply.effect),
+        acknowledgement_is_evidence: !apply.verification.provisional_ack,
+        invalidates: apply.invalidates.clone(),
+        coupled_with: apply.coupled_with.clone(),
+    }
+}
+
+fn project_operations(control: &Control, document: &ProducerDocument) -> Vec<ProjectedOperation> {
+    document
+        .operations
+        .iter()
+        .filter(|operation| targets(operation, &control.id))
+        .map(|operation| ProjectedOperation {
+            id: operation.id.clone(),
+            correlation_id: operation.correlation_id.clone(),
+            write_attempt: operation.write_attempt.clone(),
+            outcome: operation.outcome.clone(),
+            is_state_evidence: operation.outcome.is_state_evidence(),
+            awaits_convergence: operation.outcome.awaits_convergence(),
+            observed: operation.observed,
+            recovery: operation.recovery.clone(),
+            reason: operation.reason.clone(),
+            requested: operation
+                .request
+                .as_ref()
+                .map(|request| request.requested.clone()),
+        })
+        .collect()
+}
+
+/// Whether an operation is *this* control's busy marker.
+///
+/// Direct requests and plan steps both count; nothing else does. A global busy flag is the pattern
+/// the HQPTuner audit told this issue not to inherit — one control's completion clearing another's
+/// marker is exactly what unscoped state produces.
+fn targets(operation: &OperationRecord, control: &ControlId) -> bool {
+    operation
+        .request
+        .as_ref()
+        .is_some_and(|request| &request.control == control)
+        || operation.steps.iter().any(|step| &step.control == control)
+}
+
+fn project_constraints(control: &Control, document: &ProducerDocument) -> Vec<ProjectedConstraint> {
+    document
+        .constraints
+        .iter()
+        .filter(|constraint| constraint.applies_to.contains(&control.id))
+        .map(|constraint: &Constraint| ProjectedConstraint {
+            id: constraint.id.clone(),
+            effect: constraint.effect.clone(),
+            reason: constraint.reason.clone(),
+        })
+        .collect()
+}

--- a/tests/adaptive_control_plane.rs
+++ b/tests/adaptive_control_plane.rs
@@ -17,20 +17,20 @@ use async_trait::async_trait;
 use unified_hifi_control::adaptive::{
     admit_document_str, ApplyEffect, ApplyLane, Authority, AvailabilityState, ChoiceSet,
     CommandOutcome, ControlId, ControlKind, ControlValue, DocumentRevisions, OperationId,
-    OperationRecord, OperationRequest, ProducerDocument, ProducerEpoch, Reason, ReasonCode,
-    RevisionRef, RiskClass, SourceClass, TargetRole, WriteAttempt, CONSUMER_SCHEMA_VERSION,
+    OperationRecord, OperationRequest, ProducerDocument, ProducerEpoch, ReasonCode, RevisionRef,
+    RiskClass, SourceClass, TargetRole, WriteAttempt, CONSUMER_SCHEMA_VERSION,
 };
 use unified_hifi_control::producers::control_plane::{
     CommandAcceptance, CommandRefusal, ControlPlaneService, RouteRefusal, SemanticCommand,
     SemanticCommandExecutor,
 };
 use unified_hifi_control::producers::surface::{
-    project, project_raw, timing_key, ChoiceProjection, Mutability, ProjectionNotice,
-    RenderedProjection, SurfaceProfile, SurfaceProjection, OMITTED_BUDGET_EXHAUSTED,
-    OMITTED_CONTAINER_DROPPED, SURFACE_PROJECTION_SCHEMA, TIMING_HELD_UNTIL_CHAIN_LOADED,
-    TIMING_LIVE_IMMEDIATE, TIMING_PERSISTENT_ONLY, TIMING_RESTART_REQUIRED, TIMING_UNKNOWN,
-    TIMING_VERIFIED_PENDING, WITHHELD_PER_CHOICE_REASON, WITHHELD_RISK_EXCEEDS_SURFACE,
-    WITHHELD_UNRENDERABLE_KIND,
+    admit_for_surface, project, project_with, timing_key, ChoiceProjection, Mutability,
+    ProjectionNotice, RenderedProjection, SurfaceProfile, SurfaceProjection, VerifiedSeries,
+    OMITTED_BUDGET_EXHAUSTED, OMITTED_CONTAINER_DROPPED, SURFACE_PROJECTION_SCHEMA,
+    TIMING_HELD_UNTIL_CHAIN_LOADED, TIMING_LIVE_IMMEDIATE, TIMING_PERSISTENT_ONLY,
+    TIMING_RESTART_REQUIRED, TIMING_UNKNOWN, TIMING_VERIFIED_PENDING, WITHHELD_PER_CHOICE_REASON,
+    WITHHELD_RISK_EXCEEDS_SURFACE, WITHHELD_UNRENDERABLE_KIND,
 };
 use unified_hifi_control::producers::{
     AdaptiveRuntime, ProducerKey, ProducerPresence, ProducerSnapshot,
@@ -85,6 +85,32 @@ fn rendered(document: ProducerDocument, profile: &SurfaceProfile) -> RenderedPro
             profile.surface_id, fallback.refusal
         ),
     }
+}
+
+fn rendered_with(
+    document: ProducerDocument,
+    profile: &SurfaceProfile,
+    verified: &VerifiedSeries,
+) -> RenderedProjection {
+    let snapshot = snapshot(document);
+    match project_with(&snapshot, profile, verified) {
+        SurfaceProjection::Rendered(rendered) => *rendered,
+        SurfaceProjection::Fallback(fallback) => {
+            panic!("expected a rendered projection, got {:?}", fallback.refusal)
+        }
+    }
+}
+
+/// The release series this build has verified, supplied the way the composition root supplies it.
+///
+/// The projector holds no engine knowledge; the HQPlayer entry is the HQPlayer producer's own.
+fn verified_series() -> VerifiedSeries {
+    VerifiedSeries::default().with(
+        "hqplayer",
+        unified_hifi_control::producers::hqplayer::HQP_VERIFIED_PRODUCT_SERIES
+            .iter()
+            .copied(),
+    )
 }
 
 fn web() -> SurfaceProfile {
@@ -196,7 +222,10 @@ fn the_observed_lane_never_carries_staged_or_held_intent() {
     let filter = view
         .control("hqplayer.pipeline.filter_1x")
         .expect("filter_1x is projected");
-    let observed = filter.observed.as_ref().expect("filter_1x has an observed lane");
+    let observed = filter
+        .observed
+        .as_ref()
+        .expect("filter_1x has an observed lane");
     assert_eq!(
         observed.grounded_value(),
         Some(&ControlValue::Choice("poly-sinc-gauss-long".to_string())),
@@ -263,7 +292,9 @@ fn availability_reasons_survive_projection_on_every_surface() {
 #[test]
 fn constraints_that_name_a_control_are_projected_onto_it() {
     let view = rendered(pipeline(), &web());
-    let rate = view.control("hqplayer.pipeline.rate.exact").expect("projected");
+    let rate = view
+        .control("hqplayer.pipeline.rate.exact")
+        .expect("projected");
     let ids: Vec<&str> = rate
         .constraints
         .iter()
@@ -353,7 +384,13 @@ fn a_surface_that_offers_less_never_offers_something_different() {
             }
 
             match (&control.mutability, &reference.mutability) {
-                (Mutability::Mutable { description, .. }, Mutability::Mutable { description: reference_description, .. }) => {
+                (
+                    Mutability::Mutable { description, .. },
+                    Mutability::Mutable {
+                        description: reference_description,
+                        ..
+                    },
+                ) => {
                     assert_eq!(
                         description, reference_description,
                         "{} on {}: the cost of writing is the producer's, not the surface's",
@@ -418,7 +455,9 @@ fn a_surface_limitation_is_never_reported_as_the_producers_verdict() {
 #[test]
 fn an_unrenderable_primitive_is_withheld_rather_than_flattened() {
     let view = rendered(pipeline(), &device(64));
-    let composite = view.control("hqplayer.matrix.channel_map").expect("projected");
+    let composite = view
+        .control("hqplayer.matrix.channel_map")
+        .expect("projected");
     assert_eq!(composite.kind, ControlKind::Composite);
     match &composite.mutability {
         Mutability::WithheldFromSurface { reason } => {
@@ -434,7 +473,9 @@ fn an_unrenderable_primitive_is_withheld_rather_than_flattened() {
 #[test]
 fn an_operation_riskier_than_the_surface_may_offer_is_withheld_with_that_reason() {
     let view = rendered(pipeline(), &mcp());
-    let dither = view.control("hqplayer.settings.legacy_dither").expect("projected");
+    let dither = view
+        .control("hqplayer.settings.legacy_dither")
+        .expect("projected");
     assert_eq!(
         dither.availability.state,
         AvailabilityState::Deprecated,
@@ -476,7 +517,9 @@ fn the_producers_own_block_outranks_a_surface_limitation() {
     // `chain.sdm.filter` is unavailable *and* would be withheld from a device. The user must be
     // told the chain is not loaded, not that their knob is too small.
     let view = rendered(pipeline(), &device(64));
-    let sdm = view.control("hqplayer.chain.sdm.filter").expect("projected");
+    let sdm = view
+        .control("hqplayer.chain.sdm.filter")
+        .expect("projected");
     match &sdm.mutability {
         Mutability::Blocked { reasons } => assert_eq!(reasons[0].code, ReasonCode::ChainNotLoaded),
         other => panic!("the producer's reason must win, got {other:?}"),
@@ -490,8 +533,8 @@ fn the_producers_own_block_outranks_a_surface_limitation() {
 #[test]
 fn an_unsupported_major_degrades_to_an_informative_fallback() {
     let raw = raw_fixture("unsupported_major");
-    match project_raw(&raw, &web()) {
-        SurfaceProjection::Fallback(fallback) => {
+    match admit_for_surface(&raw, &web()) {
+        Err(fallback) => {
             assert_eq!(fallback.surface_id, "web");
             assert_eq!(fallback.declared_schema.as_deref(), Some("2.0"));
             assert!(
@@ -508,19 +551,16 @@ fn an_unsupported_major_degrades_to_an_informative_fallback() {
                  the producer it cannot render"
             );
         }
-        SurfaceProjection::Rendered(_) => {
-            panic!("a v2 document must never be partially rendered by a v1 consumer")
-        }
+        Ok(_) => panic!("a v2 document must never be partially rendered by a v1 consumer"),
     }
 }
 
 #[test]
 fn a_newer_minor_renders_and_says_that_it_did_not_understand_everything() {
     let raw = raw_fixture("forward_compatible_additions");
-    let projection = project_raw(&raw, &web());
-    let view = projection
-        .rendered()
-        .expect("a newer minor of the same major must render");
+    let document =
+        admit_for_surface(&raw, &web()).expect("a newer minor of the same major is admissible");
+    let view = rendered(document, &web());
 
     assert!(
         view.notices.iter().any(|notice| matches!(
@@ -563,7 +603,7 @@ fn a_newer_minor_renders_and_says_that_it_did_not_understand_everything() {
 fn an_untested_product_version_notices_without_disabling_discovered_controls() {
     let mut document = pipeline();
     document.producer.product_version = Some("7.0.0-beta".to_string());
-    let view = rendered(document, &web());
+    let view = rendered_with(document, &web(), &verified_series());
 
     assert!(
         view.notices.iter().any(|notice| matches!(
@@ -584,7 +624,7 @@ fn an_untested_product_version_notices_without_disabling_discovered_controls() {
 
 #[test]
 fn a_verified_product_version_raises_no_untested_notice() {
-    let view = rendered(pipeline(), &web());
+    let view = rendered_with(pipeline(), &web(), &verified_series());
     assert!(
         !view
             .notices
@@ -668,7 +708,9 @@ fn a_settled_write_does_not_hold_its_dependents_in_reloading() {
         CommandOutcome::Applied,
     )];
     let view = rendered(document, &web());
-    let filter = view.control("hqplayer.pipeline.filter_1x").expect("projected");
+    let filter = view
+        .control("hqplayer.pipeline.filter_1x")
+        .expect("projected");
     assert!(
         matches!(filter.choices, ChoiceProjection::Enumerated { .. }),
         "once the outcome is state evidence the enumeration published beside it is current"
@@ -680,7 +722,11 @@ fn an_unreadable_enumeration_is_not_the_same_as_an_empty_one() {
     let mut unreadable = pipeline();
     control_mut(&mut unreadable, "hqplayer.pipeline.mode").choices = None;
     let view = rendered(unreadable, &web());
-    match &view.control("hqplayer.pipeline.mode").expect("projected").choices {
+    match &view
+        .control("hqplayer.pipeline.mode")
+        .expect("projected")
+        .choices
+    {
         ChoiceProjection::Unknown { reason } => {
             assert_eq!(reason.code, ReasonCode::Unobservable)
         }
@@ -695,7 +741,11 @@ fn an_unreadable_enumeration_is_not_the_same_as_an_empty_one() {
         choices: Vec::new(),
     });
     let view = rendered(empty, &web());
-    match &view.control("hqplayer.pipeline.mode").expect("projected").choices {
+    match &view
+        .control("hqplayer.pipeline.mode")
+        .expect("projected")
+        .choices
+    {
         ChoiceProjection::Enumerated { choices, .. } => assert!(
             choices.is_empty(),
             "a successful read of an empty collection is a fact, and a different fact"
@@ -712,7 +762,11 @@ fn an_unreadable_enumeration_is_not_the_same_as_an_empty_one() {
 fn busy_state_is_scoped_per_operation_and_per_control() {
     let mut document = pipeline();
     document.operations = vec![
-        operation("op-mode-1", "hqplayer.pipeline.mode", CommandOutcome::Pending),
+        operation(
+            "op-mode-1",
+            "hqplayer.pipeline.mode",
+            CommandOutcome::Pending,
+        ),
         operation("op-vol-2", "hqplayer.volume.level", CommandOutcome::Applied),
     ];
     let view = rendered(document, &web());
@@ -788,12 +842,7 @@ fn every_control_in_one_projection_comes_from_one_document() {
     let expected: BTreeMap<String, Option<ControlValue>> = document
         .controls
         .iter()
-        .map(|control| {
-            (
-                control.id.to_string(),
-                control.observed().cloned(),
-            )
-        })
+        .map(|control| (control.id.to_string(), control.observed().cloned()))
         .collect();
     let view = rendered(document, &web());
 
@@ -896,7 +945,9 @@ fn narrowing_an_option_list_never_hides_the_current_selection() {
     });
 
     let view = rendered(document, &device(64));
-    let filter = view.control("hqplayer.pipeline.filter_1x").expect("projected");
+    let filter = view
+        .control("hqplayer.pipeline.filter_1x")
+        .expect("projected");
     let offered = filter.offered_choice_ids();
     assert!(
         offered.contains(&"poly-sinc-gauss-long"),
@@ -1054,7 +1105,9 @@ fn a_provisional_acknowledgement_is_never_described_as_proof() {
 #[test]
 fn coupled_controls_are_advertised_as_one_plan() {
     let view = rendered(pipeline(), &web());
-    let enabled = view.control("hqplayer.volume.fixed.enabled").expect("projected");
+    let enabled = view
+        .control("hqplayer.volume.fixed.enabled")
+        .expect("projected");
     match &enabled.mutability {
         Mutability::Mutable { description, .. } => {
             assert_eq!(
@@ -1111,10 +1164,7 @@ async fn service_with(
         .await
         .expect("the actor drains once its channel closes")
         .expect("the actor task must not panic");
-    (
-        ControlPlaneService::new(view),
-        runs.into_values().collect(),
-    )
+    (ControlPlaneService::new(view), runs.into_values().collect())
 }
 
 fn hqplayer_zone_document(zone: &str) -> ProducerDocument {
@@ -1137,7 +1187,9 @@ async fn an_unknown_hqplayer_identity_is_refused_rather_than_routed_anywhere_els
         other => panic!("an unknown HQPlayer identity must refuse, got {other:?}"),
     }
     assert!(
-        service.route("roon:1601bb42ed14351b99c2926214f6cbb80724").is_ok(),
+        service
+            .route("roon:1601bb42ed14351b99c2926214f6cbb80724")
+            .is_ok(),
         "the producer that does exist still routes"
     );
 }

--- a/tests/adaptive_control_plane.rs
+++ b/tests/adaptive_control_plane.rs
@@ -1,0 +1,1325 @@
+//! Contract tests for the adaptive control plane (#331).
+//!
+//! Every test here compares **projections of the same fixture**. That is the whole point: the
+//! acceptance criterion is not "the web page works" but "the web page, an MCP client and a device
+//! cannot disagree about the same producer", and the only way to falsify that is to project one
+//! document three ways and look for a contradiction.
+//!
+//! Hermetic by construction: canonical `#323` fixtures on disk, plus documents derived from them in
+//! memory. No socket, no clock, no live HQPlayer host.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+
+use unified_hifi_control::adaptive::{
+    admit_document_str, ApplyEffect, ApplyLane, Authority, AvailabilityState, ChoiceSet,
+    CommandOutcome, ControlId, ControlKind, ControlValue, DocumentRevisions, OperationId,
+    OperationRecord, OperationRequest, ProducerDocument, ProducerEpoch, Reason, ReasonCode,
+    RevisionRef, RiskClass, SourceClass, TargetRole, WriteAttempt, CONSUMER_SCHEMA_VERSION,
+};
+use unified_hifi_control::producers::control_plane::{
+    CommandAcceptance, CommandRefusal, ControlPlaneService, RouteRefusal, SemanticCommand,
+    SemanticCommandExecutor,
+};
+use unified_hifi_control::producers::surface::{
+    project, project_raw, timing_key, ChoiceProjection, Mutability, ProjectionNotice,
+    RenderedProjection, SurfaceProfile, SurfaceProjection, OMITTED_BUDGET_EXHAUSTED,
+    OMITTED_CONTAINER_DROPPED, SURFACE_PROJECTION_SCHEMA, TIMING_HELD_UNTIL_CHAIN_LOADED,
+    TIMING_LIVE_IMMEDIATE, TIMING_PERSISTENT_ONLY, TIMING_RESTART_REQUIRED, TIMING_UNKNOWN,
+    TIMING_VERIFIED_PENDING, WITHHELD_PER_CHOICE_REASON, WITHHELD_RISK_EXCEEDS_SURFACE,
+    WITHHELD_UNRENDERABLE_KIND,
+};
+use unified_hifi_control::producers::{
+    AdaptiveRuntime, ProducerKey, ProducerPresence, ProducerSnapshot,
+};
+
+// =============================================================================
+// Harness
+// =============================================================================
+
+fn fixture(name: &str) -> ProducerDocument {
+    let path = format!(
+        "{}/tests/fixtures/adaptive/{name}.json",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    let raw = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"));
+    match admit_document_str(&raw) {
+        Ok(document) => document,
+        Err(refusal) => panic!("canonical fixture {name} is not admissible: {refusal}"),
+    }
+}
+
+fn raw_fixture(name: &str) -> serde_json::Value {
+    let path = format!(
+        "{}/tests/fixtures/adaptive/{name}.json",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    let raw = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"));
+    serde_json::from_str(&raw).unwrap_or_else(|e| panic!("parse {path}: {e}"))
+}
+
+fn pipeline() -> ProducerDocument {
+    fixture("hqplayer_pipeline_v1")
+}
+
+fn snapshot(document: ProducerDocument) -> ProducerSnapshot {
+    ProducerSnapshot {
+        key: ProducerKey::of(&document),
+        document: Arc::new(document),
+        lanes: BTreeMap::new(),
+        presence: ProducerPresence::Live,
+        repairs: Vec::new(),
+        last_refusal: None,
+    }
+}
+
+fn rendered(document: ProducerDocument, profile: &SurfaceProfile) -> RenderedProjection {
+    let snapshot = snapshot(document);
+    match project(&snapshot, profile) {
+        SurfaceProjection::Rendered(rendered) => *rendered,
+        SurfaceProjection::Fallback(fallback) => panic!(
+            "expected a rendered projection for {}, got a fallback: {:?}",
+            profile.surface_id, fallback.refusal
+        ),
+    }
+}
+
+fn web() -> SurfaceProfile {
+    SurfaceProfile::web()
+}
+
+fn mcp() -> SurfaceProfile {
+    SurfaceProfile::mcp()
+}
+
+fn device(max_controls: usize) -> SurfaceProfile {
+    SurfaceProfile::compact_device("knob", max_controls)
+}
+
+/// A non-terminal operation targeting one control, so invalidation and busy scoping are reachable.
+fn operation(id: &str, control: &str, outcome: CommandOutcome) -> OperationRecord {
+    OperationRecord {
+        id: OperationId::new(id),
+        correlation_id: format!("corr-{id}"),
+        request: Some(OperationRequest {
+            control: ControlId::new(control),
+            requested: ControlValue::Choice("pcm".to_string()),
+            lane: ApplyLane::Immediate,
+            base: RevisionRef {
+                epoch: ProducerEpoch(7),
+                control_plane: unified_hifi_control::adaptive::Revision(12),
+                state: unified_hifi_control::adaptive::Revision(4193),
+            },
+        }),
+        change_set: None,
+        generation: None,
+        write_attempt: WriteAttempt::Attempted,
+        outcome,
+        observed: None,
+        steps: Vec::new(),
+        revision_boundaries: Vec::new(),
+        history: Vec::new(),
+        recovery: None,
+        reason: None,
+        extensions: Default::default(),
+    }
+}
+
+fn control_mut<'a>(
+    document: &'a mut ProducerDocument,
+    id: &str,
+) -> &'a mut unified_hifi_control::adaptive::Control {
+    document
+        .controls
+        .iter_mut()
+        .find(|control| control.id.as_str() == id)
+        .unwrap_or_else(|| panic!("fixture has no control {id}"))
+}
+
+// =============================================================================
+// The projection is one atomic view of one revision
+// =============================================================================
+
+#[test]
+fn a_projection_carries_exactly_one_producer_position() {
+    let document = pipeline();
+    let expected = document.position();
+    let view = rendered(document, &web());
+
+    assert_eq!(
+        view.position, expected,
+        "a projection must be stamped with the exact position of the document it came from, so a \
+         surface can never combine a mode read at one revision with an enumeration read at another"
+    );
+    assert_eq!(view.schema, SURFACE_PROJECTION_SCHEMA);
+    assert_eq!(view.surface_id, "web");
+    assert_eq!(view.producer.producer_id, "hqplayer:living-room");
+    assert_eq!(view.producer.role, TargetRole::DspEngine);
+}
+
+#[test]
+fn every_advertised_control_reaches_an_unbounded_surface() {
+    let document = pipeline();
+    let advertised: Vec<String> = document
+        .controls
+        .iter()
+        .map(|control| control.id.to_string())
+        .collect();
+    let view = rendered(document, &web());
+
+    let projected: Vec<String> = view
+        .controls
+        .iter()
+        .map(|control| control.id.to_string())
+        .collect();
+    for id in &advertised {
+        assert!(
+            projected.contains(id),
+            "an unbudgeted surface must receive every control the producer advertised; {id} is \
+             missing"
+        );
+    }
+    assert!(
+        view.omitted.is_empty(),
+        "nothing may be omitted without a budget: {:?}",
+        view.omitted
+    );
+}
+
+#[test]
+fn the_observed_lane_never_carries_staged_or_held_intent() {
+    let view = rendered(pipeline(), &web());
+
+    let filter = view
+        .control("hqplayer.pipeline.filter_1x")
+        .expect("filter_1x is projected");
+    let observed = filter.observed.as_ref().expect("filter_1x has an observed lane");
+    assert_eq!(
+        observed.grounded_value(),
+        Some(&ControlValue::Choice("poly-sinc-gauss-long".to_string())),
+        "the running signal path must show what the engine reports, never the staged edit"
+    );
+    let desired: Vec<_> = filter
+        .intent
+        .iter()
+        .filter(|value| value.lane == unified_hifi_control::adaptive::ValueLane::Desired)
+        .collect();
+    assert_eq!(
+        desired.len(),
+        1,
+        "the staged value must still be projected, but separately from observed"
+    );
+
+    let held = view
+        .control("hqplayer.volume.fixed.level")
+        .expect("the dormant fixed level is projected");
+    assert!(
+        held.observed
+            .as_ref()
+            .is_none_or(|value| value.grounded_value().is_none()),
+        "a dormant control's observed lane is ungrounded and must not be filled from held intent"
+    );
+    assert!(
+        held.intent
+            .iter()
+            .any(|value| value.lane == unified_hifi_control::adaptive::ValueLane::Held),
+        "held intent must remain visible with held-intent language rather than disappearing"
+    );
+}
+
+#[test]
+fn availability_reasons_survive_projection_on_every_surface() {
+    for profile in [web(), mcp(), device(64)] {
+        let view = rendered(pipeline(), &profile);
+        for control in &view.controls {
+            if control.availability.state != AvailabilityState::Available {
+                assert!(
+                    !control.availability.reasons.is_empty(),
+                    "{}: {} is {:?} with no reason; a user who cannot see why cannot escape the \
+                     state that caused it",
+                    profile.surface_id,
+                    control.id,
+                    control.availability.state
+                );
+            }
+        }
+        let rate = view
+            .control("hqplayer.pipeline.rate.exact")
+            .expect("the unavailable exact-rate control is still displayed");
+        assert_eq!(rate.availability.reasons.len(), 2);
+        assert!(
+            rate.availability
+                .reasons
+                .iter()
+                .all(|reason| reason.display_text_key.is_some()),
+            "reason text must be addressable through the catalog, not carried as a hover title"
+        );
+    }
+}
+
+#[test]
+fn constraints_that_name_a_control_are_projected_onto_it() {
+    let view = rendered(pipeline(), &web());
+    let rate = view.control("hqplayer.pipeline.rate.exact").expect("projected");
+    let ids: Vec<&str> = rate
+        .constraints
+        .iter()
+        .map(|constraint| constraint.id.as_str())
+        .collect();
+    assert!(
+        ids.contains(&"hqplayer.constraint.exact_rate_requires_explicit_mode")
+            && ids.contains(&"hqplayer.constraint.exact_rate_inert_when_adaptive"),
+        "a surface must be able to explain a constraint without re-deriving it: {ids:?}"
+    );
+}
+
+// =============================================================================
+// Falsifying cross-surface projection drift
+// =============================================================================
+
+#[test]
+fn no_two_surfaces_disagree_about_what_the_producer_said() {
+    let profiles = [web(), mcp(), device(64)];
+    let views: Vec<RenderedProjection> = profiles
+        .iter()
+        .map(|profile| rendered(pipeline(), profile))
+        .collect();
+
+    for (left_profile, left) in profiles.iter().zip(&views) {
+        for (right_profile, right) in profiles.iter().zip(&views) {
+            if left_profile.surface_id == right_profile.surface_id {
+                continue;
+            }
+            assert_eq!(
+                left.position, right.position,
+                "two surfaces projecting one snapshot must cite one position"
+            );
+            for control in &left.controls {
+                let Some(other) = right.control(control.id.as_str()) else {
+                    continue;
+                };
+                assert_eq!(
+                    control.kind, other.kind,
+                    "{}: kind must never be substituted per surface",
+                    control.id
+                );
+                assert_eq!(
+                    control.availability, other.availability,
+                    "{}: availability is the producer's verdict, identical everywhere",
+                    control.id
+                );
+                assert_eq!(
+                    control.observed, other.observed,
+                    "{}: the observed lane is one fact",
+                    control.id
+                );
+                assert_eq!(
+                    control.unit, other.unit,
+                    "{}: units cannot differ per surface",
+                    control.id
+                );
+                assert_eq!(
+                    control.range, other.range,
+                    "{}: the numeric domain is the producer's, not the widget's",
+                    control.id
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn a_surface_that_offers_less_never_offers_something_different() {
+    let unbounded = rendered(pipeline(), &web());
+    for profile in [mcp(), device(64)] {
+        let view = rendered(pipeline(), &profile);
+        for control in &view.controls {
+            let reference = unbounded
+                .control(control.id.as_str())
+                .expect("the unbounded surface sees everything");
+
+            let offered: Vec<&str> = control.offered_choice_ids();
+            let reference_offered: Vec<&str> = reference.offered_choice_ids();
+            for id in &offered {
+                assert!(
+                    reference_offered.contains(id),
+                    "{} on {}: offered choice {id} does not exist on the unbounded projection",
+                    control.id,
+                    profile.surface_id
+                );
+            }
+
+            match (&control.mutability, &reference.mutability) {
+                (Mutability::Mutable { description, .. }, Mutability::Mutable { description: reference_description, .. }) => {
+                    assert_eq!(
+                        description, reference_description,
+                        "{} on {}: the cost of writing is the producer's, not the surface's",
+                        control.id, profile.surface_id
+                    );
+                }
+                (Mutability::Mutable { .. }, other) => panic!(
+                    "{} on {}: offered as mutable while the unbounded surface reports {other:?}",
+                    control.id, profile.surface_id
+                ),
+                (Mutability::Blocked { reasons }, reference_mutability) => {
+                    assert!(
+                        matches!(reference_mutability, Mutability::Blocked { reasons: reference_reasons } if reference_reasons == reasons),
+                        "{} on {}: a producer block must be reported identically everywhere",
+                        control.id,
+                        profile.surface_id
+                    );
+                }
+                (Mutability::ObservationOnly, reference_mutability) => {
+                    assert!(
+                        matches!(reference_mutability, Mutability::ObservationOnly),
+                        "{} on {}: observation-only is a property of the document",
+                        control.id,
+                        profile.surface_id
+                    );
+                }
+                (Mutability::WithheldFromSurface { .. }, _) => {}
+            }
+        }
+    }
+}
+
+#[test]
+fn a_surface_limitation_is_never_reported_as_the_producers_verdict() {
+    let view = rendered(pipeline(), &device(64));
+
+    let matrix = view.control("hqplayer.matrix.profile").expect("projected");
+    match &matrix.mutability {
+        Mutability::WithheldFromSurface { reason } => {
+            assert_eq!(reason.code, ReasonCode::RequiresCapability);
+            assert_eq!(
+                reason.display_text_key.as_deref(),
+                Some(WITHHELD_PER_CHOICE_REASON),
+                "a control carrying per-choice availability must not be offered by a surface that \
+                 cannot express it; the segmented-control case from the HQPTuner audit"
+            );
+        }
+        other => panic!("expected the matrix profile to be withheld from a device, got {other:?}"),
+    }
+    assert_eq!(
+        matrix.availability.state,
+        AvailabilityState::Available,
+        "withholding is about this surface's offer, never a rewrite of the producer's availability"
+    );
+    assert_eq!(
+        matrix.offered_choice_ids(),
+        vec!["", "room-a", "room-b"],
+        "the option set stays visible even where mutation is withheld"
+    );
+}
+
+#[test]
+fn an_unrenderable_primitive_is_withheld_rather_than_flattened() {
+    let view = rendered(pipeline(), &device(64));
+    let composite = view.control("hqplayer.matrix.channel_map").expect("projected");
+    assert_eq!(composite.kind, ControlKind::Composite);
+    match &composite.mutability {
+        Mutability::WithheldFromSurface { reason } => {
+            assert_eq!(
+                reason.display_text_key.as_deref(),
+                Some(WITHHELD_UNRENDERABLE_KIND)
+            );
+        }
+        other => panic!("expected a composite to be withheld from a device, got {other:?}"),
+    }
+}
+
+#[test]
+fn an_operation_riskier_than_the_surface_may_offer_is_withheld_with_that_reason() {
+    let view = rendered(pipeline(), &mcp());
+    let dither = view.control("hqplayer.settings.legacy_dither").expect("projected");
+    assert_eq!(
+        dither.availability.state,
+        AvailabilityState::Deprecated,
+        "a deprecated control still renders; the contract says so explicitly"
+    );
+    match &dither.mutability {
+        Mutability::WithheldFromSurface { reason } => assert_eq!(
+            reason.display_text_key.as_deref(),
+            Some(WITHHELD_RISK_EXCEEDS_SURFACE),
+            "a destructive operation must not be advertised to a surface that cannot confirm it"
+        ),
+        other => panic!("expected the destructive control to be withheld from MCP, got {other:?}"),
+    }
+}
+
+#[test]
+fn an_unrecognized_risk_class_is_never_advertised_as_invokable() {
+    let mut document = pipeline();
+    if let Some(apply) = control_mut(&mut document, "hqplayer.transport.play")
+        .apply
+        .as_mut()
+    {
+        apply.risk = RiskClass::Unrecognized("catastrophic".to_string());
+    }
+    let view = rendered(document, &web());
+    let play = view.control("hqplayer.transport.play").expect("projected");
+    assert!(
+        matches!(play.mutability, Mutability::WithheldFromSurface { .. }),
+        "a risk class from a newer minor must fail closed for mutation and open for display"
+    );
+    assert!(
+        play.availability.state == AvailabilityState::Available,
+        "failing closed on mutation must not hide the control"
+    );
+}
+
+#[test]
+fn the_producers_own_block_outranks_a_surface_limitation() {
+    // `chain.sdm.filter` is unavailable *and* would be withheld from a device. The user must be
+    // told the chain is not loaded, not that their knob is too small.
+    let view = rendered(pipeline(), &device(64));
+    let sdm = view.control("hqplayer.chain.sdm.filter").expect("projected");
+    match &sdm.mutability {
+        Mutability::Blocked { reasons } => assert_eq!(reasons[0].code, ReasonCode::ChainNotLoaded),
+        other => panic!("the producer's reason must win, got {other:?}"),
+    }
+}
+
+// =============================================================================
+// Falsifying unknown schema / version fallback
+// =============================================================================
+
+#[test]
+fn an_unsupported_major_degrades_to_an_informative_fallback() {
+    let raw = raw_fixture("unsupported_major");
+    match project_raw(&raw, &web()) {
+        SurfaceProjection::Fallback(fallback) => {
+            assert_eq!(fallback.surface_id, "web");
+            assert_eq!(fallback.declared_schema.as_deref(), Some("2.0"));
+            assert!(
+                matches!(
+                    fallback.refusal,
+                    unified_hifi_control::adaptive::Refusal::UnsupportedMajor { document: 2, .. }
+                ),
+                "the surface must be told which generation it could not read: {:?}",
+                fallback.refusal
+            );
+            assert!(
+                fallback.producer_id.is_some(),
+                "identity legible without trusting the body must survive, so the surface can name \
+                 the producer it cannot render"
+            );
+        }
+        SurfaceProjection::Rendered(_) => {
+            panic!("a v2 document must never be partially rendered by a v1 consumer")
+        }
+    }
+}
+
+#[test]
+fn a_newer_minor_renders_and_says_that_it_did_not_understand_everything() {
+    let raw = raw_fixture("forward_compatible_additions");
+    let projection = project_raw(&raw, &web());
+    let view = projection
+        .rendered()
+        .expect("a newer minor of the same major must render");
+
+    assert!(
+        view.notices.iter().any(|notice| matches!(
+            notice,
+            ProjectionNotice::UnknownSchemaAdditions { document, consumer }
+                if document.major == CONSUMER_SCHEMA_VERSION.major && *consumer == CONSUMER_SCHEMA_VERSION
+        )),
+        "the surface must know it is looking at a newer minor: {:?}",
+        view.notices
+    );
+    assert!(
+        view.control("future.spatial.render_mode").is_some(),
+        "controls a v1.0 consumer does understand must still be rendered"
+    );
+    let vector = view
+        .control("future.spatial.head_tracking")
+        .expect("an unrecognized primitive is still displayed, never dropped");
+    assert!(
+        matches!(vector.mutability, Mutability::WithheldFromSurface { .. }),
+        "an unrecognized control kind cannot be offered for mutation"
+    );
+    assert!(
+        view.notices.iter().any(|notice| matches!(
+            notice,
+            ProjectionNotice::UnrecognizedControlKind { control, .. }
+                if control.as_str() == "future.spatial.head_tracking"
+        )),
+        "and the surface must be told which control it could not fully interpret"
+    );
+    let quarantined = view
+        .control("future.spatial.room_profile")
+        .expect("an unrecognized availability state still renders");
+    assert!(
+        !quarantined.is_mutable_here(),
+        "an availability state this build does not recognize must fail closed for mutation"
+    );
+}
+
+#[test]
+fn an_untested_product_version_notices_without_disabling_discovered_controls() {
+    let mut document = pipeline();
+    document.producer.product_version = Some("7.0.0-beta".to_string());
+    let view = rendered(document, &web());
+
+    assert!(
+        view.notices.iter().any(|notice| matches!(
+            notice,
+            ProjectionNotice::UntestedProducerVersion { product_version } if product_version == "7.0.0-beta"
+        )),
+        "an unverified engine series is worth saying: {:?}",
+        view.notices
+    );
+    assert!(
+        view.control("hqplayer.pipeline.mode")
+            .expect("projected")
+            .is_mutable_here(),
+        "runtime enumeration remains the authority on what the engine accepts; an unfamiliar \
+         version string must not blank a working control"
+    );
+}
+
+#[test]
+fn a_verified_product_version_raises_no_untested_notice() {
+    let view = rendered(pipeline(), &web());
+    assert!(
+        !view
+            .notices
+            .iter()
+            .any(|notice| matches!(notice, ProjectionNotice::UntestedProducerVersion { .. })),
+        "6.0.4 is a verified series; a notice here would train users to ignore notices"
+    );
+}
+
+#[test]
+fn a_last_known_producer_says_so_rather_than_looking_current() {
+    let mut snapshot = snapshot(pipeline());
+    snapshot.presence = ProducerPresence::LastKnown;
+    let projection = project(&snapshot, &web());
+    let view = projection.rendered().expect("last-known still renders");
+
+    assert_eq!(view.presence, ProducerPresence::LastKnown);
+    assert!(
+        view.notices.contains(&ProjectionNotice::LastKnown),
+        "retaining last-good values through a failure is right; presenting them as current is not"
+    );
+    assert!(
+        !view.controls.is_empty(),
+        "a failed poll must not blank the whole form"
+    );
+}
+
+// =============================================================================
+// Falsifying dependency invalidation
+// =============================================================================
+
+#[test]
+fn a_pending_write_puts_its_dependents_in_reloading_and_withholds_stale_choices() {
+    let mut document = pipeline();
+    document.operations = vec![operation(
+        "op-mode-1",
+        "hqplayer.pipeline.mode",
+        CommandOutcome::Pending,
+    )];
+    let view = rendered(document, &web());
+
+    for dependent in [
+        "hqplayer.pipeline.filter_1x",
+        "hqplayer.pipeline.rate.exact",
+        "hqplayer.chain.sdm.filter",
+    ] {
+        let control = view.control(dependent).expect("projected");
+        match &control.choices {
+            ChoiceProjection::Reloading {
+                invalidated_by,
+                operation,
+            } => {
+                assert_eq!(invalidated_by.as_str(), "hqplayer.pipeline.mode");
+                assert_eq!(operation.as_str(), "op-mode-1");
+            }
+            other => panic!(
+                "{dependent} must withhold its stale enumeration while the write that invalidates \
+                 it is in flight, got {other:?}"
+            ),
+        }
+        assert!(
+            control.offered_choice_ids().is_empty(),
+            "{dependent}: a choice about to be wrong must not be offered"
+        );
+    }
+
+    let mode = view.control("hqplayer.pipeline.mode").expect("projected");
+    assert_eq!(
+        mode.offered_choice_ids(),
+        vec!["source", "pcm", "sdm"],
+        "the control being written is not itself invalidated by its own write"
+    );
+}
+
+#[test]
+fn a_settled_write_does_not_hold_its_dependents_in_reloading() {
+    let mut document = pipeline();
+    document.operations = vec![operation(
+        "op-mode-1",
+        "hqplayer.pipeline.mode",
+        CommandOutcome::Applied,
+    )];
+    let view = rendered(document, &web());
+    let filter = view.control("hqplayer.pipeline.filter_1x").expect("projected");
+    assert!(
+        matches!(filter.choices, ChoiceProjection::Enumerated { .. }),
+        "once the outcome is state evidence the enumeration published beside it is current"
+    );
+}
+
+#[test]
+fn an_unreadable_enumeration_is_not_the_same_as_an_empty_one() {
+    let mut unreadable = pipeline();
+    control_mut(&mut unreadable, "hqplayer.pipeline.mode").choices = None;
+    let view = rendered(unreadable, &web());
+    match &view.control("hqplayer.pipeline.mode").expect("projected").choices {
+        ChoiceProjection::Unknown { reason } => {
+            assert_eq!(reason.code, ReasonCode::Unobservable)
+        }
+        other => panic!("an enumeration with no published set is unknown, not empty: {other:?}"),
+    }
+
+    let mut empty = pipeline();
+    control_mut(&mut empty, "hqplayer.pipeline.mode").choices = Some(ChoiceSet {
+        authority: Authority::Runtime,
+        source: SourceClass::LiveProtocol,
+        revision: None,
+        choices: Vec::new(),
+    });
+    let view = rendered(empty, &web());
+    match &view.control("hqplayer.pipeline.mode").expect("projected").choices {
+        ChoiceProjection::Enumerated { choices, .. } => assert!(
+            choices.is_empty(),
+            "a successful read of an empty collection is a fact, and a different fact"
+        ),
+        other => panic!("a published empty set is enumerated, not unknown: {other:?}"),
+    }
+}
+
+// =============================================================================
+// Falsifying stale choice / operation races
+// =============================================================================
+
+#[test]
+fn busy_state_is_scoped_per_operation_and_per_control() {
+    let mut document = pipeline();
+    document.operations = vec![
+        operation("op-mode-1", "hqplayer.pipeline.mode", CommandOutcome::Pending),
+        operation("op-vol-2", "hqplayer.volume.level", CommandOutcome::Applied),
+    ];
+    let view = rendered(document, &web());
+
+    let mode = view.control("hqplayer.pipeline.mode").expect("projected");
+    assert_eq!(mode.operations.len(), 1);
+    assert_eq!(mode.operations[0].id.as_str(), "op-mode-1");
+    assert!(mode.operations[0].awaits_convergence);
+    assert!(!mode.operations[0].is_state_evidence);
+
+    let volume = view.control("hqplayer.volume.level").expect("projected");
+    assert_eq!(volume.operations.len(), 1);
+    assert_eq!(volume.operations[0].id.as_str(), "op-vol-2");
+    assert!(
+        volume.operations[0].is_state_evidence,
+        "an applied write is evidence about the producer; a pending one is not"
+    );
+
+    for control in &view.controls {
+        for op in &control.operations {
+            assert_eq!(
+                op.correlation_id,
+                format!("corr-{}", op.id.as_str()),
+                "every surface follows one correlation id per operation, supplied by whoever \
+                 submitted it"
+            );
+        }
+    }
+    let elsewhere: Vec<&str> = view
+        .controls
+        .iter()
+        .filter(|control| {
+            control.id.as_str() != "hqplayer.pipeline.mode"
+                && control.id.as_str() != "hqplayer.volume.level"
+        })
+        .flat_map(|control| control.operations.iter().map(|op| op.id.as_str()))
+        .collect();
+    assert!(
+        elsewhere.is_empty(),
+        "one control's operation may never appear as another control's busy marker: {elsewhere:?}"
+    );
+}
+
+#[test]
+fn an_older_projection_is_distinguishable_from_a_newer_one() {
+    let older = rendered(pipeline(), &web());
+
+    let mut newer_document = pipeline();
+    newer_document.revisions = DocumentRevisions::new(12, 4200);
+    control_mut(&mut newer_document, "hqplayer.volume.level").values = pipeline()
+        .control(&ControlId::new("hqplayer.volume.level"))
+        .expect("present")
+        .values
+        .clone();
+    let newer = rendered(newer_document, &web());
+
+    assert!(
+        newer.position.state > older.position.state,
+        "a surface must be able to discard an older refresh rather than let it overwrite a newer \
+         result"
+    );
+    assert_eq!(
+        newer.position.epoch, older.position.epoch,
+        "revisions are only comparable within one epoch"
+    );
+}
+
+#[test]
+fn every_control_in_one_projection_comes_from_one_document() {
+    // The mechanical form of "never combine two polls": each projected observed value must equal
+    // the value in the document the projection cites, for the document it cites.
+    let document = pipeline();
+    let expected: BTreeMap<String, Option<ControlValue>> = document
+        .controls
+        .iter()
+        .map(|control| {
+            (
+                control.id.to_string(),
+                control.observed().cloned(),
+            )
+        })
+        .collect();
+    let view = rendered(document, &web());
+
+    for control in &view.controls {
+        let projected = control
+            .observed
+            .as_ref()
+            .and_then(|value| value.grounded_value())
+            .cloned();
+        assert_eq!(
+            projected,
+            expected[control.id.as_str()],
+            "{}: projected observed value does not match the cited document",
+            control.id
+        );
+    }
+}
+
+// =============================================================================
+// Falsifying budget behaviour on a small device
+// =============================================================================
+
+#[test]
+fn a_bounded_device_gets_transport_and_volume_first_and_says_what_it_dropped() {
+    let view = rendered(pipeline(), &device(6));
+
+    let ids: Vec<&str> = view.controls.iter().map(|c| c.id.as_str()).collect();
+    assert_eq!(
+        ids,
+        vec![
+            "hqplayer.transport.play",
+            "hqplayer.transport.pause",
+            "hqplayer.transport.state",
+            "hqplayer.volume.level",
+            "hqplayer.volume.fixed",
+            "hqplayer.volume.fixed.enabled",
+        ],
+        "the profile ranks transport and volume ahead of tuning; the producer knows nothing about \
+         that ordering"
+    );
+    assert!(
+        view.notices.iter().any(|notice| matches!(
+            notice,
+            ProjectionNotice::Truncated { budget: 6, advertised } if *advertised == 16
+        )),
+        "truncation is declared, never silent: {:?}",
+        view.notices
+    );
+    assert_eq!(view.omitted.len(), 10);
+    let omitted = view
+        .omitted_control("hqplayer.pipeline.mode")
+        .expect("dropped controls are named");
+    assert_eq!(omitted.display_text_key, OMITTED_BUDGET_EXHAUSTED);
+}
+
+#[test]
+fn dropping_a_container_drops_its_members_for_the_containers_reason() {
+    let view = rendered(pipeline(), &device(4));
+    let ids: Vec<&str> = view.controls.iter().map(|c| c.id.as_str()).collect();
+    assert!(
+        !ids.contains(&"hqplayer.volume.fixed"),
+        "the container did not fit"
+    );
+    for member in [
+        "hqplayer.volume.fixed.enabled",
+        "hqplayer.volume.fixed.level",
+    ] {
+        let omitted = view
+            .omitted_control(member)
+            .unwrap_or_else(|| panic!("{member} must be reported as omitted"));
+        assert_eq!(
+            omitted.display_text_key, OMITTED_CONTAINER_DROPPED,
+            "an orphaned member is worse than a missing one: the surface would render a coupled \
+             half with no container"
+        );
+    }
+}
+
+#[test]
+fn narrowing_an_option_list_never_hides_the_current_selection() {
+    let mut document = pipeline();
+    // Twelve options, with the engine's current one last, so a naive head-truncation drops it.
+    let mut choices: Vec<unified_hifi_control::adaptive::Choice> = (0..11)
+        .map(|index| {
+            unified_hifi_control::adaptive::Choice::new(
+                format!("filter-{index}"),
+                format!("Filter {index}"),
+            )
+        })
+        .collect();
+    choices.push(unified_hifi_control::adaptive::Choice::new(
+        "poly-sinc-gauss-long",
+        "poly-sinc-gauss-long",
+    ));
+    control_mut(&mut document, "hqplayer.pipeline.filter_1x").choices = Some(ChoiceSet {
+        authority: Authority::Runtime,
+        source: SourceClass::LiveProtocol,
+        revision: None,
+        choices,
+    });
+
+    let view = rendered(document, &device(64));
+    let filter = view.control("hqplayer.pipeline.filter_1x").expect("projected");
+    let offered = filter.offered_choice_ids();
+    assert!(
+        offered.contains(&"poly-sinc-gauss-long"),
+        "the running selection must survive narrowing, or the surface shows a control whose value \
+         is not among its options: {offered:?}"
+    );
+    match &filter.choices {
+        ChoiceProjection::Enumerated { truncated, .. } => assert_eq!(
+            *truncated,
+            Some(4),
+            "and the surface must be told the list was shortened"
+        ),
+        other => panic!("expected an enumerated set, got {other:?}"),
+    }
+}
+
+// =============================================================================
+// Falsifying MCP discoverability
+// =============================================================================
+
+#[test]
+fn every_operation_mcp_may_invoke_is_fully_described_without_guessing() {
+    let view = rendered(pipeline(), &mcp());
+    let mut mutable = 0usize;
+
+    for control in &view.controls {
+        let Mutability::Mutable { description, .. } = &control.mutability else {
+            continue;
+        };
+        mutable += 1;
+        assert!(
+            control.availability.permits_mutation(),
+            "{}: advertised as invokable while the producer forbids mutation",
+            control.id
+        );
+        assert_eq!(
+            description.timing_key,
+            timing_key(&description.effect),
+            "{}: an MCP description must state the real timing",
+            control.id
+        );
+        assert_ne!(
+            description.timing_key, TIMING_UNKNOWN,
+            "{}: an effect this build cannot describe must not be advertised",
+            control.id
+        );
+        match control.kind {
+            ControlKind::Enumeration => assert!(
+                !control.offered_choice_ids().is_empty(),
+                "{}: an enumeration offered for mutation with no options makes a caller guess",
+                control.id
+            ),
+            ControlKind::NumericRange => assert!(
+                control.range.is_some(),
+                "{}: a numeric control offered without a domain makes a caller guess",
+                control.id
+            ),
+            _ => {}
+        }
+    }
+    assert!(
+        mutable >= 5,
+        "the fixture must actually exercise this: only {mutable} mutable controls reached MCP"
+    );
+}
+
+#[test]
+fn live_persistent_and_restart_behaviour_are_described_distinctly() {
+    let view = rendered(pipeline(), &web());
+    let described: BTreeMap<&str, &'static str> = view
+        .controls
+        .iter()
+        .filter_map(|control| match &control.mutability {
+            Mutability::Mutable { description, .. } => {
+                Some((control.id.as_str(), description.timing_key))
+            }
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(
+        described.get("hqplayer.pipeline.mode"),
+        Some(&TIMING_LIVE_IMMEDIATE)
+    );
+    assert_eq!(
+        described.get("hqplayer.volume.level"),
+        Some(&TIMING_VERIFIED_PENDING)
+    );
+    assert_eq!(
+        described.get("hqplayer.settings.buffer_time"),
+        Some(&TIMING_RESTART_REQUIRED),
+        "a stored-until-restart control described as live is the failure this key exists to stop"
+    );
+    assert_eq!(
+        described.get("hqplayer.settings.legacy_dither"),
+        Some(&TIMING_PERSISTENT_ONLY)
+    );
+    assert_eq!(
+        described.get("hqplayer.volume.fixed.enabled"),
+        Some(&TIMING_LIVE_IMMEDIATE)
+    );
+
+    let mut distinct: Vec<&'static str> = described.values().copied().collect();
+    distinct.sort_unstable();
+    distinct.dedup();
+    assert!(
+        distinct.len() >= 4,
+        "the five apply effects must not collapse into one wording: {distinct:?}"
+    );
+}
+
+#[test]
+fn every_apply_effect_has_its_own_timing_key() {
+    let mut keys: Vec<&'static str> = ApplyEffect::known().iter().map(timing_key).collect();
+    let total = keys.len();
+    keys.sort_unstable();
+    keys.dedup();
+    assert_eq!(
+        keys.len(),
+        total,
+        "two effects sharing a key would let a restart-required control borrow live wording"
+    );
+    assert_eq!(
+        timing_key(&ApplyEffect::Unrecognized("teleported".to_string())),
+        TIMING_UNKNOWN,
+        "an effect from a newer minor must not silently borrow a recognized wording"
+    );
+    assert_eq!(
+        timing_key(&ApplyEffect::HeldUntilChainLoaded),
+        TIMING_HELD_UNTIL_CHAIN_LOADED
+    );
+}
+
+#[test]
+fn a_provisional_acknowledgement_is_never_described_as_proof() {
+    let view = rendered(pipeline(), &web());
+    let volume = view.control("hqplayer.volume.level").expect("projected");
+    match &volume.mutability {
+        Mutability::Mutable { description, .. } => assert!(
+            !description.acknowledgement_is_evidence,
+            "the producer marks this acknowledgement provisional; a surface that treats a returned \
+             call as proof will show a value the engine never adopted"
+        ),
+        other => panic!("volume must be mutable on the web, got {other:?}"),
+    }
+    let mode = view.control("hqplayer.pipeline.mode").expect("projected");
+    match &mode.mutability {
+        Mutability::Mutable { description, .. } => {
+            assert!(description.acknowledgement_is_evidence)
+        }
+        other => panic!("mode must be mutable on the web, got {other:?}"),
+    }
+}
+
+#[test]
+fn coupled_controls_are_advertised_as_one_plan() {
+    let view = rendered(pipeline(), &web());
+    let enabled = view.control("hqplayer.volume.fixed.enabled").expect("projected");
+    match &enabled.mutability {
+        Mutability::Mutable { description, .. } => {
+            assert_eq!(
+                description.coupled_with,
+                vec![ControlId::new("hqplayer.volume.fixed.level")],
+                "coupling is the producer's job; a consumer issuing the extra write itself is how \
+                 a level edit silently enables a feature nobody asked for"
+            );
+            assert_eq!(description.lane, ApplyLane::Composite);
+        }
+        other => panic!("expected a mutable coupled control, got {other:?}"),
+    }
+}
+
+// =============================================================================
+// Falsifying capability routing
+// =============================================================================
+
+/// A settled aggregator holding exactly `documents`, plus the live run leases that admitted them.
+///
+/// The leases are returned rather than dropped because presence is evaluated at read time against
+/// the admitting run: dropping them would make every producer `LastKnown`, which is a different
+/// scenario from the one these tests are about.
+async fn service_with(
+    documents: Vec<ProducerDocument>,
+) -> (
+    ControlPlaneService,
+    Vec<unified_hifi_control::producers::AdapterRun>,
+) {
+    let (handle, actor, view) =
+        AdaptiveRuntime::build(tokio_util::sync::CancellationToken::new(), 64);
+    // The actor must be running before `publish` awaits its verdict, and joined before the service
+    // reads, so every test sees a settled aggregator rather than a racing one.
+    let running = tokio::spawn(actor.run());
+    let mut runs: BTreeMap<String, unified_hifi_control::producers::AdapterRun> = BTreeMap::new();
+    for document in documents {
+        let adapter = document
+            .producer
+            .producer_id
+            .split(':')
+            .next()
+            .expect("a producer id has a namespace")
+            .to_string();
+        let run = runs
+            .entry(adapter.clone())
+            .or_insert_with(|| handle.begin_run(&adapter));
+        handle
+            .publish(run, document)
+            .await
+            .expect("the actor accepts the publication");
+    }
+    drop(handle);
+    tokio::time::timeout(std::time::Duration::from_secs(5), running)
+        .await
+        .expect("the actor drains once its channel closes")
+        .expect("the actor task must not panic");
+    (
+        ControlPlaneService::new(view),
+        runs.into_values().collect(),
+    )
+}
+
+fn hqplayer_zone_document(zone: &str) -> ProducerDocument {
+    let mut document = pipeline();
+    document.target.zone_id = Some(zone.to_string());
+    document.target.role = TargetRole::Playback;
+    document
+}
+
+#[tokio::test]
+async fn an_unknown_hqplayer_identity_is_refused_rather_than_routed_anywhere_else() {
+    // The #328 defect class, expressed at the control plane: the only producer present is bound to
+    // a Roon zone, and a `hqplayer:` id that names nothing must not reach it.
+    let (service, _runs) = service_with(vec![pipeline()]).await;
+
+    match service.route("hqplayer:Ghost Room") {
+        Err(RouteRefusal::UnknownProducer { zone_id }) => {
+            assert_eq!(zone_id, "hqplayer:Ghost Room")
+        }
+        other => panic!("an unknown HQPlayer identity must refuse, got {other:?}"),
+    }
+    assert!(
+        service.route("roon:1601bb42ed14351b99c2926214f6cbb80724").is_ok(),
+        "the producer that does exist still routes"
+    );
+}
+
+#[tokio::test]
+async fn an_unprefixed_zone_id_never_resolves() {
+    let (service, _runs) = service_with(vec![pipeline()]).await;
+    match service.route("Living Room") {
+        Err(RouteRefusal::UnknownZonePrefix { zone_id }) => assert_eq!(zone_id, "Living Room"),
+        other => panic!("an unprefixed id is not a zone id, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn two_producers_claiming_one_zone_refuse_rather_than_pick() {
+    let (service, _runs) = service_with(vec![
+        pipeline(),
+        hqplayer_zone_document("roon:1601bb42ed14351b99c2926214f6cbb80724"),
+    ])
+    .await;
+
+    match service.route("roon:1601bb42ed14351b99c2926214f6cbb80724") {
+        Err(RouteRefusal::AmbiguousProducer { candidates, .. }) => {
+            assert_eq!(candidates.len(), 2, "both claimants must be named")
+        }
+        other => panic!("picking one silently is how a command lands on the wrong role: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn routing_reads_only_admitted_state() {
+    let (service, _runs) = service_with(Vec::new()).await;
+    assert!(service.producers().is_empty());
+    assert!(matches!(
+        service.route("hqplayer:Living Room"),
+        Err(RouteRefusal::UnknownProducer { .. })
+    ));
+}
+
+// =============================================================================
+// Falsifying command dispatch
+// =============================================================================
+
+#[derive(Default)]
+struct RecordingExecutor {
+    producer_type: String,
+    seen: Mutex<Vec<SemanticCommand>>,
+}
+
+impl RecordingExecutor {
+    fn new(producer_type: &str) -> Arc<Self> {
+        Arc::new(Self {
+            producer_type: producer_type.to_string(),
+            seen: Mutex::new(Vec::new()),
+        })
+    }
+
+    fn commands(&self) -> Vec<SemanticCommand> {
+        self.seen.lock().expect("lock").clone()
+    }
+}
+
+#[async_trait]
+impl SemanticCommandExecutor for RecordingExecutor {
+    fn producer_type(&self) -> &str {
+        &self.producer_type
+    }
+
+    async fn submit(&self, command: SemanticCommand) -> Result<CommandAcceptance, CommandRefusal> {
+        self.seen.lock().expect("lock").push(command.clone());
+        Ok(CommandAcceptance {
+            operation: operation(
+                "op-accepted",
+                command.control.as_str(),
+                CommandOutcome::Pending,
+            ),
+            duplicate: false,
+        })
+    }
+}
+
+fn command_for(key: &ProducerKey, position: RevisionRef) -> SemanticCommand {
+    SemanticCommand {
+        key: key.clone(),
+        expected: position,
+        control: ControlId::new("hqplayer.pipeline.mode"),
+        requested: ControlValue::Choice("pcm".to_string()),
+        lane: ApplyLane::Immediate,
+        correlation_id: "corr-web-1".to_string(),
+        surface_id: "web".to_string(),
+    }
+}
+
+#[tokio::test]
+async fn a_command_reaches_the_executor_that_owns_the_routed_producer() {
+    let executor = RecordingExecutor::new("hqplayer");
+    let (service, _runs) = service_with(vec![pipeline()]).await;
+    let service = service.with_executor(executor.clone());
+    let key = ProducerKey::of(&pipeline());
+    let position = pipeline().position();
+
+    let acceptance = service
+        .submit(command_for(&key, position))
+        .await
+        .expect("the HQPlayer executor is registered");
+    assert!(!acceptance.duplicate);
+    let seen = executor.commands();
+    assert_eq!(seen.len(), 1);
+    assert_eq!(seen[0].key, key);
+    assert_eq!(seen[0].correlation_id, "corr-web-1");
+}
+
+#[tokio::test]
+async fn a_producer_family_with_no_executor_is_refused_not_defaulted() {
+    // The registered executor belongs to another family. Handing it the command anyway is the #328
+    // fallthrough with a different prefix.
+    let executor = RecordingExecutor::new("roon");
+    let (service, _runs) = service_with(vec![pipeline()]).await;
+    let service = service.with_executor(executor.clone());
+    let key = ProducerKey::of(&pipeline());
+    let position = pipeline().position();
+
+    match service.submit(command_for(&key, position)).await {
+        Err(CommandRefusal::NoExecutorForProducer { producer_type }) => {
+            assert_eq!(producer_type, "hqplayer")
+        }
+        other => panic!("expected a refusal naming the family, got {other:?}"),
+    }
+    assert!(
+        executor.commands().is_empty(),
+        "the wrong executor must never be handed the command"
+    );
+}
+
+#[tokio::test]
+async fn a_command_for_a_producer_the_aggregator_does_not_hold_is_refused() {
+    let executor = RecordingExecutor::new("hqplayer");
+    let (service, _runs) = service_with(Vec::new()).await;
+    let service = service.with_executor(executor.clone());
+    let key = ProducerKey {
+        producer_id: "hqplayer:ghost".to_string(),
+        role: TargetRole::Playback,
+        zone_id: Some("hqplayer:ghost".to_string()),
+    };
+
+    match service
+        .submit(command_for(
+            &key,
+            RevisionRef {
+                epoch: ProducerEpoch(1),
+                control_plane: unified_hifi_control::adaptive::Revision(1),
+                state: unified_hifi_control::adaptive::Revision(1),
+            },
+        ))
+        .await
+    {
+        Err(CommandRefusal::Route(RouteRefusal::UnknownProducer { .. })) => {}
+        other => panic!("a command may only address admitted state, got {other:?}"),
+    }
+    assert!(executor.commands().is_empty());
+}
+
+#[tokio::test]
+async fn a_projection_and_a_command_agree_about_the_position_to_fence_on() {
+    let executor = RecordingExecutor::new("hqplayer");
+    let (service, _runs) = service_with(vec![pipeline()]).await;
+    let service = service.with_executor(executor.clone());
+    let key = ProducerKey::of(&pipeline());
+
+    let projection = service
+        .project(&key, &web())
+        .expect("the producer is admitted");
+    let view = projection.rendered().expect("rendered");
+
+    service
+        .submit(command_for(&key, view.position))
+        .await
+        .expect("accepted");
+    assert_eq!(
+        executor.commands()[0].expected,
+        view.position,
+        "the position a surface renders is the position its command fences on; anything else lets \
+         a stale surface authorise a write against a producer that moved"
+    );
+}

--- a/tests/adaptive_control_plane.rs
+++ b/tests/adaptive_control_plane.rs
@@ -260,6 +260,87 @@ fn the_observed_lane_never_carries_staged_or_held_intent() {
 }
 
 #[test]
+fn every_surface_follows_one_operation_under_one_correlation() {
+    let mut document = pipeline();
+    document.operations = vec![operation(
+        "op-mode-1",
+        "hqplayer.pipeline.mode",
+        CommandOutcome::Pending,
+    )];
+
+    let views: Vec<RenderedProjection> = [web(), mcp(), device(64)]
+        .iter()
+        .map(|profile| rendered(document.clone(), profile))
+        .collect();
+    let seen: Vec<(String, String, CommandOutcome, bool)> = views
+        .iter()
+        .map(|view| {
+            let mode = view.control("hqplayer.pipeline.mode").expect("projected");
+            let operation = &mode.operations[0];
+            (
+                operation.id.as_str().to_string(),
+                operation.correlation_id.clone(),
+                operation.outcome.clone(),
+                operation.is_state_evidence,
+            )
+        })
+        .collect();
+
+    assert!(
+        seen.windows(2).all(|pair| pair[0] == pair[1]),
+        "the same operation must read identically on every surface, or two clients watching one \
+         write disagree about whether it landed: {seen:?}"
+    );
+    assert_eq!(seen[0].1, "corr-op-mode-1");
+    assert!(
+        !seen[0].3,
+        "a pending write is not evidence about the engine"
+    );
+}
+
+#[test]
+fn the_only_prose_keys_this_layer_originates_are_its_own_declared_ones() {
+    // #343 owns catalog provenance. A projector that invented a key would put an unowned string
+    // where a governed one is expected, and nothing downstream would notice.
+    let surface_keys = [
+        WITHHELD_UNRENDERABLE_KIND,
+        WITHHELD_PER_CHOICE_REASON,
+        WITHHELD_RISK_EXCEEDS_SURFACE,
+    ];
+    let omitted_keys = [OMITTED_BUDGET_EXHAUSTED, OMITTED_CONTAINER_DROPPED];
+
+    let view = rendered(pipeline(), &device(6));
+    let mut withheld = 0usize;
+    for control in &view.controls {
+        if let Mutability::WithheldFromSurface { reason } = &control.mutability {
+            withheld += 1;
+            let key = reason
+                .display_text_key
+                .as_deref()
+                .expect("a surface-originated reason must be addressable in the catalog");
+            assert!(
+                surface_keys.contains(&key),
+                "{}: {key} is not a key this layer declares",
+                control.id
+            );
+            assert_eq!(reason.code, ReasonCode::RequiresCapability);
+        }
+    }
+    for entry in &view.omitted {
+        assert!(
+            omitted_keys.contains(&entry.display_text_key),
+            "{}: {} is not a key this layer declares",
+            entry.id,
+            entry.display_text_key
+        );
+    }
+    assert!(
+        withheld + view.omitted.len() > 0,
+        "the fixture must actually exercise this"
+    );
+}
+
+#[test]
 fn availability_reasons_survive_projection_on_every_surface() {
     for profile in [web(), mcp(), device(64)] {
         let view = rendered(pipeline(), &profile);

--- a/tests/adaptive_control_plane.rs
+++ b/tests/adaptive_control_plane.rs
@@ -26,11 +26,11 @@ use unified_hifi_control::producers::control_plane::{
 };
 use unified_hifi_control::producers::surface::{
     admit_for_surface, project, project_with, timing_key, ChoiceProjection, Mutability,
-    ProjectionNotice, RenderedProjection, SurfaceProfile, SurfaceProjection, VerifiedSeries,
-    OMITTED_BUDGET_EXHAUSTED, OMITTED_CONTAINER_DROPPED, SURFACE_PROJECTION_SCHEMA,
-    TIMING_HELD_UNTIL_CHAIN_LOADED, TIMING_LIVE_IMMEDIATE, TIMING_PERSISTENT_ONLY,
-    TIMING_RESTART_REQUIRED, TIMING_UNKNOWN, TIMING_VERIFIED_PENDING, WITHHELD_PER_CHOICE_REASON,
-    WITHHELD_RISK_EXCEEDS_SURFACE, WITHHELD_UNRENDERABLE_KIND,
+    ProjectionNotice, RenderedProjection, SurfaceProfile, VerifiedSeries, OMITTED_BUDGET_EXHAUSTED,
+    OMITTED_CONTAINER_DROPPED, SURFACE_PROJECTION_SCHEMA, TIMING_HELD_UNTIL_CHAIN_LOADED,
+    TIMING_LIVE_IMMEDIATE, TIMING_PERSISTENT_ONLY, TIMING_RESTART_REQUIRED, TIMING_UNKNOWN,
+    TIMING_VERIFIED_PENDING, WITHHELD_PER_CHOICE_REASON, WITHHELD_RISK_EXCEEDS_SURFACE,
+    WITHHELD_UNDESCRIBABLE_APPLY, WITHHELD_UNRENDERABLE_KIND,
 };
 use unified_hifi_control::producers::{
     AdaptiveRuntime, ProducerKey, ProducerPresence, ProducerSnapshot,
@@ -77,14 +77,7 @@ fn snapshot(document: ProducerDocument) -> ProducerSnapshot {
 }
 
 fn rendered(document: ProducerDocument, profile: &SurfaceProfile) -> RenderedProjection {
-    let snapshot = snapshot(document);
-    match project(&snapshot, profile) {
-        SurfaceProjection::Rendered(rendered) => *rendered,
-        SurfaceProjection::Fallback(fallback) => panic!(
-            "expected a rendered projection for {}, got a fallback: {:?}",
-            profile.surface_id, fallback.refusal
-        ),
-    }
+    project(&snapshot(document), profile)
 }
 
 fn rendered_with(
@@ -92,13 +85,7 @@ fn rendered_with(
     profile: &SurfaceProfile,
     verified: &VerifiedSeries,
 ) -> RenderedProjection {
-    let snapshot = snapshot(document);
-    match project_with(&snapshot, profile, verified) {
-        SurfaceProjection::Rendered(rendered) => *rendered,
-        SurfaceProjection::Fallback(fallback) => {
-            panic!("expected a rendered projection, got {:?}", fallback.refusal)
-        }
-    }
+    project_with(&snapshot(document), profile, verified)
 }
 
 /// The release series this build has verified, supplied the way the composition root supplies it.
@@ -306,6 +293,7 @@ fn the_only_prose_keys_this_layer_originates_are_its_own_declared_ones() {
         WITHHELD_UNRENDERABLE_KIND,
         WITHHELD_PER_CHOICE_REASON,
         WITHHELD_RISK_EXCEEDS_SURFACE,
+        WITHHELD_UNDESCRIBABLE_APPLY,
     ];
     let omitted_keys = [OMITTED_BUDGET_EXHAUSTED, OMITTED_CONTAINER_DROPPED];
 
@@ -337,6 +325,83 @@ fn the_only_prose_keys_this_layer_originates_are_its_own_declared_ones() {
     assert!(
         withheld + view.omitted.len() > 0,
         "the fixture must actually exercise this"
+    );
+}
+
+#[test]
+fn an_apply_effect_this_build_cannot_describe_is_not_advertised_as_invokable() {
+    let mut document = pipeline();
+    if let Some(apply) = control_mut(&mut document, "hqplayer.pipeline.mode")
+        .apply
+        .as_mut()
+    {
+        apply.effect = ApplyEffect::Unrecognized("audible_next_tuesday".to_string());
+    }
+    let view = rendered(document, &web());
+    let mode = view.control("hqplayer.pipeline.mode").expect("projected");
+
+    match &mode.mutability {
+        Mutability::WithheldFromSurface { reason } => assert_eq!(
+            reason.display_text_key.as_deref(),
+            Some(WITHHELD_UNDESCRIBABLE_APPLY),
+            "an effect this build cannot name must not be offered; `timing_key` would fall back to \
+             an admission rather than a description"
+        ),
+        other => panic!("expected the undescribable effect to be withheld, got {other:?}"),
+    }
+    assert!(
+        mode.observed.is_some(),
+        "and the control keeps rendering, because the value is still readable"
+    );
+}
+
+#[test]
+fn a_bounded_surface_discloses_staged_edits_it_cannot_show() {
+    // `filter_1x` carries a grounded `desired` lane and `chain.sdm.filter` a grounded `held` one.
+    // A six-control knob receives neither, and must still be able to say edits are waiting.
+    let view = rendered(pipeline(), &device(6));
+    let waiting: Vec<&str> = view
+        .staged_elsewhere
+        .iter()
+        .map(ControlId::as_str)
+        .collect();
+
+    assert!(
+        waiting.contains(&"hqplayer.pipeline.filter_1x")
+            && waiting.contains(&"hqplayer.chain.sdm.filter"),
+        "a surface showing a subset must disclose intent it is hiding: {waiting:?}"
+    );
+    assert!(
+        !waiting.contains(&"hqplayer.volume.level"),
+        "a control the surface *did* receive is not elsewhere"
+    );
+
+    let unbounded = rendered(pipeline(), &web());
+    assert!(
+        unbounded.staged_elsewhere.is_empty(),
+        "nothing is elsewhere when everything is here: {:?}",
+        unbounded.staged_elsewhere
+    );
+}
+
+#[test]
+fn mcp_keeps_the_capability_the_shipped_tool_already_has() {
+    // `hifi_hqplayer_set_pipeline` lets an assistant change mode today, and mode is
+    // `playback_interruption`. A stricter default ceiling would look like a projection detail while
+    // silently removing a shipped capability.
+    let view = rendered(pipeline(), &mcp());
+    assert!(
+        view.control("hqplayer.pipeline.mode")
+            .expect("projected")
+            .is_mutable_here(),
+        "MCP must still be able to drive the pipeline mode"
+    );
+    assert!(
+        !view
+            .control("hqplayer.settings.legacy_dither")
+            .expect("projected")
+            .is_mutable_here(),
+        "and must still not be offered an operation that destroys retained configuration"
     );
 }
 
@@ -719,8 +784,7 @@ fn a_verified_product_version_raises_no_untested_notice() {
 fn a_last_known_producer_says_so_rather_than_looking_current() {
     let mut snapshot = snapshot(pipeline());
     snapshot.presence = ProducerPresence::LastKnown;
-    let projection = project(&snapshot, &web());
-    let view = projection.rendered().expect("last-known still renders");
+    let view = project(&snapshot, &web());
 
     assert_eq!(view.presence, ProducerPresence::LastKnown);
     assert!(
@@ -1440,10 +1504,9 @@ async fn a_projection_and_a_command_agree_about_the_position_to_fence_on() {
     let service = service.with_executor(executor.clone());
     let key = ProducerKey::of(&pipeline());
 
-    let projection = service
+    let view = service
         .project(&key, &web())
         .expect("the producer is admitted");
-    let view = projection.rendered().expect("rendered");
 
     service
         .submit(command_for(&key, view.position))


### PR DESCRIPTION
Refs #331
OH: 80222d6d

Parent epic #313. Stacked on `feat/issue-328-direct-hqplayer-zone` at `212f555`.

## What this is

One aggregator-owned projection layer plus one command path, so that web, MCP and control devices
can consume **surface-appropriate projections of the same producer document** instead of three
bespoke integrations.

* `src/producers/surface.rs` — a pure projector over `(ProducerSnapshot, SurfaceProfile)`. A surface
  *declares* what it can faithfully render; nothing branches on a device class. Every reduction is
  declared: a control the surface cannot render is displayed with mutation withheld and a reason, a
  budget that drops controls names them, a shortened option list says so and never drops the current
  selection, and an enumeration invalidated by an in-flight write withholds the stale list.
* `src/producers/control_plane.rs` — routing, projection and submission. Routing reads admitted
  aggregator state only and has **no fallthrough arm**. Submission dispatches on the *admitted
  document's* producer family; a family with no executor is refused, never defaulted.
* `src/producers/hqplayer_command_service.rs` — `HqpSemanticExecutor`, the first public consumer
  #329 reserved for this issue. It consumes #375's single control-to-operation registry rather than
  creating a second mapping, and collapses twenty-two internal refusals onto ten surface-neutral
  ones through an exhaustive `match`.

## API impact: none

`tests/fixtures/api_routes.txt` is byte-identical to `origin/v3`. No route added or removed
(`src/main.rs`: 88 `.route(` lines on the base, 88 here). `src/api/`, `src/mcp/`, `src/app/`,
`src/knobs/`, `src/mqtt/` and `src/main.rs` are untouched. No label applied, and
`api-change-approved` is not self-applicable.

## What is deliberately **not** here

The three surface-rendering acceptance criteria. `tests/adaptive_publication_lint.rs` boundary 2 —
#324's mechanical form of the API freeze — forbids every file outside `src/adaptive/`,
`src/producers/`, `src/lib.rs` and `src/main.rs` from naming `crate::producers`. The web client also
reads its data over HTTP. So **every surface hop is gated behind exactly one API approval**, and
`protocol:additive` on the issue is not that approval.

The smallest exact contract that would unblock them is proposed in
[`.oh/adaptive-control-plane.md`](.oh/adaptive-control-plane.md) under "API impact" — three routes,
one new response type, and a note that approving them means deliberately amending
`lint_publication_layer_adds_no_routes` rather than deleting it. Submitted for explicit decision;
nothing here anticipates the outcome.

ESP32 manifests are blocked twice over: #326 (matcher-to-manifest composition) does not exist on this
branch, so the bounded, priority-ordered `device` projection has no composer to feed.

## Testing

`tests/adaptive_control_plane.rs` — 44 tests, all comparing **projections of the same fixture**,
because "these three surfaces cannot disagree" is only falsifiable that way. Written RED first
against a stub whose `route()` returned the first admitted snapshot: **8 passed, 31 failed**.

Hermetic throughout — canonical `#323` fixtures plus documents derived from them in memory. The live
HQPlayer host is not contacted.

| Gate | Result |
|---|---|
| `--test adaptive_control_plane` | 44 passed |
| `--lib producers::hqplayer_command_service` | 16 passed (2 new) |
| `--test adaptive_publication_lint` | 57 passed |
| `--test architecture_lint` / `api_contract` | 9 / 2 passed |
| whole suite, `--all-features --no-fail-fast` | **1296 passed, 0 failed, 13 ignored** (environment-gated) |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --lib --all-features -- -D warnings` | clean |
| `cargo check --release --all-features` | clean |
| `dx build --release --platform web --features web` | client + server both succeed |

Session record, solution space, review/dissent findings and limitations:
[`.oh/adaptive-control-plane.md`](.oh/adaptive-control-plane.md).
