### PR TITLE
feat(mcp): modularize src/mcp and add a contract test harness (#394)

### DIFF
--- a/src/mcp/handler.rs
+++ b/src/mcp/handler.rs
@@ -1,0 +1,81 @@
+//! The MCP `ServerHandler`: advertise tools, and dispatch calls to them.
+//!
+//! Dispatch only. Every arm delegates to a handler in
+//! [`crate::mcp::tools`]; no tool behavior lives here. #397 extends this impl
+//! with the resource methods.
+
+use crate::api::{load_app_settings, AppState};
+use crate::mcp::tools::{self, HifiTools};
+use async_trait::async_trait;
+use rust_mcp_sdk::{
+    mcp_server::ServerHandler,
+    schema::{
+        schema_utils::CallToolError, CallToolRequestParams, CallToolResult, ListToolsResult,
+        PaginatedRequestParams, RpcError,
+    },
+    McpServer,
+};
+use std::sync::Arc;
+
+/// MCP server handler with access to app state.
+pub struct HifiMcpHandler {
+    state: AppState,
+}
+
+impl HifiMcpHandler {
+    pub fn new(state: AppState) -> Self {
+        Self { state }
+    }
+}
+
+#[async_trait]
+impl ServerHandler for HifiMcpHandler {
+    async fn handle_list_tools_request(
+        &self,
+        _params: Option<PaginatedRequestParams>,
+        _runtime: Arc<dyn McpServer>,
+    ) -> Result<ListToolsResult, RpcError> {
+        // Read settings per request: the operator can toggle the HQPlayer
+        // adapter while the server is running, and the advertised tool list has
+        // to follow.
+        let settings = load_app_settings();
+
+        Ok(ListToolsResult {
+            meta: None,
+            next_cursor: None,
+            tools: tools::list_tools(settings.adapters.hqplayer),
+        })
+    }
+
+    async fn handle_call_tool_request(
+        &self,
+        params: CallToolRequestParams,
+        _runtime: Arc<dyn McpServer>,
+    ) -> Result<CallToolResult, CallToolError> {
+        let tool: HifiTools = HifiTools::try_from(params).map_err(CallToolError::new)?;
+        let state = &self.state;
+
+        match tool {
+            HifiTools::HifiZonesTool(_) => tools::zones::handle_zones(state).await,
+            HifiTools::HifiNowPlayingTool(args) => {
+                tools::zones::handle_now_playing(state, args).await
+            }
+            HifiTools::HifiControlTool(args) => {
+                tools::transport::handle_control(state, args).await
+            }
+            HifiTools::HifiSearchTool(args) => tools::library::handle_search(state, args).await,
+            HifiTools::HifiPlayTool(args) => tools::library::handle_play(state, args).await,
+            HifiTools::HifiStatusTool(_) => tools::status::handle_status(state).await,
+            HifiTools::HifiHqplayerStatusTool(_) => tools::hqplayer::handle_status(state).await,
+            HifiTools::HifiHqplayerProfilesTool(_) => {
+                tools::hqplayer::handle_profiles(state).await
+            }
+            HifiTools::HifiHqplayerLoadProfileTool(args) => {
+                tools::hqplayer::handle_load_profile(state, args).await
+            }
+            HifiTools::HifiHqplayerSetPipelineTool(args) => {
+                tools::hqplayer::handle_set_pipeline(state, args).await
+            }
+        }
+    }
+}

--- a/src/mcp/handler.rs
+++ b/src/mcp/handler.rs
@@ -60,16 +60,12 @@ impl ServerHandler for HifiMcpHandler {
             HifiTools::HifiNowPlayingTool(args) => {
                 tools::zones::handle_now_playing(state, args).await
             }
-            HifiTools::HifiControlTool(args) => {
-                tools::transport::handle_control(state, args).await
-            }
+            HifiTools::HifiControlTool(args) => tools::transport::handle_control(state, args).await,
             HifiTools::HifiSearchTool(args) => tools::library::handle_search(state, args).await,
             HifiTools::HifiPlayTool(args) => tools::library::handle_play(state, args).await,
             HifiTools::HifiStatusTool(_) => tools::status::handle_status(state).await,
             HifiTools::HifiHqplayerStatusTool(_) => tools::hqplayer::handle_status(state).await,
-            HifiTools::HifiHqplayerProfilesTool(_) => {
-                tools::hqplayer::handle_profiles(state).await
-            }
+            HifiTools::HifiHqplayerProfilesTool(_) => tools::hqplayer::handle_profiles(state).await,
             HifiTools::HifiHqplayerLoadProfileTool(args) => {
                 tools::hqplayer::handle_load_profile(state, args).await
             }

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1,637 +1,57 @@
-//! MCP (Model Context Protocol) server for AI assistant integration
+//! MCP (Model Context Protocol) server for AI assistant integration.
 //!
-//! Provides HTTP endpoints for MCP clients with both Streamable HTTP and SSE transports.
-//! Routes are integrated into the main Axum app on port 8088 at /mcp endpoint.
+//! Provides HTTP endpoints for MCP clients over the Streamable HTTP transport.
+//! Routes are integrated into the main Axum app on port 8088 at `/mcp`.
+//!
+//! # Layout
+//!
+//! This module is the transport and wiring layer only. Everything else lives in
+//! a submodule, so concurrent work on the MCP surface (epic #392) edits
+//! different files:
+//!
+//! | Module      | Responsibility                                           |
+//! |-------------|----------------------------------------------------------|
+//! | `mod.rs`    | Axum route handlers, session recovery, SDK wiring        |
+//! | [`server`]  | the `initialize` result: identity, capabilities, protocol |
+//! | [`handler`] | the `ServerHandler` impl: advertise tools, dispatch calls |
+//! | [`tools`]   | tool definitions + handlers, by family                   |
+//! | [`types`]   | response shapes and result constructors                  |
+//! | [`routing`] | zone-prefix -> adapter, in exactly one place             |
+//!
+//! # The MCP surface is pinned by tests
+//!
+//! `tests/mcp_contract.rs` snapshots `tools/list` and `initialize` against
+//! committed fixtures and pins every tool's runtime behavior, including the
+//! error strings a model reads. Epic #392 is additive-only, so a fixture diff on
+//! a PR in that epic is a bug report, not a chore. Regenerate deliberately:
+//!
+//! ```sh
+//! UPDATE_MCP_FIXTURES=1 cargo test --test mcp_contract
+//! ```
 
-use crate::api::{load_app_settings, AppState};
-use async_trait::async_trait;
+pub mod handler;
+pub mod routing;
+pub mod server;
+pub mod tools;
+pub mod types;
+
+use crate::api::AppState;
 use axum::http::{HeaderMap, Method, Uri};
 use axum::{body::Body, extract::Extension, response::IntoResponse};
 use rust_mcp_sdk::{
     id_generator::{FastIdGenerator, UuidGenerator},
-    macros::{mcp_tool, JsonSchema},
-    mcp_server::{McpAppState, McpHttpHandler, ServerHandler, ToMcpServerHandler},
-    schema::{
-        schema_utils::CallToolError, CallToolRequestParams, CallToolResult, Implementation,
-        InitializeResult, ListToolsResult, PaginatedRequestParams, ProtocolVersion, RpcError,
-        ServerCapabilities, ServerCapabilitiesTools, TextContent,
-    },
+    mcp_server::{McpAppState, McpHttpHandler, ToMcpServerHandler},
     session_store::InMemorySessionStore,
-    tool_box, McpServer, TransportOptions,
+    TransportOptions,
 };
-use serde::{Deserialize, Serialize};
 use std::{sync::Arc, time::Duration};
+
+pub use handler::HifiMcpHandler;
+pub use server::server_details;
+pub use tools::HifiTools;
 
 /// MCP session header name
 const MCP_SESSION_ID_HEADER: &str = "mcp-session-id";
-
-// ============================================================================
-// Tool Definitions
-// ============================================================================
-
-/// List all available playback zones
-#[mcp_tool(
-    name = "hifi_zones",
-    description = "List all available playback zones (Roon, LMS, OpenHome, UPnP)",
-    read_only_hint = true
-)]
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
-pub struct HifiZonesTool {}
-
-/// Get current playback state for a zone
-#[mcp_tool(
-    name = "hifi_now_playing",
-    description = "Get current playback state for a zone (track, artist, album, play state, volume)",
-    read_only_hint = true
-)]
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
-pub struct HifiNowPlayingTool {
-    /// The zone ID to query (get from hifi_zones)
-    pub zone_id: String,
-}
-
-/// Control playback
-#[mcp_tool(
-    name = "hifi_control",
-    description = "Control playback: play, pause, playpause (toggle), next, previous, or adjust volume"
-)]
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
-pub struct HifiControlTool {
-    /// The zone ID to control
-    pub zone_id: String,
-    /// Action: play, pause, playpause, next, previous, volume_set, volume_up, volume_down
-    pub action: String,
-    /// For volume actions: the level (0-100 for volume_set) or amount to change
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub value: Option<f64>,
-}
-
-/// Search for music
-#[mcp_tool(
-    name = "hifi_search",
-    description = "Search for tracks, albums, or artists. Roon: searches Library, TIDAL, or Qobuz (use source param). LMS: searches all installed providers including streaming plugins (zone_id recommended as different players may have different sources configured).",
-    read_only_hint = true
-)]
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
-pub struct HifiSearchTool {
-    /// Search query (e.g., "Hotel California", "Eagles", "jazz piano")
-    pub query: String,
-    /// Zone ID for context-aware results. Recommended for LMS (different players may have different sources).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub zone_id: Option<String>,
-    /// Where to search: "library" (default), "tidal", or "qobuz". Roon only; LMS searches all providers.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub source: Option<String>,
-}
-
-/// Search and play music in one command
-#[mcp_tool(
-    name = "hifi_play",
-    description = "Search and play music. Searches and plays, queues, or starts radio from the first matching result. Use action='queue' to add to queue. action='radio' and source param are Roon-only; LMS searches all providers."
-)]
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
-pub struct HifiPlayTool {
-    /// What to play (e.g., "early Michael Jackson", "Dark Side of the Moon")
-    pub query: String,
-    /// Zone ID to play on (get from hifi_zones)
-    pub zone_id: String,
-    /// Where to search: "library" (default), "tidal", or "qobuz". Roon only; LMS searches all providers.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub source: Option<String>,
-    /// What to do: "play" (default), "queue", or "radio". radio is Roon-only.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub action: Option<String>,
-}
-
-/// Get overall bridge status
-#[mcp_tool(
-    name = "hifi_status",
-    description = "Get overall bridge status (Roon connection, HQPlayer config)",
-    read_only_hint = true
-)]
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
-pub struct HifiStatusTool {}
-
-/// Get HQPlayer status
-#[mcp_tool(
-    name = "hifi_hqplayer_status",
-    description = "Get HQPlayer Embedded status and current pipeline settings",
-    read_only_hint = true
-)]
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
-pub struct HifiHqplayerStatusTool {}
-
-/// List HQPlayer profiles
-#[mcp_tool(
-    name = "hifi_hqplayer_profiles",
-    description = "List available HQPlayer Embedded configurations",
-    read_only_hint = true
-)]
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
-pub struct HifiHqplayerProfilesTool {}
-
-/// Load an HQPlayer profile
-#[mcp_tool(
-    name = "hifi_hqplayer_load_profile",
-    description = "Load an HQPlayer Embedded configuration (will restart HQPlayer)",
-    destructive_hint = true
-)]
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
-pub struct HifiHqplayerLoadProfileTool {
-    /// Configuration name to load (get from hifi_hqplayer_profiles)
-    pub profile: String,
-}
-
-/// Change an HQPlayer pipeline setting
-#[mcp_tool(
-    name = "hifi_hqplayer_set_pipeline",
-    description = "Change an HQPlayer pipeline setting (mode, samplerate, filter1x, filterNx, shaper, dither)"
-)]
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
-pub struct HifiHqplayerSetPipelineTool {
-    /// Setting to change: mode, samplerate, filter1x, filterNx, shaper, dither
-    pub setting: String,
-    /// New value for the setting
-    pub value: String,
-}
-
-// Generate toolbox enum with all tools
-tool_box!(
-    HifiTools,
-    [
-        HifiZonesTool,
-        HifiNowPlayingTool,
-        HifiControlTool,
-        HifiSearchTool,
-        HifiPlayTool,
-        HifiStatusTool,
-        HifiHqplayerStatusTool,
-        HifiHqplayerProfilesTool,
-        HifiHqplayerLoadProfileTool,
-        HifiHqplayerSetPipelineTool
-    ]
-);
-
-// ============================================================================
-// Response Types (for JSON serialization)
-// ============================================================================
-
-#[derive(Debug, Serialize)]
-struct McpZone {
-    zone_id: String,
-    zone_name: String,
-    state: String,
-    volume: Option<f64>,
-    is_muted: Option<bool>,
-}
-
-#[derive(Debug, Serialize)]
-struct McpNowPlaying {
-    zone_id: String,
-    zone_name: String,
-    state: String,
-    title: Option<String>,
-    artist: Option<String>,
-    album: Option<String>,
-    volume: Option<f64>,
-    is_muted: Option<bool>,
-}
-
-#[derive(Debug, Serialize)]
-struct McpSearchResult {
-    title: String,
-    subtitle: Option<String>,
-}
-
-#[derive(Debug, Serialize)]
-struct McpHqpStatus {
-    connected: bool,
-    host: Option<String>,
-    pipeline: Option<McpPipelineStatus>,
-}
-
-#[derive(Debug, Serialize)]
-struct McpPipelineStatus {
-    state: String,
-    filter: String,
-    shaper: String,
-    rate: u32,
-}
-
-// ============================================================================
-// Server Handler
-// ============================================================================
-
-/// MCP server handler with access to app state
-pub struct HifiMcpHandler {
-    state: AppState,
-}
-
-impl HifiMcpHandler {
-    pub fn new(state: AppState) -> Self {
-        Self { state }
-    }
-
-    fn text_result(text: String) -> CallToolResult {
-        CallToolResult::text_content(vec![TextContent::from(text)])
-    }
-
-    fn error_result(msg: String) -> Result<CallToolResult, CallToolError> {
-        Ok(CallToolResult::text_content(vec![TextContent::from(
-            format!("Error: {}", msg),
-        )]))
-    }
-
-    fn json_result<T: Serialize>(data: &T) -> CallToolResult {
-        let json = serde_json::to_string_pretty(data).unwrap_or_else(|_| "{}".to_string());
-        Self::text_result(json)
-    }
-
-    // Helper method for volume control
-    async fn set_volume(
-        &self,
-        zone_id: &str,
-        value: f64,
-        relative: bool,
-    ) -> Result<CallToolResult, CallToolError> {
-        let result = if zone_id.starts_with("lms:") {
-            self.state
-                .lms
-                .change_volume(zone_id, value as f32, relative)
-                .await
-        } else if zone_id.starts_with("roon:") || !zone_id.contains(':') {
-            self.state
-                .roon
-                .change_volume(zone_id, value as f32, relative)
-                .await
-        } else {
-            return Self::error_result("Volume control not supported for this zone type".into());
-        };
-
-        match result {
-            Ok(()) => Ok(Self::text_result(format!(
-                "Volume {}",
-                if relative { "adjusted" } else { "set" }
-            ))),
-            Err(e) => Self::error_result(format!("Volume error: {}", e)),
-        }
-    }
-}
-
-#[async_trait]
-impl ServerHandler for HifiMcpHandler {
-    async fn handle_list_tools_request(
-        &self,
-        _params: Option<PaginatedRequestParams>,
-        _runtime: Arc<dyn McpServer>,
-    ) -> Result<ListToolsResult, RpcError> {
-        let mut tools = HifiTools::tools();
-
-        // Filter out HQPlayer tools if adapter is disabled in settings
-        let settings = load_app_settings();
-        if !settings.adapters.hqplayer {
-            tools.retain(|t| !t.name.starts_with("hifi_hqplayer"));
-        }
-
-        Ok(ListToolsResult {
-            meta: None,
-            next_cursor: None,
-            tools,
-        })
-    }
-
-    async fn handle_call_tool_request(
-        &self,
-        params: CallToolRequestParams,
-        _runtime: Arc<dyn McpServer>,
-    ) -> Result<CallToolResult, CallToolError> {
-        let tool: HifiTools = HifiTools::try_from(params).map_err(CallToolError::new)?;
-
-        match tool {
-            HifiTools::HifiZonesTool(_) => {
-                let zones = self.state.aggregator.get_zones().await;
-                let mcp_zones: Vec<McpZone> = zones
-                    .into_iter()
-                    .map(|z| McpZone {
-                        zone_id: z.zone_id,
-                        zone_name: z.zone_name,
-                        state: z.state.to_string(),
-                        volume: z.volume_control.as_ref().map(|v| v.value as f64),
-                        is_muted: z.volume_control.as_ref().map(|v| v.is_muted),
-                    })
-                    .collect();
-                Ok(Self::json_result(&mcp_zones))
-            }
-
-            HifiTools::HifiNowPlayingTool(args) => {
-                match self.state.aggregator.get_zone(&args.zone_id).await {
-                    Some(z) => {
-                        let np = McpNowPlaying {
-                            zone_id: z.zone_id,
-                            zone_name: z.zone_name,
-                            state: z.state.to_string(),
-                            title: z.now_playing.as_ref().map(|n| n.title.clone()),
-                            artist: z.now_playing.as_ref().map(|n| n.artist.clone()),
-                            album: z.now_playing.as_ref().map(|n| n.album.clone()),
-                            volume: z.volume_control.as_ref().map(|v| v.value as f64),
-                            is_muted: z.volume_control.as_ref().map(|v| v.is_muted),
-                        };
-                        Ok(Self::json_result(&np))
-                    }
-                    None => Self::error_result(format!("Zone not found: {}", args.zone_id)),
-                }
-            }
-
-            HifiTools::HifiControlTool(args) => {
-                // Map MCP actions to backend actions
-                let backend_action = match args.action.as_str() {
-                    "play" => "play",
-                    "pause" => "pause",
-                    "playpause" => "play_pause",
-                    "next" => "next",
-                    "previous" | "prev" => "previous",
-                    "volume_set" => {
-                        if let Some(v) = args.value {
-                            return self.set_volume(&args.zone_id, v, false).await;
-                        }
-                        return Self::error_result("volume_set requires a value (0-100)".into());
-                    }
-                    "volume_up" => {
-                        let delta = args.value.unwrap_or(5.0);
-                        return self.set_volume(&args.zone_id, delta, true).await;
-                    }
-                    "volume_down" => {
-                        let delta = args.value.unwrap_or(5.0);
-                        return self.set_volume(&args.zone_id, -delta, true).await;
-                    }
-                    other => other,
-                };
-
-                // Determine which adapter to use based on zone_id prefix
-                let result = if args.zone_id.starts_with("lms:") {
-                    self.state
-                        .lms
-                        .control(&args.zone_id, backend_action, None)
-                        .await
-                } else if args.zone_id.starts_with("openhome:") {
-                    self.state
-                        .openhome
-                        .control(&args.zone_id, backend_action, None)
-                        .await
-                } else if args.zone_id.starts_with("upnp:") {
-                    self.state
-                        .upnp
-                        .control(&args.zone_id, backend_action, None)
-                        .await
-                } else {
-                    // Default to Roon
-                    self.state.roon.control(&args.zone_id, backend_action).await
-                };
-
-                match result {
-                    Ok(()) => {
-                        // Return updated state
-                        if let Some(zone) = self.state.aggregator.get_zone(&args.zone_id).await {
-                            let np = McpNowPlaying {
-                                zone_id: zone.zone_id,
-                                zone_name: zone.zone_name,
-                                state: zone.state.to_string(),
-                                title: zone.now_playing.as_ref().map(|n| n.title.clone()),
-                                artist: zone.now_playing.as_ref().map(|n| n.artist.clone()),
-                                album: zone.now_playing.as_ref().map(|n| n.album.clone()),
-                                volume: zone.volume_control.as_ref().map(|v| v.value as f64),
-                                is_muted: zone.volume_control.as_ref().map(|v| v.is_muted),
-                            };
-                            let json = serde_json::to_string_pretty(&np)
-                                .unwrap_or_else(|_| "{}".to_string());
-                            Ok(Self::text_result(format!(
-                                "Action '{}' executed.\n\nCurrent state:\n{}",
-                                args.action, json
-                            )))
-                        } else {
-                            Ok(Self::text_result(format!(
-                                "Action '{}' executed.",
-                                args.action
-                            )))
-                        }
-                    }
-                    Err(e) => Self::error_result(format!("Control error: {}", e)),
-                }
-            }
-
-            HifiTools::HifiSearchTool(args) => {
-                // Route based on zone_id prefix
-                if args.zone_id.as_ref().is_some_and(|z| z.starts_with("lms:")) {
-                    // LMS search - uses globalsearch for all providers (library, TIDAL, Qobuz, etc.)
-                    match self
-                        .state
-                        .lms
-                        .search(&args.query, args.zone_id.as_deref(), Some(10))
-                        .await
-                    {
-                        Ok(results) => {
-                            let mcp_results: Vec<McpSearchResult> = results
-                                .into_iter()
-                                .map(|item| {
-                                    let subtitle = match item.result_type {
-                                        crate::adapters::lms::LmsSearchResultType::Album => {
-                                            item.artist.map(|a| format!("Album by {}", a))
-                                        }
-                                        crate::adapters::lms::LmsSearchResultType::Artist => {
-                                            Some("Artist".to_string())
-                                        }
-                                        crate::adapters::lms::LmsSearchResultType::Track => {
-                                            match (&item.artist, &item.album) {
-                                                (Some(a), Some(al)) => {
-                                                    Some(format!("{} - {}", a, al))
-                                                }
-                                                (Some(a), None) => Some(a.clone()),
-                                                _ => None,
-                                            }
-                                        }
-                                    };
-                                    McpSearchResult {
-                                        title: item.title,
-                                        subtitle,
-                                    }
-                                })
-                                .collect();
-                            Ok(Self::json_result(&mcp_results))
-                        }
-                        Err(e) => Self::error_result(format!("Search error: {}", e)),
-                    }
-                } else {
-                    // Roon search (default)
-                    use crate::adapters::roon::SearchSource;
-
-                    let source = match args.source.as_deref() {
-                        Some("tidal") => SearchSource::Tidal,
-                        Some("qobuz") => SearchSource::Qobuz,
-                        _ => SearchSource::Library,
-                    };
-                    let zone_id = args.zone_id.as_deref();
-
-                    match self
-                        .state
-                        .roon
-                        .search(&args.query, zone_id, Some(10), source)
-                        .await
-                    {
-                        Ok(results) => {
-                            let mcp_results: Vec<McpSearchResult> = results
-                                .into_iter()
-                                .map(|item| McpSearchResult {
-                                    title: item.title,
-                                    subtitle: item.subtitle,
-                                })
-                                .collect();
-                            Ok(Self::json_result(&mcp_results))
-                        }
-                        Err(e) => Self::error_result(format!("Search error: {}", e)),
-                    }
-                }
-            }
-
-            HifiTools::HifiPlayTool(args) => {
-                // Route based on zone_id prefix
-                if args.zone_id.starts_with("lms:") {
-                    use crate::adapters::lms::LmsPlayAction;
-
-                    // LMS: source param ignored (library only), radio not supported
-                    if args.action.as_deref() == Some("radio") {
-                        return Self::error_result(
-                            "Radio mode not supported for LMS. Use 'play' or 'queue'.".into(),
-                        );
-                    }
-
-                    let action = LmsPlayAction::parse(args.action.as_deref());
-
-                    match self
-                        .state
-                        .lms
-                        .search_and_play(&args.query, &args.zone_id, action)
-                        .await
-                    {
-                        Ok(message) => Ok(Self::text_result(message)),
-                        Err(e) => Self::error_result(format!("Play error: {}", e)),
-                    }
-                } else {
-                    // Roon play (default)
-                    use crate::adapters::roon::{PlayAction, SearchSource};
-
-                    let source = match args.source.as_deref() {
-                        Some("tidal") => SearchSource::Tidal,
-                        Some("qobuz") => SearchSource::Qobuz,
-                        _ => SearchSource::Library,
-                    };
-                    let action = PlayAction::parse(args.action.as_deref().unwrap_or("play"));
-
-                    match self
-                        .state
-                        .roon
-                        .search_and_play(&args.query, &args.zone_id, source, action)
-                        .await
-                    {
-                        Ok(message) => Ok(Self::text_result(message)),
-                        Err(e) => Self::error_result(format!("Play error: {}", e)),
-                    }
-                }
-            }
-
-            HifiTools::HifiStatusTool(_) => {
-                let roon_status = self.state.roon.get_status().await;
-                let hqp_status = self.state.hqplayer.get_status().await;
-
-                let status = serde_json::json!({
-                    "roon": {
-                        "connected": roon_status.connected,
-                        "core_name": roon_status.core_name,
-                    },
-                    "hqplayer": {
-                        "connected": hqp_status.connected,
-                        "host": hqp_status.host,
-                    }
-                });
-                Ok(Self::json_result(&status))
-            }
-
-            HifiTools::HifiHqplayerStatusTool(_) => {
-                let status = self.state.hqplayer.get_status().await;
-                let pipeline = self.state.hqplayer.get_pipeline_status().await.ok();
-
-                let mcp_status = McpHqpStatus {
-                    connected: status.connected,
-                    host: status.host,
-                    pipeline: pipeline.map(|p| McpPipelineStatus {
-                        state: p.status.state,
-                        filter: p.status.active_filter,
-                        shaper: p.status.active_shaper,
-                        rate: p.status.active_rate,
-                    }),
-                };
-                Ok(Self::json_result(&mcp_status))
-            }
-
-            HifiTools::HifiHqplayerProfilesTool(_) => {
-                let profiles = self.state.hqplayer.get_cached_profiles().await;
-                let profile_names: Vec<String> = profiles.into_iter().map(|p| p.title).collect();
-                Ok(Self::json_result(&profile_names))
-            }
-
-            HifiTools::HifiHqplayerLoadProfileTool(args) => {
-                match self.state.hqplayer.load_profile(&args.profile).await {
-                    Ok(()) => Ok(Self::text_result(format!(
-                        "Loaded profile: {}",
-                        args.profile
-                    ))),
-                    Err(e) => Self::error_result(format!("Failed to load profile: {}", e)),
-                }
-            }
-
-            HifiTools::HifiHqplayerSetPipelineTool(args) => {
-                // All settings now use name-based lookups - adapter handles conversion
-                // Only samplerate needs numeric parsing (Hz value)
-                let result = match args.setting.as_str() {
-                    "mode" => {
-                        // Accepts name like "PCM", "DSD", "[source]"
-                        self.state.hqplayer.set_mode(&args.value).await
-                    }
-                    "filter1x" | "filter_1x" => {
-                        self.state.hqplayer.set_filter_1x(&args.value).await
-                    }
-                    "filterNx" | "filter_nx" | "filternx" => {
-                        self.state.hqplayer.set_filter_nx(&args.value).await
-                    }
-                    "shaper" | "dither" => self.state.hqplayer.set_shaper(&args.value).await,
-                    "rate" | "samplerate" => {
-                        // Samplerate uses Hz value (e.g., "48000", "96000")
-                        if let Ok(v) = args.value.parse::<u32>() {
-                            self.state.hqplayer.set_rate(v).await
-                        } else {
-                            return Self::error_result(
-                                "Invalid rate value (expected Hz like 48000, 96000)".into(),
-                            );
-                        }
-                    }
-                    _ => {
-                        return Self::error_result(format!(
-                            "Unknown setting: {}. Valid: mode, samplerate, filter1x, filterNx, shaper, dither",
-                            args.setting
-                        ));
-                    }
-                };
-
-                match result {
-                    Ok(()) => Ok(Self::text_result(format!(
-                        "Set {} to {}",
-                        args.setting, args.value
-                    ))),
-                    Err(e) => Self::error_result(format!("Failed to set {}: {}", args.setting, e)),
-                }
-            }
-        }
-    }
-}
 
 // ============================================================================
 // MCP State Container (for Extension layer)
