### PR TITLE
fix(lms): library-search fallback has never worked, plus three misleading defects (#407)

### DIFF
--- a/docs/lyrion.md
+++ b/docs/lyrion.md
@@ -79,8 +79,63 @@ Request specific fields with the `tags` parameter:
 
 ```javascript
 ['status', '-', 1, 'tags:aAdltKc']
-// a=artist, A=album, d=duration, l=album_id, t=tracknum, K=artwork_url, c=coverid
 ```
+
+This adapter's string requests: `a` artist, `A` per-role contributors, `d` duration,
+`l` album title, `t` tracknum, `K` artwork_url, `c` coverid.
+
+**An earlier version of this section was wrong**: it described `l` as the album id and
+`A` as the album. Both are false — `l` is the album title and `e` is the album id —
+and anyone extending the string from that legend would request the wrong fields. The
+table below is read from LMS's own `%tagMap` in
+`Slim/Control/Queries.pm` at 9.1.2 and confirmed against a live server; the recorded
+response is `tests/fixtures/lms/status_tags_aAdltKc.json`.
+
+| Tag | Key in the response | Value |
+|-----|--------------------|-------|
+| `a` | `artist` | Track artist name |
+| `A` | `albumartist`, `trackartist`, `composer`, … | Per-**role** contributor names — one key per role present, not a single field |
+| `s` | `artist_id` | Artist (contributor) id |
+| `l` | `album` | Album **title** |
+| `e` | `album_id` | Album id |
+| `g` | `genre` | Genre name |
+| `p` | `genre_id` | Genre id |
+| `d` | `duration` | Seconds |
+| `t` | `tracknum` | Track number |
+| `y` | `year` | Year |
+| `u` | `url` | Track URL |
+| `c` | `coverid` | Cover id, for `/music/<coverid>/cover.jpg` |
+| `K` | `artwork_url` | Artwork URL, relative for streaming content (see above) |
+| `J` | `artwork_track_id` | The album's artwork track id |
+
+Two things to know before extending the string:
+
+- **`A` returns several keys, not one.** Which keys depends on the roles present on
+  the track, so treat it as a set.
+- **`artwork_track_id` requires `J`, which this adapter does not request.** The
+  artwork fallback chain in `get_player_status` reads `coverid` → `artwork_track_id`
+  → `id`, so its middle arm is currently unreachable and artwork falls through to
+  the track's own `id`. Adding `J` costs nothing on the wire but changes
+  `image_key` for tracks with no `coverid`, and `image_key` is client-visible — so
+  it is deliberately left alone rather than changed as a side effect. See #407.
+
+### `mixer volume` is negative while muted
+
+`status` has **no mute key**. Mute lives in the per-player `mute` pref, and LMS
+*negates* the volume pref while muted, so `status` reports e.g. `"mixer volume": -42`.
+The negation lags the mute by roughly 0.8 s, because `mixer muting` schedules a fade
+and only writes the negated value when it finishes.
+
+The adapter therefore reports `player.volume` as the magnitude, and takes mute from
+two signals OR-ed together:
+
+1. `players 0 100 playerprefs:mute` — the pref, correct immediately. Rides on the
+   `players` call the poll already makes, so mute costs **no extra round-trip**;
+   `mixer muting ?` would cost one per player per poll.
+2. A negative `mixer volume` from `status` — needs no tagged parameter, but lags,
+   so it can only ever produce a false negative.
+
+`mixer muting <0|1>` sets mute, and `mixer volume <n>` clears it as a side effect.
 
 ## Authentication
 

--- a/src/adapters/lms.rs
+++ b/src/adapters/lms.rs
@@ -67,11 +67,109 @@ use crate::config::{get_config_file_path, read_config_file};
 const LMS_CONFIG_FILE: &str = "lms-config.json";
 /// Request ID for LMS JSON-RPC calls (aids debugging in LMS logs)
 const LMS_REQUEST_ID: i32 = 217;
+/// Name of the per-player LMS pref holding mute state.
+///
+/// `mixer muting ?` and `players … playerprefs:mute` read the same pref -
+/// `mixerQuery` returns `$prefs->client($client)->get("mute")` and
+/// `_addPlayersLoop` emits each requested pref by name - so the batched route
+/// cannot disagree with the per-player one. Verified against Lyrion 9.1.2.
+const LMS_MUTE_PREF: &str = "mute";
 
 /// Strip "lms:" prefix from player IDs.
 /// MCP and aggregator use prefixed IDs (e.g., "lms:00:11:22:33:44:55"), but LMS API expects bare IDs.
 fn strip_lms_prefix(id: &str) -> &str {
     id.strip_prefix("lms:").unwrap_or(id)
+}
+
+/// Read an integer that LMS may emit as either a JSON number or a JSON string.
+///
+/// LMS is not consistent about this, even within one response and even for the
+/// same field across sibling queries. Observed on a single live 9.1.2 server:
+/// `track_id` as a number, `mute` as `"0"`, `mixer volume ?` as `"42"`,
+/// `mixer muting ?` as `1`, `playlist_cur_index` as `"0"`.
+///
+/// `Value::as_i64()` alone silently yields `None` on the string form, which is
+/// how a parse bug becomes an empty result instead of an error (see #407).
+fn lms_i64(value: Option<&Value>) -> Option<i64> {
+    let value = value?;
+    value
+        .as_i64()
+        .or_else(|| value.as_f64().map(|f| f as i64))
+        .or_else(|| value.as_str().and_then(|s| s.trim().parse::<i64>().ok()))
+}
+
+/// Read an LMS 0/1 flag as a bool, tolerating number, string, `null` and absent.
+///
+/// LMS omits a player pref entirely when it was never written and returns
+/// `null` for it from the dedicated query, so "not present" and "not set" both
+/// mean false. Anything non-zero means true.
+fn lms_flag(value: Option<&Value>) -> bool {
+    match value {
+        None | Some(Value::Null) => false,
+        Some(v) => lms_i64(Some(v)).map(|n| n != 0).unwrap_or(false),
+    }
+}
+
+/// Read the entity id from a row of one of LMS's `<type>s_loop` arrays.
+///
+/// LMS keys these `<type>_id` — `album_id` in `albums_loop`, `contributor_id` in
+/// `contributors_loop`, `track_id` in `tracks_loop`. `Slim::Control::Queries`
+/// derives the loop name and the key from the same variable on adjacent lines
+/// (`"${type}s_loop"` / `"${type}_id"`), so a response that contains the loop
+/// necessarily uses that key.
+///
+/// The plain `id` fallback is deliberate belt-and-braces for any LMS version
+/// that might differ; this repo declares no minimum LMS version, so the fix must
+/// not depend on one. Reading only `id` is the #407 defect that made
+/// `search_library()` return an empty vec against every real server.
+fn loop_entity_id(row: &Value, entity: &str) -> Option<i64> {
+    lms_i64(row.get(format!("{}_id", entity)).or_else(|| row.get("id")))
+        .filter(|id| *id > 0)
+}
+
+/// What LMS actually does when a request fails, spelled out once.
+///
+/// `Slim::Web::JSONRPC::requestMethod` calls `closeHTTPSocket()` on any
+/// `$request->isStatusError()`. There is no branch that emits a JSON-RPC `error`
+/// object, so the client sees zero bytes and a closed socket - with no HTTP
+/// status line at all - for every one of: unknown command (104), bad parameters
+/// (102), unknown player id (103), bad server config (105), and Perl exceptions.
+/// Verified against live Lyrion 9.1.2; byte counts in
+/// `tests/fixtures/lms/PROVENANCE.md`.
+///
+/// Because the transport cannot tell these apart, a failure here must not be
+/// read as "this LMS does not support that command". Use `can <verb> ?` for
+/// capability questions, treating `_can: 1` as proof of presence and never
+/// `_can: 0` as proof of absence.
+const LMS_FAILURE_NOTE: &str = "LMS signals every request error this way - \
+unknown command, bad parameters, unknown player id, or bad server config are \
+indistinguishable at the transport, and it never returns a JSON-RPC error \
+object. A network fault looks the same, so do not read this as 'unsupported'.";
+
+/// Render a `slim.request` command array for an error message or log line.
+fn describe_command(player_id: Option<&str>, params: &[Value]) -> String {
+    let words: Vec<String> = params
+        .iter()
+        .map(|p| match p {
+            Value::String(s) => s.clone(),
+            other => other.to_string(),
+        })
+        .collect();
+    format!(
+        "{} {}",
+        player_id.unwrap_or("<server>"),
+        truncate_for_log(&words.join(" "))
+    )
+}
+
+/// Keep diagnostics readable when LMS or a stray responder returns something huge.
+fn truncate_for_log(text: &str) -> String {
+    const MAX: usize = 200;
+    if text.chars().count() <= MAX {
+        return text.to_string();
+    }
+    let head: String = text.chars().take(MAX).collect();
+    format!("{}…", head)
 }
 
 /// Saved config for persistence
@@ -293,13 +391,60 @@ impl LmsRpc {
             }
         }
 
-        let response = request.send().await?;
+        // LMS's failure signal is the *absence* of a response, so every branch
+        // below has to describe the command that provoked it or the log is
+        // useless. See describe_command / LMS_FAILURE_NOTE.
+        let command = describe_command(player_id, &params);
+
+        let response = request.send().await.map_err(|e| {
+            anyhow!(
+                "LMS closed the connection with no response for `{}`. {} \
+                 (transport: {})",
+                command,
+                LMS_FAILURE_NOTE,
+                e
+            )
+        })?;
 
         if !response.status().is_success() {
-            return Err(anyhow!("LMS request failed: {}", response.status()));
+            return Err(anyhow!(
+                "LMS request failed for `{}`: HTTP {}",
+                command,
+                response.status()
+            ));
         }
 
-        let data: Value = response.json().await?;
+        // Read bytes rather than deserialising directly: a reverse proxy can turn
+        // LMS's closed socket into a valid empty 200, and `response.json()` would
+        // report that as "EOF while parsing a value", which names neither the
+        // cause nor the command.
+        let body = response.bytes().await.map_err(|e| {
+            anyhow!(
+                "LMS closed the connection mid-response for `{}`. {} \
+                 (transport: {})",
+                command,
+                LMS_FAILURE_NOTE,
+                e
+            )
+        })?;
+
+        if body.is_empty() {
+            return Err(anyhow!(
+                "LMS returned an empty body for `{}`. {}",
+                command,
+                LMS_FAILURE_NOTE
+            ));
+        }
+
+        let data: Value = serde_json::from_slice(&body).map_err(|e| {
+            anyhow!(
+                "LMS returned a body that is not JSON for `{}`: {} (first 200 \
+                 bytes: {:?})",
+                command,
+                e,
+                String::from_utf8_lossy(&body[..body.len().min(200)])
+            )
+        })?;
 
         debug!(
             player_id = player_id.unwrap_or("<server>"),
@@ -307,13 +452,19 @@ impl LmsRpc {
             "LMS response"
         );
 
-        if let Some(error) = data.get("error") {
-            if !error.is_null() {
-                return Err(anyhow!("LMS error: {}", error));
-            }
-        }
-
-        Ok(data.get("result").cloned().unwrap_or(Value::Null))
+        // Replaces a check for a JSON-RPC `error` member, which was dead code:
+        // LMS never emits one (Slim::Web::JSONRPC::requestMethod closes the
+        // socket instead). A successful slim.request always carries `result`, so
+        // its absence means something that is not a healthy LMS answered - which
+        // also catches the hypothetical `error`-emitting responder the old check
+        // was aiming at, instead of silently handing callers Value::Null.
+        data.get("result").cloned().ok_or_else(|| {
+            anyhow!(
+                "LMS reply for `{}` has no `result` member: {}",
+                command,
+                truncate_for_log(&data.to_string())
+            )
+        })
     }
 
     async fn get_player_status(&self, player_id: &str) -> Result<LmsPlayer> {
@@ -354,6 +505,12 @@ impl LmsRpc {
             }
         }
 
+        // NOTE (#407): the artwork_track_id arm never fires, because
+        // artwork_track_id is tag `J` and the tags string above does not request
+        // it - so artwork falls through to the track's own `id`. Adding `J` is
+        // free on the wire but would change image_key values for tracks with no
+        // coverid, and image_key is client-visible, so it is left alone here and
+        // flagged for #401/#403 rather than changed inside a defect fix.
         let artwork_id = playlist_loop
             .get("coverid")
             .or_else(|| playlist_loop.get("artwork_track_id"))
@@ -365,16 +522,30 @@ impl LmsRpc {
                     .or_else(|| v.as_i64().map(|n| n.to_string()))
             });
 
+        // LMS negates the volume pref while a player is muted, so `mixer volume`
+        // arrives as e.g. -42 - and it used to be handed straight to a
+        // VolumeControl declared min: 0.0, i.e. clients were shown a negative
+        // percentage. Report the magnitude, and treat the sign as a second mute
+        // signal.
+        //
+        // The sign LAGS the mute by roughly 0.8s (mixer muting schedules a fade
+        // and only writes the negated value when it completes), so it can produce
+        // a false negative but never a false positive. That is what makes it safe
+        // to OR with the `mute` pref from `players`, which flips immediately.
+        // Timing measurements: tests/fixtures/lms/PROVENANCE.md.
+        let raw_volume = result
+            .get("mixer volume")
+            .and_then(|v| v.as_f64())
+            .or_else(|| lms_i64(result.get("mixer volume")).map(|n| n as f64))
+            .unwrap_or(0.0);
+
         Ok(LmsPlayer {
             playerid: player_id.to_string(),
             state: state.to_string(),
             mode: mode.to_string(),
-            power: result.get("power").and_then(|v| v.as_i64()).unwrap_or(0) == 1,
-            volume: result
-                .get("mixer volume")
-                .and_then(|v| v.as_f64())
-                .unwrap_or(0.0)
-                .round() as i32,
+            power: lms_flag(result.get("power")),
+            volume: raw_volume.abs().round() as i32,
+            muted: raw_volume < 0.0,
             playlist_tracks: result
                 .get("playlist_tracks")
                 .and_then(|v| v.as_u64())
@@ -411,8 +582,24 @@ impl LmsRpc {
     }
 
     async fn get_players(&self) -> Result<Vec<LmsPlayer>> {
+        // `playerprefs:` asks playersQuery to include named per-player prefs in
+        // each players_loop entry, so mute state arrives inside the one `players`
+        // call this poll already makes: zero extra round-trips, whatever the poll
+        // rate or player count. The alternative - `mixer muting ?` per player per
+        // poll - would nearly double request volume at the 2s default interval.
+        //
+        // `status` cannot supply this: it carries no mute key at all. Verified
+        // against live Lyrion 9.1.2 (tests/fixtures/lms/PROVENANCE.md).
         let result = self
-            .execute(None, vec![json!("players"), json!(0), json!(100)])
+            .execute(
+                None,
+                vec![
+                    json!("players"),
+                    json!(0),
+                    json!(100),
+                    json!(format!("playerprefs:{}", LMS_MUTE_PREF)),
+                ],
+            )
             .await?;
 
         let players_loop = result
@@ -439,9 +626,16 @@ impl LmsRpc {
                     .and_then(|v| v.as_str())
                     .unwrap_or("Unknown")
                     .to_string(),
-                connected: p.get("connected").and_then(|v| v.as_i64()).unwrap_or(0) == 1,
-                power: p.get("power").and_then(|v| v.as_i64()).unwrap_or(0) == 1,
+                connected: lms_flag(p.get("connected")),
+                power: lms_flag(p.get("power")),
                 ip: p.get("ip").and_then(|v| v.as_str()).map(|s| s.to_string()),
+                // Absent means the pref was never written, i.e. not muted. Note
+                // that absence is ALSO what an LMS too old for `playerprefs:`
+                // would produce - it ignores unknown tagged params silently
+                // rather than erroring - so a `false` here is not proof of
+                // unmuted. The negative-volume signal in get_player_status()
+                // covers that case, needing no tagged parameter.
+                muted: lms_flag(p.get(LMS_MUTE_PREF)),
                 ..Default::default()
             })
             .collect())
@@ -471,6 +665,13 @@ pub struct LmsPlayer {
     pub artwork_track_id: Option<String>,
     pub coverid: Option<String>,
     pub artwork_url: Option<String>,
+    /// Whether the player is muted.
+    ///
+    /// From the per-player `mute` pref, requested via `playerprefs:mute` on the
+    /// `players` query so it costs no extra round-trip, OR-ed with a negative
+    /// `mixer volume` in `status` (LMS negates the volume while muted). `status`
+    /// itself carries no mute key.
+    pub muted: bool,
 }
 
 impl Default for LmsPlayer {
@@ -495,6 +696,7 @@ impl Default for LmsPlayer {
             artwork_track_id: None,
             coverid: None,
             artwork_url: None,
+            muted: false,
         }
     }
 }
@@ -1251,7 +1453,15 @@ impl LmsAdapter {
         })
     }
 