@@ -796,33 +216,6 @@ pub async fn handle_mcp_delete(
 ///
 /// Call this to get the extension layer, then add MCP routes and the layer to your router.
 pub fn create_mcp_extension(state: AppState) -> axum::Extension<McpExtState> {
-    let server_details = InitializeResult {
-        server_info: Implementation {
-            name: "unified-hifi-control".into(),
-            version: env!("CARGO_PKG_VERSION").into(),
-            title: Some("Unified Hi-Fi Control".into()),
-            description: Some("Control your music system via MCP".into()),
-            icons: vec![],
-            website_url: Some("https://github.com/open-horizon-labs/unified-hifi-control".into()),
-        },
-        capabilities: ServerCapabilities {
-            tools: Some(ServerCapabilitiesTools { list_changed: None }),
-            ..Default::default()
-        },
-        meta: None,
-        instructions: Some(
-            "Unified Hi-Fi Control MCP Server - Control Your Music System\n\n\
-            Use hifi_zones to list available zones, hifi_now_playing to see what's playing, \
-            hifi_control for playback control, hifi_search to find music, and hifi_play to play it.\n\n\
-            Note: hifi_search and hifi_play currently work with Roon and LMS zones only. \
-            Transport controls (play/pause/next/volume) work with all zones (Roon, LMS, OpenHome, UPnP).\n\n\
-            To build a playlist: call hifi_play multiple times with action='queue'. The first track \
-            can use action='play' to start playback, then subsequent tracks use action='queue' to add to the queue."
-                .into(),
-        ),
-        protocol_version: ProtocolVersion::V2025_11_25.into(),
-    };
-
     let handler = HifiMcpHandler::new(state);
 
     // Create MCP app state (mirrors what HyperServer does internally)
@@ -830,7 +223,7 @@ pub fn create_mcp_extension(state: AppState) -> axum::Extension<McpExtState> {
         session_store: Arc::new(InMemorySessionStore::new()),
         id_generator: Arc::new(UuidGenerator {}),
         stream_id_gen: Arc::new(FastIdGenerator::new(Some("s_"))),
-        server_details: Arc::new(server_details),
+        server_details: Arc::new(server::server_details()),
         handler: handler.to_mcp_server_handler(),
         ping_interval: Duration::from_secs(12),
         transport_options: Arc::new(TransportOptions::default()),

--- a/src/mcp/routing.rs
+++ b/src/mcp/routing.rs
@@ -1,0 +1,267 @@
+//! Zone-prefix routing for MCP tools.
+//!
+//! Every MCP tool that talks to a backend decides which adapter to use from the
+//! zone id's prefix. Before issue #394 that decision was open-coded in four
+//! places with three *different* rules; this module is the single place it lives.
+//!
+//! # This preserves today's behavior exactly, including its defects
+//!
+//! Two things here are known to be wrong, and #394 deliberately does not fix
+//! either — correcting them is #398's job:
+//!
+//! 1. An unprefixed zone id is treated as Roon.
+//! 2. An *unrecognised* prefix (`sonos:foo`) is also treated as Roon by
+//!    transport, search and play — silently, with no capability check.
+//!
+//! [`ZoneTarget::Unknown`] exists so #398 has something to change: today every
+//! call site folds `Unknown` into Roon, and the fix is to stop doing that. Do
+//! not collapse `Unknown` into [`ZoneTarget::Roon`] — that would erase the seam.
+//!
+//! # The three rules are not interchangeable
+//!
+//! Transport and volume disagree, and the disagreement is observable:
+//!
+//! | zone id        | transport ([`Self::for_transport`]) | volume ([`Self::for_volume`]) |
+//! |----------------|-------------------------------------|-------------------------------|
+//! | `lms:x`        | LMS                                 | LMS                           |
+//! | `roon:x`       | Roon                                | Roon                          |
+//! | `x` (bare)     | Roon                                | Roon                          |
+//! | `openhome:x`   | OpenHome                            | **refused**                   |
+//! | `upnp:x`       | UPnP                                | **refused**                   |
+//! | `sonos:x`      | **Roon**                            | **refused**                   |
+//!
+//! A single `is_lms()`-style predicate cannot express that. Any attempt to
+//! unify these into one rule changes behavior; `tests/mcp_contract.rs`
+//! (`volume_routing_differs_from_transport_routing`) fails if you try.
+
+/// Which adapter a zone id refers to, by prefix alone.
+///
+/// Classification is purely syntactic: it says nothing about whether the zone
+/// exists, is reachable, or supports the operation being attempted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ZoneTarget {
+    /// `lms:` prefix.
+    Lms,
+    /// `openhome:` prefix.
+    OpenHome,
+    /// `upnp:` prefix.
+    Upnp,
+    /// Explicit `roon:` prefix, or a bare id with no prefix at all.
+    ///
+    /// The bare-id case is today's silent default and belongs to #398.
+    Roon,
+    /// A prefix that matches no adapter, e.g. `sonos:x`.
+    ///
+    /// Kept distinct from [`Self::Roon`] on purpose: every call site currently
+    /// routes it to Roon anyway, and #398's fix is to stop. Merging the two
+    /// variants would remove the only place that distinction is visible.
+    Unknown,
+}
+
+impl ZoneTarget {
+    /// Classify a zone id by prefix.
+    pub fn classify(zone_id: &str) -> Self {
+        if zone_id.starts_with("lms:") {
+            Self::Lms
+        } else if zone_id.starts_with("openhome:") {
+            Self::OpenHome
+        } else if zone_id.starts_with("upnp:") {
+            Self::Upnp
+        } else if zone_id.starts_with("roon:") || !zone_id.contains(':') {
+            // Bare ids land here. This is #398's defect, frozen by #394.
+            Self::Roon
+        } else {
+            Self::Unknown
+        }
+    }
+
+    /// Classify an optional zone id, as `hifi_search` supplies.
+    ///
+    /// `None` means "no zone context", which today routes to Roon exactly as a
+    /// bare id does.
+    pub fn classify_opt(zone_id: Option<&str>) -> Self {
+        zone_id.map_or(Self::Roon, Self::classify)
+    }
+}
+
+/// Where a transport command (`play`/`pause`/`next`/...) is sent.
+///
+/// Four adapters, with Roon as the catch-all — including for unrecognised
+/// prefixes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransportRoute {
+    Lms,
+    OpenHome,
+    Upnp,
+    Roon,
+}
+
+/// Where a volume command is sent, or that it is refused.
+///
+/// Narrower than [`TransportRoute`]: only LMS and Roon expose volume control,
+/// and everything else — including unrecognised prefixes — is refused rather
+/// than defaulted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VolumeRoute {
+    Lms,
+    Roon,
+    /// No volume control for this zone type.
+    Unsupported,
+}
+
+/// Where a library operation (`hifi_search` / `hifi_play`) is sent.
+///
+/// Only LMS is distinguished; everything else goes to Roon.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LibraryRoute {
+    Lms,
+    Roon,
+}
+
+impl ZoneTarget {
+    /// Transport routing. `Unknown` falls through to Roon — today's behavior.
+    pub fn for_transport(self) -> TransportRoute {
+        match self {
+            Self::Lms => TransportRoute::Lms,
+            Self::OpenHome => TransportRoute::OpenHome,
+            Self::Upnp => TransportRoute::Upnp,
+            // Unknown prefixes default to Roon. #398 changes this, #394 does not.
+            Self::Roon | Self::Unknown => TransportRoute::Roon,
+        }
+    }
+
+    /// Volume routing. Unlike transport, anything that is not LMS or Roon is
+    /// refused rather than defaulted.
+    pub fn for_volume(self) -> VolumeRoute {
+        match self {
+            Self::Lms => VolumeRoute::Lms,
+            Self::Roon => VolumeRoute::Roon,
+            Self::OpenHome | Self::Upnp | Self::Unknown => VolumeRoute::Unsupported,
+        }
+    }
+
+    /// Library routing for `hifi_search` and `hifi_play`.
+    pub fn for_library(self) -> LibraryRoute {
+        match self {
+            Self::Lms => LibraryRoute::Lms,
+            // Everything else, Unknown included, goes to Roon today.
+            Self::Roon | Self::OpenHome | Self::Upnp | Self::Unknown => LibraryRoute::Roon,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_known_prefixes() {
+        assert_eq!(ZoneTarget::classify("lms:aa:bb:cc"), ZoneTarget::Lms);
+        assert_eq!(ZoneTarget::classify("openhome:uuid"), ZoneTarget::OpenHome);
+        assert_eq!(ZoneTarget::classify("upnp:uuid"), ZoneTarget::Upnp);
+        assert_eq!(ZoneTarget::classify("roon:1601a5d4"), ZoneTarget::Roon);
+    }
+
+    /// Frozen defect, not a design choice: see the module docs and #398.
+    #[test]
+    fn bare_ids_classify_as_roon_today() {
+        assert_eq!(ZoneTarget::classify("1601a5d4"), ZoneTarget::Roon);
+        assert_eq!(ZoneTarget::classify(""), ZoneTarget::Roon);
+        assert_eq!(ZoneTarget::classify_opt(None), ZoneTarget::Roon);
+    }
+
+    #[test]
+    fn unrecognised_prefixes_are_distinguishable_from_roon() {
+        assert_eq!(ZoneTarget::classify("sonos:abc"), ZoneTarget::Unknown);
+        assert_eq!(ZoneTarget::classify("chromecast:abc"), ZoneTarget::Unknown);
+        // The distinction is the seam #398 needs; do not collapse it.
+        assert_ne!(
+            ZoneTarget::classify("sonos:abc"),
+            ZoneTarget::classify("roon:abc")
+        );
+    }
+
+    /// Transport's catch-all is Roon, for bare ids AND unknown prefixes.
+    #[test]
+    fn transport_routes_everything_unrecognised_to_roon() {
+        assert_eq!(
+            ZoneTarget::classify("lms:x").for_transport(),
+            TransportRoute::Lms
+        );
+        assert_eq!(
+            ZoneTarget::classify("openhome:x").for_transport(),
+            TransportRoute::OpenHome
+        );
+        assert_eq!(
+            ZoneTarget::classify("upnp:x").for_transport(),
+            TransportRoute::Upnp
+        );
+        assert_eq!(
+            ZoneTarget::classify("roon:x").for_transport(),
+            TransportRoute::Roon
+        );
+        assert_eq!(
+            ZoneTarget::classify("bare").for_transport(),
+            TransportRoute::Roon
+        );
+        assert_eq!(
+            ZoneTarget::classify("sonos:x").for_transport(),
+            TransportRoute::Roon
+        );
+    }
+
+    /// Volume refuses where transport defaults. This asymmetry is the reason
+    /// routing cannot be one predicate.
+    #[test]
+    fn volume_refuses_where_transport_defaults_to_roon() {
+        assert_eq!(ZoneTarget::classify("lms:x").for_volume(), VolumeRoute::Lms);
+        assert_eq!(ZoneTarget::classify("roon:x").for_volume(), VolumeRoute::Roon);
+        assert_eq!(ZoneTarget::classify("bare").for_volume(), VolumeRoute::Roon);
+
+        for zone_id in ["openhome:x", "upnp:x", "sonos:x"] {
+            assert_eq!(
+                ZoneTarget::classify(zone_id).for_volume(),
+                VolumeRoute::Unsupported,
+                "{zone_id} must be refused for volume"
+            );
+        }
+
+        // For the two prefixed adapters the asymmetry is "own adapter for
+        // transport, refused for volume".
+        for zone_id in ["openhome:x", "upnp:x"] {
+            assert_ne!(
+                ZoneTarget::classify(zone_id).for_transport(),
+                TransportRoute::Roon,
+                "{zone_id} must reach its own adapter for transport"
+            );
+        }
+    }
+
+    /// `sonos:x` is the case that proves the two rules differ: refused for
+    /// volume, routed to Roon for transport.
+    #[test]
+    fn unknown_prefix_is_refused_for_volume_but_routed_to_roon_for_transport() {
+        let target = ZoneTarget::classify("sonos:x");
+        assert_eq!(target.for_volume(), VolumeRoute::Unsupported);
+        assert_eq!(target.for_transport(), TransportRoute::Roon);
+    }
+
+    #[test]
+    fn library_routes_only_lms_away_from_roon() {
+        assert_eq!(
+            ZoneTarget::classify("lms:x").for_library(),
+            LibraryRoute::Lms
+        );
+        for zone_id in ["roon:x", "bare", "openhome:x", "upnp:x", "sonos:x"] {
+            assert_eq!(
+                ZoneTarget::classify(zone_id).for_library(),
+                LibraryRoute::Roon,
+                "{zone_id} must route to Roon for search/play"
+            );
+        }
+        assert_eq!(
+            ZoneTarget::classify_opt(None).for_library(),
+            LibraryRoute::Roon
+        );
+    }
+}

--- a/src/mcp/routing.rs
+++ b/src/mcp/routing.rs
@@ -215,7 +215,10 @@ mod tests {
     #[test]
     fn volume_refuses_where_transport_defaults_to_roon() {
         assert_eq!(ZoneTarget::classify("lms:x").for_volume(), VolumeRoute::Lms);
-        assert_eq!(ZoneTarget::classify("roon:x").for_volume(), VolumeRoute::Roon);
+        assert_eq!(
+            ZoneTarget::classify("roon:x").for_volume(),
+            VolumeRoute::Roon
+        );
         assert_eq!(ZoneTarget::classify("bare").for_volume(), VolumeRoute::Roon);
 
         for zone_id in ["openhome:x", "upnp:x", "sonos:x"] {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1,0 +1,60 @@
+//! The `initialize` response: server identity, declared capabilities,
+//! instructions, and protocol version.
+//!
+//! Extracted from `create_mcp_extension` so it can be inspected without
+//! building an `AppState` or a transport.
+//!
+//! # Declared capabilities gate request dispatch
+//!
+//! rust-mcp-sdk checks the declared capability set *before* any handler runs. So
+//! declaring only `tools` is not merely "resources are unimplemented" — every
+//! resource method returns JSON-RPC `-32603 Server does not support resources`.
+//! That refusal is pinned by
+//! `tests/mcp_contract.rs::resource_methods_are_refused_while_only_tools_is_declared`,
+//! so #397 shows up as a visible refusal-to-success diff rather than as a silent
+//! change. The SDK gate keys only on the *presence* of `resources`; it never
+//! inspects `subscribe` or `listChanged`.
+//!
+//! This function is #397's primary target.
+
+use rust_mcp_sdk::schema::{
+    Implementation, InitializeResult, ProtocolVersion, ServerCapabilities, ServerCapabilitiesTools,
+};
+
+/// The `initialize` result this server advertises.
+///
+/// Every field is snapshotted in `tests/fixtures/mcp_initialize.json`. Changing
+/// any of them — instructions included, since a model reads them — fails
+/// `initialize_result_matches_fixture`, which is the intended behavior: the
+/// fixture is regenerated deliberately, never incidentally.
+///
+/// `server_info.version` comes from `CARGO_PKG_VERSION`, which release builds
+/// inject from the git tag, so the fixture redacts it and asserts it separately.
+pub fn server_details() -> InitializeResult {
+    InitializeResult {
+        server_info: Implementation {
+            name: "unified-hifi-control".into(),
+            version: env!("CARGO_PKG_VERSION").into(),
+            title: Some("Unified Hi-Fi Control".into()),
+            description: Some("Control your music system via MCP".into()),
+            icons: vec![],
+            website_url: Some("https://github.com/open-horizon-labs/unified-hifi-control".into()),
+        },
+        capabilities: ServerCapabilities {
+            tools: Some(ServerCapabilitiesTools { list_changed: None }),
+            ..Default::default()
+        },
+        meta: None,
+        instructions: Some(
+            "Unified Hi-Fi Control MCP Server - Control Your Music System\n\n\
+            Use hifi_zones to list available zones, hifi_now_playing to see what's playing, \
+            hifi_control for playback control, hifi_search to find music, and hifi_play to play it.\n\n\
+            Note: hifi_search and hifi_play currently work with Roon and LMS zones only. \
+            Transport controls (play/pause/next/volume) work with all zones (Roon, LMS, OpenHome, UPnP).\n\n\
+            To build a playlist: call hifi_play multiple times with action='queue'. The first track \
+            can use action='play' to start playback, then subsequent tracks use action='queue' to add to the queue."
+                .into(),
+        ),
+        protocol_version: ProtocolVersion::V2025_11_25.into(),
+    }
+}

--- a/src/mcp/tools/hqplayer.rs
+++ b/src/mcp/tools/hqplayer.rs
@@ -1,0 +1,139 @@
+//! HQPlayer pipeline inspection and control.
+//!
+//! These four tools are advertised only when the HQPlayer adapter is enabled in
+//! settings — see [`crate::mcp::tools::list_tools`].
+//!
+//! # The setting alias table is contract
+//!
+//! [`handle_set_pipeline`] accepts several spellings per setting
+//! (`filter1x`/`filter_1x`, `filterNx`/`filter_nx`/`filternx`, `shaper`/`dither`,
+//! `rate`/`samplerate`). None of that appears in `tools/list`, so dropping an
+//! alias would turn a documented input into "Unknown setting" with a green
+//! snapshot suite. `tests/mcp_contract.rs::hqplayer_set_pipeline_alias_table_is_pinned`
+//! checks every alias individually.
+
+use crate::api::AppState;
+use crate::mcp::types::{error_result, json_result, text_result, McpHqpStatus, McpPipelineStatus};
+use rust_mcp_sdk::{
+    macros::{mcp_tool, JsonSchema},
+    schema::{schema_utils::CallToolError, CallToolResult},
+};
+use serde::{Deserialize, Serialize};
+
+/// Get HQPlayer status
+#[mcp_tool(
+    name = "hifi_hqplayer_status",
+    description = "Get HQPlayer Embedded status and current pipeline settings",
+    read_only_hint = true
+)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct HifiHqplayerStatusTool {}
+
+/// List HQPlayer profiles
+#[mcp_tool(
+    name = "hifi_hqplayer_profiles",
+    description = "List available HQPlayer Embedded configurations",
+    read_only_hint = true
+)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct HifiHqplayerProfilesTool {}
+
+/// Load an HQPlayer profile
+#[mcp_tool(
+    name = "hifi_hqplayer_load_profile",
+    description = "Load an HQPlayer Embedded configuration (will restart HQPlayer)",
+    destructive_hint = true
+)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct HifiHqplayerLoadProfileTool {
+    /// Configuration name to load (get from hifi_hqplayer_profiles)
+    pub profile: String,
+}
+
+/// Change an HQPlayer pipeline setting
+#[mcp_tool(
+    name = "hifi_hqplayer_set_pipeline",
+    description = "Change an HQPlayer pipeline setting (mode, samplerate, filter1x, filterNx, shaper, dither)"
+)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct HifiHqplayerSetPipelineTool {
+    /// Setting to change: mode, samplerate, filter1x, filterNx, shaper, dither
+    pub setting: String,
+    /// New value for the setting
+    pub value: String,
+}
+
+/// The setting names this tool advertises, used in the refusal message.
+///
+/// Kept next to the alias match below so the two stay in step.
+const VALID_SETTINGS: &str = "mode, samplerate, filter1x, filterNx, shaper, dither";
+
+pub async fn handle_status(state: &AppState) -> Result<CallToolResult, CallToolError> {
+    let status = state.hqplayer.get_status().await;
+    let pipeline = state.hqplayer.get_pipeline_status().await.ok();
+
+    let mcp_status = McpHqpStatus {
+        connected: status.connected,
+        host: status.host,
+        pipeline: pipeline.map(|p| McpPipelineStatus {
+            state: p.status.state,
+            filter: p.status.active_filter,
+            shaper: p.status.active_shaper,
+            rate: p.status.active_rate,
+        }),
+    };
+    Ok(json_result(&mcp_status))
+}
+
+pub async fn handle_profiles(state: &AppState) -> Result<CallToolResult, CallToolError> {
+    let profiles = state.hqplayer.get_cached_profiles().await;
+    let profile_names: Vec<String> = profiles.into_iter().map(|p| p.title).collect();
+    Ok(json_result(&profile_names))
+}
+
+pub async fn handle_load_profile(
+    state: &AppState,
+    args: HifiHqplayerLoadProfileTool,
+) -> Result<CallToolResult, CallToolError> {
+    match state.hqplayer.load_profile(&args.profile).await {
+        Ok(()) => Ok(text_result(format!("Loaded profile: {}", args.profile))),
+        Err(e) => error_result(format!("Failed to load profile: {}", e)),
+    }
+}
+
+pub async fn handle_set_pipeline(
+    state: &AppState,
+    args: HifiHqplayerSetPipelineTool,
+) -> Result<CallToolResult, CallToolError> {
+    // All settings use name-based lookups; the adapter handles the conversion.
+    // Only samplerate needs numeric parsing (an Hz value).
+    let result = match args.setting.as_str() {
+        // Accepts a name like "PCM", "DSD", "[source]".
+        "mode" => state.hqplayer.set_mode(&args.value).await,
+        "filter1x" | "filter_1x" => state.hqplayer.set_filter_1x(&args.value).await,
+        "filterNx" | "filter_nx" | "filternx" => state.hqplayer.set_filter_nx(&args.value).await,
+        "shaper" | "dither" => state.hqplayer.set_shaper(&args.value).await,
+        "rate" | "samplerate" => {
+            // Samplerate uses an Hz value, e.g. "48000", "96000".
+            if let Ok(v) = args.value.parse::<u32>() {
+                state.hqplayer.set_rate(v).await
+            } else {
+                return error_result("Invalid rate value (expected Hz like 48000, 96000)".into());
+            }
+        }
+        _ => {
+            return error_result(format!(
+                "Unknown setting: {}. Valid: {}",
+                args.setting, VALID_SETTINGS
+            ));
+        }
+    };
+
+    match result {
+        Ok(()) => Ok(text_result(format!(
+            "Set {} to {}",
+            args.setting, args.value
+        ))),
+        Err(e) => error_result(format!("Failed to set {}: {}", args.setting, e)),
+    }
+}

--- a/src/mcp/tools/library.rs
+++ b/src/mcp/tools/library.rs
@@ -1,0 +1,193 @@
+//! Library search and playback.
+//!
+//! Both tools route on `lms:` only; everything else, including an absent
+//! `zone_id`, goes to Roon (see [`crate::mcp::routing`]).
+//!
+//! This module is the primary target for #396 (opaque content references) and
+//! #399 (hierarchical browse). Note what `McpSearchResult` lacks: any stable
+//! identifier. A client that finds something here can only hand the title back
+//! to `hifi_play`, which re-searches and takes the first match. That is #392's
+//! keystone finding — recorded in `FIELD_ROLES` in `tests/mcp_contract.rs` as a
+//! known defect, and out of scope for #394.
+
+use crate::api::AppState;
+use crate::mcp::routing::{LibraryRoute, ZoneTarget};
+use crate::mcp::types::{error_result, json_result, text_result, McpSearchResult};
+use rust_mcp_sdk::{
+    macros::{mcp_tool, JsonSchema},
+    schema::{schema_utils::CallToolError, CallToolResult},
+};
+use serde::{Deserialize, Serialize};
+
+/// How many results to request from a backend.
+const SEARCH_LIMIT: usize = 10;
+
+/// Search for music
+#[mcp_tool(
+    name = "hifi_search",
+    description = "Search for tracks, albums, or artists. Roon: searches Library, TIDAL, or Qobuz (use source param). LMS: searches all installed providers including streaming plugins (zone_id recommended as different players may have different sources configured).",
+    read_only_hint = true
+)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct HifiSearchTool {
+    /// Search query (e.g., "Hotel California", "Eagles", "jazz piano")
+    pub query: String,
+    /// Zone ID for context-aware results. Recommended for LMS (different players may have different sources).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub zone_id: Option<String>,
+    /// Where to search: "library" (default), "tidal", or "qobuz". Roon only; LMS searches all providers.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+}
+
+/// Search and play music in one command
+#[mcp_tool(
+    name = "hifi_play",
+    description = "Search and play music. Searches and plays, queues, or starts radio from the first matching result. Use action='queue' to add to queue. action='radio' and source param are Roon-only; LMS searches all providers."
+)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct HifiPlayTool {
+    /// What to play (e.g., "early Michael Jackson", "Dark Side of the Moon")
+    pub query: String,
+    /// Zone ID to play on (get from hifi_zones)
+    pub zone_id: String,
+    /// Where to search: "library" (default), "tidal", or "qobuz". Roon only; LMS searches all providers.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    /// What to do: "play" (default), "queue", or "radio". radio is Roon-only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub action: Option<String>,
+}
+
+/// Parse the `source` parameter into Roon's search source.
+///
+/// Anything unrecognised falls back to Library, matching the documented default.
+fn roon_search_source(source: Option<&str>) -> crate::adapters::roon::SearchSource {
+    use crate::adapters::roon::SearchSource;
+    match source {
+        Some("tidal") => SearchSource::Tidal,
+        Some("qobuz") => SearchSource::Qobuz,
+        _ => SearchSource::Library,
+    }
+}
+
+pub async fn handle_search(
+    state: &AppState,
+    args: HifiSearchTool,
+) -> Result<CallToolResult, CallToolError> {
+    match ZoneTarget::classify_opt(args.zone_id.as_deref()).for_library() {
+        LibraryRoute::Lms => {
+            // LMS uses globalsearch, which covers every installed provider
+            // (library, TIDAL, Qobuz, ...), so `source` does not apply.
+            match state
+                .lms
+                .search(
+                    &args.query,
+                    args.zone_id.as_deref(),
+                    Some(SEARCH_LIMIT),
+                )
+                .await
+            {
+                Ok(results) => {
+                    let mcp_results: Vec<McpSearchResult> = results
+                        .into_iter()
+                        .map(|item| McpSearchResult {
+                            subtitle: lms_subtitle(&item),
+                            title: item.title,
+                        })
+                        .collect();
+                    Ok(json_result(&mcp_results))
+                }
+                Err(e) => error_result(format!("Search error: {}", e)),
+            }
+        }
+        LibraryRoute::Roon => {
+            match state
+                .roon
+                .search(
+                    &args.query,
+                    args.zone_id.as_deref(),
+                    Some(SEARCH_LIMIT),
+                    roon_search_source(args.source.as_deref()),
+                )
+                .await
+            {
+                Ok(results) => {
+                    let mcp_results: Vec<McpSearchResult> = results
+                        .into_iter()
+                        .map(|item| McpSearchResult {
+                            title: item.title,
+                            subtitle: item.subtitle,
+                        })
+                        .collect();
+                    Ok(json_result(&mcp_results))
+                }
+                Err(e) => error_result(format!("Search error: {}", e)),
+            }
+        }
+    }
+}
+
+/// Render an LMS search hit's subtitle.
+///
+/// LMS returns typed results with separate artist/album fields; the subtitle is
+/// the human-readable rendering of that type.
+fn lms_subtitle(item: &crate::adapters::lms::LmsSearchResult) -> Option<String> {
+    use crate::adapters::lms::LmsSearchResultType;
+    match item.result_type {
+        LmsSearchResultType::Album => item.artist.as_ref().map(|a| format!("Album by {}", a)),
+        LmsSearchResultType::Artist => Some("Artist".to_string()),
+        LmsSearchResultType::Track => match (&item.artist, &item.album) {
+            (Some(a), Some(al)) => Some(format!("{} - {}", a, al)),
+            (Some(a), None) => Some(a.clone()),
+            _ => None,
+        },
+    }
+}
+
+pub async fn handle_play(
+    state: &AppState,
+    args: HifiPlayTool,
+) -> Result<CallToolResult, CallToolError> {
+    match ZoneTarget::classify(&args.zone_id).for_library() {
+        LibraryRoute::Lms => {
+            use crate::adapters::lms::LmsPlayAction;
+
+            // LMS ignores `source` (library only) and has no radio mode. The
+            // refusal names the supported actions so the model can retry.
+            if args.action.as_deref() == Some("radio") {
+                return error_result(
+                    "Radio mode not supported for LMS. Use 'play' or 'queue'.".into(),
+                );
+            }
+
+            let action = LmsPlayAction::parse(args.action.as_deref());
+            match state
+                .lms
+                .search_and_play(&args.query, &args.zone_id, action)
+                .await
+            {
+                Ok(message) => Ok(text_result(message)),
+                Err(e) => error_result(format!("Play error: {}", e)),
+            }
+        }
+        LibraryRoute::Roon => {
+            use crate::adapters::roon::PlayAction;
+
+            let action = PlayAction::parse(args.action.as_deref().unwrap_or("play"));
+            match state
+                .roon
+                .search_and_play(
+                    &args.query,
+                    &args.zone_id,
+                    roon_search_source(args.source.as_deref()),
+                    action,
+                )
+                .await
+            {
+                Ok(message) => Ok(text_result(message)),
+                Err(e) => error_result(format!("Play error: {}", e)),
+            }
+        }
+    }
+}

--- a/src/mcp/tools/library.rs
+++ b/src/mcp/tools/library.rs
@@ -19,8 +19,16 @@ use rust_mcp_sdk::{
 };
 use serde::{Deserialize, Serialize};
 
-/// How many results to request from a backend.
-const SEARCH_LIMIT: usize = 10;
+/// How many results to request from LMS.
+///
+/// Kept separate from [`ROON_SEARCH_LIMIT`] even though both are 10 today. They
+/// were two independent literals before #394, and a refactor mandated to change
+/// no behavior should not quietly couple them: the two backends page and rank
+/// differently, so a future tuning of one is not a decision about the other.
+const LMS_SEARCH_LIMIT: usize = 10;
+
+/// How many results to request from Roon.
+const ROON_SEARCH_LIMIT: usize = 10;
 
 /// Search for music
 #[mcp_tool(
@@ -81,11 +89,7 @@ pub async fn handle_search(
             // (library, TIDAL, Qobuz, ...), so `source` does not apply.
             match state
                 .lms
-                .search(
-                    &args.query,
-                    args.zone_id.as_deref(),
-                    Some(SEARCH_LIMIT),
-                )
+                .search(&args.query, args.zone_id.as_deref(), Some(LMS_SEARCH_LIMIT))
                 .await
             {
                 Ok(results) => {
@@ -107,7 +111,7 @@ pub async fn handle_search(
                 .search(
                     &args.query,
                     args.zone_id.as_deref(),
-                    Some(SEARCH_LIMIT),
+                    Some(ROON_SEARCH_LIMIT),
                     roon_search_source(args.source.as_deref()),
                 )
                 .await

--- a/src/mcp/tools/mod.rs
+++ b/src/mcp/tools/mod.rs
@@ -1,0 +1,108 @@
+//! The tool registry: which tools exist, and which are advertised.
+//!
+//! Each family module below holds its tools' `#[mcp_tool]` definitions *and*
+//! their handlers, so a tool's advertised contract (name, description, input
+//! schema) sits next to the behavior that has to match it.
+//!
+//! # Adding a tool
+//!
+//! 1. Define it, with its handler, in the family module it belongs to (or a new
+//!    one).
+//! 2. **Append** it to the [`tool_box!`] list below.
+//! 3. Add a dispatch arm in [`crate::mcp::handler`].
+//! 4. Regenerate `tests/fixtures/mcp_tools.json` deliberately, and add the
+//!    tool's parameters to `EXPECTED_TOOL_PARAMS` and any new returned fields to
+//!    `FIELD_ROLES`, both in `tests/mcp_contract.rs`.
+//!
+//! Append rather than insert: `tools/list` order follows this list, and the
+//! fixture pins it. Appending leaves the existing entries untouched, so the diff
+//! reads as additive. Inserting mid-list shifts everything below it.
+
+pub mod hqplayer;
+pub mod library;
+pub mod status;
+pub mod transport;
+pub mod zones;
+
+use rust_mcp_sdk::schema::Tool;
+use rust_mcp_sdk::tool_box;
+
+pub use hqplayer::{
+    HifiHqplayerLoadProfileTool, HifiHqplayerProfilesTool, HifiHqplayerSetPipelineTool,
+    HifiHqplayerStatusTool,
+};
+pub use library::{HifiPlayTool, HifiSearchTool};
+pub use status::HifiStatusTool;
+pub use transport::HifiControlTool;
+pub use zones::{HifiNowPlayingTool, HifiZonesTool};
+
+// Generate the toolbox enum with all tools.
+//
+// This also generates `HifiTools::tools()` and
+// `TryFrom<CallToolRequestParams>`, which together produce the exact
+// `tools/list` bytes (via the `JsonSchema` derive) and parse incoming calls.
+// Do not hand-roll either: `tests/fixtures/mcp_tools.json` pins the output.
+tool_box!(
+    HifiTools,
+    [
+        HifiZonesTool,
+        HifiNowPlayingTool,
+        HifiControlTool,
+        HifiSearchTool,
+        HifiPlayTool,
+        HifiStatusTool,
+        HifiHqplayerStatusTool,
+        HifiHqplayerProfilesTool,
+        HifiHqplayerLoadProfileTool,
+        HifiHqplayerSetPipelineTool
+    ]
+);
+
+/// The tools to advertise in `tools/list`.
+///
+/// HQPlayer tools are hidden when the adapter is disabled, because AGENTS.md
+/// requires that every advertised tool work as documented — advertising the
+/// HQPlayer surface with no HQPlayer behind it fails that.
+///
+/// Takes the flag rather than reading settings itself so the filter is testable
+/// without touching the filesystem; the caller
+/// ([`crate::mcp::handler::HifiMcpHandler::handle_list_tools_request`]) supplies
+/// it from `load_app_settings()`.
+pub fn list_tools(hqplayer_enabled: bool) -> Vec<Tool> {
+    let mut tools = HifiTools::tools();
+    if !hqplayer_enabled {
+        tools.retain(|t| !t.name.starts_with("hifi_hqplayer"));
+    }
+    tools
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn advertises_ten_tools_when_hqplayer_is_enabled() {
+        assert_eq!(list_tools(true).len(), 10);
+    }
+
+    /// The filter must remove exactly the four HQPlayer tools and nothing else.
+    #[test]
+    fn hides_only_the_hqplayer_tools_when_disabled() {
+        let enabled: Vec<String> = list_tools(true).into_iter().map(|t| t.name).collect();
+        let disabled: Vec<String> = list_tools(false).into_iter().map(|t| t.name).collect();
+
+        assert_eq!(disabled.len(), 6);
+        assert!(disabled.iter().all(|n| !n.starts_with("hifi_hqplayer")));
+
+        let removed: Vec<&String> = enabled.iter().filter(|n| !disabled.contains(n)).collect();
+        assert_eq!(removed.len(), 4, "only the HQPlayer tools may be filtered");
+        assert!(removed.iter().all(|n| n.starts_with("hifi_hqplayer")));
+
+        // Relative order of the surviving tools is preserved.
+        let surviving: Vec<&String> = enabled
+            .iter()
+            .filter(|n| !n.starts_with("hifi_hqplayer"))
+            .collect();
+        assert_eq!(surviving, disabled.iter().collect::<Vec<_>>());
+    }
+}

--- a/src/mcp/tools/status.rs
+++ b/src/mcp/tools/status.rs
@@ -1,0 +1,44 @@
+//! Overall bridge status.
+
+use crate::api::AppState;
+use crate::mcp::types::json_result;
+use rust_mcp_sdk::{
+    macros::{mcp_tool, JsonSchema},
+    schema::{schema_utils::CallToolError, CallToolResult},
+};
+use serde::{Deserialize, Serialize};
+
+/// Get overall bridge status
+#[mcp_tool(
+    name = "hifi_status",
+    description = "Get overall bridge status (Roon connection, HQPlayer config)",
+    read_only_hint = true
+)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct HifiStatusTool {}
+
+/// # Do not convert this to a typed struct
+///
+/// `serde_json` without the `preserve_order` feature serializes maps as
+/// `BTreeMap`, i.e. alphabetically, so this payload emits `hqplayer` before
+/// `roon`. A struct would serialize in declaration order instead and silently
+/// reorder the keys in the text clients receive.
+///
+/// `tests/mcp_contract.rs::hifi_status_shape_is_pinned` asserts the ordering, so
+/// the mistake is caught — but it is cheaper to not make it.
+pub async fn handle_status(state: &AppState) -> Result<CallToolResult, CallToolError> {
+    let roon_status = state.roon.get_status().await;
+    let hqp_status = state.hqplayer.get_status().await;
+
+    let status = serde_json::json!({
+        "roon": {
+            "connected": roon_status.connected,
+            "core_name": roon_status.core_name,
+        },
+        "hqplayer": {
+            "connected": hqp_status.connected,
+            "host": hqp_status.host,
+        }
+    });
+    Ok(json_result(&status))
+}

--- a/src/mcp/tools/transport.rs
+++ b/src/mcp/tools/transport.rs
@@ -1,0 +1,139 @@
+//! Transport control: play, pause, skip, volume.
+//!
+//! # Two lookup tables live here, and neither is visible in `tools/list`
+//!
+//! 1. The MCP action -> backend action map. `playpause` becomes `play_pause`,
+//!    and `prev` is accepted as a synonym for `previous`. Getting either wrong
+//!    breaks the tool while leaving every snapshot green, so
+//!    `tests/mcp_contract.rs::lms_round_trip_pins_the_action_map_and_the_volume_sign`
+//!    asserts the command the backend actually receives.
+//! 2. Volume handling: `volume_set` requires a value, `volume_up`/`volume_down`
+//!    default the delta to 5, and `volume_down` negates it. The sign is the kind
+//!    of thing a careless edit inverts silently.
+//!
+//! Volume also uses a *different* routing rule from transport — see
+//! [`crate::mcp::routing`]. `sonos:x` is refused for volume but routed to Roon
+//! for transport. That asymmetry is deliberate today and load-bearing for #398.
+
+use crate::api::AppState;
+use crate::mcp::routing::{TransportRoute, VolumeRoute, ZoneTarget};
+use crate::mcp::types::{error_result, now_playing_from_zone, text_result};
+use rust_mcp_sdk::{
+    macros::{mcp_tool, JsonSchema},
+    schema::{schema_utils::CallToolError, CallToolResult},
+};
+use serde::{Deserialize, Serialize};
+
+/// Control playback
+#[mcp_tool(
+    name = "hifi_control",
+    description = "Control playback: play, pause, playpause (toggle), next, previous, or adjust volume"
+)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct HifiControlTool {
+    /// The zone ID to control
+    pub zone_id: String,
+    /// Action: play, pause, playpause, next, previous, volume_set, volume_up, volume_down
+    pub action: String,
+    /// For volume actions: the level (0-100 for volume_set) or amount to change
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<f64>,
+}
+
+/// Default step for `volume_up` / `volume_down` when no value is supplied.
+const DEFAULT_VOLUME_DELTA: f64 = 5.0;
+
+pub async fn handle_control(
+    state: &AppState,
+    args: HifiControlTool,
+) -> Result<CallToolResult, CallToolError> {
+    // Map MCP actions to backend actions. Volume actions divert to the volume
+    // path, which routes differently from transport.
+    let backend_action = match args.action.as_str() {
+        "play" => "play",
+        "pause" => "pause",
+        "playpause" => "play_pause",
+        "next" => "next",
+        "previous" | "prev" => "previous",
+        "volume_set" => {
+            if let Some(v) = args.value {
+                return set_volume(state, &args.zone_id, v, false).await;
+            }
+            return error_result("volume_set requires a value (0-100)".into());
+        }
+        "volume_up" => {
+            let delta = args.value.unwrap_or(DEFAULT_VOLUME_DELTA);
+            return set_volume(state, &args.zone_id, delta, true).await;
+        }
+        "volume_down" => {
+            let delta = args.value.unwrap_or(DEFAULT_VOLUME_DELTA);
+            // Negated: the same relative call, opposite direction.
+            return set_volume(state, &args.zone_id, -delta, true).await;
+        }
+        // Anything unrecognised is passed through for the adapter to reject, so
+        // the refusal comes from whoever actually knows the action set.
+        other => other,
+    };
+
+    let result = match ZoneTarget::classify(&args.zone_id).for_transport() {
+        TransportRoute::Lms => state.lms.control(&args.zone_id, backend_action, None).await,
+        TransportRoute::OpenHome => {
+            state
+                .openhome
+                .control(&args.zone_id, backend_action, None)
+                .await
+        }
+        TransportRoute::Upnp => state.upnp.control(&args.zone_id, backend_action, None).await,
+        TransportRoute::Roon => state.roon.control(&args.zone_id, backend_action).await,
+    };
+
+    match result {
+        Ok(()) => {
+            // Report the observed state back, so the model does not have to
+            // follow every command with hifi_now_playing.
+            if let Some(zone) = state.aggregator.get_zone(&args.zone_id).await {
+                let np = now_playing_from_zone(zone);
+                let json = serde_json::to_string_pretty(&np).unwrap_or_else(|_| "{}".to_string());
+                Ok(text_result(format!(
+                    "Action '{}' executed.\n\nCurrent state:\n{}",
+                    args.action, json
+                )))
+            } else {
+                Ok(text_result(format!("Action '{}' executed.", args.action)))
+            }
+        }
+        Err(e) => error_result(format!("Control error: {}", e)),
+    }
+}
+
+/// Volume, absolute or relative.
+///
+/// Refuses zone types with no volume control rather than defaulting them to
+/// Roon the way transport does.
+async fn set_volume(
+    state: &AppState,
+    zone_id: &str,
+    value: f64,
+    relative: bool,
+) -> Result<CallToolResult, CallToolError> {
+    let result = match ZoneTarget::classify(zone_id).for_volume() {
+        VolumeRoute::Lms => state.lms.change_volume(zone_id, value as f32, relative).await,
+        VolumeRoute::Roon => {
+            state
+                .roon
+                .change_volume(zone_id, value as f32, relative)
+                .await
+        }
+        VolumeRoute::Unsupported => {
+            return error_result("Volume control not supported for this zone type".into());
+        }
+    };
+
+    match result {
+        Ok(()) => Ok(text_result(format!(
+            "Volume {}",
+            if relative { "adjusted" } else { "set" }
+        ))),
+        Err(e) => error_result(format!("Volume error: {}", e)),
+    }
+}

--- a/src/mcp/tools/transport.rs
+++ b/src/mcp/tools/transport.rs
@@ -83,7 +83,12 @@ pub async fn handle_control(
                 .control(&args.zone_id, backend_action, None)
                 .await
         }
-        TransportRoute::Upnp => state.upnp.control(&args.zone_id, backend_action, None).await,
+        TransportRoute::Upnp => {
+            state
+                .upnp
+                .control(&args.zone_id, backend_action, None)
+                .await
+        }
         TransportRoute::Roon => state.roon.control(&args.zone_id, backend_action).await,
     };
 
@@ -117,7 +122,12 @@ async fn set_volume(
     relative: bool,
 ) -> Result<CallToolResult, CallToolError> {
     let result = match ZoneTarget::classify(zone_id).for_volume() {
-        VolumeRoute::Lms => state.lms.change_volume(zone_id, value as f32, relative).await,
+        VolumeRoute::Lms => {
+            state
+                .lms
+                .change_volume(zone_id, value as f32, relative)
+                .await
+        }
         VolumeRoute::Roon => {
             state
                 .roon

--- a/src/mcp/tools/zones.rs
+++ b/src/mcp/tools/zones.rs
@@ -1,0 +1,59 @@
+//! Zone discovery and now-playing.
+//!
+//! Read-only. Both tools read from the aggregator, never from an adapter, per
+//! AGENTS.md ("Adapters are dumb, Aggregator owns state").
+
+use crate::api::AppState;
+use crate::mcp::types::{error_result, json_result, now_playing_from_zone, McpZone};
+use rust_mcp_sdk::{
+    macros::{mcp_tool, JsonSchema},
+    schema::{schema_utils::CallToolError, CallToolResult},
+};
+use serde::{Deserialize, Serialize};
+
+/// List all available playback zones
+#[mcp_tool(
+    name = "hifi_zones",
+    description = "List all available playback zones (Roon, LMS, OpenHome, UPnP)",
+    read_only_hint = true
+)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct HifiZonesTool {}
+
+/// Get current playback state for a zone
+#[mcp_tool(
+    name = "hifi_now_playing",
+    description = "Get current playback state for a zone (track, artist, album, play state, volume)",
+    read_only_hint = true
+)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct HifiNowPlayingTool {
+    /// The zone ID to query (get from hifi_zones)
+    pub zone_id: String,
+}
+
+pub async fn handle_zones(state: &AppState) -> Result<CallToolResult, CallToolError> {
+    let zones = state.aggregator.get_zones().await;
+    let mcp_zones: Vec<McpZone> = zones
+        .into_iter()
+        .map(|z| McpZone {
+            zone_id: z.zone_id,
+            zone_name: z.zone_name,
+            state: z.state.to_string(),
+            volume: z.volume_control.as_ref().map(|v| v.value as f64),
+            is_muted: z.volume_control.as_ref().map(|v| v.is_muted),
+        })
+        .collect();
+    Ok(json_result(&mcp_zones))
+}
+
+pub async fn handle_now_playing(
+    state: &AppState,
+    args: HifiNowPlayingTool,
+) -> Result<CallToolResult, CallToolError> {
+    match state.aggregator.get_zone(&args.zone_id).await {
+        Some(zone) => Ok(json_result(&now_playing_from_zone(zone))),
+        // The id is echoed back so a client can tell a typo from an absent zone.
+        None => error_result(format!("Zone not found: {}", args.zone_id)),
+    }
+}

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -1,0 +1,114 @@
+//! MCP response shapes and result constructors.
+//!
+//! # Field order is part of the contract
+//!
+//! These structs serialize in **declaration order**, and their serialized form
+//! is text an MCP client reads. Reordering a field changes the payload. Add new
+//! fields at the end, and add them to `FIELD_ROLES` in
+//! `tests/mcp_contract.rs` — AGENTS.md forbids returning data no tool can use,
+//! and that test enforces it.
+//!
+//! `hifi_status` deliberately does *not* have a struct here. It is built with a
+//! `serde_json::json!` literal, and `serde_json` without `preserve_order`
+//! serializes maps as `BTreeMap` — alphabetically. Giving it a struct would
+//! switch it to declaration order and reorder the keys clients receive.
+//! `tests/mcp_contract.rs::hifi_status_shape_is_pinned` asserts the ordering.
+//!
+//! This module is #395's (result envelope) primary target.
+
+use rust_mcp_sdk::schema::{schema_utils::CallToolError, CallToolResult, TextContent};
+use serde::Serialize;
+
+// =============================================================================
+// Response types
+// =============================================================================
+
+#[derive(Debug, Serialize)]
+pub struct McpZone {
+    pub zone_id: String,
+    pub zone_name: String,
+    pub state: String,
+    pub volume: Option<f64>,
+    pub is_muted: Option<bool>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct McpNowPlaying {
+    pub zone_id: String,
+    pub zone_name: String,
+    pub state: String,
+    pub title: Option<String>,
+    pub artist: Option<String>,
+    pub album: Option<String>,
+    pub volume: Option<f64>,
+    pub is_muted: Option<bool>,
+}
+
+/// A search hit.
+///
+/// Note what is missing: any stable identifier. A client that finds something
+/// here can only hand the title back to `hifi_play`, which re-searches and takes
+/// the first match. That is #392's keystone finding and #396's job; it is
+/// recorded as a known defect in `FIELD_ROLES`, not endorsed here.
+#[derive(Debug, Serialize)]
+pub struct McpSearchResult {
+    pub title: String,
+    pub subtitle: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct McpHqpStatus {
+    pub connected: bool,
+    pub host: Option<String>,
+    pub pipeline: Option<McpPipelineStatus>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct McpPipelineStatus {
+    pub state: String,
+    pub filter: String,
+    pub shaper: String,
+    pub rate: u32,
+}
+
+// =============================================================================
+// Result constructors
+// =============================================================================
+
+/// Plain text content.
+pub fn text_result(text: String) -> CallToolResult {
+    CallToolResult::text_content(vec![TextContent::from(text)])
+}
+
+/// A failure reported *to the model* as readable text rather than as a protocol
+/// error, so it can read the reason and retry.
+///
+/// The `Error: ` prefix and the wording after it are contract: a model decides
+/// what to do next by reading this string. `tests/mcp_contract.rs` pins the
+/// exact text of every refusal.
+pub fn error_result(msg: String) -> Result<CallToolResult, CallToolError> {
+    Ok(text_result(format!("Error: {}", msg)))
+}
+
+/// Pretty-printed JSON content.
+pub fn json_result<T: Serialize>(data: &T) -> CallToolResult {
+    let json = serde_json::to_string_pretty(data).unwrap_or_else(|_| "{}".to_string());
+    text_result(json)
+}
+
+/// Build the now-playing payload from an aggregator zone.
+///
+/// Shared by `hifi_now_playing` and by `hifi_control`'s post-command state
+/// block, which is why it lives here rather than in either tool module.
+pub fn now_playing_from_zone(zone: crate::bus::Zone) -> McpNowPlaying {
+    McpNowPlaying {
+        zone_id: zone.zone_id,
+        zone_name: zone.zone_name,
+        state: zone.state.to_string(),
+        title: zone.now_playing.as_ref().map(|n| n.title.clone()),
+        artist: zone.now_playing.as_ref().map(|n| n.artist.clone()),
+        album: zone.now_playing.as_ref().map(|n| n.album.clone()),
+        volume: zone.volume_control.as_ref().map(|v| v.value as f64),
+        is_muted: zone.volume_control.as_ref().map(|v| v.is_muted),
+    }
+}

--- a/tests/fixtures/mcp_initialize.json
+++ b/tests/fixtures/mcp_initialize.json
@@ -1,0 +1,14 @@
+{
+  "capabilities": {
+    "tools": {}
+  },
+  "instructions": "Unified Hi-Fi Control MCP Server - Control Your Music System\n\nUse hifi_zones to list available zones, hifi_now_playing to see what's playing, hifi_control for playback control, hifi_search to find music, and hifi_play to play it.\n\nNote: hifi_search and hifi_play currently work with Roon and LMS zones only. Transport controls (play/pause/next/volume) work with all zones (Roon, LMS, OpenHome, UPnP).\n\nTo build a playlist: call hifi_play multiple times with action='queue'. The first track can use action='play' to start playback, then subsequent tracks use action='queue' to add to the queue.",
+  "protocolVersion": "2025-11-25",
+  "serverInfo": {
+    "description": "Control your music system via MCP",
+    "name": "unified-hifi-control",
+    "title": "Unified Hi-Fi Control",
+    "version": "<CARGO_PKG_VERSION>",
+    "websiteUrl": "https://github.com/open-horizon-labs/unified-hifi-control"
+  }
+}

--- a/tests/fixtures/mcp_tools.json
+++ b/tests/fixtures/mcp_tools.json
@@ -1,0 +1,191 @@
+[
+  {
+    "annotations": {
+      "readOnlyHint": true
+    },
+    "description": "List all available playback zones (Roon, LMS, OpenHome, UPnP)",
+    "inputSchema": {
+      "properties": {},
+      "type": "object"
+    },
+    "name": "hifi_zones"
+  },
+  {
+    "annotations": {
+      "readOnlyHint": true
+    },
+    "description": "Get current playback state for a zone (track, artist, album, play state, volume)",
+    "inputSchema": {
+      "properties": {
+        "zone_id": {
+          "description": "The zone ID to query (get from hifi_zones)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "zone_id"
+      ],
+      "type": "object"
+    },
+    "name": "hifi_now_playing"
+  },
+  {
+    "description": "Control playback: play, pause, playpause (toggle), next, previous, or adjust volume",
+    "inputSchema": {
+      "properties": {
+        "action": {
+          "description": "Action: play, pause, playpause, next, previous, volume_set, volume_up, volume_down",
+          "type": "string"
+        },
+        "value": {
+          "description": "For volume actions: the level (0-100 for volume_set) or amount to change",
+          "nullable": true,
+          "type": "number"
+        },
+        "zone_id": {
+          "description": "The zone ID to control",
+          "type": "string"
+        }
+      },
+      "required": [
+        "zone_id",
+        "action"
+      ],
+      "type": "object"
+    },
+    "name": "hifi_control"
+  },
+  {
+    "annotations": {
+      "readOnlyHint": true
+    },
+    "description": "Search for tracks, albums, or artists. Roon: searches Library, TIDAL, or Qobuz (use source param). LMS: searches all installed providers including streaming plugins (zone_id recommended as different players may have different sources configured).",
+    "inputSchema": {
+      "properties": {
+        "query": {
+          "description": "Search query (e.g., \"Hotel California\", \"Eagles\", \"jazz piano\")",
+          "type": "string"
+        },
+        "source": {
+          "description": "Where to search: \"library\" (default), \"tidal\", or \"qobuz\". Roon only; LMS searches all providers.",
+          "nullable": true,
+          "type": "string"
+        },
+        "zone_id": {
+          "description": "Zone ID for context-aware results. Recommended for LMS (different players may have different sources).",
+          "nullable": true,
+          "type": "string"
+        }
+      },
+      "required": [
+        "query"
+      ],
+      "type": "object"
+    },
+    "name": "hifi_search"
+  },
+  {
+    "description": "Search and play music. Searches and plays, queues, or starts radio from the first matching result. Use action='queue' to add to queue. action='radio' and source param are Roon-only; LMS searches all providers.",
+    "inputSchema": {
+      "properties": {
+        "action": {
+          "description": "What to do: \"play\" (default), \"queue\", or \"radio\". radio is Roon-only.",
+          "nullable": true,
+          "type": "string"
+        },
+        "query": {
+          "description": "What to play (e.g., \"early Michael Jackson\", \"Dark Side of the Moon\")",
+          "type": "string"
+        },
+        "source": {
+          "description": "Where to search: \"library\" (default), \"tidal\", or \"qobuz\". Roon only; LMS searches all providers.",
+          "nullable": true,
+          "type": "string"
+        },
+        "zone_id": {
+          "description": "Zone ID to play on (get from hifi_zones)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "query",
+        "zone_id"
+      ],
+      "type": "object"
+    },
+    "name": "hifi_play"
+  },
+  {
+    "annotations": {
+      "readOnlyHint": true
+    },
+    "description": "Get overall bridge status (Roon connection, HQPlayer config)",
+    "inputSchema": {
+      "properties": {},
+      "type": "object"
+    },
+    "name": "hifi_status"
+  },
+  {
+    "annotations": {
+      "readOnlyHint": true
+    },
+    "description": "Get HQPlayer Embedded status and current pipeline settings",
+    "inputSchema": {
+      "properties": {},
+      "type": "object"
+    },
+    "name": "hifi_hqplayer_status"
+  },
+  {
+    "annotations": {
+      "readOnlyHint": true
+    },
+    "description": "List available HQPlayer Embedded configurations",
+    "inputSchema": {
+      "properties": {},
+      "type": "object"
+    },
+    "name": "hifi_hqplayer_profiles"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true
+    },
+    "description": "Load an HQPlayer Embedded configuration (will restart HQPlayer)",
+    "inputSchema": {
+      "properties": {
+        "profile": {
+          "description": "Configuration name to load (get from hifi_hqplayer_profiles)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "profile"
+      ],
+      "type": "object"
+    },
+    "name": "hifi_hqplayer_load_profile"
+  },
+  {
+    "description": "Change an HQPlayer pipeline setting (mode, samplerate, filter1x, filterNx, shaper, dither)",
+    "inputSchema": {
+      "properties": {
+        "setting": {
+          "description": "Setting to change: mode, samplerate, filter1x, filterNx, shaper, dither",
+          "type": "string"
+        },
+        "value": {
+          "description": "New value for the setting",
+          "type": "string"
+        }
+      },
+      "required": [
+        "setting",
+        "value"
+      ],
+      "type": "object"
+    },
+    "name": "hifi_hqplayer_set_pipeline"
+  }
+]

--- a/tests/fixtures/mcp_tools.json
+++ b/tests/fixtures/mcp_tools.json
@@ -1,35 +1,5 @@
-[
-  {
-    "annotations": {
-      "readOnlyHint": true
-    },
-    "description": "List all available playback zones (Roon, LMS, OpenHome, UPnP)",
-    "inputSchema": {
-      "properties": {},
-      "type": "object"
-    },
-    "name": "hifi_zones"
-  },
-  {
-    "annotations": {
-      "readOnlyHint": true
-    },
-    "description": "Get current playback state for a zone (track, artist, album, play state, volume)",
-    "inputSchema": {
-      "properties": {
-        "zone_id": {
-          "description": "The zone ID to query (get from hifi_zones)",
-          "type": "string"
-        }
-      },
-      "required": [
-        "zone_id"
-      ],
-      "type": "object"
-    },
-    "name": "hifi_now_playing"
-  },
-  {
+{
+  "hifi_control": {
     "description": "Control playback: play, pause, playpause (toggle), next, previous, or adjust volume",
     "inputSchema": {
       "properties": {
@@ -52,39 +22,85 @@
         "action"
       ],
       "type": "object"
-    },
-    "name": "hifi_control"
+    }
   },
-  {
+  "hifi_hqplayer_load_profile": {
     "annotations": {
-      "readOnlyHint": true
+      "destructiveHint": true
     },
-    "description": "Search for tracks, albums, or artists. Roon: searches Library, TIDAL, or Qobuz (use source param). LMS: searches all installed providers including streaming plugins (zone_id recommended as different players may have different sources configured).",
+    "description": "Load an HQPlayer Embedded configuration (will restart HQPlayer)",
     "inputSchema": {
       "properties": {
-        "query": {
-          "description": "Search query (e.g., \"Hotel California\", \"Eagles\", \"jazz piano\")",
-          "type": "string"
-        },
-        "source": {
-          "description": "Where to search: \"library\" (default), \"tidal\", or \"qobuz\". Roon only; LMS searches all providers.",
-          "nullable": true,
-          "type": "string"
-        },
-        "zone_id": {
-          "description": "Zone ID for context-aware results. Recommended for LMS (different players may have different sources).",
-          "nullable": true,
+        "profile": {
+          "description": "Configuration name to load (get from hifi_hqplayer_profiles)",
           "type": "string"
         }
       },
       "required": [
-        "query"
+        "profile"
       ],
       "type": "object"
-    },
-    "name": "hifi_search"
+    }
   },
-  {
+  "hifi_hqplayer_profiles": {
+    "annotations": {
+      "readOnlyHint": true
+    },
+    "description": "List available HQPlayer Embedded configurations",
+    "inputSchema": {
+      "properties": {},
+      "type": "object"
+    }
+  },
+  "hifi_hqplayer_set_pipeline": {
+    "description": "Change an HQPlayer pipeline setting (mode, samplerate, filter1x, filterNx, shaper, dither)",
+    "inputSchema": {
+      "properties": {
+        "setting": {
+          "description": "Setting to change: mode, samplerate, filter1x, filterNx, shaper, dither",
+          "type": "string"
+        },
+        "value": {
+          "description": "New value for the setting",
+          "type": "string"
+        }
+      },
+      "required": [
+        "setting",
+        "value"
+      ],
+      "type": "object"
+    }
+  },
+  "hifi_hqplayer_status": {
+    "annotations": {
+      "readOnlyHint": true
+    },
+    "description": "Get HQPlayer Embedded status and current pipeline settings",
+    "inputSchema": {
+      "properties": {},
+      "type": "object"
+    }
+  },
+  "hifi_now_playing": {
+    "annotations": {
+      "readOnlyHint": true
+    },
+    "description": "Get current playback state for a zone (track, artist, album, play state, volume)",
+    "inputSchema": {
+      "properties": {
+        "zone_id": {
+          "description": "The zone ID to query (get from hifi_zones)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "zone_id"
+      ],
+      "type": "object"
+    }
+  },
+  "hifi_play": {
     "description": "Search and play music. Searches and plays, queues, or starts radio from the first matching result. Use action='queue' to add to queue. action='radio' and source param are Roon-only; LMS searches all providers.",
     "inputSchema": {
       "properties": {
@@ -112,10 +128,37 @@
         "zone_id"
       ],
       "type": "object"
-    },
-    "name": "hifi_play"
+    }
   },
-  {
+  "hifi_search": {
+    "annotations": {
+      "readOnlyHint": true
+    },
+    "description": "Search for tracks, albums, or artists. Roon: searches Library, TIDAL, or Qobuz (use source param). LMS: searches all installed providers including streaming plugins (zone_id recommended as different players may have different sources configured).",
+    "inputSchema": {
+      "properties": {
+        "query": {
+          "description": "Search query (e.g., \"Hotel California\", \"Eagles\", \"jazz piano\")",
+          "type": "string"
+        },
+        "source": {
+          "description": "Where to search: \"library\" (default), \"tidal\", or \"qobuz\". Roon only; LMS searches all providers.",
+          "nullable": true,
+          "type": "string"
+        },
+        "zone_id": {
+          "description": "Zone ID for context-aware results. Recommended for LMS (different players may have different sources).",
+          "nullable": true,
+          "type": "string"
+        }
+      },
+      "required": [
+        "query"
+      ],
+      "type": "object"
+    }
+  },
+  "hifi_status": {
     "annotations": {
       "readOnlyHint": true
     },
@@ -123,69 +166,16 @@
     "inputSchema": {
       "properties": {},
       "type": "object"
-    },
-    "name": "hifi_status"
+    }
   },
-  {
+  "hifi_zones": {
     "annotations": {
       "readOnlyHint": true
     },
-    "description": "Get HQPlayer Embedded status and current pipeline settings",
+    "description": "List all available playback zones (Roon, LMS, OpenHome, UPnP)",
     "inputSchema": {
       "properties": {},
       "type": "object"
-    },
-    "name": "hifi_hqplayer_status"
-  },
-  {
-    "annotations": {
-      "readOnlyHint": true
-    },
-    "description": "List available HQPlayer Embedded configurations",
-    "inputSchema": {
-      "properties": {},
-      "type": "object"
-    },
-    "name": "hifi_hqplayer_profiles"
-  },
-  {
-    "annotations": {
-      "destructiveHint": true
-    },
-    "description": "Load an HQPlayer Embedded configuration (will restart HQPlayer)",
-    "inputSchema": {
-      "properties": {
-        "profile": {
-          "description": "Configuration name to load (get from hifi_hqplayer_profiles)",
-          "type": "string"
-        }
-      },
-      "required": [
-        "profile"
-      ],
-      "type": "object"
-    },
-    "name": "hifi_hqplayer_load_profile"
-  },
-  {
-    "description": "Change an HQPlayer pipeline setting (mode, samplerate, filter1x, filterNx, shaper, dither)",
-    "inputSchema": {
-      "properties": {
-        "setting": {
-          "description": "Setting to change: mode, samplerate, filter1x, filterNx, shaper, dither",
-          "type": "string"
-        },
-        "value": {
-          "description": "New value for the setting",
-          "type": "string"
-        }
-      },
-      "required": [
-        "setting",
-        "value"
-      ],
-      "type": "object"
-    },
-    "name": "hifi_hqplayer_set_pipeline"
+    }
   }
-]
+}

--- a/tests/mcp_contract.rs
+++ b/tests/mcp_contract.rs
@@ -54,6 +54,7 @@ use unified_hifi_control::bus::create_bus;
 use unified_hifi_control::coordinator::AdapterCoordinator;
 use unified_hifi_control::knobs::KnobStore;
 use unified_hifi_control::mcp;
+use unified_hifi_control::mcp::types::{McpPipelineStatus, McpSearchResult};
 
 use mock_servers::{MockHqpServer, MockLmsServer, MockOpenHomeDevice, MockUpnpRenderer};
 
@@ -495,6 +496,51 @@ async fn initialize_result_matches_fixture() {
         .expect("serverInfo.version") = json!("<CARGO_PKG_VERSION>");
 
     assert_matches_fixture("mcp_initialize.json", &result);
+}
+
+/// The wire snapshot above cannot see a *raised* declared protocol version,
+/// because the SDK negotiates down to whatever the client asked for: declare
+/// `2026-06-18`, have the client ask for `2025-11-25`, and the result still says
+/// `2025-11-25`. Lowering it is caught (the request becomes an outright error);
+/// raising it is not.
+///
+/// So the declared value is also asserted directly off `server_details()` — the
+/// reason that function was extracted from `create_mcp_extension`. This reads
+/// production's own value instead of restating it, and it is what makes
+/// `SERVER_PROTOCOL_VERSION` above a checked mirror rather than a second source
+/// of truth.
+#[test]
+fn declared_protocol_version_and_capabilities_are_pinned() {
+    let details = mcp::server_details();
+
+    let declared: String = details.protocol_version.into();
+    assert_eq!(
+        declared, SERVER_PROTOCOL_VERSION,
+        "the declared protocol version changed. The wire snapshot cannot catch a \
+         raised version, so this assertion is the one that matters — update \
+         SERVER_PROTOCOL_VERSION only when the change is intended."
+    );
+
+    // Capabilities gate request dispatch in the SDK, so the declared set decides
+    // which methods are reachable at all. #397 adds `resources`; #394 must not.
+    assert!(
+        details.capabilities.tools.is_some(),
+        "tools capability must be declared"
+    );
+    assert!(
+        details.capabilities.resources.is_none(),
+        "#394 must not declare a resources capability — that is #397's work"
+    );
+    assert!(
+        details.capabilities.prompts.is_none(),
+        "no prompts capability is declared today"
+    );
+    assert!(
+        details.capabilities.logging.is_none(),
+        "no logging capability is declared today"
+    );
+
+    assert_eq!(details.server_info.version, env!("CARGO_PKG_VERSION"));
 }
 
 /// Older clients must still get a session: the SDK negotiates down to the
@@ -1172,6 +1218,7 @@ async fn search_and_play_routing_is_pinned() {
 struct LmsHarness {
     app: TestApp,
     mock: MockLmsServer,
+    lms: Arc<LmsAdapter>,
     player_id: &'static str,
     _settings: SettingsFixture,
     _aggregator: tokio::task::JoinHandle<()>,
@@ -1231,13 +1278,18 @@ impl LmsHarness {
         Self {
             app,
             mock,
+            lms,
             player_id: Self::PLAYER_ID,
             _settings: settings,
             _aggregator: aggregator_task,
         }
     }
 
+    /// Stop the adapter before dropping the fixture. Without this its polling
+    /// task outlives the test and can write `lms-config.json` into a `TempDir`
+    /// that `SettingsFixture` has already removed.
     async fn stop(self) {
+        self.lms.stop().await;
         self._aggregator.abort();
         self.mock.stop().await;
     }
@@ -1594,16 +1646,33 @@ async fn no_tool_returns_an_unclassified_field() {
         collect_keys(&parsed, &mut returned);
     }
 
-    // `hifi_search`'s result fields are unreachable without a live music library,
-    // so they are listed explicitly. Keep in sync with `McpSearchResult`.
-    for field in ["title", "subtitle"] {
-        returned.insert(field.to_string());
-    }
-    // `McpPipelineStatus` only serializes when HQPlayer is connected with a live
-    // pipeline. Keep in sync with that struct.
-    for field in ["state", "filter", "shaper", "rate"] {
-        returned.insert(field.to_string());
-    }
+    // Two response shapes cannot be reached over the wire here: hifi_search needs
+    // a live music library, and McpPipelineStatus only serializes when HQPlayer is
+    // connected with a running pipeline.
+    //
+    // Their fields are collected by serializing the production types rather than
+    // by listing names in a comment. A hand-written list would have a hole exactly
+    // where it matters most: renaming McpSearchResult::subtitle would leave
+    // `subtitle` classified and the new name unnoticed — and McpSearchResult is
+    // the struct #396 exists to change.
+    collect_keys(
+        &serde_json::to_value(McpSearchResult {
+            title: String::new(),
+            subtitle: None,
+        })
+        .expect("McpSearchResult must serialize"),
+        &mut returned,
+    );
+    collect_keys(
+        &serde_json::to_value(McpPipelineStatus {
+            state: String::new(),
+            filter: String::new(),
+            shaper: String::new(),
+            rate: 0,
+        })
+        .expect("McpPipelineStatus must serialize"),
+        &mut returned,
+    );
 
     let unclassified: Vec<&String> = returned
         .iter()

--- a/tests/mcp_contract.rs
+++ b/tests/mcp_contract.rs
@@ -29,6 +29,8 @@
 //! Regenerate only when the change to the MCP surface is intended and approved.
 //! A fixture diff on an "additive only" PR is a bug report, not a chore.
 
+mod mock_servers;
+
 use axum::{
     body::Body,
     http::{header, Method, Request},
@@ -52,6 +54,8 @@ use unified_hifi_control::bus::create_bus;
 use unified_hifi_control::coordinator::AdapterCoordinator;
 use unified_hifi_control::knobs::KnobStore;
 use unified_hifi_control::mcp;
+
+use mock_servers::{MockHqpServer, MockLmsServer, MockOpenHomeDevice, MockUpnpRenderer};
 
 // =============================================================================
 // Fixture plumbing
@@ -191,7 +195,13 @@ struct TestApp {
 }
 
 async fn build_state(lms: Option<Arc<LmsAdapter>>) -> AppState {
-    let bus = create_bus();
+    build_state_with_bus(create_bus(), lms).await
+}
+
+async fn build_state_with_bus(
+    bus: unified_hifi_control::bus::SharedBus,
+    lms: Option<Arc<LmsAdapter>>,
+) -> AppState {
     let coordinator = Arc::new(AdapterCoordinator::new(bus.clone()));
     let roon = Arc::new(RoonAdapter::new_disconnected(bus.clone()));
     let hqp_instances = Arc::new(HqpInstanceManager::new(bus.clone()));
@@ -664,4 +674,973 @@ async fn every_tool_has_a_nonempty_description() {
             "{name}: tool description must be non-empty"
         );
     }
+}
+
+// =============================================================================
+// 4. Capabilities gate: what the server refuses today
+// =============================================================================
+
+/// `create_mcp_extension` declares only `tools`, and rust-mcp-sdk 0.8.3 gates
+/// request dispatch on the *declared* capability before any handler runs
+/// (`ServerCapabilities::can_handle_request`, which rejects all five resource
+/// methods when `resources.is_none()`). So the resource methods are not merely
+/// unimplemented — they return a concrete JSON-RPC error, and that error is part
+/// of today's surface.
+///
+/// Pinned here so #397 shows up as a visible diff (refusal -> success) rather
+/// than as a silent change from one behavior to another. The SDK gate keys only
+/// on the *presence* of `resources`; it never inspects `subscribe` or
+/// `listChanged`.
+///
+/// This test records current behavior. It does not endorse it, and #394 must not
+/// declare a `resources` capability — that is #397's work.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn resource_methods_are_refused_while_only_tools_is_declared() {
+    let _settings = SettingsFixture::with_hqplayer(true);
+    let app = TestApp::new().await;
+    let (session_id, init) = app.initialize().await;
+
+    // Precondition: the declared capability set contains tools and not resources.
+    assert!(
+        init.pointer("/capabilities/tools").is_some(),
+        "tools capability must be declared: {init}"
+    );
+    assert!(
+        init.pointer("/capabilities/resources").is_none(),
+        "#394 must not declare a resources capability — that is #397's work: {init}"
+    );
+
+    for (id, method, params) in [
+        (10, "resources/list", json!({})),
+        (11, "resources/read", json!({ "uri": "hifi://zones" })),
+        (12, "resources/templates/list", json!({})),
+    ] {
+        let (_, response) = app
+            .post(
+                Some(&session_id),
+                json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params }),
+            )
+            .await;
+        let response =
+            response.unwrap_or_else(|| panic!("{method} must return a JSON-RPC response"));
+
+        let error = response
+            .get("error")
+            .unwrap_or_else(|| panic!("{method} must be refused today, got: {response}"));
+        assert_eq!(
+            error.get("code").and_then(Value::as_i64),
+            Some(-32603),
+            "{method}: expected the capability gate's internal-error code, got {error}"
+        );
+        let message = error
+            .get("message")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        assert!(
+            message.contains("does not support resources"),
+            "{method}: the refusal must name the missing capability, got {message:?}"
+        );
+    }
+}
+
+// =============================================================================
+// 5. Every dispatch arm, and the lookup tables tools/list cannot see
+// =============================================================================
+//
+// `handle_call_tool_request` is one match with ten arms and three pure lookup
+// tables inside it. None of that is visible in tools/list: inverting the sign of
+// `volume_down`, or dropping the `filternx` alias, would leave every snapshot in
+// this file green. So each arm is reached and its observable output pinned.
+//
+// Adapters are disconnected here on purpose. Error text is contract too: an MCP
+// client reads these strings and decides what to do next, and they are exactly
+// what a careless move of a match arm garbles.
+
+/// A zone id no adapter knows, but which routes to Roon by today's rules.
+const UNKNOWN_ROON_ZONE: &str = "roon:does-not-exist";
+
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn hifi_zones_returns_an_empty_array_with_no_zones() {
+    let _settings = SettingsFixture::with_hqplayer(true);
+    let app = TestApp::new().await;
+
+    let text = result_text(&app.call_tool("hifi_zones", json!({})).await);
+    assert_eq!(text, "[]", "hifi_zones must return a JSON array");
+}
+
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn hifi_now_playing_reports_unknown_zones_by_id() {
+    let _settings = SettingsFixture::with_hqplayer(true);
+    let app = TestApp::new().await;
+
+    let text = result_text(
+        &app.call_tool("hifi_now_playing", json!({ "zone_id": UNKNOWN_ROON_ZONE }))
+            .await,
+    );
+    assert_eq!(
+        text,
+        format!("Error: Zone not found: {UNKNOWN_ROON_ZONE}"),
+        "the refusal must name the zone so a client can correct itself"
+    );
+}
+
+/// `hifi_status` is one of only two tools whose full payload is deterministic
+/// with no backend, so its shape is pinned exactly.
+///
+/// It is built with a `serde_json::json!` literal rather than a struct. That is
+/// deliberate: `serde_json` without `preserve_order` serializes maps as
+/// `BTreeMap` (alphabetical), while a struct serializes in declaration order.
+/// Converting this response to a typed struct would reorder the keys in the text
+/// a client receives, so the ordering is asserted as well as the content.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn hifi_status_shape_is_pinned() {
+    let _settings = SettingsFixture::with_hqplayer(true);
+    let app = TestApp::new().await;
+
+    let text = result_text(&app.call_tool("hifi_status", json!({})).await);
+    let parsed: Value = serde_json::from_str(&text)
+        .unwrap_or_else(|e| panic!("hifi_status must return JSON: {e}\n{text}"));
+
+    assert_eq!(
+        parsed,
+        json!({
+            "roon": { "connected": false, "core_name": null },
+            "hqplayer": { "connected": false, "host": null }
+        }),
+        "hifi_status payload drifted"
+    );
+    assert!(
+        text.find("\"hqplayer\"").unwrap_or(usize::MAX) < text.find("\"roon\"").unwrap_or(0),
+        "hifi_status keys must stay alphabetical (BTreeMap order); a typed struct \
+         would reorder them and change the text clients receive:\n{text}"
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn hifi_hqplayer_status_shape_is_pinned() {
+    let _settings = SettingsFixture::with_hqplayer(true);
+    let app = TestApp::new().await;
+
+    let text = result_text(&app.call_tool("hifi_hqplayer_status", json!({})).await);
+    let parsed: Value = serde_json::from_str(&text)
+        .unwrap_or_else(|e| panic!("hifi_hqplayer_status must return JSON: {e}\n{text}"));
+
+    assert_eq!(
+        parsed,
+        json!({ "connected": false, "host": null, "pipeline": null }),
+        "hifi_hqplayer_status payload drifted"
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn hifi_hqplayer_profiles_returns_an_array() {
+    let _settings = SettingsFixture::with_hqplayer(true);
+    let app = TestApp::new().await;
+
+    let text = result_text(&app.call_tool("hifi_hqplayer_profiles", json!({})).await);
+    assert_eq!(text, "[]", "hifi_hqplayer_profiles must return a JSON array");
+}
+
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn hifi_hqplayer_load_profile_reports_failure_prefix() {
+    let _settings = SettingsFixture::with_hqplayer(true);
+    let app = TestApp::new().await;
+
+    let text = result_text(
+        &app.call_tool("hifi_hqplayer_load_profile", json!({ "profile": "4x-Sinc-L" }))
+            .await,
+    );
+    assert!(
+        text.starts_with("Error: Failed to load profile: "),
+        "unexpected load_profile failure text: {text:?}"
+    );
+}
+
+/// The HQPlayer setting alias table (`filter1x|filter_1x`,
+/// `filterNx|filter_nx|filternx`, `shaper|dither`, `rate|samplerate`, `mode`) is
+/// a pure lookup inside one match arm, invisible to `tools/list`. Dropping an
+/// alias while moving the arm turns a documented input into "Unknown setting" —
+/// the AGENTS.md "no broken tools" failure, with a green snapshot suite. Every
+/// alias is therefore checked individually.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn hqplayer_set_pipeline_alias_table_is_pinned() {
+    let _settings = SettingsFixture::with_hqplayer(true);
+    let app = TestApp::new().await;
+
+    // Recognised aliases reach the adapter, which is disconnected, so they fail
+    // with the per-setting failure prefix rather than "Unknown setting".
+    for setting in [
+        "mode",
+        "filter1x",
+        "filter_1x",
+        "filterNx",
+        "filter_nx",
+        "filternx",
+        "shaper",
+        "dither",
+    ] {
+        let text = result_text(
+            &app.call_tool(
+                "hifi_hqplayer_set_pipeline",
+                json!({ "setting": setting, "value": "poly-sinc-gauss-long" }),
+            )
+            .await,
+        );
+        assert!(
+            text.starts_with(&format!("Error: Failed to set {setting}: ")),
+            "alias {setting:?} must be recognised and reach the adapter, got {text:?}"
+        );
+    }
+
+    // `rate` and `samplerate` are the only settings that parse their value.
+    for setting in ["rate", "samplerate"] {
+        let text = result_text(
+            &app.call_tool(
+                "hifi_hqplayer_set_pipeline",
+                json!({ "setting": setting, "value": "96000" }),
+            )
+            .await,
+        );
+        assert!(
+            text.starts_with(&format!("Error: Failed to set {setting}: ")),
+            "alias {setting:?} must be recognised, got {text:?}"
+        );
+
+        let text = result_text(
+            &app.call_tool(
+                "hifi_hqplayer_set_pipeline",
+                json!({ "setting": setting, "value": "not-a-number" }),
+            )
+            .await,
+        );
+        assert_eq!(
+            text, "Error: Invalid rate value (expected Hz like 48000, 96000)",
+            "{setting:?} must reject a non-numeric rate before reaching the adapter"
+        );
+    }
+
+    // Anything else is refused, and the refusal lists the valid settings.
+    let text = result_text(
+        &app.call_tool(
+            "hifi_hqplayer_set_pipeline",
+            json!({ "setting": "oversampling", "value": "8x" }),
+        )
+        .await,
+    );
+    assert_eq!(
+        text,
+        "Error: Unknown setting: oversampling. Valid: mode, samplerate, filter1x, filterNx, shaper, dither",
+        "the refusal must enumerate the valid settings"
+    );
+}
+
+/// `hifi_control`'s volume handling: the required-value rule for `volume_set`,
+/// the defaulted delta for `volume_up`/`volume_down`, and the fact that volume
+/// uses a different routing rule from transport. The exact backend command each
+/// action produces is pinned by the LMS mock round-trip below.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn hifi_control_volume_argument_handling_is_pinned() {
+    let _settings = SettingsFixture::with_hqplayer(true);
+    let app = TestApp::new().await;
+
+    // volume_set with no value is refused before any routing happens.
+    let text = result_text(
+        &app.call_tool(
+            "hifi_control",
+            json!({ "zone_id": UNKNOWN_ROON_ZONE, "action": "volume_set" }),
+        )
+        .await,
+    );
+    assert_eq!(
+        text, "Error: volume_set requires a value (0-100)",
+        "volume_set without a value must be refused with its documented range"
+    );
+
+    // volume_up / volume_down do not require a value; they default the delta and
+    // reach the volume path (Roon here), not the transport path.
+    for action in ["volume_up", "volume_down"] {
+        let text = result_text(
+            &app.call_tool(
+                "hifi_control",
+                json!({ "zone_id": UNKNOWN_ROON_ZONE, "action": action }),
+            )
+            .await,
+        );
+        assert_eq!(
+            text, "Error: Volume error: Not connected to Roon",
+            "{action} must default its delta and reach the Roon volume path"
+        );
+    }
+}
+
+/// `hifi_play` refuses `action='radio'` for LMS before touching the network. The
+/// exact wording is contract: the model is expected to read it and retry with a
+/// supported action.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn hifi_play_refuses_radio_for_lms() {
+    let _settings = SettingsFixture::with_hqplayer(true);
+    let app = TestApp::new().await;
+
+    let text = result_text(
+        &app.call_tool(
+            "hifi_play",
+            json!({
+                "query": "Kind of Blue",
+                "zone_id": "lms:aa:bb:cc:dd:ee:ff",
+                "action": "radio"
+            }),
+        )
+        .await,
+    );
+    assert_eq!(
+        text, "Error: Radio mode not supported for LMS. Use 'play' or 'queue'.",
+        "the refusal must name the supported actions"
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn hifi_search_and_hifi_play_report_errors_with_their_own_prefixes() {
+    let _settings = SettingsFixture::with_hqplayer(true);
+    let app = TestApp::new().await;
+
+    let text = result_text(&app.call_tool("hifi_search", json!({ "query": "Eagles" })).await);
+    assert_eq!(
+        text, "Error: Search error: Browse service not available - not connected to Roon",
+        "hifi_search must prefix failures with 'Search error'"
+    );
+
+    let text = result_text(
+        &app.call_tool(
+            "hifi_play",
+            json!({ "query": "Eagles", "zone_id": UNKNOWN_ROON_ZONE }),
+        )
+        .await,
+    );
+    assert_eq!(
+        text, "Error: Play error: Browse service not available - not connected to Roon",
+        "hifi_play must prefix failures with 'Play error'"
+    );
+}
+
+// =============================================================================
+// 6. Zone-prefix routing
+// =============================================================================
+//
+// Each adapter refuses an unknown id with its own distinctive wording, so the
+// error text identifies which adapter a call actually reached. That makes routing
+// observable end to end, without mocks and without reading the source.
+
+/// Transport routing: `lms:` / `openhome:` / `upnp:` go to their adapters and
+/// EVERYTHING ELSE goes to Roon — including bare ids and unrecognised prefixes.
+///
+/// The Roon default is a known defect (#398). #394 freezes it rather than fixing
+/// it, so a green run here means "unchanged", never "correct".
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn transport_routing_including_the_roon_default_is_pinned() {
+    let _settings = SettingsFixture::with_hqplayer(true);
+    let app = TestApp::new().await;
+
+    let cases: &[(&str, &str, &str)] = &[
+        ("lms:aa:bb:cc:dd:ee:ff", "not configured", "explicit lms:"),
+        ("openhome:abc", "Device not found: abc", "explicit openhome:"),
+        ("upnp:abc", "Renderer not found: abc", "explicit upnp:"),
+        ("roon:abc", "Not connected to Roon", "explicit roon:"),
+        // Today's defaults. Both belong to #398, not #394.
+        ("1601a5d4bare", "Not connected to Roon", "bare id -> Roon"),
+        ("sonos:abc", "Not connected to Roon", "unknown prefix -> Roon"),
+    ];
+
+    for (zone_id, expected_fragment, label) in cases {
+        let text = result_text(
+            &app.call_tool("hifi_control", json!({ "zone_id": zone_id, "action": "play" }))
+                .await,
+        );
+        assert!(
+            text.contains(expected_fragment),
+            "{label} ({zone_id}): expected the error to contain {expected_fragment:?}, \
+             which identifies the adapter reached; got {text:?}"
+        );
+    }
+}
+
+/// Volume routing is a *different* rule from transport routing, and the
+/// difference is load-bearing: `sonos:abc` is refused for volume but routed to
+/// Roon for transport. Unifying these into one predicate would change behavior.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn volume_routing_differs_from_transport_routing() {
+    let _settings = SettingsFixture::with_hqplayer(true);
+    let app = TestApp::new().await;
+
+    let volume_supported: &[(&str, &str)] = &[
+        ("lms:aa:bb:cc:dd:ee:ff", "not configured"),
+        ("roon:abc", "Not connected to Roon"),
+        ("1601a5d4bare", "Not connected to Roon"),
+    ];
+    for (zone_id, expected_fragment) in volume_supported {
+        let text = result_text(
+            &app.call_tool(
+                "hifi_control",
+                json!({ "zone_id": zone_id, "action": "volume_set", "value": 30 }),
+            )
+            .await,
+        );
+        assert!(
+            text.contains(expected_fragment),
+            "{zone_id}: volume must reach an adapter; got {text:?}"
+        );
+    }
+
+    for zone_id in ["openhome:abc", "upnp:abc", "sonos:abc"] {
+        let text = result_text(
+            &app.call_tool(
+                "hifi_control",
+                json!({ "zone_id": zone_id, "action": "volume_set", "value": 30 }),
+            )
+            .await,
+        );
+        assert_eq!(
+            text, "Error: Volume control not supported for this zone type",
+            "{zone_id}: volume must be refused, not silently routed"
+        );
+    }
+}
+
+/// Search and play route on `lms:` only; everything else, including an absent
+/// `zone_id`, goes to Roon.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn search_and_play_routing_is_pinned() {
+    let _settings = SettingsFixture::with_hqplayer(true);
+    let app = TestApp::new().await;
+
+    // Roon's browse-backed paths word their refusal differently from transport's,
+    // so match case-insensitively on the part that names the adapter.
+    let roon = "not connected to roon";
+
+    // hifi_search's zone_id is optional. Absent -> Roon.
+    let text = result_text(&app.call_tool("hifi_search", json!({ "query": "q" })).await);
+    assert!(
+        text.to_lowercase().contains(roon),
+        "an absent zone_id must route search to Roon; got {text:?}"
+    );
+
+    for (zone_id, expected_fragment) in [
+        ("lms:aa:bb:cc:dd:ee:ff", "not configured"),
+        ("openhome:abc", roon),
+        ("upnp:abc", roon),
+        ("sonos:abc", roon),
+    ] {
+        let text = result_text(
+            &app.call_tool("hifi_search", json!({ "query": "q", "zone_id": zone_id }))
+                .await,
+        );
+        assert!(
+            text.to_lowercase().contains(expected_fragment),
+            "search {zone_id}: expected {expected_fragment:?}, got {text:?}"
+        );
+
+        let text = result_text(
+            &app.call_tool("hifi_play", json!({ "query": "q", "zone_id": zone_id }))
+                .await,
+        );
+        assert!(
+            text.to_lowercase().contains(expected_fragment),
+            "play {zone_id}: expected {expected_fragment:?}, got {text:?}"
+        );
+    }
+}
+
+// =============================================================================
+// 7. Round-trips against tests/mock_servers/
+// =============================================================================
+
+/// A `TestApp` wired to a live mock LMS server, with the aggregator running so
+/// discovered players actually reach `hifi_zones`.
+struct LmsHarness {
+    app: TestApp,
+    mock: MockLmsServer,
+    player_id: &'static str,
+    _settings: SettingsFixture,
+    _aggregator: tokio::task::JoinHandle<()>,
+}
+
+impl LmsHarness {
+    const PLAYER_ID: &'static str = "aa:bb:cc:dd:ee:ff";
+
+    fn zone_id(&self) -> String {
+        format!("lms:{}", self.player_id)
+    }
+
+    /// `SettingsFixture` points `UHC_CONFIG_DIR` at a fresh temp dir, so
+    /// `LmsAdapter::configure`'s on-disk config is isolated per test too.
+    async fn start() -> Self {
+        let settings = SettingsFixture::with_hqplayer(true);
+
+        let mock = MockLmsServer::start().await;
+        mock.add_player(Self::PLAYER_ID, "Living Room").await;
+        mock.set_mode(Self::PLAYER_ID, "pause").await;
+        mock.set_volume(Self::PLAYER_ID, 42).await;
+        mock.set_now_playing(Self::PLAYER_ID, "So What", "Miles Davis", "Kind of Blue")
+            .await;
+
+        let bus = create_bus();
+        let lms = Arc::new(LmsAdapter::new(bus.clone()));
+        lms.configure(
+            mock.addr().ip().to_string(),
+            Some(mock.addr().port()),
+            None,
+            None,
+        )
+        .await;
+
+        let state = build_state_with_bus(bus, Some(lms.clone())).await;
+
+        // The aggregator only learns about zones by consuming bus events.
+        let aggregator = state.aggregator.clone();
+        let aggregator_task = tokio::spawn(async move { aggregator.run().await });
+
+        lms.start().await.expect("LMS adapter must start");
+
+        let app = TestApp::with_state(state.clone());
+
+        // Wait for the player to propagate: adapter connect -> ZoneDiscovered -> aggregator.
+        let zone_id = format!("lms:{}", Self::PLAYER_ID);
+        let mut found = false;
+        for _ in 0..100 {
+            if state.aggregator.get_zone(&zone_id).await.is_some() {
+                found = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+        assert!(found, "LMS player never reached the aggregator as {zone_id}");
+
+        Self {
+            app,
+            mock,
+            player_id: Self::PLAYER_ID,
+            _settings: settings,
+            _aggregator: aggregator_task,
+        }
+    }
+
+    async fn stop(self) {
+        self._aggregator.abort();
+        self.mock.stop().await;
+    }
+}
+
+/// LMS round-trip: a real mock server, a real adapter, real bus events, and the
+/// MCP tool call driven over the real `/mcp` route.
+///
+/// This also pins `hifi_control`'s action map at the point where it is actually
+/// observable — the backend command the mock receives. `playpause` must become
+/// LMS `pause` (a toggle) and not `play`; `previous` and `prev` must both become
+/// `playlist index -1`. `tools/list` says nothing about any of this.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn lms_round_trip_pins_the_action_map_and_the_volume_sign() {
+    let h = LmsHarness::start().await;
+    let zone_id = h.zone_id();
+
+    // hifi_zones sees the discovered player.
+    let text = result_text(&h.app.call_tool("hifi_zones", json!({})).await);
+    let zones: Value = serde_json::from_str(&text).expect("hifi_zones must return JSON");
+    let zone = zones
+        .as_array()
+        .and_then(|z| z.iter().find(|z| z.get("zone_id") == Some(&json!(zone_id))))
+        .unwrap_or_else(|| panic!("hifi_zones must include {zone_id}: {text}"));
+    assert_eq!(zone.get("zone_name"), Some(&json!("Living Room")));
+    assert_eq!(zone.get("volume"), Some(&json!(42.0)));
+
+    // hifi_now_playing sees the track.
+    let text = result_text(
+        &h.app
+            .call_tool("hifi_now_playing", json!({ "zone_id": zone_id }))
+            .await,
+    );
+    let np: Value = serde_json::from_str(&text).expect("hifi_now_playing must return JSON");
+    assert_eq!(np.get("title"), Some(&json!("So What")));
+    assert_eq!(np.get("artist"), Some(&json!("Miles Davis")));
+    assert_eq!(np.get("album"), Some(&json!("Kind of Blue")));
+
+    // The MCP action -> backend command map, observed on the wire.
+    let expected: &[(&str, Value, &[&str])] = &[
+        ("play", Value::Null, &["play"]),
+        ("pause", Value::Null, &["pause"]),
+        // playpause maps to backend "play_pause", which LMS expresses as a bare
+        // "pause" toggle. Mapping it to "play" instead would break the toggle.
+        ("playpause", Value::Null, &["pause"]),
+        ("next", Value::Null, &["playlist", "index", "+1"]),
+        ("previous", Value::Null, &["playlist", "index", "-1"]),
+        ("prev", Value::Null, &["playlist", "index", "-1"]),
+        // Absolute volume.
+        ("volume_set", json!(30), &["mixer", "volume", "30"]),
+        // Relative volume, and the sign that no snapshot can see.
+        ("volume_up", json!(7), &["mixer", "volume", "+7"]),
+        ("volume_down", json!(7), &["mixer", "volume", "-7"]),
+        // Defaulted delta of 5.
+        ("volume_up", Value::Null, &["mixer", "volume", "+5"]),
+        ("volume_down", Value::Null, &["mixer", "volume", "-5"]),
+    ];
+
+    for (action, value, expected_command) in expected {
+        h.mock.clear_commands().await;
+
+        let mut args = json!({ "zone_id": zone_id, "action": action });
+        if !value.is_null() {
+            args["value"] = value.clone();
+        }
+        let text = result_text(&h.app.call_tool("hifi_control", args).await);
+        assert!(
+            !text.starts_with("Error:"),
+            "hifi_control {action} failed: {text}"
+        );
+
+        let commands = h.mock.write_commands(h.player_id).await;
+        let expected_command: Vec<String> =
+            expected_command.iter().map(|s| s.to_string()).collect();
+        assert!(
+            commands.contains(&expected_command),
+            "hifi_control action={action:?} value={value} must send {expected_command:?}; \
+             mock received {commands:?}"
+        );
+    }
+
+    h.stop().await;
+}
+
+/// `hifi_control` returns the action name plus the zone's post-command state.
+/// The prose framing is what a model reads back to the user.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn lms_control_result_reports_action_and_current_state() {
+    let h = LmsHarness::start().await;
+    let zone_id = h.zone_id();
+
+    let text = result_text(
+        &h.app
+            .call_tool("hifi_control", json!({ "zone_id": zone_id, "action": "play" }))
+            .await,
+    );
+
+    assert!(
+        text.starts_with("Action 'play' executed.\n\nCurrent state:\n{"),
+        "hifi_control must report the action and then the zone state: {text:?}"
+    );
+    let state_json = text
+        .split_once("Current state:\n")
+        .map(|(_, json)| json)
+        .expect("current state block");
+    let parsed: Value = serde_json::from_str(state_json)
+        .unwrap_or_else(|e| panic!("state block must be JSON: {e}\n{state_json}"));
+    assert_eq!(parsed.get("zone_id"), Some(&json!(zone_id)));
+
+    h.stop().await;
+}
+
+/// HQPlayer round-trip against the mock's TCP XML protocol: `hifi_hqplayer_status`
+/// must report the live connection rather than the disconnected default.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn hqplayer_round_trip_reports_a_live_connection() {
+    let _settings = SettingsFixture::with_hqplayer(true);
+    let mock = MockHqpServer::start().await;
+
+    let state = build_state(None).await;
+    state
+        .hqplayer
+        .configure(
+            mock.addr().ip().to_string(),
+            Some(mock.addr().port()),
+            None,
+            None,
+            None,
+        )
+        .await;
+    state
+        .hqplayer
+        .connect()
+        .await
+        .expect("HQPlayer must connect to the mock");
+
+    let app = TestApp::with_state(state.clone());
+
+    let mut connected = false;
+    for _ in 0..50 {
+        if state.hqplayer.get_status().await.connected {
+            connected = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    assert!(connected, "HQPlayer adapter never connected to the mock");
+
+    let text = result_text(&app.call_tool("hifi_hqplayer_status", json!({})).await);
+    let parsed: Value = serde_json::from_str(&text)
+        .unwrap_or_else(|e| panic!("hifi_hqplayer_status must return JSON: {e}\n{text}"));
+    assert_eq!(
+        parsed.get("connected"),
+        Some(&json!(true)),
+        "hifi_hqplayer_status must report the live connection: {text}"
+    );
+    assert_eq!(
+        parsed.get("host"),
+        Some(&json!(mock.addr().ip().to_string())),
+        "hifi_hqplayer_status must report the configured host: {text}"
+    );
+
+    mock.stop().await;
+}
+
+/// OpenHome and UPnP have no `configure()` — they are SSDP-discovery only, so a
+/// mock cannot be injected without a discovery seam that #394 has no mandate to
+/// add. What is verifiable today, and what the refactor could break, is that
+/// their prefixes reach *their* adapters: the mock devices answer SSDP-shaped
+/// HTTP, and each adapter refuses an unknown id with its own distinctive wording.
+///
+/// So this asserts the routing edge (already covered above) *and* that the mock
+/// devices are reachable, documenting the gap rather than papering over it.
+/// Closing it properly belongs with whichever issue first needs OpenHome/UPnP
+/// content operations (#399 / #400).
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn openhome_and_upnp_prefixes_reach_their_own_adapters() {
+    let _settings = SettingsFixture::with_hqplayer(true);
+    let openhome_mock = MockOpenHomeDevice::start().await;
+    let upnp_mock = MockUpnpRenderer::start().await;
+
+    // The mock devices are live and serving their descriptions.
+    let client = reqwest::Client::new();
+    for url in [
+        openhome_mock.description_url(),
+        upnp_mock.description_url(),
+    ] {
+        let body = client
+            .get(&url)
+            .send()
+            .await
+            .expect("mock device must respond")
+            .text()
+            .await
+            .expect("mock device body");
+        assert!(
+            body.contains("MediaRenderer") || body.contains("av-openhome-org"),
+            "unexpected device description at {url}: {body}"
+        );
+    }
+
+    let app = TestApp::new().await;
+
+    // Routing: each prefix reaches its own adapter, identified by the adapter's
+    // own refusal wording. `Device not found` is OpenHome's; `Renderer not found`
+    // is UPnP's. A mis-wired refactor would surface Roon's wording instead.
+    let text = result_text(
+        &app.call_tool(
+            "hifi_control",
+            json!({ "zone_id": "openhome:mock-uuid", "action": "play" }),
+        )
+        .await,
+    );
+    assert_eq!(text, "Error: Control error: Device not found: mock-uuid");
+
+    let text = result_text(
+        &app.call_tool(
+            "hifi_control",
+            json!({ "zone_id": "upnp:mock-uuid", "action": "play" }),
+        )
+        .await,
+    );
+    assert_eq!(text, "Error: Control error: Renderer not found: mock-uuid");
+
+    openhome_mock.stop().await;
+    upnp_mock.stop().await;
+}
+
+// =============================================================================
+// 8. No orphaned fields
+// =============================================================================
+//
+// AGENTS.md: "No orphaned fields - Don't return data (like item_key) that can't
+// be used by any tool." This encodes that guardrail as a test.
+//
+// Every field name any tool returns must appear below, classified as either
+// consumed by some tool's input or explicitly display-only WITH A REASON. The
+// inventory is read from real tool responses, so adding a field to a response
+// type fails this test until it is classified.
+
+/// Why a returned field is not an input to any tool.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum FieldRole {
+    /// Consumed by the named tool parameter — the field closes a loop.
+    Consumed(&'static str),
+    /// Deliberately display-only. The reason is required, not decorative: a bare
+    /// allowlist reads as approval, and at least one entry here is a known defect
+    /// rather than a design choice.
+    DisplayOnly(&'static str),
+}
+
+use FieldRole::{Consumed, DisplayOnly};
+
+/// Today's truth, including its defects. `#394` freezes this; it fixes nothing.
+const FIELD_ROLES: &[(&str, FieldRole)] = &[
+    // Zone identity closes the loop: every zone-scoped tool takes it.
+    ("zone_id", Consumed("hifi_now_playing/hifi_control/hifi_play.zone_id")),
+    ("zone_name", DisplayOnly(
+        "human label; every tool addresses a zone by zone_id, never by name",
+    )),
+    ("state", DisplayOnly(
+        "playback state readout; hifi_control.action is the write path",
+    )),
+    ("volume", DisplayOnly(
+        "current level readout; hifi_control.value is the write path",
+    )),
+    ("is_muted", DisplayOnly(
+        "mute readout with no corresponding write: hifi_control has no mute action",
+    )),
+    ("title", DisplayOnly(
+        "hifi_search returns {title, subtitle} and no key, so the only route from \
+         'found it' to 'playing it' is handing the title back to hifi_play, which \
+         re-searches and takes the first match. That is #392's keystone finding and \
+         #396's job — NOT an endorsed design. Listed to freeze today's behavior.",
+    )),
+    ("artist", DisplayOnly(
+        "now-playing readout; hifi_play takes a free-text query, not a field",
+    )),
+    ("album", DisplayOnly(
+        "now-playing readout; hifi_play takes a free-text query, not a field",
+    )),
+    ("subtitle", DisplayOnly(
+        "search-result label, same defect as `title`; see #396",
+    )),
+    // hifi_status / hifi_hqplayer_status readouts.
+    ("connected", DisplayOnly(
+        "boolean health readout; nothing takes a connection state as input",
+    )),
+    ("host", DisplayOnly(
+        "diagnostic address; configuring a host is an HTTP/settings concern, not an MCP tool",
+    )),
+    ("core_name", DisplayOnly(
+        "Roon core label for the operator; no tool selects a core",
+    )),
+    ("roon", DisplayOnly(
+        "hifi_status grouping key, not a value a client passes anywhere",
+    )),
+    ("hqplayer", DisplayOnly(
+        "hifi_status grouping key, not a value a client passes anywhere",
+    )),
+    ("pipeline", DisplayOnly(
+        "hifi_hqplayer_status grouping key wrapping the pipeline readout",
+    )),
+    ("filter", DisplayOnly(
+        "pipeline readout; hifi_hqplayer_set_pipeline writes it via \
+         setting='filter1x'/'filterNx', which is a different name",
+    )),
+    ("shaper", Consumed("hifi_hqplayer_set_pipeline.setting='shaper'")),
+    ("rate", Consumed("hifi_hqplayer_set_pipeline.setting='rate'")),
+];
+
+/// Collect every key name reachable in a JSON value, at any depth.
+fn collect_keys(value: &Value, into: &mut std::collections::BTreeSet<String>) {
+    match value {
+        Value::Object(map) => {
+            for (k, v) in map {
+                into.insert(k.clone());
+                collect_keys(v, into);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_keys(item, into);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn no_tool_returns_an_unclassified_field() {
+    let h = LmsHarness::start().await;
+    let zone_id = h.zone_id();
+
+    // Drive every tool that returns structured data, with a live LMS zone so the
+    // zone and now-playing payloads are fully populated rather than empty.
+    let structured_calls: Vec<(&str, Value)> = vec![
+        ("hifi_zones", json!({})),
+        ("hifi_now_playing", json!({ "zone_id": zone_id })),
+        ("hifi_status", json!({})),
+        ("hifi_hqplayer_status", json!({})),
+    ];
+
+    let mut returned = std::collections::BTreeSet::new();
+    for (tool, args) in structured_calls {
+        let text = result_text(&h.app.call_tool(tool, args).await);
+        let parsed: Value = serde_json::from_str(&text)
+            .unwrap_or_else(|e| panic!("{tool} must return JSON: {e}\n{text}"));
+        collect_keys(&parsed, &mut returned);
+    }
+
+    // `hifi_search`'s result fields are unreachable without a live music library,
+    // so they are listed explicitly. Keep in sync with `McpSearchResult`.
+    for field in ["title", "subtitle"] {
+        returned.insert(field.to_string());
+    }
+    // `McpPipelineStatus` only serializes when HQPlayer is connected with a live
+    // pipeline. Keep in sync with that struct.
+    for field in ["state", "filter", "shaper", "rate"] {
+        returned.insert(field.to_string());
+    }
+
+    let unclassified: Vec<&String> = returned
+        .iter()
+        .filter(|f| !FIELD_ROLES.iter().any(|(name, _)| *name == f.as_str()))
+        .collect();
+    assert!(
+        unclassified.is_empty(),
+        "MCP tools return field(s) {unclassified:?} that are neither consumed by a \
+         tool input nor classified as display-only.\n\n\
+         AGENTS.md: \"No orphaned fields - Don't return data (like item_key) that \
+         can't be used by any tool.\"\n\n\
+         Add each one to FIELD_ROLES in tests/mcp_contract.rs, either as \
+         Consumed(\"<tool>.<param>\") or as DisplayOnly with a real reason. If the \
+         honest reason is \"a client cannot act on this\", the field is the bug."
+    );
+
+    // Every display-only justification must actually say something.
+    for (field, role) in FIELD_ROLES {
+        if let DisplayOnly(reason) = role {
+            assert!(
+                reason.len() > 15,
+                "{field}: display-only fields need a real reason, not {reason:?}"
+            );
+        }
+    }
+
+    // Guard against the table rotting into a list of fields nothing returns.
+    let stale: Vec<&str> = FIELD_ROLES
+        .iter()
+        .map(|(name, _)| *name)
+        .filter(|name| !returned.contains(*name))
+        .collect();
+    assert!(
+        stale.is_empty(),
+        "FIELD_ROLES lists field(s) {stale:?} that no tool returns any more — \
+         remove them so the table stays evidence rather than folklore"
+    );
+
+    h.stop().await;
 }

--- a/tests/mcp_contract.rs
+++ b/tests/mcp_contract.rs
@@ -89,8 +89,7 @@ fn assert_matches_fixture(name: &str, actual: &Value) {
     );
 
     if std::env::var("UPDATE_MCP_FIXTURES").as_deref() == Ok("1") {
-        std::fs::create_dir_all(path.parent().expect("fixture dir"))
-            .expect("create fixture dir");
+        std::fs::create_dir_all(path.parent().expect("fixture dir")).expect("create fixture dir");
         std::fs::write(&path, &rendered).expect("write fixture");
         eprintln!("updated fixture: {}", path.display());
         return;
@@ -475,7 +474,9 @@ async fn tools_list_matches_fixture() {
         // tool would show up as one added key and one removed key with identical
         // bodies, which reads as additive when it is not.
         let mut body = tool.clone();
-        body.as_object_mut().expect("tool must be an object").remove("name");
+        body.as_object_mut()
+            .expect("tool must be an object")
+            .remove("name");
         assert!(
             by_name.insert(name.clone(), body).is_none(),
             "duplicate tool name in tools/list: {name}"
@@ -859,9 +860,7 @@ async fn a_stale_session_id_is_transparently_recovered() {
     let tools = response
         .pointer("/result/tools")
         .and_then(Value::as_array)
-        .unwrap_or_else(|| {
-            panic!("recovered request must return the tool list, got: {response}")
-        });
+        .unwrap_or_else(|| panic!("recovered request must return the tool list, got: {response}"));
     assert_eq!(
         tools.len(),
         10,
@@ -1106,7 +1105,10 @@ async fn hifi_hqplayer_profiles_returns_an_array() {
     let app = TestApp::new().await;
 
     let text = result_text(&app.call_tool("hifi_hqplayer_profiles", json!({})).await);
-    assert_eq!(text, "[]", "hifi_hqplayer_profiles must return a JSON array");
+    assert_eq!(
+        text, "[]",
+        "hifi_hqplayer_profiles must return a JSON array"
+    );
 }
 
 #[tokio::test]
@@ -1116,8 +1118,11 @@ async fn hifi_hqplayer_load_profile_reports_failure_prefix() {
     let app = TestApp::new().await;
 
     let text = result_text(
-        &app.call_tool("hifi_hqplayer_load_profile", json!({ "profile": "4x-Sinc-L" }))
-            .await,
+        &app.call_tool(
+            "hifi_hqplayer_load_profile",
+            json!({ "profile": "4x-Sinc-L" }),
+        )
+        .await,
     );
     assert!(
         text.starts_with("Error: Failed to load profile: "),
@@ -1276,7 +1281,10 @@ async fn hifi_search_and_hifi_play_report_errors_with_their_own_prefixes() {
     let _settings = SettingsFixture::with_hqplayer(true);
     let app = TestApp::new().await;
 
-    let text = result_text(&app.call_tool("hifi_search", json!({ "query": "Eagles" })).await);
+    let text = result_text(
+        &app.call_tool("hifi_search", json!({ "query": "Eagles" }))
+            .await,
+    );
     assert_eq!(
         text, "Error: Search error: Browse service not available - not connected to Roon",
         "hifi_search must prefix failures with 'Search error'"
@@ -1316,18 +1324,29 @@ async fn transport_routing_including_the_roon_default_is_pinned() {
 
     let cases: &[(&str, &str, &str)] = &[
         ("lms:aa:bb:cc:dd:ee:ff", "not configured", "explicit lms:"),
-        ("openhome:abc", "Device not found: abc", "explicit openhome:"),
+        (
+            "openhome:abc",
+            "Device not found: abc",
+            "explicit openhome:",
+        ),
         ("upnp:abc", "Renderer not found: abc", "explicit upnp:"),
         ("roon:abc", "Not connected to Roon", "explicit roon:"),
         // Today's defaults. Both belong to #398, not #394.
         ("1601a5d4bare", "Not connected to Roon", "bare id -> Roon"),
-        ("sonos:abc", "Not connected to Roon", "unknown prefix -> Roon"),
+        (
+            "sonos:abc",
+            "Not connected to Roon",
+            "unknown prefix -> Roon",
+        ),
     ];
 
     for (zone_id, expected_fragment, label) in cases {
         let text = result_text(
-            &app.call_tool("hifi_control", json!({ "zone_id": zone_id, "action": "play" }))
-                .await,
+            &app.call_tool(
+                "hifi_control",
+                json!({ "zone_id": zone_id, "action": "play" }),
+            )
+            .await,
         );
         assert!(
             text.contains(expected_fragment),
@@ -1495,7 +1514,10 @@ impl LmsHarness {
             }
             tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         }
-        assert!(found, "LMS player never reached the aggregator as {zone_id}");
+        assert!(
+            found,
+            "LMS player never reached the aggregator as {zone_id}"
+        );
 
         Self {
             app,
@@ -1607,7 +1629,10 @@ async fn lms_control_result_reports_action_and_current_state() {
 
     let text = result_text(
         &h.app
-            .call_tool("hifi_control", json!({ "zone_id": zone_id, "action": "play" }))
+            .call_tool(
+                "hifi_control",
+                json!({ "zone_id": zone_id, "action": "play" }),
+            )
             .await,
     );
 
@@ -1699,10 +1724,7 @@ async fn openhome_and_upnp_prefixes_reach_their_own_adapters() {
 
     // The mock devices are live and serving their descriptions.
     let client = reqwest::Client::new();
-    for url in [
-        openhome_mock.description_url(),
-        upnp_mock.description_url(),
-    ] {
+    for url in [openhome_mock.description_url(), upnp_mock.description_url()] {
         let body = client
             .get(&url)
             .send()
@@ -1772,59 +1794,89 @@ use FieldRole::{Consumed, DisplayOnly};
 /// Today's truth, including its defects. `#394` freezes this; it fixes nothing.
 const FIELD_ROLES: &[(&str, FieldRole)] = &[
     // Zone identity closes the loop: every zone-scoped tool takes it.
-    ("zone_id", Consumed("hifi_now_playing/hifi_control/hifi_play.zone_id")),
-    ("zone_name", DisplayOnly(
-        "human label; every tool addresses a zone by zone_id, never by name",
-    )),
-    ("state", DisplayOnly(
-        "playback state readout; hifi_control.action is the write path",
-    )),
-    ("volume", DisplayOnly(
-        "current level readout; hifi_control.value is the write path",
-    )),
-    ("is_muted", DisplayOnly(
-        "mute readout with no corresponding write: hifi_control has no mute action",
-    )),
-    ("title", DisplayOnly(
-        "hifi_search returns {title, subtitle} and no key, so the only route from \
+    (
+        "zone_id",
+        Consumed("hifi_now_playing/hifi_control/hifi_play.zone_id"),
+    ),
+    (
+        "zone_name",
+        DisplayOnly("human label; every tool addresses a zone by zone_id, never by name"),
+    ),
+    (
+        "state",
+        DisplayOnly("playback state readout; hifi_control.action is the write path"),
+    ),
+    (
+        "volume",
+        DisplayOnly("current level readout; hifi_control.value is the write path"),
+    ),
+    (
+        "is_muted",
+        DisplayOnly("mute readout with no corresponding write: hifi_control has no mute action"),
+    ),
+    (
+        "title",
+        DisplayOnly(
+            "hifi_search returns {title, subtitle} and no key, so the only route from \
          'found it' to 'playing it' is handing the title back to hifi_play, which \
          re-searches and takes the first match. That is #392's keystone finding and \
          #396's job — NOT an endorsed design. Listed to freeze today's behavior.",
-    )),
-    ("artist", DisplayOnly(
-        "now-playing readout; hifi_play takes a free-text query, not a field",
-    )),
-    ("album", DisplayOnly(
-        "now-playing readout; hifi_play takes a free-text query, not a field",
-    )),
-    ("subtitle", DisplayOnly(
-        "search-result label, same defect as `title`; see #396",
-    )),
+        ),
+    ),
+    (
+        "artist",
+        DisplayOnly("now-playing readout; hifi_play takes a free-text query, not a field"),
+    ),
+    (
+        "album",
+        DisplayOnly("now-playing readout; hifi_play takes a free-text query, not a field"),
+    ),
+    (
+        "subtitle",
+        DisplayOnly("search-result label, same defect as `title`; see #396"),
+    ),
     // hifi_status / hifi_hqplayer_status readouts.
-    ("connected", DisplayOnly(
-        "boolean health readout; nothing takes a connection state as input",
-    )),
-    ("host", DisplayOnly(
-        "diagnostic address; configuring a host is an HTTP/settings concern, not an MCP tool",
-    )),
-    ("core_name", DisplayOnly(
-        "Roon core label for the operator; no tool selects a core",
-    )),
-    ("roon", DisplayOnly(
-        "hifi_status grouping key, not a value a client passes anywhere",
-    )),
-    ("hqplayer", DisplayOnly(
-        "hifi_status grouping key, not a value a client passes anywhere",
-    )),
-    ("pipeline", DisplayOnly(
-        "hifi_hqplayer_status grouping key wrapping the pipeline readout",
-    )),
-    ("filter", DisplayOnly(
-        "pipeline readout; hifi_hqplayer_set_pipeline writes it via \
+    (
+        "connected",
+        DisplayOnly("boolean health readout; nothing takes a connection state as input"),
+    ),
+    (
+        "host",
+        DisplayOnly(
+            "diagnostic address; configuring a host is an HTTP/settings concern, not an MCP tool",
+        ),
+    ),
+    (
+        "core_name",
+        DisplayOnly("Roon core label for the operator; no tool selects a core"),
+    ),
+    (
+        "roon",
+        DisplayOnly("hifi_status grouping key, not a value a client passes anywhere"),
+    ),
+    (
+        "hqplayer",
+        DisplayOnly("hifi_status grouping key, not a value a client passes anywhere"),
+    ),
+    (
+        "pipeline",
+        DisplayOnly("hifi_hqplayer_status grouping key wrapping the pipeline readout"),
+    ),
+    (
+        "filter",
+        DisplayOnly(
+            "pipeline readout; hifi_hqplayer_set_pipeline writes it via \
          setting='filter1x'/'filterNx', which is a different name",
-    )),
-    ("shaper", Consumed("hifi_hqplayer_set_pipeline.setting='shaper'")),
-    ("rate", Consumed("hifi_hqplayer_set_pipeline.setting='rate'")),
+        ),
+    ),
+    (
+        "shaper",
+        Consumed("hifi_hqplayer_set_pipeline.setting='shaper'"),
+    ),
+    (
+        "rate",
+        Consumed("hifi_hqplayer_set_pipeline.setting='rate'"),
+    ),
 ];
 
 /// Collect every key name reachable in a JSON value, at any depth.

--- a/tests/mcp_contract.rs
+++ b/tests/mcp_contract.rs
@@ -251,6 +251,30 @@ impl TestApp {
         Self { router }
     }
 
+    /// Issue a bare GET or DELETE to `/mcp`, as MCP clients do to open the SSE
+    /// stream and to tear a session down.
+    async fn request(
+        &self,
+        method: Method,
+        session_id: Option<&str>,
+    ) -> (axum::http::StatusCode, axum::http::HeaderMap) {
+        let mut builder = Request::builder()
+            .method(method)
+            .uri("/mcp")
+            .header(header::ACCEPT, "application/json, text/event-stream");
+        if let Some(sid) = session_id {
+            builder = builder.header(MCP_SESSION_ID_HEADER, sid);
+        }
+        let response = self
+            .router
+            .clone()
+            .oneshot(builder.body(Body::empty()).expect("build request"))
+            .await
+            .expect("mcp route must respond");
+
+        (response.status(), response.headers().clone())
+    }
+
     /// POST a JSON-RPC message to `/mcp` and return `(response headers, parsed result)`.
     ///
     /// `enable_json_response` is false in `create_mcp_extension`, so responses
@@ -400,8 +424,26 @@ fn result_text(result: &Value) -> String {
 // 1. tools/list snapshot
 // =============================================================================
 
-/// The `tools/list` wire payload — names, descriptions, input schemas, and
-/// annotation hints — must match the committed fixture byte for byte.
+/// Each tool's contract — description, input schema, annotation hints — pinned
+/// against the committed fixture.
+///
+/// # Why the fixture is keyed by tool name rather than being the raw array
+///
+/// Epic #392 is additive-only, so the guardrail has to distinguish two things
+/// that a positional array conflates:
+///
+/// - a tool was **added** — permitted, and should read as a purely additive diff
+/// - an existing tool's description or schema **changed** — forbidden, and should
+///   read as a loud modification
+///
+/// Keyed by name, adding a tool adds one key and leaves every existing key byte
+/// identical. As an array, appending a tool is also additive, but #399 and #400
+/// land in parallel by the epic's own plan and each appends one — so whichever
+/// merges second would face a conflict plus a mandatory regeneration, which is
+/// exactly how reflexive `UPDATE_MCP_FIXTURES=1` becomes a habit.
+///
+/// Advertised **order** is pinned separately, in
+/// [`tools_list_order_is_pinned`], so order and content fail independently.
 #[tokio::test]
 #[serial_test::serial(uhc_config_dir)]
 async fn tools_list_matches_fixture() {
@@ -422,7 +464,62 @@ async fn tools_list_matches_fixture() {
         tool_names(tools)
     );
 
-    assert_matches_fixture("mcp_tools.json", result.get("tools").expect("tools"));
+    let mut by_name = serde_json::Map::new();
+    for tool in tools {
+        let name = tool
+            .get("name")
+            .and_then(Value::as_str)
+            .expect("every tool must have a name")
+            .to_string();
+        // The name is the key, so drop it from the value: otherwise renaming a
+        // tool would show up as one added key and one removed key with identical
+        // bodies, which reads as additive when it is not.
+        let mut body = tool.clone();
+        body.as_object_mut().expect("tool must be an object").remove("name");
+        assert!(
+            by_name.insert(name.clone(), body).is_none(),
+            "duplicate tool name in tools/list: {name}"
+        );
+    }
+
+    assert_matches_fixture("mcp_tools.json", &Value::Object(by_name));
+}
+
+/// The order `tools/list` advertises, pinned separately from tool content.
+///
+/// Order is part of the wire payload and models do weight earlier tools, so it is
+/// worth pinning — but a reordering and a description change are different bugs
+/// and should not fail the same assertion.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn tools_list_order_is_pinned() {
+    let _settings = SettingsFixture::with_hqplayer(true);
+    let app = TestApp::new().await;
+
+    let result = app.list_tools().await;
+    let tools = result
+        .get("tools")
+        .and_then(Value::as_array)
+        .expect("tools array");
+
+    assert_eq!(
+        tool_names(tools),
+        vec![
+            "hifi_zones",
+            "hifi_now_playing",
+            "hifi_control",
+            "hifi_search",
+            "hifi_play",
+            "hifi_status",
+            "hifi_hqplayer_status",
+            "hifi_hqplayer_profiles",
+            "hifi_hqplayer_load_profile",
+            "hifi_hqplayer_set_pipeline",
+        ],
+        "tools/list order follows the tool_box! list in src/mcp/tools/mod.rs. \
+         APPEND new tools rather than inserting, so this assertion grows by one \
+         line instead of shifting."
+    );
 }
 
 fn tool_names(tools: &[Value]) -> Vec<String> {
@@ -513,7 +610,9 @@ async fn initialize_result_matches_fixture() {
 fn declared_protocol_version_and_capabilities_are_pinned() {
     let details = mcp::server_details();
 
-    let declared: String = details.protocol_version.into();
+    // `protocol_version` is already a String on InitializeResult; bound here so
+    // the assertion reads against production's value rather than a literal.
+    let declared: String = details.protocol_version;
     assert_eq!(
         declared, SERVER_PROTOCOL_VERSION,
         "the declared protocol version changed. The wire snapshot cannot catch a \
@@ -720,6 +819,123 @@ async fn every_tool_has_a_nonempty_description() {
             "{name}: tool description must be non-empty"
         );
     }
+}
+
+// =============================================================================
+// 3b. Transport layer: session recovery, GET, DELETE
+// =============================================================================
+//
+// Everything above POSTs with a valid session. That leaves three of the four
+// public functions in src/mcp/mod.rs unexercised — including
+// `auto_recover_session`, which is the most intricate code in the module and was
+// moved verbatim by the split. It exists because real clients hold stale sessions
+// across a server restart, so it is load-bearing rather than glue.
+
+/// A POST carrying a session id the server has never heard of must still
+/// succeed: `auto_recover_session` transparently mints a new session and rewrites
+/// the request headers, so the client's request goes through instead of failing.
+///
+/// Without this test the split could have broken stale-session recovery and every
+/// other test in this file would still pass.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn a_stale_session_id_is_transparently_recovered() {
+    let _settings = SettingsFixture::with_hqplayer(true);
+    let app = TestApp::new().await;
+
+    // Never initialized; this id exists nowhere in the session store.
+    let (_, response) = app
+        .post(
+            Some("stale-session-from-a-previous-server-process"),
+            json!({ "jsonrpc": "2.0", "id": 99, "method": "tools/list", "params": {} }),
+        )
+        .await;
+
+    let response = response.expect("a stale session must still get a JSON-RPC response");
+    assert!(
+        response.get("error").is_none(),
+        "stale session recovery must not surface an error to the client: {response}"
+    );
+    let tools = response
+        .pointer("/result/tools")
+        .and_then(Value::as_array)
+        .unwrap_or_else(|| {
+            panic!("recovered request must return the tool list, got: {response}")
+        });
+    assert_eq!(
+        tools.len(),
+        10,
+        "the recovered session must serve the same tool list as a fresh one"
+    );
+}
+
+/// GET opens the server-to-client SSE stream; DELETE tears a session down. Both
+/// are wired in `src/main.rs` and neither had any coverage. Smoked here so a
+/// mis-wired route surfaces as a test failure rather than as a client that
+/// silently cannot receive notifications.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn get_and_delete_are_wired_and_session_aware() {
+    let _settings = SettingsFixture::with_hqplayer(true);
+    let app = TestApp::new().await;
+    let (session_id, _) = app.initialize().await;
+
+    // GET without a session is rejected rather than opening a stream.
+    let (status, _) = app.request(Method::GET, None).await;
+    assert!(
+        status.is_client_error(),
+        "GET without a session must be refused, got {status}"
+    );
+
+    // DELETE without a session likewise.
+    let (status, _) = app.request(Method::DELETE, None).await;
+    assert!(
+        status.is_client_error(),
+        "DELETE without a session must be refused, got {status}"
+    );
+
+    // DELETE with a live session terminates it.
+    let (status, _) = app.request(Method::DELETE, Some(&session_id)).await;
+    assert!(
+        status.is_success(),
+        "DELETE with a valid session must succeed, got {status}"
+    );
+
+    // An unknown session id is refused, and GET and DELETE refuse it
+    // *differently*. Unlike POST, neither has an auto-recovery path.
+    //
+    // GET answering 500 rather than 404 is arguably wrong — a stale SSE
+    // reconnect is a client-side condition, not a server fault — but it is
+    // today's behavior, and #394 records rather than corrects. Recorded here so
+    // that if a later issue fixes it, the change is visible instead of incidental.
+    let (status, _) = app
+        .request(Method::DELETE, Some("never-initialized-session"))
+        .await;
+    assert_eq!(
+        status,
+        axum::http::StatusCode::NOT_FOUND,
+        "DELETE with an unknown session returns 404 today"
+    );
+
+    let (status, _) = app
+        .request(Method::GET, Some("never-initialized-session"))
+        .await;
+    assert_eq!(
+        status,
+        axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+        "GET with an unknown session returns 500 today (see the note above: \
+         recorded, not endorsed)"
+    );
+
+    // The methods really are routed: axum answers an unrouted method with 405,
+    // and PATCH is the control case.
+    let (status, _) = app.request(Method::PATCH, Some(&session_id)).await;
+    assert_eq!(
+        status,
+        axum::http::StatusCode::METHOD_NOT_ALLOWED,
+        "PATCH is not wired, so 405 here is what proves the GET/DELETE statuses \
+         above came from the handlers rather than from axum's router"
+    );
 }
 
 // =============================================================================
@@ -1263,7 +1479,13 @@ impl LmsHarness {
 
         let app = TestApp::with_state(state.clone());
 
-        // Wait for the player to propagate: adapter connect -> ZoneDiscovered -> aggregator.
+        // Wait for the player to propagate: adapter connect -> ZoneDiscovered ->
+        // aggregator.
+        //
+        // Budget is 100 x 100ms = 10s, against a local mock that normally responds
+        // in well under a second. Generous on purpose, but it is a wall-clock
+        // budget: if this ever flakes on a loaded machine, the propagation path is
+        // the thing to instrument, not the loop count to raise.
         let zone_id = format!("lms:{}", Self::PLAYER_ID);
         let mut found = false;
         for _ in 0..100 {
@@ -1690,6 +1912,12 @@ async fn no_tool_returns_an_unclassified_field() {
     );
 
     // Every display-only justification must actually say something.
+    //
+    // This measures length, not content, and a proxy can be gamed by padding. It
+    // is kept because it does real work — it caught "Roon core label" (exactly 15
+    // characters) and forced the reasons to be rewritten into something a reader
+    // can act on. If you are here because this failed, the fix is a better reason,
+    // not a longer one.
     for (field, role) in FIELD_ROLES {
         if let DisplayOnly(reason) = role {
             assert!(

--- a/tests/mcp_contract.rs
+++ b/tests/mcp_contract.rs
@@ -1,0 +1,667 @@
+//! MCP contract test harness (issue #394).
+//!
+//! Pins the MCP surface exactly as it is today so later PRs in epic #392 can be
+//! shown to be additive rather than merely claimed to be.
+//!
+//! # What is pinned, and how
+//!
+//! Two layers, deliberately:
+//!
+//! 1. **Wire-level snapshots** driven through the real Axum `/mcp` route via
+//!    `tower::ServiceExt::oneshot`. These capture the bytes an MCP client
+//!    actually receives for `initialize` and `tools/list`, including the
+//!    settings-based HQPlayer tool filtering. They exercise `create_mcp_extension`,
+//!    the streamable-HTTP transport, and the `ServerHandler` impl — i.e. every
+//!    layer a refactor could disturb. Committed fixtures:
+//!      - `tests/fixtures/mcp_tools.json`      (`tools/list`, HQPlayer enabled)
+//!      - `tests/fixtures/mcp_initialize.json` (`initialize` result)
+//!
+//! 2. **In-process assertions** over `unified_hifi_control::mcp` for things a
+//!    snapshot cannot express: JSON Schema structural validity, the documented
+//!    parameter inventory, the no-orphan-field guardrail, and zone routing.
+//!
+//! # Regenerating fixtures
+//!
+//! ```sh
+//! UPDATE_MCP_FIXTURES=1 cargo test --test mcp_contract
+//! ```
+//!
+//! Regenerate only when the change to the MCP surface is intended and approved.
+//! A fixture diff on an "additive only" PR is a bug report, not a chore.
+
+use axum::{
+    body::Body,
+    http::{header, Method, Request},
+    routing::{delete, get, post},
+    Router,
+};
+use serde_json::{json, Value};
+use std::{sync::Arc, time::Instant};
+use tokio_util::sync::CancellationToken;
+use tower::ServiceExt;
+
+use unified_hifi_control::adapters::hqplayer::{HqpInstanceManager, HqpZoneLinkService};
+use unified_hifi_control::adapters::lms::LmsAdapter;
+use unified_hifi_control::adapters::openhome::OpenHomeAdapter;
+use unified_hifi_control::adapters::roon::RoonAdapter;
+use unified_hifi_control::adapters::upnp::UPnPAdapter;
+use unified_hifi_control::adapters::Startable;
+use unified_hifi_control::aggregator::ZoneAggregator;
+use unified_hifi_control::api::AppState;
+use unified_hifi_control::bus::create_bus;
+use unified_hifi_control::coordinator::AdapterCoordinator;
+use unified_hifi_control::knobs::KnobStore;
+use unified_hifi_control::mcp;
+
+// =============================================================================
+// Fixture plumbing
+// =============================================================================
+
+const MCP_SESSION_ID_HEADER: &str = "mcp-session-id";
+
+/// The protocol version the server declares in `create_mcp_extension`.
+///
+/// The SDK negotiates down to whatever the client asks for, so the test client
+/// asks for exactly this: that way the `initialize` snapshot pins the *declared*
+/// version, and lowering the declared version turns a client request for this
+/// version into an outright error rather than a silent downgrade.
+const SERVER_PROTOCOL_VERSION: &str = "2025-11-25";
+
+fn fixture_path(name: &str) -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(name)
+}
+
+/// Compare `actual` against a committed fixture, or rewrite the fixture when
+/// `UPDATE_MCP_FIXTURES=1`.
+fn assert_matches_fixture(name: &str, actual: &Value) {
+    let path = fixture_path(name);
+    let rendered = format!(
+        "{}\n",
+        serde_json::to_string_pretty(actual).expect("fixture value must serialize")
+    );
+
+    if std::env::var("UPDATE_MCP_FIXTURES").as_deref() == Ok("1") {
+        std::fs::create_dir_all(path.parent().expect("fixture dir"))
+            .expect("create fixture dir");
+        std::fs::write(&path, &rendered).expect("write fixture");
+        eprintln!("updated fixture: {}", path.display());
+        return;
+    }
+
+    let expected = std::fs::read_to_string(&path).unwrap_or_else(|e| {
+        panic!(
+            "missing fixture {}: {e}\n\
+             Generate it with: UPDATE_MCP_FIXTURES=1 cargo test --test mcp_contract",
+            path.display()
+        )
+    });
+
+    if expected != rendered {
+        // Point at the first differing line; a 400-line JSON diff is unreadable.
+        let first_diff = expected
+            .lines()
+            .zip(rendered.lines())
+            .enumerate()
+            .find(|(_, (a, b))| a != b)
+            .map(|(i, (a, b))| format!("line {}:\n  fixture: {a}\n  actual:  {b}", i + 1))
+            .unwrap_or_else(|| "line counts differ".to_string());
+
+        panic!(
+            "MCP contract drift in {}\n\n{first_diff}\n\n\
+             The MCP surface changed. If that was intentional AND approved, regenerate with:\n\
+             \x20 UPDATE_MCP_FIXTURES=1 cargo test --test mcp_contract\n\
+             Otherwise this is the bug: epic #392 is additive-only.",
+            path.display()
+        );
+    }
+}
+
+/// Scoped env var override. `std::env::set_var` is process-global, so every
+/// test that uses this must be `#[serial_test::serial(uhc_config_dir)]`.
+struct EnvGuard {
+    key: &'static str,
+    previous: Option<String>,
+}
+
+impl EnvGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let previous = std::env::var(key).ok();
+        std::env::set_var(key, value);
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        match &self.previous {
+            Some(v) => std::env::set_var(self.key, v),
+            None => std::env::remove_var(self.key),
+        }
+    }
+}
+
+/// A config dir containing exactly the app settings we want, so
+/// `load_app_settings()` is deterministic instead of reading the developer's
+/// real `~/.config`.
+struct SettingsFixture {
+    _dir: tempfile::TempDir,
+    _guard: EnvGuard,
+}
+
+impl SettingsFixture {
+    fn with_hqplayer(enabled: bool) -> Self {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let settings = json!({
+            "hide_knobs_page": false,
+            "hide_hqp_page": false,
+            "hide_lms_page": false,
+            "adapters": {
+                "roon": true,
+                "upnp": true,
+                "openhome": true,
+                "lms": true,
+                "hqplayer": enabled,
+            }
+        });
+        std::fs::write(
+            dir.path().join("app-settings.json"),
+            serde_json::to_vec_pretty(&settings).expect("serialize settings"),
+        )
+        .expect("write settings");
+
+        let guard = EnvGuard::set("UHC_CONFIG_DIR", &dir.path().to_string_lossy());
+        Self {
+            _dir: dir,
+            _guard: guard,
+        }
+    }
+}
+
+// =============================================================================
+// Test app
+// =============================================================================
+
+/// Disconnected adapters, no network. Overridable so mock-server round-trip
+/// tests can substitute a configured adapter.
+struct TestApp {
+    router: Router,
+}
+
+async fn build_state(lms: Option<Arc<LmsAdapter>>) -> AppState {
+    let bus = create_bus();
+    let coordinator = Arc::new(AdapterCoordinator::new(bus.clone()));
+    let roon = Arc::new(RoonAdapter::new_disconnected(bus.clone()));
+    let hqp_instances = Arc::new(HqpInstanceManager::new(bus.clone()));
+    let hqplayer = hqp_instances.get_default().await;
+    let hqp_zone_links = Arc::new(HqpZoneLinkService::new(hqp_instances.clone()));
+    let lms = lms.unwrap_or_else(|| Arc::new(LmsAdapter::new(bus.clone())));
+    let openhome = Arc::new(OpenHomeAdapter::new(bus.clone()));
+    let upnp = Arc::new(UPnPAdapter::new(bus.clone()));
+    let aggregator = Arc::new(ZoneAggregator::new(bus.clone()));
+
+    let startable_adapters: Vec<Arc<dyn Startable>> =
+        vec![roon.clone(), lms.clone(), openhome.clone(), upnp.clone()];
+
+    AppState::new(
+        roon,
+        hqplayer,
+        hqp_instances,
+        hqp_zone_links,
+        lms,
+        openhome,
+        upnp,
+        KnobStore::new(),
+        bus,
+        aggregator,
+        coordinator,
+        startable_adapters,
+        Instant::now(),
+        CancellationToken::new(),
+    )
+}
+
+impl TestApp {
+    async fn new() -> Self {
+        Self::with_state(build_state(None).await)
+    }
+
+    fn with_state(state: AppState) -> Self {
+        // Exactly the three MCP routes from main.rs, nothing else.
+        let router = Router::new()
+            .route("/mcp", get(mcp::handle_mcp_get))
+            .route("/mcp", post(mcp::handle_mcp_post))
+            .route("/mcp", delete(mcp::handle_mcp_delete))
+            .layer(mcp::create_mcp_extension(state.clone()))
+            .with_state(state);
+
+        Self { router }
+    }
+
+    /// POST a JSON-RPC message to `/mcp` and return `(response headers, parsed result)`.
+    ///
+    /// `enable_json_response` is false in `create_mcp_extension`, so responses
+    /// arrive SSE-framed; the `data:` payload is the JSON-RPC envelope.
+    async fn post(
+        &self,
+        session_id: Option<&str>,
+        payload: Value,
+    ) -> (axum::http::HeaderMap, Option<Value>) {
+        let mut builder = Request::builder()
+            .method(Method::POST)
+            .uri("/mcp")
+            .header(header::CONTENT_TYPE, "application/json")
+            .header(header::ACCEPT, "application/json, text/event-stream");
+        if let Some(sid) = session_id {
+            builder = builder.header(MCP_SESSION_ID_HEADER, sid);
+        }
+        let request = builder
+            .body(Body::from(payload.to_string()))
+            .expect("build request");
+
+        let response = self
+            .router
+            .clone()
+            .oneshot(request)
+            .await
+            .expect("mcp route must respond");
+
+        let headers = response.headers().clone();
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .expect("read mcp body");
+        let body = String::from_utf8_lossy(&body).to_string();
+
+        (headers, parse_sse_json(&body))
+    }
+
+    /// `initialize`, then `notifications/initialized`. Returns the session id
+    /// and the `result` object of the initialize response.
+    async fn initialize(&self) -> (String, Value) {
+        self.initialize_with_protocol(SERVER_PROTOCOL_VERSION).await
+    }
+
+    async fn initialize_with_protocol(&self, protocol_version: &str) -> (String, Value) {
+        let (headers, result) = self
+            .post(
+                None,
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": protocol_version,
+                        "capabilities": {},
+                        "clientInfo": { "name": "mcp-contract-test", "version": "1.0.0" }
+                    }
+                }),
+            )
+            .await;
+
+        let session_id = headers
+            .get(MCP_SESSION_ID_HEADER)
+            .and_then(|v| v.to_str().ok())
+            .expect("initialize must return an mcp-session-id header")
+            .to_string();
+
+        let result = result.expect("initialize must return a JSON-RPC response");
+        let result = result
+            .get("result")
+            .cloned()
+            .unwrap_or_else(|| panic!("initialize returned no result: {result}"));
+
+        self.post(
+            Some(&session_id),
+            json!({ "jsonrpc": "2.0", "method": "notifications/initialized" }),
+        )
+        .await;
+
+        (session_id, result)
+    }
+
+    /// `tools/list` against an initialized session.
+    async fn list_tools(&self) -> Value {
+        let (session_id, _) = self.initialize().await;
+        let (_, response) = self
+            .post(
+                Some(&session_id),
+                json!({ "jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {} }),
+            )
+            .await;
+        let response = response.expect("tools/list must return a JSON-RPC response");
+        response
+            .get("result")
+            .cloned()
+            .unwrap_or_else(|| panic!("tools/list returned no result: {response}"))
+    }
+
+    /// `tools/call` against an initialized session. Returns the `result` object.
+    async fn call_tool(&self, name: &str, arguments: Value) -> Value {
+        let (session_id, _) = self.initialize().await;
+        let (_, response) = self
+            .post(
+                Some(&session_id),
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": 3,
+                    "method": "tools/call",
+                    "params": { "name": name, "arguments": arguments }
+                }),
+            )
+            .await;
+        let response = response.expect("tools/call must return a JSON-RPC response");
+        response
+            .get("result")
+            .cloned()
+            .unwrap_or_else(|| panic!("tools/call {name} returned no result: {response}"))
+    }
+}
+
+/// Extract the first `data:` payload from an SSE body, or parse the body as
+/// plain JSON if the transport ever switches to `enable_json_response`.
+fn parse_sse_json(body: &str) -> Option<Value> {
+    for line in body.lines() {
+        if let Some(data) = line.strip_prefix("data:") {
+            return serde_json::from_str(data.trim()).ok();
+        }
+    }
+    serde_json::from_str(body).ok()
+}
+
+/// The concatenated text content of a `tools/call` result.
+fn result_text(result: &Value) -> String {
+    result
+        .get("content")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| item.get("text").and_then(Value::as_str))
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+        .unwrap_or_default()
+}
+
+// =============================================================================
+// 1. tools/list snapshot
+// =============================================================================
+
+/// The `tools/list` wire payload — names, descriptions, input schemas, and
+/// annotation hints — must match the committed fixture byte for byte.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn tools_list_matches_fixture() {
+    let _settings = SettingsFixture::with_hqplayer(true);
+    let app = TestApp::new().await;
+
+    let result = app.list_tools().await;
+    let tools = result
+        .get("tools")
+        .and_then(Value::as_array)
+        .expect("tools/list result must contain a tools array");
+
+    assert_eq!(
+        tools.len(),
+        10,
+        "expected 10 tools with HQPlayer enabled, got {}: {:?}",
+        tools.len(),
+        tool_names(tools)
+    );
+
+    assert_matches_fixture("mcp_tools.json", result.get("tools").expect("tools"));
+}
+
+fn tool_names(tools: &[Value]) -> Vec<String> {
+    tools
+        .iter()
+        .filter_map(|t| t.get("name").and_then(Value::as_str))
+        .map(str::to_string)
+        .collect()
+}
+
+/// The settings-based HQPlayer filter in `handle_list_tools_request` is part of
+/// the contract: with the adapter disabled, the four `hifi_hqplayer_*` tools
+/// must not be advertised, and nothing else may change.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn hqplayer_tools_filtered_when_adapter_disabled() {
+    let _settings = SettingsFixture::with_hqplayer(false);
+    let app = TestApp::new().await;
+
+    let result = app.list_tools().await;
+    let tools = result
+        .get("tools")
+        .and_then(Value::as_array)
+        .expect("tools array");
+    let names = tool_names(tools);
+
+    assert_eq!(
+        names,
+        vec![
+            "hifi_zones",
+            "hifi_now_playing",
+            "hifi_control",
+            "hifi_search",
+            "hifi_play",
+            "hifi_status",
+        ],
+        "HQPlayer disabled must yield exactly the six non-HQPlayer tools, in order"
+    );
+}
+
+// =============================================================================
+// 2. initialize snapshot
+// =============================================================================
+
+/// The `initialize` result — server info, declared capabilities, instructions,
+/// and protocol version — must match the committed fixture.
+///
+/// `serverInfo.version` comes from `CARGO_PKG_VERSION`, which release builds
+/// inject from the git tag, so it is redacted in the fixture and asserted
+/// separately.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn initialize_result_matches_fixture() {
+    let _settings = SettingsFixture::with_hqplayer(true);
+    let app = TestApp::new().await;
+
+    let (_, mut result) = app.initialize().await;
+
+    let version = result
+        .pointer("/serverInfo/version")
+        .and_then(Value::as_str)
+        .expect("serverInfo.version must be present")
+        .to_string();
+    assert_eq!(
+        version,
+        env!("CARGO_PKG_VERSION"),
+        "serverInfo.version must be the crate version"
+    );
+    *result
+        .pointer_mut("/serverInfo/version")
+        .expect("serverInfo.version") = json!("<CARGO_PKG_VERSION>");
+
+    assert_matches_fixture("mcp_initialize.json", &result);
+}
+
+/// Older clients must still get a session: the SDK negotiates down to the
+/// client's protocol version. Pinned so a change to the declared version can't
+/// silently start rejecting the clients that are deployed today.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn initialize_negotiates_down_for_older_clients() {
+    let _settings = SettingsFixture::with_hqplayer(true);
+    let app = TestApp::new().await;
+
+    for requested in ["2024-11-05", "2025-03-26", "2025-06-18"] {
+        let (session_id, result) = app.initialize_with_protocol(requested).await;
+        assert!(
+            !session_id.is_empty(),
+            "client asking for {requested} must get a session"
+        );
+        assert_eq!(
+            result.get("protocolVersion").and_then(Value::as_str),
+            Some(requested),
+            "server must echo the older client's protocol version"
+        );
+    }
+}
+
+// =============================================================================
+// 3. Input schemas are valid JSON Schema, and document every parameter
+// =============================================================================
+
+/// Every parameter each tool accepts, in declaration order, paired with whether
+/// it is required. Encoded here rather than derived so that adding, renaming, or
+/// changing the optionality of a parameter is a visible edit to this table.
+const EXPECTED_TOOL_PARAMS: &[(&str, &[(&str, bool)])] = &[
+    ("hifi_zones", &[]),
+    ("hifi_now_playing", &[("zone_id", true)]),
+    (
+        "hifi_control",
+        &[("zone_id", true), ("action", true), ("value", false)],
+    ),
+    (
+        "hifi_search",
+        &[("query", true), ("zone_id", false), ("source", false)],
+    ),
+    (
+        "hifi_play",
+        &[
+            ("query", true),
+            ("zone_id", true),
+            ("source", false),
+            ("action", false),
+        ],
+    ),
+    ("hifi_status", &[]),
+    ("hifi_hqplayer_status", &[]),
+    ("hifi_hqplayer_profiles", &[]),
+    ("hifi_hqplayer_load_profile", &[("profile", true)]),
+    (
+        "hifi_hqplayer_set_pipeline",
+        &[("setting", true), ("value", true)],
+    ),
+];
+
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn every_input_schema_is_structurally_valid_json_schema() {
+    let _settings = SettingsFixture::with_hqplayer(true);
+    let app = TestApp::new().await;
+    let result = app.list_tools().await;
+    let tools = result
+        .get("tools")
+        .and_then(Value::as_array)
+        .expect("tools array");
+
+    for tool in tools {
+        let name = tool
+            .get("name")
+            .and_then(Value::as_str)
+            .expect("tool must have a name");
+        let schema = tool
+            .get("inputSchema")
+            .unwrap_or_else(|| panic!("{name}: missing inputSchema"));
+
+        assert_eq!(
+            schema.get("type").and_then(Value::as_str),
+            Some("object"),
+            "{name}: inputSchema.type must be \"object\""
+        );
+
+        let properties = schema
+            .get("properties")
+            .and_then(Value::as_object)
+            .cloned()
+            .unwrap_or_default();
+
+        for (prop, spec) in &properties {
+            let spec = spec
+                .as_object()
+                .unwrap_or_else(|| panic!("{name}.{prop}: property spec must be an object"));
+            // A property is well-formed if it constrains its value somehow.
+            assert!(
+                spec.contains_key("type")
+                    || spec.contains_key("anyOf")
+                    || spec.contains_key("oneOf")
+                    || spec.contains_key("allOf")
+                    || spec.contains_key("$ref")
+                    || spec.contains_key("enum"),
+                "{name}.{prop}: property must declare type/enum/$ref/anyOf/oneOf/allOf, got {spec:?}"
+            );
+            // Descriptions are what the model reads to fill the parameter in.
+            assert!(
+                spec.get("description")
+                    .and_then(Value::as_str)
+                    .is_some_and(|d| !d.trim().is_empty()),
+                "{name}.{prop}: every parameter must carry a non-empty description"
+            );
+        }
+
+        let required: Vec<&str> = schema
+            .get("required")
+            .and_then(Value::as_array)
+            .map(|items| items.iter().filter_map(Value::as_str).collect())
+            .unwrap_or_default();
+        for req in &required {
+            assert!(
+                properties.contains_key(*req),
+                "{name}: required lists \"{req}\" which is not in properties"
+            );
+        }
+
+        // Every documented parameter appears, with the documented optionality.
+        let expected = EXPECTED_TOOL_PARAMS
+            .iter()
+            .find(|(t, _)| *t == name)
+            .map(|(_, params)| *params)
+            .unwrap_or_else(|| {
+                panic!("{name}: not listed in EXPECTED_TOOL_PARAMS — add it deliberately")
+            });
+
+        let mut actual: Vec<&str> = properties.keys().map(String::as_str).collect();
+        actual.sort_unstable();
+        let mut expected_names: Vec<&str> = expected.iter().map(|(p, _)| *p).collect();
+        expected_names.sort_unstable();
+        assert_eq!(
+            actual, expected_names,
+            "{name}: input schema properties drifted from the documented parameter list"
+        );
+
+        for (param, is_required) in expected {
+            assert_eq!(
+                required.contains(param),
+                *is_required,
+                "{name}.{param}: required-ness drifted (schema required = {required:?})"
+            );
+        }
+    }
+}
+
+/// Tool descriptions are documentation the model reads (AGENTS.md). An empty or
+/// missing description makes a tool unusable.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn every_tool_has_a_nonempty_description() {
+    let _settings = SettingsFixture::with_hqplayer(true);
+    let app = TestApp::new().await;
+    let result = app.list_tools().await;
+    let tools = result
+        .get("tools")
+        .and_then(Value::as_array)
+        .expect("tools array");
+
+    for tool in tools {
+        let name = tool.get("name").and_then(Value::as_str).unwrap_or("<?>");
+        assert!(
+            tool.get("description")
+                .and_then(Value::as_str)
+                .is_some_and(|d| !d.trim().is_empty()),
+            "{name}: tool description must be non-empty"
+        );
+    }
+}

--- a/tests/mock_servers/hqplayer.rs
+++ b/tests/mock_servers/hqplayer.rs
@@ -132,10 +132,22 @@ async fn handle_connection(stream: TcpStream, state: Arc<RwLock<MockHqpState>>) 
 
 /// Process an XML command and return a response
 async fn process_command(command: &str, state: &Arc<RwLock<MockHqpState>>) -> String {
-    // Skip XML declaration
     let command = command.trim();
-    if command.starts_with("<?xml") {
-        return String::new(); // Ignore declaration line
+
+    // Strip a leading XML declaration rather than discarding the whole line.
+    //
+    // HqpAdapter::build_command emits the declaration and the command on ONE
+    // line (`<?xml version="1.0"?><GetInfo/>`), so rejecting any line starting
+    // with `<?xml` made the mock unreachable from the real adapter: it answered
+    // with nothing and the adapter timed out. A bare declaration line still
+    // yields an empty response, so clients that send them separately are
+    // unaffected.
+    let command = match command.find("?>") {
+        Some(end) if command.starts_with("<?xml") => command[end + 2..].trim(),
+        _ => command,
+    };
+    if command.is_empty() {
+        return String::new();
     }
 
     // Parse command name from XML

--- a/tests/mock_servers/lms.rs
+++ b/tests/mock_servers/lms.rs
@@ -48,9 +48,36 @@ impl MockPlayer {
     }
 }
 
+/// A command as it arrived on the wire: the target player id and the raw
+/// command array LMS was asked to run.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RecordedCommand {
+    pub player_id: String,
+    pub command: Vec<Value>,
+}
+
+impl RecordedCommand {
+    /// The command array rendered as strings, e.g. `["mixer", "volume", "-5"]`.
+    /// Convenient for asserting on the exact backend command an MCP action
+    /// produced without matching on `Value` variants.
+    pub fn parts(&self) -> Vec<String> {
+        self.command
+            .iter()
+            .map(|v| match v {
+                Value::String(s) => s.clone(),
+                other => other.to_string(),
+            })
+            .collect()
+    }
+}
+
 /// Mock LMS server state
 struct MockLmsState {
     players: HashMap<String, MockPlayer>,
+    /// Every command received, in arrival order. Lets a test assert which
+    /// backend command an MCP action actually produced (issue #394) rather than
+    /// only observing the resulting state.
+    commands: Vec<RecordedCommand>,
 }
 
 /// Mock LMS Server
@@ -65,6 +92,7 @@ impl MockLmsServer {
     pub async fn start() -> Self {
         let state = Arc::new(RwLock::new(MockLmsState {
             players: HashMap::new(),
+            commands: Vec::new(),
         }));
 
         let app = Router::new()
@@ -124,6 +152,32 @@ impl MockLmsServer {
         }
     }
 
+    /// Drop the recorded command log. Call before the action under test so
+    /// polling traffic (`players`, `status`) does not have to be filtered out.
+    pub async fn clear_commands(&self) {
+        self.state.write().await.commands.clear();
+    }
+
+    /// Commands received for `player_id`, excluding the read-only polling
+    /// commands the adapter issues on its own schedule.
+    pub async fn write_commands(&self, player_id: &str) -> Vec<Vec<String>> {
+        const POLLING: &[&str] = &["players", "status", "serverstatus", "syncgroups"];
+        self.state
+            .read()
+            .await
+            .commands
+            .iter()
+            .filter(|c| c.player_id == player_id)
+            .filter(|c| {
+                c.command
+                    .first()
+                    .and_then(Value::as_str)
+                    .is_none_or(|first| !POLLING.contains(&first))
+            })
+            .map(RecordedCommand::parts)
+            .collect()
+    }
+
     /// Stop the mock server
     pub async fn stop(self) {
         self.handle.abort();
@@ -166,6 +220,13 @@ async fn handle_jsonrpc(
         .first()
         .and_then(|v| v.as_str())
         .ok_or(StatusCode::BAD_REQUEST)?;
+
+    // Record every command before dispatching, so tests can assert which
+    // backend command an MCP action produced (issue #394).
+    state.write().await.commands.push(RecordedCommand {
+        player_id: player_id.to_string(),
+        command: commands.clone(),
+    });
 
     // Handle commands that modify state
     match command {


### PR DESCRIPTION
Fixes #394

Parent epic: #392. OH: 80222d6d

**This PR changes no behavior.** It relieves the two constraints that make the rest of #392 unsafe: one 855-line module, and zero MCP test coverage.

**Do not merge** — awaiting operator approval per AGENTS.md and #392. No labels added, no force-push.

---

## CI ~~is not a meaningful gate here~~ — corrected

**Struck through.** I was briefed that feature-branch PRs here run zero CI workflows. That is true only when the PR's *base* is another feature branch. This PR targets `v3`, which matches `pull_request: branches: [master, v3]`, so it gets the full Lint / Test / Build set and **CI is a real gate**.

It immediately earned that: **CI's Lint job caught a `cargo fmt --check` failure that my local verification could not**, because I had been told `cargo clippy -- -D warnings` was the gate and ran exactly that. Fixed in `e877066` as a formatting-only commit. All 26 checks now pass.

The complete gate, for the record — `make css` runs first in both jobs:

| Job | Command |
|---|---|
| Lint | `cargo fmt --check` **and** `cargo clippy -- -D warnings` |
| Test | `cargo test --workspace` |
| Build WASM / Build Linux x64 / Smoke Test Binary / Synology Package Contract | — |

Everything below was also run locally, with output pasted rather than summarized.

## The commit order is the argument

| Commit | Content | `src/mcp/` |
|---|---|---|
| `169551a` | `tests/mcp_contract.rs` + fixtures | **unsplit**, 855 lines |
| `92f79ab` | every dispatch arm, both routing rules | **unsplit**, 855 lines |
| `7bb0470` | **the split** | 11 modules |
| `53d5ef6` | close two execute-gate dissent holes | 11 modules |
| `06821cb` | transport coverage, keyed fixture | 11 modules |
| `e877066` | `cargo fmt` (formatting only) | 11 modules |

The contract tests were written and passing against the original module, then the module was replaced underneath them. They still pass, and **neither fixture needed regenerating**:

```
$ git diff 92f79ab..7bb0470 -- tests/fixtures/
(no output)
```

`tools/list` and `initialize` are byte-identical across the split. That is the behavior-preservation proof, and it only exists because the tests came first.

## Decomposition

Vertical slices by tool family, so a tool's advertised contract (description, input schema) sits next to the behavior that has to match it — #396 changes both for `hifi_play`.

```
src/mcp/mod.rs              transport, session recovery, SDK wiring    248
src/mcp/server.rs           server_details() -> InitializeResult        60  [#397]
src/mcp/handler.rs          ServerHandler: advertise + dispatch         81  [#397]
src/mcp/types.rs            response shapes + result constructors      114  [#395]
src/mcp/routing.rs          zone prefix -> adapter, one place          268  [#398]
src/mcp/tools/mod.rs        tool_box! registry + list_tools()          108  [#399/#400]
src/mcp/tools/zones.rs      hifi_zones, hifi_now_playing                59
src/mcp/tools/transport.rs  hifi_control + volume                     139
src/mcp/tools/library.rs    hifi_search, hifi_play                    193  [#396/#399]
src/mcp/tools/status.rs     hifi_status                                44
src/mcp/tools/hqplayer.rs   the four HQPlayer tools                   139
```

Three decompositions were compared and one more rejected outright; see the solution-space gate report below. **One justification stated at that gate was later withdrawn** in the ship report: the merge-conflict argument for this layout did not survive inspection of the epic's actual waves. The layout stands on review surface, the routing centralization, and the `server_details()` / `list_tools()` seams.

### Routing was open-coded in four places with three different rules

Now `ZoneTarget` in `routing.rs`, called by every site:

```
$ grep -rn 'starts_with("lms:")\|starts_with("openhome:")\|starts_with("upnp:")\|starts_with("roon:")' src/mcp/
src/mcp/routing.rs:64:        if zone_id.starts_with("lms:") {
src/mcp/routing.rs:66:        } else if zone_id.starts_with("openhome:") {
src/mcp/routing.rs:68:        } else if zone_id.starts_with("upnp:") {
src/mcp/routing.rs:70:        } else if zone_id.starts_with("roon:") || !zone_id.contains(':') {
```

The rules are **not** interchangeable, and the difference is observable:

| zone id | transport | volume |
|---|---|---|
| `lms:x` | LMS | LMS |
| `roon:x` / bare `x` | Roon | Roon |
| `openhome:x` / `upnp:x` | own adapter | **refused** |
| `sonos:x` | **Roon** | **refused** |

A single `is_lms()`-style predicate cannot express that. `ZoneTarget::Unknown` is kept distinct from `Roon` even though every call site currently folds it into Roon — that distinction is the seam #398 needs, and collapsing it would erase the only place the silent default is visible.

**Today's defects are frozen, not fixed.** The Roon default for unprefixed ids and the silent Roon fallback for unrecognised prefixes both belong to #398. `routing.rs` says so at the point of the defect, and the tests say a green run means "unchanged", never "correct".

## What I ran locally

```
$ cargo test --test mcp_contract
test result: ok. 48 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ cargo test --lib
test result: ok. 95 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ cargo fmt --check                      # the gate I had missed
(exit 0)

$ cargo clippy -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 9.12s      (exit 0)

$ cargo clippy --test mcp_contract       # new test file
(no findings in tests/mcp_contract.rs)

$ make css && dx build --release --platform web --features web
#   rustup toolchain ahead of Homebrew's on PATH, RUSTC_WRAPPER unset
  1.91s  INFO Client build completed successfully! 🚀
137.73s  INFO Server build completed successfully! 🚀
```

Every other test target, run individually — all green:

```
adapter_integration    42      protocol_schema        41
zones_sha_integration  20      volume_safety          14
volume_step             9      architecture_lint       8
await_in_lock_lint      4      ignored_send_lint       4
arbitrary_find_lint     3      release_hardening       3
aggregator_lint         2      api_contract            2
arch_packaging          6      oneshot_leak_lint       1
spawn_cancellation_lint 1      unbounded_channel_lint  1
client_harness         41  (+1 pre-existing failure, see below)
protocol_integration   32  (+1 pre-existing failure, see below)
```

## The snapshot bites (AC requirement)

Changed `hifi_zones`'s description in `src/mcp/tools/zones.rs` to `"... UPnP, Sonos)"`:

```
$ cargo test --test mcp_contract tools_list_matches_fixture
test tools_list_matches_fixture ... FAILED

MCP contract drift in tests/fixtures/mcp_tools.json

line 175:
  fixture:     "description": "List all available playback zones (Roon, LMS, OpenHome, UPnP)",
  actual:      "description": "List all available playback zones (Roon, LMS, OpenHome, UPnP, Sonos)",

The MCP surface changed. If that was intentional AND approved, regenerate with:
  UPDATE_MCP_FIXTURES=1 cargo test --test mcp_contract
Otherwise this is the bug: epic #392 is additive-only.
```

Reverted; 48/48 green. Demonstrated both before and after the split.

Two further guardrails were also demonstrated biting, because the dissent showed both had holes:

```
$ # declared protocol version lowered to V2025_06_18
$ cargo test --test mcp_contract declared_protocol_version
assertion `left == right` failed: the declared protocol version changed. The wire
snapshot cannot catch a raised version, so this assertion is the one that matters
  left: "2025-06-18"   right: "2025-11-25"

$ # McpSearchResult::subtitle renamed to caption
$ cargo test --test mcp_contract no_tool_returns_an_unclassified_field
MCP tools return field(s) ["caption"] that are neither consumed by a tool input
nor classified as display-only.
```

Both reverted.

## What the harness pins

`tests/mcp_contract.rs`, 48 tests, two layers:

**Wire level**, through the real Axum `/mcp` route via `tower::oneshot` — so `create_mcp_extension`, the SSE-framed streamable-HTTP transport, session handling and the `ServerHandler` impl are all exercised. This needed **no new seams**, which is why it could be written against the unsplit code.

- `tools/list`: all 10 tools, descriptions, input schemas, annotation hints
- `initialize`: server info, capabilities, instructions, protocol version
- the settings-based HQPlayer filter: with the adapter off, exactly the six non-HQPlayer tools in order
- protocol negotiation for `2024-11-05` / `2025-03-26` / `2025-06-18`
- stale-session auto-recovery, plus GET and DELETE

**Behavior**, because a `tools/list` snapshot guards declarative macro output while the risk lives in the 330-line dispatch match:

- every one of the 10 arms reached, output pinned, error strings included — a model reads `"Radio mode not supported for LMS. Use 'play' or 'queue'."` and retries, so that text is contract
- the full HQPlayer alias table case by case: `mode`, `filter1x`, `filter_1x`, `filterNx`, `filter_nx`, `filternx`, `shaper`, `dither`, `rate`, `samplerate`
- the action map pinned **at the backend** via a new command log on `MockLmsServer`: `playpause` must arrive as LMS `pause`, `previous`/`prev` as `playlist index -1`, `volume_up`/`volume_down` as `+N`/`-N` with a defaulted delta of 5
- `hifi_status` asserted to keep BTreeMap key order, so nobody "tidies" the `json!` literal into a struct and silently reorders the text clients receive
- both routing rules and the fact that they differ
- no orphaned fields (AGENTS.md), inventory derived from the production types

## Deliberate calls I made

- **Harness drives both HTTP and in-process.** #394 left this open. HTTP for the wire snapshots because it covers every layer the split touches and needed no new seams; in-process for schema validity, the filter, orphan fields and routing.
- **Fixture keyed by tool name, not a positional array.** #392 is additive-only, and an array conflates "a tool was added" (permitted) with "an existing tool changed" (forbidden). Keyed, adding a tool adds one key and leaves every existing key byte-identical. #399 and #400 land in parallel and each appends a tool, so the array format would have forced the second to merge into a regeneration. Content equivalence with the array version was verified, not assumed.
- **Order pinned separately** from content, so a reordering and a description change fail different assertions.
- **No JSON Schema validation crate added.** Structural checks plus an explicit `EXPECTED_TOOL_PARAMS` table are dependency-free and make a parameter change a visible edit.
- **`serverInfo.version` redacted in the fixture** and asserted separately, because release builds inject it from the git tag — otherwise the test passes locally and fails every release build.
- **`hifi_status` kept as a `json!` literal.** `serde_json` without `preserve_order` emits BTreeMap order; a struct emits declaration order. Converting it would reorder keys clients see.
- **`SEARCH_LIMIT` split back into two constants.** These were two independent literals before this PR; collapsing them coupled two backends that page and rank differently. A refactor mandated to change no behavior shouldn't introduce couplings either.
- **Resource-method refusal pinned** (raised by the #397 design gate mid-task, verified empirically rather than accepted): `resources/list`, `resources/read` and `resources/templates/list` return `-32603 "does not support resources"` today, because the SDK gates dispatch on the declared capability. Pinned so #397 lands as a visible refusal-to-success diff. #394 does **not** declare the capability, and a test asserts that as a precondition.
- **Two test-fixture bugs fixed.** `MockLmsServer` gained a command log — without it, which backend command an MCP action produced was unobservable. `MockHqpServer` rejected any line starting with `<?xml`, but `HqpAdapter::build_command` sends the declaration and command on **one** line, so the HQPlayer adapter was unreachable from its own mock; it now strips the declaration instead of discarding the line, which is strictly more permissive.

## Deliberately left undone

- **`cargo clippy --all-targets` is not clean and cannot be.** `src/lib.rs` denies `clippy::unwrap_used`, `expect_used` and `panic` crate-wide; the `#[cfg(test)]` modules inside `src/` violate that 76 times — `src/config/mod.rs` (25), `src/adapters/lms_discovery.rs` (17), `src/adapters/lms.rs` (15), others. All pre-existing, count identical before and after this branch. `src/mcp/**` contributes **zero** findings. This AC needs rewording or a separate lint-debt issue.
- **Two `/hqp/discover` tests fail in my sandbox but pass in CI — a local-environment artifact, not repo breakage.** Both do live UDP SSDP broadcast, which my sandbox blocks. CI runs them green:
  ```
  $ gh run view 30674744344 --job 91299539795 --log | grep hqp_discover
  test shared_endpoints::get_hqp_discover ... ok
  test api_endpoints::hqp_discover_returns_json ... ok
  ```
  **Correcting my own earlier characterization:** I called these "pre-existing failures". My evidence (they fail at base commit `c47d36a`, and with this branch's changes stashed) proved only that *my branch does not cause them*, which was the question I needed answered — then I overstated it into "the repo has two failing tests", which CI disproves. Neither path touches `src/mcp`. Original local evidence, for completeness:
  ```
  $ # at c47d36a
  $ cargo test --test protocol_integration api_endpoints::hqp_discover_returns_json
  test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 32 filtered out
  ```
  Neither path touches `src/mcp`.
- **OpenHome and UPnP have no protocol round-trip.** Neither adapter has a `configure()`; they are SSDP-discovery only. Covered: mocks confirmed live, each prefix confirmed to reach its own adapter via that adapter's distinctive refusal. Adding a discovery seam is a behavior change.
- **Roon's success path is untested, and this is a gap in the central claim.** `MockRoonCore` is an in-memory state holder, not a server, so the Roon adapter cannot be driven by it — every Roon assertion here is an error-path assertion. Concretely: `hifi_search`'s Roon branch maps `item.title` to `title` and `item.subtitle` to `subtitle`, and if the split had swapped those two, **nothing in 48 tests would notice**. That mapping was preserved by inspection. A Roon mock server is its own project.
- **`GET /mcp` with an unknown session returns 500 where DELETE returns 404.** Found while writing the transport tests. Arguably wrong — a stale SSE reconnect is a client condition, not a server fault — but it is today's behavior, so it is recorded rather than corrected.
- **The `MockHqpServer` follow-up.** `adapter_integration.rs::hqp_mock_responds_to_getinfo` still hand-rolls the two-line workaround and still carries a comment blaming "a complex TCP protocol" for what was a mock bug. Test-only cleanup, filed separately.

## Rollback

Self-contained: nothing outside `src/mcp/`, `tests/mcp_contract.rs`, two mock servers and two new fixtures is touched.

- **Whole branch:** revert `e877066`, `06821cb`, `53d5ef6`, `7bb0470`, `92f79ab`, `169551a` — or simply don't merge. No migration, no config, no persisted state, no HTTP surface.
- **Split only, keeping the tests:** revert `7bb0470` alone. The tests were written against the unsplit module and pass against it, so that is a supported state rather than a broken one.
- **Runtime:** the MCP endpoint is one Axum route; disabling it is a `src/main.rs` route removal.
- **`tests/fixtures/api_routes.txt` untouched**, so no `api-change-approved` label is needed.

## Residual risk

1. **`UPDATE_MCP_FIXTURES=1` erases the guardrail in one command.** Weaker than I first thought, now that CI is known to run `cargo test --workspace` on PRs targeting `v3` — a red snapshot does block. But CI cannot tell a legitimate regeneration from a lazy one, so the failure message still has to argue its own case to whoever reads it.
2. **Green means "unchanged", never "correct".** The two things this pins hardest are defects: the Roon default, and search results with no addressable identity. Both are labelled at the point of the defect.
3. **Roon's untested success path** — above.
4. **Derive-macro output is not language-guaranteed stable** across compiler or SDK versions. A spurious fixture diff after a toolchain bump would look like a contract break.

## Gate reports

Solution / execute / ship, each with a review and a dissent, in the comments. The dissents blocked three times and each block produced a real fix:

- **solution-space dissent** — snapshots guard the low-risk half; the 330-line dispatch and its three lookup tables were nearly uncovered → `92f79ab`
- **execute dissent** — a *raised* protocol version was invisible to the snapshot; the orphan-field inventory was hand-listed exactly where #396 will edit → `53d5ef6`
- **ship dissent** — three of four public functions in `mod.rs` untested including `auto_recover_session`'s 55 lines; the array fixture conflates additive with modifying changes → `06821cb`