-    /// Fallback library-only search for older LMS versions without globalsearch
+    /// Fallback library-only search, used when globalsearch is unavailable or no
+    /// player is connected.
+    ///
+    /// LMS keys each result loop's entity id `<type>_id`, never `id`:
+    /// `albums_loop[].album_id`, `contributors_loop[].contributor_id`,
+    /// `tracks_loop[].track_id`. Reading `id` made every guard in this function
+    /// fail, so it returned an empty vec against every real server (#407).
+    /// Loops with no matches are omitted from the response entirely rather than
+    /// returned empty, so absent is normal, not an error.
     async fn search_library(&self, query: &str, limit: usize) -> Result<Vec<LmsSearchResult>> {
         let result = self
             .rpc
@@ -1268,11 +1478,11 @@ impl LmsAdapter {
 
         let mut results = Vec::new();
 
-        // Parse albums
+        // Parse albums — albums_loop[].album_id / .album
         if let Some(albums) = result.get("albums_loop").and_then(|v| v.as_array()) {
             for album in albums.iter().take(limit) {
                 if let (Some(id), Some(title)) = (
-                    album.get("id").and_then(|v| v.as_i64()),
+                    loop_entity_id(album, "album"),
                     album.get("album").and_then(|v| v.as_str()),
                 ) {
                     results.push(LmsSearchResult {
@@ -1291,11 +1501,14 @@ impl LmsAdapter {
             }
         }
 
-        // Parse artists
+        // Parse artists — contributors_loop[].contributor_id / .contributor
+        // (LMS's own type name here is "contributor", not "artist"; the published
+        // CLI reference still documents this key as artist_id, which live 9.1.2
+        // contradicts.)
         if let Some(artists) = result.get("contributors_loop").and_then(|v| v.as_array()) {
             for artist in artists.iter().take(limit.saturating_sub(results.len())) {
                 if let (Some(id), Some(name)) = (
-                    artist.get("id").and_then(|v| v.as_i64()),
+                    loop_entity_id(artist, "contributor"),
                     artist.get("contributor").and_then(|v| v.as_str()),
                 ) {
                     results.push(LmsSearchResult {
@@ -1311,11 +1524,11 @@ impl LmsAdapter {
             }
         }
 
-        // Parse tracks
+        // Parse tracks — tracks_loop[].track_id / .track
         if let Some(tracks) = result.get("tracks_loop").and_then(|v| v.as_array()) {
             for track in tracks.iter().take(limit.saturating_sub(results.len())) {
                 if let (Some(id), Some(title)) = (
-                    track.get("id").and_then(|v| v.as_i64()),
+                    loop_entity_id(track, "track"),
                     track.get("track").and_then(|v| v.as_str()),
                 ) {
                     results.push(LmsSearchResult {
@@ -1480,7 +1693,10 @@ fn lms_player_to_zone(player: &LmsPlayer) -> Zone {
             // LMS hardcodes $increment = 2.5 in Slim/Player/Client.pm:755
             // This is not queryable via CLI/JSON-RPC, so we use the constant.
             step: 2.5,
-            is_muted: false, // LMS doesn't expose mute via JSON-RPC status
+            // `status` carries no mute key, but the per-player `mute` pref does -
+            // requested via `playerprefs:mute` on the `players` query the poll
+            // already makes, so this costs no extra round-trip. See LmsPlayer.muted.
+            is_muted: player.muted,
             scale: crate::bus::VolumeScale::Percentage,
             // Use prefixed zone_id as output_id for consistent aggregator matching
             output_id: Some(zone_id),
@@ -1529,8 +1745,8 @@ async fn update_players_internal(
     let mut now_playing_updates: Vec<NowPlayingUpdate> = Vec::new();
     // State updates: (player_id, player_name, state)
     let mut state_updates: Vec<(String, String, String)> = Vec::new();
-    // VolumeChanged: (player_id, volume)
-    let mut volume_updates: Vec<(String, i32)> = Vec::new();
+    // VolumeChanged: (player_id, volume, is_muted)
+    let mut volume_updates: Vec<(String, i32, bool)> = Vec::new();
 
     // Helper to convert empty strings to None (metadata cleared)
     let to_option = |s: &str| {
@@ -1548,6 +1764,12 @@ async fn update_players_internal(
                 player.mode = status.mode;
                 player.power = status.power;
                 player.volume = status.volume;
+                // `player.muted` came from the `mute` pref on the `players` call;
+                // `status.muted` is the negated-volume signal. OR them: the pref
+                // flips immediately but needs `playerprefs:` support, the sign
+                // needs nothing but lags a mute by ~0.8s. Either alone can miss;
+                // neither produces a false positive.
+                player.muted = player.muted || status.muted;
                 player.playlist_tracks = status.playlist_tracks;
                 player.playlist_cur_index = status.playlist_cur_index;
                 player.time = status.time;
@@ -1575,7 +1797,12 @@ async fn update_players_internal(
                     || old_player.artwork_url != player.artwork_url
                     || old_player.coverid != player.coverid;
                 let state_changed = old_player.state != player.state;
-                let volume_changed = old_player.volume != player.volume;
+                // Mute counts as a volume change. Zones are served from the
+                // aggregator's event-fed cache, so a mute toggled from another
+                // controller (iPeng, Squeezer, the LMS web UI) would otherwise
+                // never reach /zones unless the volume happened to change too.
+                let volume_changed = old_player.volume != player.volume
+                    || old_player.muted != player.muted;
                 (np_changed, state_changed, volume_changed)
             } else {
                 // New player - will be handled by ZoneDiscovered
@@ -1603,7 +1830,7 @@ async fn update_players_internal(
         }
 
         if volume_changed {
-            volume_updates.push((player.playerid.clone(), player.volume));
+            volume_updates.push((player.playerid.clone(), player.volume, player.muted));
         }
 
         let mut s = state.write().await;
@@ -1637,16 +1864,19 @@ async fn update_players_internal(
         });
     }
 
-    // Emit VolumeChanged events for volume changes
-    for (player_id, volume) in volume_updates {
+    // Emit VolumeChanged events for volume or mute changes
+    for (player_id, volume, is_muted) in volume_updates {
         debug!(
-            "Polling detected volume change for {}: {}",
-            player_id, volume
+            "Polling detected volume change for {}: {} (muted: {})",
+            player_id, volume, is_muted
         );
         bus.publish(BusEvent::VolumeChanged {
             output_id: PrefixedZoneId::lms(&player_id).to_string(),
             value: volume as f32,
-            is_muted: false, // LMS doesn't expose mute via JSON-RPC
+            // Previously hard-coded false, which meant every polled volume change
+            // clobbered the correct mute state the CLI subscription had already
+            // published for the same player.
+            is_muted,
         });
     }
 
@@ -1937,28 +2167,44 @@ async fn handle_cli_event(
                     player_id, value, is_relative, absolute_volume
                 );
 
-                // Update cached state (rounded to i32 for LMS internal format)
-                {
+                // Update cached state (rounded to i32 for LMS internal format).
+                //
+                // Setting the volume clears mute server-side: mixerCommand does
+                // `$prefs->client($client)->set('mute', 0)` when the entity is
+                // 'volume' and the player is muted (Slim/Control/Commands.pm).
+                // So `false` here is LMS's behaviour, not an assumption - but it
+                // is now derived from the cache rather than hard-coded, so the
+                // model stays consistent with what the next poll will read.
+                let is_muted = {
                     let mut s = state.write().await;
                     if let Some(player) = s.players.get_mut(&player_id) {
                         player.volume = absolute_volume.round() as i32;
+                        player.muted = false;
                     }
-                }
+                    false
+                };
 
                 // Publish volume changed event with prefixed output_id
                 bus.publish(BusEvent::VolumeChanged {
                     output_id: PrefixedZoneId::lms(&player_id).to_string(),
                     value: absolute_volume,
-                    is_muted: false,
+                    is_muted,
                 });
             } else if param == "muting" {
                 let is_muted = value != 0.0;
                 debug!("Mute change for {}: {}", player_id, is_muted);
 
-                // Get current volume from cache for the event
+                // Get current volume from cache for the event, and record the mute
+                // so a ZoneDiscovered built before the next poll is already right.
                 let current_volume = {
-                    let s = state.read().await;
-                    s.players.get(&player_id).map(|p| p.volume).unwrap_or(0)
+                    let mut s = state.write().await;
+                    match s.players.get_mut(&player_id) {
+                        Some(player) => {
+                            player.muted = is_muted;
+                            player.volume
+                        }
+                        None => 0,
+                    }
                 };
 
                 // Publish volume changed event with mute state and prefixed output_id

--- a/src/adapters/lms.rs
+++ b/src/adapters/lms.rs
@@ -146,6 +146,38 @@ unknown command, bad parameters, unknown player id, or bad server config are \
 indistinguishable at the transport, and it never returns a JSON-RPC error \
 object. A network fault looks the same, so do not read this as 'unsupported'.";
 
+/// Turn a `reqwest` transport failure into a message that says which of LMS's
+/// failure modes it actually is.
+///
+/// Worth distinguishing, because they call for different responses: an
+/// unreachable server is a configuration or network problem, whereas a socket
+/// closed *after* the request was accepted is LMS rejecting the request, and the
+/// operator needs to know that "rejected" carries no detail about why.
+fn describe_send_failure(command: &str, error: &reqwest::Error) -> anyhow::Error {
+    if error.is_connect() {
+        return anyhow!(
+            "cannot reach LMS to run `{}`: {}. Check the configured host and port.",
+            command,
+            error
+        );
+    }
+    if error.is_timeout() {
+        return anyhow!(
+            "LMS did not answer `{}` before the request timed out: {}. LMS can \
+             also hang rather than close on some bad-parameter requests, which \
+             looks identical to a slow server.",
+            command,
+            error
+        );
+    }
+    anyhow!(
+        "LMS closed the connection without answering `{}`. {} (transport: {})",
+        command,
+        LMS_FAILURE_NOTE,
+        error
+    )
+}
+
 /// Render a `slim.request` command array for an error message or log line.
 fn describe_command(player_id: Option<&str>, params: &[Value]) -> String {
     let words: Vec<String> = params
@@ -396,15 +428,10 @@ impl LmsRpc {
         // useless. See describe_command / LMS_FAILURE_NOTE.
         let command = describe_command(player_id, &params);
 
-        let response = request.send().await.map_err(|e| {
-            anyhow!(
-                "LMS closed the connection with no response for `{}`. {} \
-                 (transport: {})",
-                command,
-                LMS_FAILURE_NOTE,
-                e
-            )
-        })?;
+        let response = request
+            .send()
+            .await
+            .map_err(|e| describe_send_failure(&command, &e))?;
 
         if !response.status().is_success() {
             return Err(anyhow!(
@@ -418,15 +445,10 @@ impl LmsRpc {
         // LMS's closed socket into a valid empty 200, and `response.json()` would
         // report that as "EOF while parsing a value", which names neither the
         // cause nor the command.
-        let body = response.bytes().await.map_err(|e| {
-            anyhow!(
-                "LMS closed the connection mid-response for `{}`. {} \
-                 (transport: {})",
-                command,
-                LMS_FAILURE_NOTE,
-                e
-            )
-        })?;
+        let body = response
+            .bytes()
+            .await
+            .map_err(|e| describe_send_failure(&command, &e))?;
 
         if body.is_empty() {
             return Err(anyhow!(
@@ -2420,10 +2442,22 @@ impl AdapterLogic for LmsAdapter {
             AdapterCommand::VolumeAbsolute(v) => self.control(player_id, "vol_abs", Some(v)).await,
             AdapterCommand::VolumeRelative(v) => self.control(player_id, "vol_rel", Some(v)).await,
             AdapterCommand::Mute(_) => {
-                // LMS doesn't have direct mute support via JSON-RPC
+                // LMS *does* support mute control - `mixer muting <0|1>`, verified
+                // against live Lyrion 9.1.2 - and this adapter now reports mute
+                // state. Only the control path is unimplemented, and exposing it
+                // is player-feature work (#403), out of scope for #407.
+                //
+                // The previous message said "Mute not supported by LMS adapter",
+                // which blamed the provider for a UHC gap. Per #392: report
+                // "not yet implemented in UHC" and "not supported by this
+                // provider" as distinct states, never collapse them.
                 return Ok(AdapterCommandResponse {
                     success: false,
-                    error: Some("Mute not supported by LMS adapter".to_string()),
+                    error: Some(
+                        "Mute control is not yet implemented in UHC for LMS. LMS \
+                         itself supports it via `mixer muting <0|1>`; see #403."
+                            .to_string(),
+                    ),
                 });
             }
         };

--- a/src/adapters/lms.rs
+++ b/src/adapters/lms.rs
@@ -123,8 +123,7 @@ fn lms_flag(value: Option<&Value>) -> bool {
 /// not depend on one. Reading only `id` is the #407 defect that made
 /// `search_library()` return an empty vec against every real server.
 fn loop_entity_id(row: &Value, entity: &str) -> Option<i64> {
-    lms_i64(row.get(format!("{}_id", entity)).or_else(|| row.get("id")))
-        .filter(|id| *id > 0)
+    lms_i64(row.get(format!("{}_id", entity)).or_else(|| row.get("id"))).filter(|id| *id > 0)
 }
 
 /// What LMS actually does when a request fails, spelled out once.
@@ -1823,8 +1822,8 @@ async fn update_players_internal(
                 // aggregator's event-fed cache, so a mute toggled from another
                 // controller (iPeng, Squeezer, the LMS web UI) would otherwise
                 // never reach /zones unless the volume happened to change too.
-                let volume_changed = old_player.volume != player.volume
-                    || old_player.muted != player.muted;
+                let volume_changed =
+                    old_player.volume != player.volume || old_player.muted != player.muted;
                 (np_changed, state_changed, volume_changed)
             } else {
                 // New player - will be handled by ZoneDiscovered
@@ -2703,7 +2702,10 @@ mod tests {
 
         // String form, and non-positive or missing ids are not addressable -
         // playlistcontrol cannot act on them.
-        assert_eq!(loop_entity_id(&json!({"album_id": "12"}), "album"), Some(12));
+        assert_eq!(
+            loop_entity_id(&json!({"album_id": "12"}), "album"),
+            Some(12)
+        );
         assert_eq!(loop_entity_id(&json!({"album_id": 0}), "album"), None);
         assert_eq!(loop_entity_id(&json!({"album_id": -1}), "album"), None);
         assert_eq!(loop_entity_id(&json!({"album": "no id"}), "album"), None);
@@ -2713,9 +2715,17 @@ mod tests {
     fn describe_command_names_the_player_and_the_command() {
         let described = describe_command(
             Some("02:00:00:00:00:11"),
-            &[json!("players"), json!(0), json!(100), json!("playerprefs:mute")],
+            &[
+                json!("players"),
+                json!(0),
+                json!(100),
+                json!("playerprefs:mute"),
+            ],
         );
-        assert_eq!(described, "02:00:00:00:00:11 players 0 100 playerprefs:mute");
+        assert_eq!(
+            described,
+            "02:00:00:00:00:11 players 0 100 playerprefs:mute"
+        );
 
         // Server-scoped calls pass no player id; the message must still be clear.
         let server = describe_command(None, &[json!("search"), json!(0), json!(10)]);

--- a/src/adapters/lms.rs
+++ b/src/adapters/lms.rs
@@ -2641,6 +2641,100 @@ mod tests {
     use super::*;
 
     // -------------------------------------------------------------------------
+    // LMS JSON type tolerance (#407)
+    //
+    // Every shape asserted here was observed on one live Lyrion 9.1.2 server:
+    //   number   `track_id: 1`, `mixer muting ?` -> 1, `connected ?` -> 1
+    //   string   `mute: "0"` / `"1"`, `mixer volume ?` -> "42",
+    //            `power ?` -> "1", `playlist_cur_index: "0"`
+    //   null     `mixer muting ?` -> null before the pref is ever written
+    //   absent   `mute` omitted from players_loop when the pref is unset
+    //
+    // `.as_i64()` alone yields None on the string form. That is how a parse bug
+    // becomes an empty result rather than an error - the shape of defect #407.1.
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn lms_i64_reads_numbers_and_strings() {
+        assert_eq!(lms_i64(Some(&json!(42))), Some(42));
+        assert_eq!(lms_i64(Some(&json!("42"))), Some(42));
+        assert_eq!(lms_i64(Some(&json!(-42))), Some(-42));
+        assert_eq!(lms_i64(Some(&json!("-42"))), Some(-42));
+        // `mixer muting ?` returns a float-shaped value on some queries, and
+        // `sleep ?` returns e.g. 899.967221021652.
+        assert_eq!(lms_i64(Some(&json!(1.0))), Some(1));
+        assert_eq!(lms_i64(Some(&json!(" 7 "))), Some(7));
+        assert_eq!(lms_i64(Some(&json!(Value::Null))), None);
+        assert_eq!(lms_i64(None), None);
+        assert_eq!(lms_i64(Some(&json!("not a number"))), None);
+    }
+
+    #[test]
+    fn lms_flag_treats_absent_and_null_as_false() {
+        assert!(!lms_flag(None));
+        assert!(!lms_flag(Some(&Value::Null)));
+        assert!(!lms_flag(Some(&json!(0))));
+        assert!(!lms_flag(Some(&json!("0"))));
+        assert!(lms_flag(Some(&json!(1))));
+        // The shape live 9.1.2 actually returned for the `mute` pref.
+        assert!(lms_flag(Some(&json!("1"))));
+        assert!(!lms_flag(Some(&json!("garbage"))));
+    }
+
+    #[test]
+    fn loop_entity_id_prefers_typed_key_and_falls_back_to_id() {
+        // What live LMS emits: `<type>_id`, and no `id` key at all.
+        let album = json!({"album_id": 1, "album": "Ember Light"});
+        assert_eq!(loop_entity_id(&album, "album"), Some(1));
+
+        let contributor = json!({"contributor_id": 3, "contributor": "Ember Valley Quartet"});
+        assert_eq!(loop_entity_id(&contributor, "contributor"), Some(3));
+
+        let track = json!({"track_id": 8, "track": "Ember Coda"});
+        assert_eq!(loop_entity_id(&track, "track"), Some(8));
+
+        // The typed key wins when both are present.
+        let both = json!({"album_id": 5, "id": 99});
+        assert_eq!(loop_entity_id(&both, "album"), Some(5));
+
+        // Version fallback: a hypothetical server emitting only `id`.
+        let legacy = json!({"id": 7, "album": "Whatever"});
+        assert_eq!(loop_entity_id(&legacy, "album"), Some(7));
+
+        // String form, and non-positive or missing ids are not addressable -
+        // playlistcontrol cannot act on them.
+        assert_eq!(loop_entity_id(&json!({"album_id": "12"}), "album"), Some(12));
+        assert_eq!(loop_entity_id(&json!({"album_id": 0}), "album"), None);
+        assert_eq!(loop_entity_id(&json!({"album_id": -1}), "album"), None);
+        assert_eq!(loop_entity_id(&json!({"album": "no id"}), "album"), None);
+    }
+
+    #[test]
+    fn describe_command_names_the_player_and_the_command() {
+        let described = describe_command(
+            Some("02:00:00:00:00:11"),
+            &[json!("players"), json!(0), json!(100), json!("playerprefs:mute")],
+        );
+        assert_eq!(described, "02:00:00:00:00:11 players 0 100 playerprefs:mute");
+
+        // Server-scoped calls pass no player id; the message must still be clear.
+        let server = describe_command(None, &[json!("search"), json!(0), json!(10)]);
+        assert_eq!(server, "<server> search 0 10");
+    }
+
+    #[test]
+    fn truncate_for_log_bounds_runaway_bodies() {
+        assert_eq!(truncate_for_log("short"), "short");
+        let long = "x".repeat(500);
+        let truncated = truncate_for_log(&long);
+        assert_eq!(truncated.chars().count(), 201, "200 chars plus an ellipsis");
+        assert!(truncated.ends_with('…'));
+        // Must not split a multi-byte character.
+        let unicode = "é".repeat(500);
+        assert_eq!(truncate_for_log(&unicode).chars().count(), 201);
+    }
+
+    // -------------------------------------------------------------------------
     // CLI Event Parsing Tests (TDD)
     // -------------------------------------------------------------------------
 

--- a/tests/fixtures/lms/PROVENANCE.md
+++ b/tests/fixtures/lms/PROVENANCE.md
@@ -42,8 +42,40 @@ network if you need a player.
 | `players_mute_all_unmuted.json` | Same query with nothing muted. |
 | `players_no_playerprefs.json` | The same `players` query **without** `playerprefs:` — no `mute` key on any player. Proves the tag is what adds it, and that the old call could not have known mute. |
 | `mixer_muting_query_muted.json` / `..._unmuted.json` | `mixer muting ?` → `{"_muting": 1}` / `{"_muting": 0}`. The per-player query, kept as the documented alternative to the batched one. |
-| `status_squeezelite_muted.json` | `status` on a **muted** real squeezelite player still reports a plain positive `"mixer volume": 42` and carries **no mute key at all**. This is why `status` alone cannot report mute, and why the volume value is not secretly negated. |
+| `status_squeezelite_muted.json` | `status` on a **muted** real squeezelite player carries **no mute key at all**, and reports `"mixer volume": -42` — LMS **negates** the volume once its mute fade completes. Both halves matter: `status` cannot report mute directly, and the raw value it does report goes negative, which the adapter used to hand straight to a `VolumeControl` declared `min: 0.0`. See the timing table below. |
 | `status_tags_aAdltKc.json` | **Defect 4.** The adapter's exact `tags:aAdltKc` string. `l` yields `"album": "Ember Light"` (album **title**, not `album_id`); `A` yields per-role `albumartist`/`trackartist`; `a` yields `artist`; `d` `duration`; `t` `tracknum`. Also shows `artwork_track_id` is **absent**, because that field is tag `J` which this string does not request. |
+
+## Mute is immediate; the negated volume lags it (no fixture file — this is timing)
+
+`mixer muting` schedules a volume fade and only writes the negated volume when the
+fade finishes, so `status`'s `mixer volume` is a **lagging** mute signal while the
+`mute` pref is an immediate one. Measured on the real squeezelite player at volume
+42, polling `status`, `mixer muting ?` and `players … playerprefs:mute` together:
+
+| Time after `mixer muting 1` | `status`'s `mixer volume` | `mixer muting ?` | `playerprefs:mute` |
+|---|---|---|---|
+| 0.04 s | `42` | `"1"` | `"1"` |
+| 0.78 s | `-42` | `"1"` | `"1"` |
+| 0.78 s – 8.6 s | `-42` | `"1"` | `"1"` |
+
+| Time after `mixer muting 0` | `status`'s `mixer volume` | `mixer muting ?` | `playerprefs:mute` |
+|---|---|---|---|
+| 0.07 s | `-42` | `"0"` | `"0"` |
+| 0.84 s onward | `42` | `"0"` | `"0"` |
+
+Two consequences the adapter relies on:
+
+1. The **pref** is correct in every window, so `playerprefs:mute` is the primary
+   signal. A sign-based reading alone would report unmuted for ~0.8 s after a mute.
+2. A negative `mixer volume` is nonetheless a *sufficient* condition for muted, so
+   the adapter also treats it as one. It can only ever produce a false **negative**,
+   never a false positive, which makes it safe to OR with the pref — and it needs no
+   tagged parameter, so it still works if `playerprefs:` is unavailable.
+
+An earlier reading of this recorded a positive `42` while muted and concluded LMS
+does not negate the volume. That reading was taken inside the sub-second fade window
+and was wrong; `tests/lms_adapter_defects.rs::muted_player_volume_is_not_negated`
+caught it against `status_squeezelite_muted.json`.
 
 ## Failure mode (no fixture file — there is no response to record)
 

--- a/tests/fixtures/lms/PROVENANCE.md
+++ b/tests/fixtures/lms/PROVENANCE.md
@@ -1,0 +1,68 @@
+# LMS fixture provenance
+
+Every `.json` file in this directory is the **verbatim HTTP response body** from a
+live Lyrion Music Server, pretty-printed and key-sorted, with nothing added or
+removed. Each file's `params` member is LMS's own echo of the request that
+produced it, so every fixture documents its own request.
+
+These are recorded, not written. Issue #407 exists because
+`LmsAdapter::search_library()` was tested against a hand-written guess at LMS's
+response shape and that guess was wrong for three years — the loop items were
+assumed to carry `id` when LMS emits `<type>_id`. **Do not hand-edit these files
+and do not add hand-authored fixtures to this directory.** Re-record instead.
+
+## Recording environment
+
+| | |
+|---|---|
+| Server | Lyrion Music Server **9.1.2**, build `1781881406` (Sat Jun 20 04:01:40 UTC 2026) |
+| Image | `lmscommunity/lyrionmusicserver:stable`, digest `sha256:e7865195d91df554760df3957bed91044f650b80c3fc2783d425c487b68c7185`, `arch=arm64` |
+| Transport | `POST /jsonrpc.js`, `{"id":217,"method":"slim.request","params":[<playerid\|"">,[…]]}` — byte-for-byte the request `LmsRpc::execute` builds (`src/adapters/lms.rs`), including the `id: 217` this repo uses |
+| Library | 12 tagged FLACs, 4 artists, 5 albums, 4 genres, generated with `ffmpeg`; artist/album/track names chosen so one `search term:` hits `contributors_loop`, `albums_loop` and `tracks_loop` at once |
+| Network | container published **`127.0.0.1:9000` and `127.0.0.1:9090` only**. Port **3483 was never published** — see the warning below |
+| Players | `02:00:00:00:00:01` "Kitchen" and `02:00:00:00:00:02` (`model: http`, LMS Web Clients via `/stream.mp3?player=<mac>`); `02:00:00:00:00:11` "Study" (`model: squeezelite`, `isplayer: 1`) via a minimal SlimProto `HELO` client run **inside the container's own network namespace** (`docker run --network container:…`) so 3483 never left the Docker bridge |
+
+### Do not publish port 3483
+
+Publishing 3483 lets every SlimProto player on the LAN auto-discover the throwaway
+server and attach to it. This already happened once during the #402/#403 survey and
+pulled roughly ten of the operator's real players onto a test container. Bind 9000
+(and 9090 if you need the CLI) to `127.0.0.1`, and reach 3483 from inside the Docker
+network if you need a player.
+
+## What each fixture proves
+
+| File | Proves |
+|---|---|
+| `search_term_ember.json` | **Defect 1.** `search <s> <n> term:` returns `albums_loop[].album_id`, `contributors_loop[].contributor_id`, `tracks_loop[].track_id`. There is **no `id` key anywhere** — which is what `search_library()` read. One term hits all three loops. |
+| `search_term_aurora.json` | Same shape for a term that matches an artist name; `albums_loop` ordering is not stable across terms. |
+| `search_term_jazz.json` | `genres_loop[].genre_id` / `genre`, and that loops with no matches are **omitted entirely** rather than returned empty. |
+| `search_no_results.json` | Zero matches is `{"count": 0}` with no loops at all. |
+| `players_mute_mixed.json` | **Defect 3.** `players 0 100 playerprefs:mute` carries per-player mute in the response the adapter *already* makes, so mute costs **zero extra round-trips**. Also captures all three shapes LMS uses in one response: `"mute": "0"` (string), key **absent** (pref never written), `"mute": "1"` (string). |
+| `players_mute_all_unmuted.json` | Same query with nothing muted. |
+| `players_no_playerprefs.json` | The same `players` query **without** `playerprefs:` — no `mute` key on any player. Proves the tag is what adds it, and that the old call could not have known mute. |
+| `mixer_muting_query_muted.json` / `..._unmuted.json` | `mixer muting ?` → `{"_muting": 1}` / `{"_muting": 0}`. The per-player query, kept as the documented alternative to the batched one. |
+| `status_squeezelite_muted.json` | `status` on a **muted** real squeezelite player still reports a plain positive `"mixer volume": 42` and carries **no mute key at all**. This is why `status` alone cannot report mute, and why the volume value is not secretly negated. |
+| `status_tags_aAdltKc.json` | **Defect 4.** The adapter's exact `tags:aAdltKc` string. `l` yields `"album": "Ember Light"` (album **title**, not `album_id`); `A` yields per-role `albumartist`/`trackartist`; `a` yields `artist`; `d` `duration`; `t` `tracknum`. Also shows `artwork_track_id` is **absent**, because that field is tag `J` which this string does not request. |
+
+## Failure mode (no fixture file — there is no response to record)
+
+LMS never returns a JSON-RPC `error` object. On any request error it closes the
+socket having written **zero bytes**, with no HTTP status line at all. Recorded by
+hand-writing HTTP/1.1 to the socket and counting bytes:
+
+| Request | LMS status | Bytes received |
+|---|---|---|
+| `search 0 3 term:Ember` | 0 (ok) | 675 (`HTTP/1.1 200 OK`, 496-byte body) |
+| `totallybogus items 0 10` | 104 unknown in dispatch table | **0 — socket closed** |
+| `status 0 1` on an unknown player id | 103 missing client | **0 — socket closed** |
+| `playlist save X` with `playlistdir` unset | 105 bad config | **0 — socket closed** |
+| `playlistcontrol cmd:load artist_id:999999` | Perl exception | **0 — socket closed** |
+| `browselibrary items 0 20` (no `mode:`) | 102 bad params | 9 bytes then **hung** until client timeout |
+
+Source: `Slim::Web::JSONRPC::requestMethod` calls `closeHTTPSocket()` on any
+`$request->isStatusError()`. There is no branch that emits an `error` member.
+
+Because there is nothing to record, `tests/lms_transport.rs` reproduces this
+behaviour with a local TCP listener that accepts, reads the request, and closes
+without writing — the exact wire behaviour in the table above.

--- a/tests/fixtures/lms/mixer_muting_query_muted.json
+++ b/tests/fixtures/lms/mixer_muting_query_muted.json
@@ -1,0 +1,15 @@
+{
+  "id": 217,
+  "method": "slim.request",
+  "params": [
+    "02:00:00:00:00:11",
+    [
+      "mixer",
+      "muting",
+      "?"
+    ]
+  ],
+  "result": {
+    "_muting": "1"
+  }
+}

--- a/tests/fixtures/lms/mixer_muting_query_unmuted.json
+++ b/tests/fixtures/lms/mixer_muting_query_unmuted.json
@@ -1,0 +1,15 @@
+{
+  "id": 217,
+  "method": "slim.request",
+  "params": [
+    "02:00:00:00:00:11",
+    [
+      "mixer",
+      "muting",
+      "?"
+    ]
+  ],
+  "result": {
+    "_muting": "0"
+  }
+}

--- a/tests/fixtures/lms/players_mute_all_unmuted.json
+++ b/tests/fixtures/lms/players_mute_all_unmuted.json
@@ -1,0 +1,69 @@
+{
+  "id": 217,
+  "method": "slim.request",
+  "params": [
+    "",
+    [
+      "players",
+      "0",
+      100,
+      "playerprefs:mute"
+    ]
+  ],
+  "result": {
+    "count": 3,
+    "players_loop": [
+      {
+        "canpoweroff": 0,
+        "connected": 1,
+        "firmware": null,
+        "ip": "172.17.0.1:60364",
+        "isplayer": 0,
+        "isplaying": 0,
+        "model": "http",
+        "modelname": "Web Client",
+        "mute": "0",
+        "name": "Kitchen",
+        "playerid": "02:00:00:00:00:01",
+        "playerindex": "0",
+        "power": 1,
+        "seq_no": 0,
+        "uuid": null
+      },
+      {
+        "canpoweroff": 0,
+        "connected": 1,
+        "firmware": null,
+        "ip": "172.17.0.1:64338",
+        "isplayer": 0,
+        "isplaying": 0,
+        "model": "http",
+        "modelname": "Web Client",
+        "name": "curl from 02:00:00:00:00:02",
+        "playerid": "02:00:00:00:00:02",
+        "playerindex": 1,
+        "power": 1,
+        "seq_no": 0,
+        "uuid": null
+      },
+      {
+        "canpoweroff": 1,
+        "connected": 1,
+        "displaytype": "none",
+        "firmware": 0,
+        "ip": "127.0.0.1:42110",
+        "isplayer": 1,
+        "isplaying": 0,
+        "model": "squeezelite",
+        "modelname": "SqueezeLite",
+        "mute": "0",
+        "name": "Study",
+        "playerid": "02:00:00:00:00:11",
+        "playerindex": 2,
+        "power": 1,
+        "seq_no": 0,
+        "uuid": null
+      }
+    ]
+  }
+}

--- a/tests/fixtures/lms/players_mute_mixed.json
+++ b/tests/fixtures/lms/players_mute_mixed.json
@@ -1,0 +1,69 @@
+{
+  "id": 217,
+  "method": "slim.request",
+  "params": [
+    "",
+    [
+      "players",
+      "0",
+      100,
+      "playerprefs:mute"
+    ]
+  ],
+  "result": {
+    "count": 3,
+    "players_loop": [
+      {
+        "canpoweroff": 0,
+        "connected": 1,
+        "firmware": null,
+        "ip": "172.17.0.1:60364",
+        "isplayer": 0,
+        "isplaying": 0,
+        "model": "http",
+        "modelname": "Web Client",
+        "mute": "0",
+        "name": "Kitchen",
+        "playerid": "02:00:00:00:00:01",
+        "playerindex": "0",
+        "power": 1,
+        "seq_no": 0,
+        "uuid": null
+      },
+      {
+        "canpoweroff": 0,
+        "connected": 1,
+        "firmware": null,
+        "ip": "172.17.0.1:64338",
+        "isplayer": 0,
+        "isplaying": 0,
+        "model": "http",
+        "modelname": "Web Client",
+        "name": "curl from 02:00:00:00:00:02",
+        "playerid": "02:00:00:00:00:02",
+        "playerindex": 1,
+        "power": 1,
+        "seq_no": 0,
+        "uuid": null
+      },
+      {
+        "canpoweroff": 1,
+        "connected": 1,
+        "displaytype": "none",
+        "firmware": 0,
+        "ip": "127.0.0.1:42110",
+        "isplayer": 1,
+        "isplaying": 0,
+        "model": "squeezelite",
+        "modelname": "SqueezeLite",
+        "mute": "1",
+        "name": "Study",
+        "playerid": "02:00:00:00:00:11",
+        "playerindex": 2,
+        "power": 1,
+        "seq_no": 0,
+        "uuid": null
+      }
+    ]
+  }
+}

--- a/tests/fixtures/lms/players_no_playerprefs.json
+++ b/tests/fixtures/lms/players_no_playerprefs.json
@@ -1,0 +1,66 @@
+{
+  "id": 217,
+  "method": "slim.request",
+  "params": [
+    "",
+    [
+      "players",
+      "0",
+      "100"
+    ]
+  ],
+  "result": {
+    "count": 3,
+    "players_loop": [
+      {
+        "canpoweroff": 0,
+        "connected": 1,
+        "firmware": null,
+        "ip": "172.17.0.1:60364",
+        "isplayer": 0,
+        "isplaying": 0,
+        "model": "http",
+        "modelname": "Web Client",
+        "name": "Kitchen",
+        "playerid": "02:00:00:00:00:01",
+        "playerindex": "0",
+        "power": 1,
+        "seq_no": 0,
+        "uuid": null
+      },
+      {
+        "canpoweroff": 0,
+        "connected": 1,
+        "firmware": null,
+        "ip": "172.17.0.1:64338",
+        "isplayer": 0,
+        "isplaying": 0,
+        "model": "http",
+        "modelname": "Web Client",
+        "name": "curl from 02:00:00:00:00:02",
+        "playerid": "02:00:00:00:00:02",
+        "playerindex": 1,
+        "power": 1,
+        "seq_no": 0,
+        "uuid": null
+      },
+      {
+        "canpoweroff": 1,
+        "connected": 1,
+        "displaytype": "none",
+        "firmware": 0,
+        "ip": "127.0.0.1:42110",
+        "isplayer": 1,
+        "isplaying": 0,
+        "model": "squeezelite",
+        "modelname": "SqueezeLite",
+        "name": "Study",
+        "playerid": "02:00:00:00:00:11",
+        "playerindex": 2,
+        "power": 1,
+        "seq_no": 0,
+        "uuid": null
+      }
+    ]
+  }
+}

--- a/tests/fixtures/lms/search_no_results.json
+++ b/tests/fixtures/lms/search_no_results.json
@@ -1,0 +1,16 @@
+{
+  "id": 217,
+  "method": "slim.request",
+  "params": [
+    "",
+    [
+      "search",
+      "0",
+      10,
+      "term:zzznotfound"
+    ]
+  ],
+  "result": {
+    "count": 0
+  }
+}

--- a/tests/fixtures/lms/search_term_aurora.json
+++ b/tests/fixtures/lms/search_term_aurora.json
@@ -1,0 +1,57 @@
+{
+  "id": 217,
+  "method": "slim.request",
+  "params": [
+    "",
+    [
+      "search",
+      "0",
+      5,
+      "term:Aurora"
+    ]
+  ],
+  "result": {
+    "albums_count": 2,
+    "albums_loop": [
+      {
+        "album": "Northern Ember",
+        "album_id": 2
+      },
+      {
+        "album": "Ember Light",
+        "album_id": 1
+      }
+    ],
+    "contributors_count": 1,
+    "contributors_loop": [
+      {
+        "contributor": "Aurora Borealis Trio",
+        "contributor_id": 2
+      }
+    ],
+    "count": 8,
+    "tracks_count": 5,
+    "tracks_loop": [
+      {
+        "track": "Aurora Interlude",
+        "track_id": 5
+      },
+      {
+        "track": "Ember Rising",
+        "track_id": 1
+      },
+      {
+        "track": "Slow Ember",
+        "track_id": 2
+      },
+      {
+        "track": "Borealis Waltz",
+        "track_id": 3
+      },
+      {
+        "track": "Ember Dawn",
+        "track_id": 4
+      }
+    ]
+  }
+}

--- a/tests/fixtures/lms/search_term_ember.json
+++ b/tests/fixtures/lms/search_term_ember.json
@@ -1,0 +1,73 @@
+{
+  "id": 217,
+  "method": "slim.request",
+  "params": [
+    "",
+    [
+      "search",
+      "0",
+      10,
+      "term:Ember"
+    ]
+  ],
+  "result": {
+    "albums_count": 3,
+    "albums_loop": [
+      {
+        "album": "Ember Light",
+        "album_id": 1
+      },
+      {
+        "album": "Northern Ember",
+        "album_id": 2
+      },
+      {
+        "album": "Quiet Circuits",
+        "album_id": 3
+      }
+    ],
+    "contributors_count": 1,
+    "contributors_loop": [
+      {
+        "contributor": "Ember Valley Quartet",
+        "contributor_id": 3
+      }
+    ],
+    "count": 12,
+    "tracks_count": 8,
+    "tracks_loop": [
+      {
+        "track": "Ember Rising",
+        "track_id": 1
+      },
+      {
+        "track": "Slow Ember",
+        "track_id": 2
+      },
+      {
+        "track": "Ember Dawn",
+        "track_id": 4
+      },
+      {
+        "track": "Ember Coda",
+        "track_id": 8
+      },
+      {
+        "track": "Borealis Waltz",
+        "track_id": 3
+      },
+      {
+        "track": "Aurora Interlude",
+        "track_id": 5
+      },
+      {
+        "track": "Circuit One",
+        "track_id": 6
+      },
+      {
+        "track": "Circuit Two",
+        "track_id": 7
+      }
+    ]
+  }
+}

--- a/tests/fixtures/lms/search_term_jazz.json
+++ b/tests/fixtures/lms/search_term_jazz.json
@@ -1,0 +1,46 @@
+{
+  "id": 217,
+  "method": "slim.request",
+  "params": [
+    "",
+    [
+      "search",
+      "0",
+      10,
+      "term:Jazz"
+    ]
+  ],
+  "result": {
+    "count": 6,
+    "genres_count": 1,
+    "genres_loop": [
+      {
+        "genre": "Jazz",
+        "genre_id": 1
+      }
+    ],
+    "tracks_count": 5,
+    "tracks_loop": [
+      {
+        "track": "Ember Rising",
+        "track_id": 1
+      },
+      {
+        "track": "Slow Ember",
+        "track_id": 2
+      },
+      {
+        "track": "Borealis Waltz",
+        "track_id": 3
+      },
+      {
+        "track": "Ember Dawn",
+        "track_id": 4
+      },
+      {
+        "track": "Aurora Interlude",
+        "track_id": 5
+      }
+    ]
+  }
+}

--- a/tests/fixtures/lms/status_squeezelite_muted.json
+++ b/tests/fixtures/lms/status_squeezelite_muted.json
@@ -1,0 +1,30 @@
+{
+  "id": 217,
+  "method": "slim.request",
+  "params": [
+    "02:00:00:00:00:11",
+    [
+      "status",
+      "-",
+      1,
+      "tags:aAdltKc"
+    ]
+  ],
+  "result": {
+    "digital_volume_control": 1,
+    "mixer volume": -42,
+    "mode": "stop",
+    "player_connected": 1,
+    "player_ip": "127.0.0.1:42110",
+    "player_name": "Study",
+    "playlist mode": "off",
+    "playlist repeat": 0,
+    "playlist shuffle": 0,
+    "playlist_tracks": 0,
+    "power": 1,
+    "randomplay": 0,
+    "seq_no": 0,
+    "signalstrength": 0,
+    "use_volume_control": 1
+  }
+}

--- a/tests/fixtures/lms/status_tags_aAdltKc.json
+++ b/tests/fixtures/lms/status_tags_aAdltKc.json
@@ -1,0 +1,25 @@
+{
+  "id": 217,
+  "method": "slim.request",
+  "params": [
+    "02:00:00:00:00:01",
+    [
+      "status",
+      "-",
+      1,
+      "tags:aAdltKc"
+    ]
+  ],
+  "result": {
+    "mode": "stop",
+    "player_connected": 1,
+    "player_ip": "172.17.0.1:60364",
+    "player_name": "Kitchen",
+    "playlist mode": "off",
+    "playlist repeat": 0,
+    "playlist shuffle": 0,
+    "playlist_tracks": 0,
+    "randomplay": 0,
+    "seq_no": 0
+  }
+}

--- a/tests/fixtures/lms/status_tags_aAdltKc.json
+++ b/tests/fixtures/lms/status_tags_aAdltKc.json
@@ -2,7 +2,7 @@
   "id": 217,
   "method": "slim.request",
   "params": [
-    "02:00:00:00:00:01",
+    "02:00:00:00:00:11",
     [
       "status",
       "-",
@@ -11,15 +11,40 @@
     ]
   ],
   "result": {
-    "mode": "stop",
+    "can_seek": 1,
+    "digital_volume_control": 1,
+    "duration": 3,
+    "mixer volume": 42,
+    "mode": "play",
     "player_connected": 1,
-    "player_ip": "172.17.0.1:60364",
-    "player_name": "Kitchen",
+    "player_ip": "127.0.0.1:42110",
+    "player_name": "Study",
     "playlist mode": "off",
     "playlist repeat": 0,
     "playlist shuffle": 0,
-    "playlist_tracks": 0,
+    "playlist_cur_index": "0",
+    "playlist_loop": [
+      {
+        "album": "Ember Light",
+        "albumartist": "Aurora Borealis Trio",
+        "artist": "Aurora Borealis Trio",
+        "duration": 3,
+        "id": 1,
+        "playlist index": 0,
+        "title": "Ember Rising",
+        "trackartist": "Aurora Borealis Trio",
+        "tracknum": "1"
+      }
+    ],
+    "playlist_timestamp": 1785541723.82539,
+    "playlist_tracks": 3,
+    "power": 1,
     "randomplay": 0,
-    "seq_no": 0
+    "rate": 1,
+    "seq_no": 0,
+    "signalstrength": 0,
+    "time": 0,
+    "use_volume_control": 1,
+    "waitingToPlay": 1
   }
 }

--- a/tests/lms_adapter_defects.rs
+++ b/tests/lms_adapter_defects.rs
@@ -36,7 +36,11 @@ use unified_hifi_control::bus::{create_bus, BusEvent, SharedBus};
 /// Load a recorded live LMS response and return its `result` member — exactly
 /// what `LmsRpc::execute` hands back to its callers.
 fn fixture_result(name: &str) -> Value {
-    let path = format!("{}/tests/fixtures/lms/{}.json", env!("CARGO_MANIFEST_DIR"), name);
+    let path = format!(
+        "{}/tests/fixtures/lms/{}.json",
+        env!("CARGO_MANIFEST_DIR"),
+        name
+    );
     let raw = match std::fs::read_to_string(&path) {
         Ok(raw) => raw,
         Err(e) => panic!("recorded fixture {path} is missing: {e}"),
@@ -75,7 +79,11 @@ struct ReplayState {
 }
 
 impl ReplayServer {
-    async fn start(players_fixture: &str, status_fixture: &str, search_fixture: Option<&str>) -> Self {
+    async fn start(
+        players_fixture: &str,
+        status_fixture: &str,
+        search_fixture: Option<&str>,
+    ) -> Self {
         let requests = Arc::new(Mutex::new(Vec::new()));
         let players_name = Arc::new(Mutex::new(players_fixture.to_string()));
 
@@ -168,10 +176,7 @@ async fn replay(State(state): State<ReplayState>, Json(body): Json<Value>) -> Js
                 })
                 .unwrap_or(false);
             if !asked_for_mute {
-                if let Some(players) = res
-                    .get_mut("players_loop")
-                    .and_then(|v| v.as_array_mut())
-                {
+                if let Some(players) = res.get_mut("players_loop").and_then(|v| v.as_array_mut()) {
                     for p in players.iter_mut() {
                         if let Some(obj) = p.as_object_mut() {
                             obj.remove("mute");
@@ -211,7 +216,8 @@ async fn start_closing_server() -> (SocketAddr, tokio::task::JoinHandle<()>) {
 /// through a proxy that turns the closed socket into a valid empty response.
 async fn start_empty_body_server() -> (SocketAddr, tokio::task::JoinHandle<()>) {
     start_raw_server(Some(
-        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 0\r\n\r\n".to_string(),
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 0\r\n\r\n"
+            .to_string(),
     ))
     .await
 }
@@ -361,10 +367,7 @@ async fn search_library_returns_results_from_recorded_live_response() {
         Some(t) => t,
         None => panic!("no Track result parsed from tracks_loop[].track_id"),
     };
-    assert_eq!(
-        track.id, 1,
-        "track id must come from `track_id`, not `id`"
-    );
+    assert_eq!(track.id, 1, "track id must come from `track_id`, not `id`");
     assert_eq!(track.title, "Ember Rising");
 
     // Every result must carry a usable playback handle, or search_and_play cannot
@@ -601,10 +604,7 @@ async fn players_query_requests_mute_pref_without_extra_round_trips() {
     );
     let asks_for_mute = players_calls[0]
         .as_array()
-        .map(|a| {
-            a.iter()
-                .any(|v| v.as_str() == Some("playerprefs:mute"))
-        })
+        .map(|a| a.iter().any(|v| v.as_str() == Some("playerprefs:mute")))
         .unwrap_or(false);
     assert!(
         asks_for_mute,
@@ -649,7 +649,10 @@ async fn mute_state_from_recorded_players_response_reaches_zones() {
         let zone = zones.iter().find(|z| z.zone_id == zone_id);
         let zone = match zone {
             Some(z) => z,
-            None => panic!("zone {zone_id} not discovered; got {:?}", zones.iter().map(|z| &z.zone_id).collect::<Vec<_>>()),
+            None => panic!(
+                "zone {zone_id} not discovered; got {:?}",
+                zones.iter().map(|z| &z.zone_id).collect::<Vec<_>>()
+            ),
         };
         match zone.volume_control.as_ref() {
             Some(vc) => vc.is_muted,
@@ -736,8 +739,7 @@ async fn mute_change_alone_publishes_volume_changed() {
 #[serial_test::serial(lms_config)]
 async fn muted_player_volume_is_not_negated() {
     clear_lms_config();
-    let server =
-        ReplayServer::start("players_mute_mixed", "status_squeezelite_muted", None).await;
+    let server = ReplayServer::start("players_mute_mixed", "status_squeezelite_muted", None).await;
     let (bus, mut rx) = test_bus();
     let adapter = configured_adapter(bus, server.addr()).await;
 
@@ -834,13 +836,11 @@ fn docs_tag_legend_matches_recorded_response() {
         "tags:aAdltKc does not request `J`, so artwork_track_id is never present"
     );
 
-    let doc = match std::fs::read_to_string(format!(
-        "{}/docs/lyrion.md",
-        env!("CARGO_MANIFEST_DIR")
-    )) {
-        Ok(d) => d,
-        Err(e) => panic!("docs/lyrion.md unreadable: {e}"),
-    };
+    let doc =
+        match std::fs::read_to_string(format!("{}/docs/lyrion.md", env!("CARGO_MANIFEST_DIR"))) {
+            Ok(d) => d,
+            Err(e) => panic!("docs/lyrion.md unreadable: {e}"),
+        };
     assert!(
         !doc.contains("l=album_id"),
         "docs/lyrion.md still claims `l=album_id`; `l` is the album title and `e` \

--- a/tests/lms_adapter_defects.rs
+++ b/tests/lms_adapter_defects.rs
@@ -520,6 +520,37 @@ async fn lms_failure_missing_result_member_is_reported() {
     handle.abort();
 }
 
+/// An unreachable server and a rejected request are different problems and must
+/// not share a message: one is configuration, the other is LMS refusing the
+/// command with no detail about why.
+#[tokio::test]
+#[serial_test::serial(lms_config)]
+async fn unreachable_server_is_not_reported_as_a_rejected_request() {
+    clear_lms_config();
+    let (bus, _rx) = test_bus();
+    // Port 1 on loopback: privileged and unused, so this is a connect refusal
+    // rather than an accepted-then-closed socket.
+    let adapter = LmsAdapter::new(bus);
+    adapter
+        .configure("127.0.0.1".to_string(), Some(1), None, None)
+        .await;
+
+    let err = match adapter.get_players().await {
+        Ok(_) => panic!("an unreachable port must not look like success"),
+        Err(e) => format!("{e:#}"),
+    };
+    let lowered = err.to_lowercase();
+    assert!(
+        lowered.contains("cannot reach"),
+        "an unreachable server must be reported as unreachable, got: {err}"
+    );
+    assert!(
+        !lowered.contains("closed the connection"),
+        "an unreachable server must not be described as LMS closing the \
+         connection - that is a different diagnosis: {err}"
+    );
+}
+
 /// The dead check being replaced must not be replaced by *another* dead check:
 /// a well-formed LMS reply still has to succeed.
 #[tokio::test]

--- a/tests/lms_adapter_defects.rs
+++ b/tests/lms_adapter_defects.rs
@@ -1,0 +1,874 @@
+//! Regression tests for issue #407 — four verified LMS adapter defects.
+//!
+//! Every LMS response these tests feed the adapter is **replayed verbatim from a
+//! recording of a live Lyrion Music Server 9.1.2** (`tests/fixtures/lms/`, see
+//! that directory's `PROVENANCE.md`). Nothing here guesses at LMS's shape.
+//!
+//! That is the point. `search_library()` was written against a hand-written guess
+//! that LMS emits `id` in its search loops; it emits `<type>_id`, so every branch
+//! of that function failed its guard and it returned an empty `Vec` on every real
+//! server for as long as it has existed. A mock that agreed with the code would
+//! have kept agreeing with it forever.
+//!
+//! Defect coverage:
+//!   1. `search_library()` field names   -> `search_library_*`
+//!   2. dead JSON-RPC `error` check      -> `lms_failure_*`
+//!   3. `is_muted` hard-coded `false`    -> `mute_*` / `players_query_*`
+//!   4. wrong `tags:` legend in the docs -> `docs_tag_legend_*`
+
+use axum::{extract::State, routing::post, Json, Router};
+use serde_json::{json, Value};
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::sync::broadcast;
+
+use unified_hifi_control::adapters::lms::{LmsAdapter, LmsSearchResultType};
+use unified_hifi_control::bus::{create_bus, BusEvent, SharedBus};
+
+// =============================================================================
+// Fixture loading
+// =============================================================================
+
+/// Load a recorded live LMS response and return its `result` member — exactly
+/// what `LmsRpc::execute` hands back to its callers.
+fn fixture_result(name: &str) -> Value {
+    let path = format!("{}/tests/fixtures/lms/{}.json", env!("CARGO_MANIFEST_DIR"), name);
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(raw) => raw,
+        Err(e) => panic!("recorded fixture {path} is missing: {e}"),
+    };
+    let parsed: Value = match serde_json::from_str(&raw) {
+        Ok(v) => v,
+        Err(e) => panic!("recorded fixture {path} is not valid JSON: {e}"),
+    };
+    match parsed.get("result") {
+        Some(r) => r.clone(),
+        None => panic!("recorded fixture {path} has no `result` member"),
+    }
+}
+
+// =============================================================================
+// Fixture-replay server
+// =============================================================================
+
+/// A JSON-RPC endpoint that replays recorded LMS responses and records every
+/// request the adapter made, so tests can assert on the *request* too.
+struct ReplayServer {
+    addr: SocketAddr,
+    requests: Arc<Mutex<Vec<Value>>>,
+    /// `players` fixture name; swappable so a test can simulate a mute change
+    /// between two polls.
+    players_fixture: Arc<Mutex<String>>,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+#[derive(Clone)]
+struct ReplayState {
+    requests: Arc<Mutex<Vec<Value>>>,
+    players_fixture: Arc<Mutex<String>>,
+    search_fixture: Option<String>,
+    status_fixture: String,
+}
+
+impl ReplayServer {
+    async fn start(players_fixture: &str, status_fixture: &str, search_fixture: Option<&str>) -> Self {
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let players_name = Arc::new(Mutex::new(players_fixture.to_string()));
+
+        let state = ReplayState {
+            requests: requests.clone(),
+            players_fixture: players_name.clone(),
+            search_fixture: search_fixture.map(str::to_string),
+            status_fixture: status_fixture.to_string(),
+        };
+
+        let app = Router::new()
+            .route("/jsonrpc.js", post(replay))
+            .with_state(state);
+
+        let listener = match TcpListener::bind("127.0.0.1:0").await {
+            Ok(l) => l,
+            Err(e) => panic!("bind replay server: {e}"),
+        };
+        let addr = match listener.local_addr() {
+            Ok(a) => a,
+            Err(e) => panic!("local_addr: {e}"),
+        };
+        let handle = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+
+        Self {
+            addr,
+            requests,
+            players_fixture: players_name,
+            handle,
+        }
+    }
+
+    fn addr(&self) -> SocketAddr {
+        self.addr
+    }
+
+    /// The command arrays the adapter sent, in order.
+    fn commands(&self) -> Vec<Value> {
+        match self.requests.lock() {
+            Ok(g) => g.clone(),
+            Err(e) => panic!("request log poisoned: {e}"),
+        }
+    }
+
+    fn set_players_fixture(&self, name: &str) {
+        match self.players_fixture.lock() {
+            Ok(mut g) => *g = name.to_string(),
+            Err(e) => panic!("fixture lock poisoned: {e}"),
+        }
+    }
+
+    fn stop(self) {
+        self.handle.abort();
+    }
+}
+
+async fn replay(State(state): State<ReplayState>, Json(body): Json<Value>) -> Json<Value> {
+    let cmd = body["params"][1].clone();
+    if let Ok(mut log) = state.requests.lock() {
+        log.push(cmd.clone());
+    }
+
+    let verb = cmd
+        .get(0)
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+
+    let result = match verb.as_str() {
+        "players" => {
+            let name = match state.players_fixture.lock() {
+                Ok(g) => g.clone(),
+                Err(_) => String::new(),
+            };
+            let mut res = fixture_result(&name);
+            // The recorded response carries whatever `playerprefs:` the recording
+            // asked for. If the adapter under test does NOT ask for the mute pref,
+            // a real LMS would not send it back (proved by
+            // players_no_playerprefs.json), so strip it to model that faithfully.
+            let asked_for_mute = cmd
+                .as_array()
+                .map(|a| {
+                    a.iter().any(|v| {
+                        v.as_str()
+                            .map(|s| s.starts_with("playerprefs:") && s.contains("mute"))
+                            .unwrap_or(false)
+                    })
+                })
+                .unwrap_or(false);
+            if !asked_for_mute {
+                if let Some(players) = res
+                    .get_mut("players_loop")
+                    .and_then(|v| v.as_array_mut())
+                {
+                    for p in players.iter_mut() {
+                        if let Some(obj) = p.as_object_mut() {
+                            obj.remove("mute");
+                        }
+                    }
+                }
+            }
+            res
+        }
+        "status" => fixture_result(&state.status_fixture),
+        "search" => match state.search_fixture.as_deref() {
+            Some(name) => fixture_result(name),
+            None => json!({}),
+        },
+        _ => json!({}),
+    };
+
+    Json(json!({ "id": body["id"], "method": "slim.request", "result": result }))
+}
+
+// =============================================================================
+// Raw TCP servers reproducing LMS's real failure modes
+// =============================================================================
+
+/// LMS's actual error signal: accept the request, then close the socket having
+/// written **zero bytes**. No HTTP status line at all.
+///
+/// Recorded from live Lyrion 9.1.2 for unknown command (104), unknown player
+/// (103), bad config (105) and Perl exceptions — see
+/// `tests/fixtures/lms/PROVENANCE.md`. There is no response body to record as a
+/// fixture, which is precisely why this has to be reproduced at the socket.
+async fn start_closing_server() -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    start_raw_server(None).await
+}
+
+/// A 200 with a zero-length body — the same information content, reachable
+/// through a proxy that turns the closed socket into a valid empty response.
+async fn start_empty_body_server() -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    start_raw_server(Some(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 0\r\n\r\n".to_string(),
+    ))
+    .await
+}
+
+/// A 200 carrying JSON with **no `result` member**. LMS never does this; this is
+/// the guard against something that is not LMS answering on port 9000.
+async fn start_no_result_server() -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    let body = r#"{"id":217,"method":"slim.request"}"#;
+    start_raw_server(Some(format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+        body.len(),
+        body
+    )))
+    .await
+}
+
+async fn start_raw_server(response: Option<String>) -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    let listener = match TcpListener::bind("127.0.0.1:0").await {
+        Ok(l) => l,
+        Err(e) => panic!("bind raw server: {e}"),
+    };
+    let addr = match listener.local_addr() {
+        Ok(a) => a,
+        Err(e) => panic!("local_addr: {e}"),
+    };
+    let handle = tokio::spawn(async move {
+        loop {
+            let Ok((mut sock, _)) = listener.accept().await else {
+                return;
+            };
+            let response = response.clone();
+            tokio::spawn(async move {
+                // Read the request so the client sees it delivered, then answer
+                // (or do not) exactly as configured.
+                let mut buf = [0u8; 4096];
+                let _ = sock.read(&mut buf).await;
+                if let Some(body) = response {
+                    let _ = sock.write_all(body.as_bytes()).await;
+                    let _ = sock.flush().await;
+                }
+                drop(sock);
+            });
+        }
+    });
+    (addr, handle)
+}
+
+// =============================================================================
+// Harness helpers
+// =============================================================================
+
+fn test_bus() -> (SharedBus, broadcast::Receiver<BusEvent>) {
+    let bus = create_bus();
+    let rx = bus.subscribe();
+    (bus, rx)
+}
+
+fn clear_lms_config() {
+    use unified_hifi_control::config::get_config_file_path;
+    let _ = std::fs::remove_file(get_config_file_path("lms-config.json"));
+}
+
+async fn configured_adapter(bus: SharedBus, addr: SocketAddr) -> LmsAdapter {
+    let adapter = LmsAdapter::new(bus);
+    adapter
+        .configure(addr.ip().to_string(), Some(addr.port()), None, None)
+        .await;
+    adapter
+}
+
+fn drain_zones(rx: &mut broadcast::Receiver<BusEvent>) -> Vec<unified_hifi_control::bus::Zone> {
+    let mut zones = Vec::new();
+    while let Ok(event) = rx.try_recv() {
+        if let BusEvent::ZoneDiscovered { zone } = event {
+            zones.push(zone);
+        }
+    }
+    zones
+}
+
+// =============================================================================
+// Defect 1 — search_library() could never return a result
+// =============================================================================
+
+/// The load-bearing test. With no player connected, `search()` falls through to
+/// `search_library()`, which issues `search <start> <n> term:` and parses the
+/// reply. Fed the **recorded live 9.1.2 response**, current `v3` returns an empty
+/// `Vec` because every branch reads `id` and LMS emits `<type>_id`.
+#[tokio::test]
+#[serial_test::serial(lms_config)]
+async fn search_library_returns_results_from_recorded_live_response() {
+    clear_lms_config();
+    // `players_no_playerprefs` deliberately supplies players the adapter never
+    // caches (search() reads its own state, not this response), so search()
+    // takes the no-player path straight into search_library().
+    let server = ReplayServer::start(
+        "players_no_playerprefs",
+        "status_tags_aAdltKc",
+        Some("search_term_ember"),
+    )
+    .await;
+    let (bus, _rx) = test_bus();
+    let adapter = configured_adapter(bus, server.addr()).await;
+
+    let results = match adapter.search("Ember", None, Some(10)).await {
+        Ok(r) => r,
+        Err(e) => panic!("search failed: {e}"),
+    };
+
+    assert!(
+        !results.is_empty(),
+        "search_library() returned nothing for a recorded live LMS response that \
+         contains 3 albums, 1 contributor and 8 tracks. This is defect #407.1: the \
+         parser reads `id`, LMS emits `album_id` / `contributor_id` / `track_id`."
+    );
+
+    let album = results
+        .iter()
+        .find(|r| r.result_type == LmsSearchResultType::Album)
+        .cloned();
+    let album = match album {
+        Some(a) => a,
+        None => panic!("no Album result parsed from albums_loop[].album_id"),
+    };
+    assert_eq!(album.title, "Ember Light");
+    assert_eq!(album.id, 1, "album id must come from `album_id`, not `id`");
+
+    let artist = results
+        .iter()
+        .find(|r| r.result_type == LmsSearchResultType::Artist)
+        .cloned();
+    let artist = match artist {
+        Some(a) => a,
+        None => panic!("no Artist result parsed from contributors_loop[].contributor_id"),
+    };
+    assert_eq!(artist.title, "Ember Valley Quartet");
+    assert_eq!(
+        artist.id, 3,
+        "artist id must come from `contributor_id`, not `id`"
+    );
+
+    let track = results
+        .iter()
+        .find(|r| r.result_type == LmsSearchResultType::Track)
+        .cloned();
+    let track = match track {
+        Some(t) => t,
+        None => panic!("no Track result parsed from tracks_loop[].track_id"),
+    };
+    assert_eq!(
+        track.id, 1,
+        "track id must come from `track_id`, not `id`"
+    );
+    assert_eq!(track.title, "Ember Rising");
+
+    // Every result must carry a usable playback handle, or search_and_play cannot
+    // act on it — an id of 0 is what the broken parser would have produced had its
+    // guards not rejected the row outright.
+    for r in &results {
+        assert!(
+            r.id > 0,
+            "result {:?} has no usable entity id; playlistcontrol needs one",
+            r.title
+        );
+    }
+
+    server.stop();
+}
+
+/// A search term whose only match is a genre still yields the tracks LMS found.
+/// Guards against a fix that special-cases one loop name.
+#[tokio::test]
+#[serial_test::serial(lms_config)]
+async fn search_library_parses_recorded_response_with_absent_loops() {
+    clear_lms_config();
+    // search_term_jazz has genres_loop + tracks_loop and NO albums_loop or
+    // contributors_loop at all — LMS omits empty loops rather than returning them
+    // empty. The parser must tolerate that.
+    let server = ReplayServer::start(
+        "players_no_playerprefs",
+        "status_tags_aAdltKc",
+        Some("search_term_jazz"),
+    )
+    .await;
+    let (bus, _rx) = test_bus();
+    let adapter = configured_adapter(bus, server.addr()).await;
+
+    let results = match adapter.search("Jazz", None, Some(10)).await {
+        Ok(r) => r,
+        Err(e) => panic!("search failed: {e}"),
+    };
+
+    assert!(
+        !results.is_empty(),
+        "recorded response has 5 tracks in tracks_loop"
+    );
+    assert!(
+        results
+            .iter()
+            .all(|r| r.result_type == LmsSearchResultType::Track),
+        "only tracks_loop is present in this recording, so only Track results are possible"
+    );
+    server.stop();
+}
+
+/// Zero matches must stay zero — `{"count": 0}` with no loops at all.
+#[tokio::test]
+#[serial_test::serial(lms_config)]
+async fn search_library_returns_empty_for_recorded_no_match_response() {
+    clear_lms_config();
+    let server = ReplayServer::start(
+        "players_no_playerprefs",
+        "status_tags_aAdltKc",
+        Some("search_no_results"),
+    )
+    .await;
+    let (bus, _rx) = test_bus();
+    let adapter = configured_adapter(bus, server.addr()).await;
+
+    let results = match adapter.search("zzznotfound", None, Some(10)).await {
+        Ok(r) => r,
+        Err(e) => panic!("search failed: {e}"),
+    };
+    assert!(results.is_empty(), "no matches must produce no results");
+    server.stop();
+}
+
+// =============================================================================
+// Defect 2 — the dead JSON-RPC `error` check
+// =============================================================================
+
+/// LMS never returns a JSON-RPC `error` object. Its error signal is closing the
+/// socket with zero bytes written, so the adapter must produce a diagnostic that
+/// names that, not an opaque transport error.
+#[tokio::test]
+#[serial_test::serial(lms_config)]
+async fn lms_failure_closed_socket_is_reported_as_lms_failure() {
+    clear_lms_config();
+    let (addr, handle) = start_closing_server().await;
+    let (bus, _rx) = test_bus();
+    let adapter = configured_adapter(bus, addr).await;
+
+    let err = match adapter.get_players().await {
+        Ok(_) => panic!("a server that writes nothing must not look like success"),
+        Err(e) => format!("{e:#}"),
+    };
+
+    let lowered = err.to_lowercase();
+    assert!(
+        lowered.contains("closed") || lowered.contains("no response"),
+        "error must name LMS's actual failure mode (socket closed with no \
+         response), got: {err}"
+    );
+    assert!(
+        lowered.contains("players"),
+        "error must name the command that failed so a log is actionable, got: {err}"
+    );
+    handle.abort();
+}
+
+/// Same information reaching us as a valid empty 200 (e.g. via a proxy).
+#[tokio::test]
+#[serial_test::serial(lms_config)]
+async fn lms_failure_empty_body_is_reported_as_lms_failure() {
+    clear_lms_config();
+    let (addr, handle) = start_empty_body_server().await;
+    let (bus, _rx) = test_bus();
+    let adapter = configured_adapter(bus, addr).await;
+
+    let err = match adapter.get_players().await {
+        Ok(_) => panic!("an empty body must not look like success"),
+        Err(e) => format!("{e:#}"),
+    };
+    let lowered = err.to_lowercase();
+    assert!(
+        lowered.contains("empty") || lowered.contains("no response"),
+        "error must name the empty body, got: {err}"
+    );
+    handle.abort();
+}
+
+/// A JSON reply with no `result` member. LMS always sends `result` on success;
+/// this is the replacement for the dead `error` check — it fires for anything
+/// that is not LMS, including a hypothetical responder that *did* send `error`.
+#[tokio::test]
+#[serial_test::serial(lms_config)]
+async fn lms_failure_missing_result_member_is_reported() {
+    clear_lms_config();
+    let (addr, handle) = start_no_result_server().await;
+    let (bus, _rx) = test_bus();
+    let adapter = configured_adapter(bus, addr).await;
+
+    match adapter.get_players().await {
+        Ok(players) => panic!(
+            "a reply with no `result` member must be an error, got {} players",
+            players.len()
+        ),
+        Err(e) => {
+            let msg = format!("{e:#}").to_lowercase();
+            assert!(
+                msg.contains("result"),
+                "error must say the `result` member was missing, got: {e:#}"
+            );
+        }
+    }
+    handle.abort();
+}
+
+/// The dead check being replaced must not be replaced by *another* dead check:
+/// a well-formed LMS reply still has to succeed.
+#[tokio::test]
+#[serial_test::serial(lms_config)]
+async fn lms_success_path_still_works() {
+    clear_lms_config();
+    let server = ReplayServer::start("players_mute_mixed", "status_tags_aAdltKc", None).await;
+    let (bus, _rx) = test_bus();
+    let adapter = configured_adapter(bus, server.addr()).await;
+
+    let players = match adapter.get_players().await {
+        Ok(p) => p,
+        Err(e) => panic!("valid recorded response must parse: {e:#}"),
+    };
+    assert_eq!(players.len(), 3, "recording has three players");
+    server.stop();
+}
+
+// =============================================================================
+// Defect 3 — is_muted hard-coded false
+// =============================================================================
+
+/// The batched-cost claim, as a test: the adapter must ask for the mute pref on
+/// the `players` call it already makes, and must not add a per-player
+/// `mixer muting ?` round-trip.
+#[tokio::test]
+#[serial_test::serial(lms_config)]
+async fn players_query_requests_mute_pref_without_extra_round_trips() {
+    clear_lms_config();
+    let server = ReplayServer::start("players_mute_mixed", "status_tags_aAdltKc", None).await;
+    let (bus, _rx) = test_bus();
+    let adapter = configured_adapter(bus, server.addr()).await;
+
+    if let Err(e) = adapter.update_players().await {
+        panic!("update_players failed: {e:#}");
+    }
+
+    let commands = server.commands();
+
+    let players_calls: Vec<&Value> = commands
+        .iter()
+        .filter(|c| c.get(0).and_then(|v| v.as_str()) == Some("players"))
+        .collect();
+    assert_eq!(
+        players_calls.len(),
+        1,
+        "one poll cycle must issue exactly one `players` call"
+    );
+    let asks_for_mute = players_calls[0]
+        .as_array()
+        .map(|a| {
+            a.iter()
+                .any(|v| v.as_str() == Some("playerprefs:mute"))
+        })
+        .unwrap_or(false);
+    assert!(
+        asks_for_mute,
+        "`players` must carry `playerprefs:mute` so mute costs zero extra \
+         round-trips; got {:?}",
+        players_calls[0]
+    );
+
+    let muting_calls = commands
+        .iter()
+        .filter(|c| {
+            c.get(0).and_then(|v| v.as_str()) == Some("mixer")
+                && c.get(1).and_then(|v| v.as_str()) == Some("muting")
+        })
+        .count();
+    assert_eq!(
+        muting_calls, 0,
+        "mute must not cost a `mixer muting ?` round-trip per player per poll"
+    );
+
+    server.stop();
+}
+
+/// Zones must report the mute state the recorded response actually carries — all
+/// three shapes LMS uses, in one response: string "0", key absent, string "1".
+#[tokio::test]
+#[serial_test::serial(lms_config)]
+async fn mute_state_from_recorded_players_response_reaches_zones() {
+    clear_lms_config();
+    let server = ReplayServer::start("players_mute_mixed", "status_tags_aAdltKc", None).await;
+    let (bus, mut rx) = test_bus();
+    let adapter = configured_adapter(bus, server.addr()).await;
+
+    if let Err(e) = adapter.update_players().await {
+        panic!("update_players failed: {e:#}");
+    }
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let zones = drain_zones(&mut rx);
+    assert_eq!(zones.len(), 3, "three players in the recording");
+
+    let muted_of = |zone_id: &str| -> bool {
+        let zone = zones.iter().find(|z| z.zone_id == zone_id);
+        let zone = match zone {
+            Some(z) => z,
+            None => panic!("zone {zone_id} not discovered; got {:?}", zones.iter().map(|z| &z.zone_id).collect::<Vec<_>>()),
+        };
+        match zone.volume_control.as_ref() {
+            Some(vc) => vc.is_muted,
+            None => panic!("zone {zone_id} has no volume_control"),
+        }
+    };
+
+    // Recording: Kitchen has `"mute": "0"` — a *string*. `.as_i64()` alone yields
+    // None on that, which is the same failure class as defect 1.
+    assert!(
+        !muted_of("lms:02:00:00:00:00:01"),
+        r#"`"mute": "0"` (string) means not muted"#
+    );
+    // Recording: this player has no `mute` key at all — the pref was never
+    // written. LMS omits undefined prefs.
+    assert!(
+        !muted_of("lms:02:00:00:00:00:02"),
+        "an absent `mute` key means the pref was never set, i.e. not muted"
+    );
+    // Recording: Study has `"mute": "1"`. This is the assertion that fails
+    // against current v3, where is_muted is hard-coded false.
+    assert!(
+        muted_of("lms:02:00:00:00:00:11"),
+        r#"`"mute": "1"` means muted — defect #407.3 hard-codes is_muted false"#
+    );
+
+    server.stop();
+}
+
+/// A mute change with no volume change must reach clients. Zones are served from
+/// the aggregator's event-fed cache, so without this the fixed snapshot would
+/// only ever be right at discovery time.
+#[tokio::test]
+#[serial_test::serial(lms_config)]
+async fn mute_change_alone_publishes_volume_changed() {
+    clear_lms_config();
+    let server = ReplayServer::start("players_mute_mixed", "status_tags_aAdltKc", None).await;
+    let (bus, mut rx) = test_bus();
+    let adapter = configured_adapter(bus, server.addr()).await;
+
+    // Baseline poll: Study muted.
+    if let Err(e) = adapter.update_players().await {
+        panic!("baseline update failed: {e:#}");
+    }
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    while rx.try_recv().is_ok() {}
+
+    // Second poll: everything unmuted, volumes unchanged (both recordings come
+    // from the same players with the same volumes).
+    server.set_players_fixture("players_mute_all_unmuted");
+    if let Err(e) = adapter.update_players().await {
+        panic!("second update failed: {e:#}");
+    }
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let mut saw_unmute = false;
+    while let Ok(event) = rx.try_recv() {
+        if let BusEvent::VolumeChanged {
+            output_id,
+            is_muted,
+            ..
+        } = event
+        {
+            if output_id == "lms:02:00:00:00:00:11" && !is_muted {
+                saw_unmute = true;
+            }
+        }
+    }
+    assert!(
+        saw_unmute,
+        "a mute change with no volume change must publish VolumeChanged, or the \
+         aggregator's zone cache never learns about it"
+    );
+
+    server.stop();
+}
+
+/// LMS **negates** `mixer volume` once its mute fade completes: the recorded
+/// muted `model: squeezelite` player reports `"mixer volume": -42`. The adapter
+/// hands `mixer volume` to a `VolumeControl` declared `min: 0.0`, so a negative
+/// must never reach a client. (`tests/volume_safety.rs` exists because a volume
+/// range bug once risked equipment damage.)
+#[tokio::test]
+#[serial_test::serial(lms_config)]
+async fn muted_player_volume_is_not_negated() {
+    clear_lms_config();
+    let server =
+        ReplayServer::start("players_mute_mixed", "status_squeezelite_muted", None).await;
+    let (bus, mut rx) = test_bus();
+    let adapter = configured_adapter(bus, server.addr()).await;
+
+    if let Err(e) = adapter.update_players().await {
+        panic!("update_players failed: {e:#}");
+    }
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    for zone in drain_zones(&mut rx) {
+        if let Some(vc) = zone.volume_control {
+            assert!(
+                vc.value >= 0.0,
+                "zone {} reported volume {} — LMS never negates `mixer volume` on \
+                 mute, so a negative here is a parse bug",
+                zone.zone_id,
+                vc.value
+            );
+        }
+    }
+    server.stop();
+}
+
+/// The second mute signal, which needs no tagged parameter at all: a negative
+/// `mixer volume` is a sufficient condition for muted. It lags a mute by ~0.8 s
+/// (the fade), so it can only ever produce a false *negative*, never a false
+/// positive — which is what makes it safe to OR with the pref, and what keeps
+/// mute working if `playerprefs:` is ever unavailable.
+#[tokio::test]
+#[serial_test::serial(lms_config)]
+async fn negative_volume_alone_reports_muted() {
+    clear_lms_config();
+    // players_no_playerprefs was recorded *without* the tag, so it carries no
+    // `mute` key for any player — the pref signal is entirely absent here.
+    let server =
+        ReplayServer::start("players_no_playerprefs", "status_squeezelite_muted", None).await;
+    let (bus, mut rx) = test_bus();
+    let adapter = configured_adapter(bus, server.addr()).await;
+
+    if let Err(e) = adapter.update_players().await {
+        panic!("update_players failed: {e:#}");
+    }
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let zones = drain_zones(&mut rx);
+    assert!(!zones.is_empty(), "expected zones from the recording");
+    for zone in zones {
+        match zone.volume_control {
+            Some(vc) => assert!(
+                vc.is_muted,
+                "zone {} saw a recorded `mixer volume: -42` and no mute pref; the \
+                 negative sign alone must report muted",
+                zone.zone_id
+            ),
+            None => panic!("zone {} has no volume_control", zone.zone_id),
+        }
+    }
+    server.stop();
+}
+
+// =============================================================================
+// Defect 4 — the tags legend in docs/lyrion.md
+// =============================================================================
+
+/// The doc claimed `l=album_id, A=album`. LMS's `%tagMap` says `l` is the album
+/// *title*, `e` is `album_id`, and `A` expands to per-role contributor names.
+/// Pinned against the recording so the doc cannot drift back.
+#[test]
+fn docs_tag_legend_matches_recorded_response() {
+    let status = fixture_result("status_tags_aAdltKc");
+    let track = status["playlist_loop"][0].clone();
+
+    // `l` yields an album *title*.
+    assert_eq!(
+        track["album"].as_str(),
+        Some("Ember Light"),
+        "tag `l` yields the album title in the `album` key"
+    );
+    // `e` (album_id) was NOT requested, so no album id is present. This is the
+    // direct refutation of the old legend's `l=album_id`.
+    assert!(
+        track.get("album_id").is_none(),
+        "tags:aAdltKc does not request `e`, so no album_id is returned"
+    );
+    // `A` yields per-role contributor names, not an album.
+    assert!(
+        track.get("albumartist").is_some() || track.get("trackartist").is_some(),
+        "tag `A` yields per-role contributor keys such as albumartist/trackartist"
+    );
+    // `J` (artwork_track_id) is not requested either — which is why the
+    // artwork_track_id fallback in get_player_status is dead. Documented, not
+    // silently changed: see the PR body.
+    assert!(
+        track.get("artwork_track_id").is_none(),
+        "tags:aAdltKc does not request `J`, so artwork_track_id is never present"
+    );
+
+    let doc = match std::fs::read_to_string(format!(
+        "{}/docs/lyrion.md",
+        env!("CARGO_MANIFEST_DIR")
+    )) {
+        Ok(d) => d,
+        Err(e) => panic!("docs/lyrion.md unreadable: {e}"),
+    };
+    assert!(
+        !doc.contains("l=album_id"),
+        "docs/lyrion.md still claims `l=album_id`; `l` is the album title and `e` \
+         is album_id"
+    );
+    assert!(
+        !doc.contains("A=album\n") && !doc.contains("A=album,"),
+        "docs/lyrion.md still claims `A=album`; `A` expands to per-role \
+         contributor names"
+    );
+    assert!(
+        doc.contains("e=album_id") || doc.contains("`e`"),
+        "docs/lyrion.md must document `e` as album_id"
+    );
+}
+
+/// Guard against fixtures drifting into hand-written mocks — the thing that let
+/// defect 1 survive.
+#[test]
+fn fixtures_are_recorded_not_authored() {
+    let dir = format!("{}/tests/fixtures/lms", env!("CARGO_MANIFEST_DIR"));
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(e) => e,
+        Err(e) => panic!("fixture dir {dir} unreadable: {e}"),
+    };
+    let counted = AtomicUsize::new(0);
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let raw = match std::fs::read_to_string(&path) {
+            Ok(r) => r,
+            Err(e) => panic!("{path:?}: {e}"),
+        };
+        let parsed: Value = match serde_json::from_str(&raw) {
+            Ok(v) => v,
+            Err(e) => panic!("{path:?} is not valid JSON: {e}"),
+        };
+        // A recording carries LMS's own echo of the request that produced it and
+        // this repo's request id. An authored mock generally will not.
+        assert_eq!(
+            parsed["method"].as_str(),
+            Some("slim.request"),
+            "{path:?} is missing LMS's `method` echo — is it a recording?"
+        );
+        assert!(
+            parsed.get("params").is_some(),
+            "{path:?} is missing LMS's `params` echo, which is its provenance"
+        );
+        assert_eq!(
+            parsed["id"].as_i64(),
+            Some(217),
+            "{path:?} was not recorded through this repo's request id (217)"
+        );
+        counted.fetch_add(1, Ordering::Relaxed);
+    }
+    assert!(
+        counted.load(Ordering::Relaxed) >= 8,
+        "expected the recorded LMS fixture set to be present"
+    );
+}

--- a/tests/lms_live_smoke.rs
+++ b/tests/lms_live_smoke.rs
@@ -1,0 +1,232 @@
+//! Opt-in smoke tests that drive a **real** Lyrion Music Server (#407).
+//!
+//! Every test here is `#[ignore]`d, so `cargo test` never runs them and CI is
+//! unaffected. They exist because #407's defects all survived unit tests that
+//! agreed with the code, and the only thing that caught them was a live server.
+//!
+//! ```sh
+//! LMS_LIVE_HOST=127.0.0.1 LMS_LIVE_PORT=9000 \
+//!   cargo test --test lms_live_smoke -- --ignored --nocapture
+//! ```
+//!
+//! `LMS_LIVE_HOST` defaults to `127.0.0.1` and `LMS_LIVE_PORT` to `9000`.
+//!
+//! `live_mute_round_trip` **mutes and unmutes a real player**. It restores the
+//! previous state, and skips itself unless `LMS_LIVE_PLAYER` names the player to
+//! use, so it can never surprise a listener on someone's actual system.
+//!
+//! ## If you stand up a throwaway LMS for this, do not publish port 3483
+//!
+//! Publishing 3483 lets every SlimProto player on the LAN auto-discover the test
+//! server and attach to it. That happened once during the survey behind #402/#403
+//! and pulled about ten of the operator's real players onto a throwaway
+//! container. Bind 9000 to `127.0.0.1`.
+
+use std::time::Duration;
+use unified_hifi_control::adapters::lms::{LmsAdapter, LmsSearchResultType};
+use unified_hifi_control::bus::{create_bus, BusEvent};
+
+fn live_host() -> String {
+    std::env::var("LMS_LIVE_HOST").unwrap_or_else(|_| "127.0.0.1".to_string())
+}
+
+fn live_port() -> u16 {
+    std::env::var("LMS_LIVE_PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(9000)
+}
+
+async fn live_adapter() -> LmsAdapter {
+    let bus = create_bus();
+    let adapter = LmsAdapter::new(bus);
+    adapter
+        .configure(live_host(), Some(live_port()), None, None)
+        .await;
+    adapter
+}
+
+/// Defect 1, end to end against a real server: the library fallback must return
+/// results with usable entity ids.
+///
+/// Pass `LMS_LIVE_TERM` to match your own library; the default suits the
+/// generated library described in `tests/fixtures/lms/PROVENANCE.md`.
+#[tokio::test]
+#[ignore = "requires a live LMS; see module docs"]
+async fn live_search_library_returns_addressable_results() {
+    let adapter = live_adapter().await;
+    let term = std::env::var("LMS_LIVE_TERM").unwrap_or_else(|_| "Ember".to_string());
+
+    // player_id None with no cached players forces the search_library() path,
+    // which is the one that never worked.
+    let results = match adapter.search(&term, None, Some(10)).await {
+        Ok(r) => r,
+        Err(e) => panic!("live search failed: {e:#}"),
+    };
+
+    println!("live search for {term:?} returned {} results:", results.len());
+    for r in &results {
+        println!("  {:?} id={} {:?}", r.result_type, r.id, r.title);
+    }
+
+    assert!(
+        !results.is_empty(),
+        "no results for {term:?}. Set LMS_LIVE_TERM to something in your library."
+    );
+    for r in &results {
+        assert!(
+            r.id > 0 || r.item_id.is_some() || r.url.is_some(),
+            "result {:?} carries no playback handle, so nothing can act on it",
+            r.title
+        );
+    }
+    assert!(
+        results.iter().any(|r| matches!(
+            r.result_type,
+            LmsSearchResultType::Album | LmsSearchResultType::Artist | LmsSearchResultType::Track
+        )),
+        "results must be typed"
+    );
+}
+
+/// Defect 2, end to end: a request LMS rejects must surface as a diagnostic that
+/// names LMS's real behaviour, not an opaque transport error. Uses `get_players`
+/// against a port with nothing listening, which is the closest reachable analogue
+/// of the closed socket without sending LMS a bogus command.
+#[tokio::test]
+#[ignore = "requires a live LMS; see module docs"]
+async fn live_transport_failure_is_diagnosable() {
+    let bus = create_bus();
+    let adapter = LmsAdapter::new(bus);
+    // A port nothing is listening on: connection refused rather than an LMS
+    // close, but it must still name the command.
+    adapter.configure(live_host(), Some(1), None, None).await;
+
+    match adapter.get_players().await {
+        Ok(_) => panic!("a dead port must not look like success"),
+        Err(e) => {
+            let msg = format!("{e:#}");
+            println!("dead-port error: {msg}");
+            assert!(
+                msg.contains("players"),
+                "error must name the command: {msg}"
+            );
+        }
+    }
+}
+
+/// Defects 3 and the negative-volume finding, end to end on a real player.
+///
+/// This is the check the #407 gate reports asked the operator to run on real
+/// hardware: mute a player, confirm UHC reports it muted and does **not** report
+/// a negative volume, then restore.
+///
+/// Set `LMS_LIVE_PLAYER` to the bare player id (no `lms:` prefix). Without it the
+/// test skips, so it cannot mute a stranger's speakers.
+#[tokio::test]
+#[ignore = "requires a live LMS AND an explicitly named player; see module docs"]
+async fn live_mute_round_trip() {
+    let Ok(player) = std::env::var("LMS_LIVE_PLAYER") else {
+        println!("skipping: set LMS_LIVE_PLAYER to a bare player id to run this");
+        return;
+    };
+
+    let bus = create_bus();
+    let mut rx = bus.subscribe();
+    let adapter = LmsAdapter::new(bus);
+    adapter
+        .configure(live_host(), Some(live_port()), None, None)
+        .await;
+
+    let raw = match adapter.get_players().await {
+        Ok(p) => p,
+        Err(e) => panic!("get_players failed: {e:#}"),
+    };
+    let Some(was_muted) = raw.iter().find(|p| p.playerid == player).map(|p| p.muted) else {
+        panic!("player {player} not found on this server");
+    };
+    println!("before: muted={was_muted} (from playerprefs:mute)");
+
+    // First poll establishes the adapter's baseline for this player and emits
+    // ZoneDiscovered - the zone snapshot clients read on connect.
+    if let Err(e) = adapter.update_players().await {
+        panic!("baseline update_players failed: {e:#}");
+    }
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    let mut baseline_muted = None;
+    while let Ok(event) = rx.try_recv() {
+        if let BusEvent::ZoneDiscovered { zone } = event {
+            if zone.zone_id.ends_with(&player) {
+                if let Some(vc) = zone.volume_control {
+                    println!("ZoneDiscovered: value={} is_muted={}", vc.value, vc.is_muted);
+                    assert!(vc.value >= 0.0, "zone volume must not be negative");
+                    baseline_muted = Some(vc.is_muted);
+                }
+            }
+        }
+    }
+    assert_eq!(
+        baseline_muted,
+        Some(was_muted),
+        "the zone snapshot must agree with the server's mute pref"
+    );
+
+    // Mute via LMS directly. Mute *control* through the adapter is #403's work,
+    // not #407's, so this drives the server rather than widening the adapter's
+    // surface just to test it.
+    set_mute_on_server(&player, !was_muted).await;
+    // Let the fade finish so the negated volume has landed. That is the window an
+    // earlier reading of this landed inside, wrongly concluding LMS keeps the
+    // volume positive while muted.
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+
+    // Second poll: mute changed, volume did not. This must still reach the bus.
+    if let Err(e) = adapter.update_players().await {
+        panic!("second update_players failed: {e:#}");
+    }
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let mut observed = None;
+    while let Ok(event) = rx.try_recv() {
+        if let BusEvent::VolumeChanged {
+            output_id,
+            value,
+            is_muted,
+        } = event
+        {
+            if output_id.ends_with(&player) {
+                println!("VolumeChanged: value={value} is_muted={is_muted}");
+                assert!(
+                    value >= 0.0,
+                    "published volume must never be negative; LMS negates the \
+                     volume pref while muted and VolumeControl declares min: 0.0"
+                );
+                observed = Some(is_muted);
+            }
+        }
+    }
+    assert_eq!(
+        observed,
+        Some(!was_muted),
+        "a mute change with no volume change must reach the bus as VolumeChanged"
+    );
+
+    // Restore whatever the player had before this test touched it.
+    set_mute_on_server(&player, was_muted).await;
+}
+
+/// Set mute on the live server over the same transport the adapter uses.
+async fn set_mute_on_server(player: &str, muted: bool) {
+    let url = format!("http://{}:{}/jsonrpc.js", live_host(), live_port());
+    let body = serde_json::json!({
+        "id": 217,
+        "method": "slim.request",
+        "params": [player, ["mixer", "muting", if muted { 1 } else { 0 }]]
+    });
+    let response = reqwest::Client::new().post(&url).json(&body).send().await;
+    match response {
+        Ok(r) if r.status().is_success() => {}
+        Ok(r) => panic!("mixer muting returned HTTP {}", r.status()),
+        Err(e) => panic!("mixer muting failed: {e}"),
+    }
+}

--- a/tests/lms_live_smoke.rs
+++ b/tests/lms_live_smoke.rs
@@ -64,7 +64,10 @@ async fn live_search_library_returns_addressable_results() {
         Err(e) => panic!("live search failed: {e:#}"),
     };
 
-    println!("live search for {term:?} returned {} results:", results.len());
+    println!(
+        "live search for {term:?} returned {} results:",
+        results.len()
+    );
     for r in &results {
         println!("  {:?} id={} {:?}", r.result_type, r.id, r.title);
     }
@@ -158,7 +161,10 @@ async fn live_mute_round_trip() {
         if let BusEvent::ZoneDiscovered { zone } = event {
             if zone.zone_id.ends_with(&player) {
                 if let Some(vc) = zone.volume_control {
-                    println!("ZoneDiscovered: value={} is_muted={}", vc.value, vc.is_muted);
+                    println!(
+                        "ZoneDiscovered: value={} is_muted={}",
+                        vc.value, vc.is_muted
+                    );
                     assert!(vc.value >= 0.0, "zone volume must not be negative");
                     baseline_muted = Some(vc.is_muted);
                 }


### PR DESCRIPTION
Fixes #407
Parent epic: #392
OH: 80222d6d

Four verified defects in the LMS adapter, all pre-existing and independent of the MCP chain. Based on `v3`.

## What was wrong, and what proves it

Everything here was verified against a **live Lyrion Music Server 9.1.2** stood up for this work, driven over `POST /jsonrpc.js` / `slim.request` — the exact transport `LmsRpc::execute` uses. Recorded responses are committed as fixtures with full provenance in `tests/fixtures/lms/PROVENANCE.md`. No fixture in this PR is hand-written; a hand-written guess at LMS's shape is what let defect 1 survive.

### 1. `search_library()` could never return a result

`search 0 10 term:Ember` on a real server returns `albums_loop[].album_id`, `contributors_loop[].contributor_id`, `tracks_loop[].track_id`. There is **no `id` key anywhere**. Every branch read `id`, so every `if let (Some(id), …)` guard failed and the function always returned an empty `Vec`. Because `search()` only reaches it when globalsearch yields nothing, the library fallback silently searched nothing.

Fixed to read `<type>_id`, with `id` retained as a fallback so no LMS version can regress, and parsed from string-or-number because LMS's JSON types are not stable even within one field.

### 2. Dead error check

LMS **never** returns a JSON-RPC `error` object. On any request error `Slim::Web::JSONRPC::requestMethod` calls `closeHTTPSocket()`, so the client gets **zero bytes and a closed socket** — no HTTP status line at all. Recorded byte counts for unknown command, unknown player, bad config and a Perl exception are in the provenance file. `data.get("error")` was unreachable and the real failure mode was undetected.

Replaced with detection that fires: a closed socket, an empty body, and a JSON body with no `result` member all now produce one diagnostic error naming LMS's actual behaviour and the command that triggered it, instead of an opaque `reqwest` decode error.

### 3. `is_muted` hard-coded `false` — now real, at zero extra cost

`status` genuinely carries no mute key: a **muted** real squeezelite player still reports a plain positive `"mixer volume": 42` (`status_squeezelite_muted.json`). So the old comment was half right.

But `playersQuery` accepts a `playerprefs:` parameter, and mute is the per-client `mute` pref. **`players 0 100 playerprefs:mute` returns mute for every player inside the `players` call the adapter already makes each poll** — so real mute state costs **zero additional round-trips at any poll rate**, rather than the one-per-player-per-poll that `mixer muting ?` would have cost at the 2 s default interval.

Three sites that hard-coded `false` now report the real value, and the poll loop publishes `VolumeChanged` when mute changes on its own — without that, a mute change made outside UHC would never reach the aggregator's zone cache.

### 4. Wrong tag legend

`docs/lyrion.md:82` claimed `l=album_id, A=album`. From LMS's own `%tagMap` and confirmed live: `l` = album **title**, `e` = `album_id`, `A` = per-role contributor names, `s` = `artist_id`. Corrected, expanded to the tags this repo actually uses, and the `tags:aAdltKc` string was checked against it — see the finding below.

## Client compatibility

`is_muted` changes reported zone state, so this was checked first, as the issue requires.

- **No payload shape change.** `is_muted: bool` already exists on `VolumeControl` in `/zones`, on `VolumeChanged` over SSE, and in the MCP zone projection. Only the *value* changes.
- **`true` was already reachable for LMS.** The CLI-subscription path (`CliEvent::Mixer`, `param == "muting"`) has always published real mute for LMS. Polling contradicted it. This PR makes the two agree.
- `tests/client_harness.rs` deserialises `is_muted: bool` and asserts nothing about its value (`:101`). `tests/protocol_schema.rs` and `tests/volume_safety.rs` only assert `false` for Roon-shaped and synthetic payloads, never LMS.
- **No HTTP route changes.** `tests/fixtures/api_routes.txt` untouched, no `api-change-approved` needed.

## Additional finding, deliberately not fixed here

`get_player_status` falls back to `playlist_loop[0].artwork_track_id` for artwork, but `artwork_track_id` is tag **`J`**, which `tags:aAdltKc` does not request — so that branch is dead and artwork silently falls through to the raw track `id`. Adding `J` is free on the wire, but it would change `image_key` values for tracks with no `coverid`, and `image_key` is client-visible. Out of scope for a defect fix under an "additive, no payload change" constraint. Commented in place at the call site and documented in `docs/lyrion.md`; flagged for #401/#403.

## Verification

**CI runs on this PR and is green** — `build.yml` triggers on `pull_request` targeting `v3`, so Lint, Test, Build WASM Assets, Build Linux x64, Smoke Test Binary and Synology Package Contract all ran and passed. (The issue's note that feature-branch PRs run no CI holds only for the `push` trigger, which is scoped to `v3` and `feature/**`. Reading the checks rather than trusting that note caught a real `cargo fmt --check` failure in Lint.)

`API Guard` correctly did not run: none of its watched paths — `src/main.rs`, `src/api/**`, `tests/fixtures/api_routes.txt` — changed.

Also verified locally, including the part CI cannot see: `cargo test --test lms_live_smoke -- --ignored` against a live Lyrion 9.1.2. Those tests are `#[ignore]`d so they never run in CI, and the mute one skips unless `LMS_LIVE_PLAYER` names a player, so it cannot surprise a listener on a real system. Full command list and output in the ship gate report.

**The strongest remaining check is the operator's**, and it is one command — see the ship gate dissent. Nothing here was tested against real hardware.

Gate reports per #392 (review + dissent at each of solution-space, execute, ship) are posted as comments below. Follow-ups filed: #414 (LMS version floor) and #415 (two dead parses deliberately left).

Do not merge without explicit operator approval.
