### PR TITLE
fix(roon): stop discarding Core browse errors, so a stale item key is not a 10s ambiguous timeout (#405)

### DIFF
--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -134,6 +134,22 @@ type LoadRequest = oneshot::Sender<Result<LoadResult>>;
 // out the full `BROWSE_TIMEOUT` and then reported "Browse request timed out" -
 // the same thing an unreachable Core produces. The types below carry the
 // Core's actual answer back to the caller, promptly and distinguishably.
+//
+// Two things about the delivery path, both established by reading the pinned
+// fork and neither observable from here, so they are recorded rather than
+// assumed:
+//
+// - Services are tried in order with a `break` on the first that claims a
+//   message (fork `src/lib.rs:597-631`), and Transport is tried before Browse.
+//   `Transport::parse_msg` gates every push on its own subscription ids, so it
+//   returns an empty `Vec` for a browse message and declines to claim it
+//   (fork `src/transport.rs:451-540`). If that ever changes, browse errors get
+//   swallowed inside the dependency and nothing here can see it.
+// - `Browse::parse_msg` matches four literal error names against `msg["name"]`
+//   (fork `src/browse.rs:174-188`). A Core that spells one differently yields
+//   `Parsed::None`, which the fork drops, and the caller times out as it did
+//   before - with this module's tests still green. That half is wire-level and
+//   is #408's to pin.
 
 /// Which browse/load rejection Roon Core reported.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -141,6 +157,12 @@ pub enum RoonBrowseErrorKind {
     /// The `item_key` is not valid in the browse session it was used in: it has
     /// expired, the session was reset, or it was minted somewhere else.
     /// Recoverable - re-acquire the key (search or browse again) and retry.
+    ///
+    /// The recovery instruction in [`RoonBrowseErrorKind::explain`] is written
+    /// for a caller that holds a key - `play_item` and `/roon/browse`. `search`
+    /// mints and consumes its own keys internally, so a rejection there reaches
+    /// a client that never held one; retrying the search is still the right
+    /// move, but a caller-facing surface may want to reword it (#395, #396).
     InvalidItemKey,
     /// The `level` / `pop_levels` in the request do not exist in this session.
     /// Recoverable - browse again from a level the caller still holds.
@@ -435,10 +457,14 @@ impl RoonState {
     /// long-lived browse tree is ever built on one session key (#399), stamp the
     /// pending entries with a connection generation instead.
     ///
-    /// Resolution is exactly-once: every path removes the entry before sending,
-    /// so a repeated rejection finds nothing and a waiter can never be resolved
-    /// twice. A `KeyMismatch` leaves the entry for the caller's own timeout to
-    /// clean up, so no path strands one.
+    /// Resolution is exactly-once because every path removes the entry before
+    /// sending *and* every mutation of these maps is synchronous while the one
+    /// state `RwLock` is held - so a caller's timeout cleanup and this routing
+    /// can interleave but never overlap. A repeated rejection finds nothing; a
+    /// caller that timed out first leaves nothing to find. A `KeyMismatch`
+    /// deliberately does **not** remove: that entry belongs to a caller still
+    /// inside its `BROWSE_TIMEOUT`, whose own cleanup owns it. Removing it here
+    /// would be the strand, not the fix.
     ///
     /// Both maps are searched for an entry where *both* the request id and the
     /// session key match before any mismatch is reported. A mismatched entry in
@@ -2410,7 +2436,17 @@ mod tests {
     // tests exercise the real routing functions, the real `oneshot` channels
     // and the real `BROWSE_TIMEOUT`. They do not exercise the fork's
     // `parse_msg`, nor the three-line result match in `browse()`/`load()` that
-    // hands the oneshot payload back to the caller.
+    // hands the oneshot payload back to the caller. In particular, nothing here
+    // proves that a real Core's error names match the four literals the fork
+    // matches on - if they did not, these tests would stay green and the
+    // ten-second hang would be live. That half is #408's.
+    //
+    // Which evidence supports which claim, since it is easy to conflate:
+    // `a_rejected_item_key_resolves_far_inside_the_browse_timeout` is the
+    // promptness proof; `browse_rejection_resolves_only_the_matching_waiter`
+    // and `a_mismatched_entry_in_one_map_does_not_hide_a_match_in_the_other`
+    // are the correlation proofs. A fast suite alone would not have caught an
+    // implementation that promptly resolved the *wrong* waiter.
 
     use std::time::Instant;
     use tokio::sync::oneshot::error::TryRecvError;

--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -120,6 +120,159 @@ type BrowseRequest = oneshot::Sender<Result<BrowseResult>>;
 /// Pending load request - stores the oneshot sender to deliver the result
 type LoadRequest = oneshot::Sender<Result<LoadResult>>;
 
+// =============================================================================
+// Core-reported browse rejections (issue #405)
+// =============================================================================
+//
+// Roon Core answers an unusable browse or load request with a named error
+// instead of a result. The pinned fork surfaces that as
+// `Parsed::Error(RoonApiError::Browse*)`, carrying both the originating
+// `req_id` and the request's `multi_session_key` (see the fork's
+// `src/browse.rs:174-188`).
+//
+// Before #405 the event loop dropped those messages, so the waiting caller sat
+// out the full `BROWSE_TIMEOUT` and then reported "Browse request timed out" -
+// the same thing an unreachable Core produces. The types below carry the
+// Core's actual answer back to the caller, promptly and distinguishably.
+
+/// Which browse/load rejection Roon Core reported.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RoonBrowseErrorKind {
+    /// The `item_key` is not valid in the browse session it was used in: it has
+    /// expired, the session was reset, or it was minted somewhere else.
+    /// Recoverable - re-acquire the key (search or browse again) and retry.
+    InvalidItemKey,
+    /// The `level` / `pop_levels` in the request do not exist in this session.
+    /// Recoverable - browse again from a level the caller still holds.
+    InvalidLevels,
+    /// The `zone_or_output_id` in the request is unknown to the Core. Not
+    /// fixed by retrying: the caller has to name a zone that exists.
+    ZoneNotFound,
+    /// The Core reported an unexpected failure for this request.
+    UnexpectedError,
+}
+
+impl RoonBrowseErrorKind {
+    /// Stable machine-readable tag for logs and callers.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::InvalidItemKey => "invalid_item_key",
+            Self::InvalidLevels => "invalid_levels",
+            Self::ZoneNotFound => "zone_not_found",
+            Self::UnexpectedError => "unexpected_error",
+        }
+    }
+
+    /// True when the caller can recover by re-acquiring its reference and
+    /// retrying immediately, rather than by waiting for the Core.
+    pub fn is_recoverable(self) -> bool {
+        matches!(self, Self::InvalidItemKey | Self::InvalidLevels)
+    }
+
+    /// Human-readable explanation, including the recovery instruction where
+    /// there is one. Deliberately never contains the word "timeout" - callers
+    /// and operators must be able to tell these apart at a glance.
+    fn explain(self) -> &'static str {
+        match self {
+            Self::InvalidItemKey => {
+                "Roon Core rejected the item key: it is no longer valid in this \
+                 browse session - search or browse again to get a fresh key"
+            }
+            Self::InvalidLevels => {
+                "Roon Core rejected the browse level: this browse session is not \
+                 at that level - browse again from a level you still hold"
+            }
+            Self::ZoneNotFound => {
+                "Roon Core does not recognise the zone or output in this browse \
+                 request"
+            }
+            Self::UnexpectedError => {
+                "Roon Core reported an unexpected error for this browse request"
+            }
+        }
+    }
+}
+
+/// A browse or load request that Roon Core answered with a rejection.
+///
+/// Distinct from a timeout: the Core answered, and it answered "no". Returned
+/// inside the `anyhow::Error` that `browse`, `load`, `search`, `play_item` and
+/// `search_and_play` already return, so no signature changes; recover it with
+/// [`RoonBrowseError::from_error`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RoonBrowseError {
+    /// What the Core rejected.
+    pub kind: RoonBrowseErrorKind,
+    /// The `multi_session_key` the rejected request ran in, as reported by the
+    /// Core. `None` only if the request carried no session key.
+    pub session_key: Option<String>,
+}
+
+impl RoonBrowseError {
+    fn new(kind: RoonBrowseErrorKind, session_key: Option<&str>) -> Self {
+        Self {
+            kind,
+            session_key: session_key.map(str::to_string),
+        }
+    }
+
+    /// Recover the typed rejection from an error returned by the browse-backed
+    /// adapter methods. `None` means the failure was something else - a
+    /// timeout, a lost Core, or Browse not being connected - so callers can
+    /// keep those classes apart without matching on message text.
+    pub fn from_error(err: &anyhow::Error) -> Option<&Self> {
+        err.downcast_ref::<Self>()
+    }
+}
+
+impl std::error::Error for RoonBrowseError {}
+
+impl std::fmt::Display for RoonBrowseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.kind.explain())?;
+        if let Some(session_key) = &self.session_key {
+            write!(f, " (browse session '{}')", session_key)?;
+        }
+        Ok(())
+    }
+}
+
+/// Where a Core rejection ended up. Reported for logging and asserted by the
+/// correlation tests; the caller-visible effect is the resolved oneshot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ErrorRouting {
+    /// Delivered to the pending browse holding this `req_id`.
+    Browse,
+    /// Delivered to the pending load holding this `req_id`.
+    Load,
+    /// Delivered to the pending image request holding this `req_id`.
+    Image,
+    /// The waiter was found and removed, but its receiver was already gone.
+    ReceiverGone,
+    /// No request with this `req_id` is pending - it was already resolved, or
+    /// the caller timed out and cleaned up. Dropping the rejection is correct.
+    NoWaiter,
+    /// A request with this `req_id` is pending but carries a different session
+    /// or image key, so it was left alone to hit its own timeout rather than
+    /// being resolved with someone else's rejection.
+    KeyMismatch,
+}
+
+/// Deliver a Core rejection to a waiting browse or load request.
+/// Returns whether the waiter was still listening.
+fn deliver_browse_rejection<T>(
+    sender: oneshot::Sender<Result<T>>,
+    kind: RoonBrowseErrorKind,
+    session_key: Option<&str>,
+) -> bool {
+    sender
+        .send(Err(anyhow::Error::new(RoonBrowseError::new(
+            kind,
+            session_key,
+        ))))
+        .is_ok()
+}
+
 /// Image data returned from Roon
 #[derive(Debug, Clone)]
 pub struct ImageData {
@@ -244,6 +397,29 @@ struct RoonState {
     pending_browses: HashMap<usize, (Option<String>, BrowseRequest)>,
     /// Pending load requests: request_id -> (session_key, oneshot sender)
     pending_loads: HashMap<usize, (Option<String>, LoadRequest)>,
+}
+
+impl RoonState {
+    /// Route a Core browse/load rejection to the exact request waiting on it.
+    ///
+    /// TODO(#405): not implemented yet - this reproduces the pre-#405 behavior
+    /// (the rejection is dropped and no waiter is resolved) so the correlation
+    /// tests fail against it.
+    fn route_browse_rejection(
+        &mut self,
+        _req_id: usize,
+        _session_key: Option<&str>,
+        _kind: RoonBrowseErrorKind,
+    ) -> ErrorRouting {
+        ErrorRouting::NoWaiter
+    }
+
+    /// Route a Core image rejection to the request waiting on it.
+    ///
+    /// TODO(#405): not implemented yet - see `route_browse_rejection`.
+    fn route_image_rejection(&mut self, _req_id: usize, _image_key: &str) -> ErrorRouting {
+        ErrorRouting::NoWaiter
+    }
 }
 
 /// Roon adapter
@@ -2050,6 +2226,361 @@ mod tests {
         assert!(
             bus_zone.volume_control.is_none(),
             "should be None when output has no volume"
+        );
+    }
+
+    // =========================================================================
+    // Core-reported browse rejections (issue #405)
+    // =========================================================================
+    //
+    // Test strategy: these unit-scope the correlation logic. They do NOT drive
+    // a Roon protocol mock - `tests/mock_servers/roon.rs` holds state and
+    // speaks no protocol, and building a protocol-level Roon fake is #408's
+    // job. Duplicating it here would conflict with that work. What is scoped
+    // here is exactly the concurrency-sensitive part: which waiter a rejection
+    // resolves when several requests are in flight, and what happens to the
+    // ones it must not touch.
+    //
+    // Coverage boundary, stated so the next agent does not over-trust it: the
+    // tests exercise the real routing functions, the real `oneshot` channels
+    // and the real `BROWSE_TIMEOUT`. They do not exercise the fork's
+    // `parse_msg`, nor the three-line result match in `browse()`/`load()` that
+    // hands the oneshot payload back to the caller.
+
+    use std::time::Instant;
+    use tokio::sync::oneshot::error::TryRecvError;
+
+    /// Queue a pending browse the way `browse()` does, returning its receiver.
+    fn pending_browse(
+        state: &mut RoonState,
+        req_id: usize,
+        session_key: &str,
+    ) -> oneshot::Receiver<Result<BrowseResult>> {
+        let (tx, rx) = oneshot::channel();
+        state
+            .pending_browses
+            .insert(req_id, (Some(session_key.to_string()), tx));
+        rx
+    }
+
+    /// Queue a pending load the way `load()` does, returning its receiver.
+    fn pending_load(
+        state: &mut RoonState,
+        req_id: usize,
+        session_key: &str,
+    ) -> oneshot::Receiver<Result<LoadResult>> {
+        let (tx, rx) = oneshot::channel();
+        state
+            .pending_loads
+            .insert(req_id, (Some(session_key.to_string()), tx));
+        rx
+    }
+
+    /// Queue a pending image request the way `get_image()` does.
+    fn pending_image(
+        state: &mut RoonState,
+        req_id: usize,
+        image_key: &str,
+    ) -> oneshot::Receiver<Option<ImageData>> {
+        let (tx, rx) = oneshot::channel();
+        state
+            .pending_images
+            .insert(req_id, (image_key.to_string(), tx));
+        rx
+    }
+
+    /// The rejection a receiver was resolved with, or a description of why it
+    /// was not resolved.
+    fn rejection_kind<T>(rx: &mut oneshot::Receiver<Result<T>>) -> RoonBrowseErrorKind {
+        match rx.try_recv() {
+            Ok(Err(err)) => match RoonBrowseError::from_error(&err) {
+                Some(rejection) => rejection.kind,
+                None => unreachable!("resolved with an untyped error: {err}"),
+            },
+            Ok(Ok(_)) => unreachable!("resolved with a success result"),
+            Err(TryRecvError::Empty) => unreachable!("waiter was never resolved"),
+            Err(TryRecvError::Closed) => unreachable!("waiter's sender was dropped"),
+        }
+    }
+
+    fn assert_still_waiting<T>(rx: &mut oneshot::Receiver<Result<T>>, what: &str) {
+        assert!(
+            matches!(rx.try_recv(), Err(TryRecvError::Empty)),
+            "{what} must still be waiting - it was resolved or its sender dropped"
+        );
+    }
+
+    #[test]
+    fn browse_rejection_resolves_only_the_matching_waiter() {
+        // Several browse and load requests in flight, as the adapter routinely
+        // has during search() and play_item(). One is rejected by the Core.
+        let mut state = RoonState::default();
+        let mut first = pending_browse(&mut state, 11, "search_a");
+        let mut rejected = pending_browse(&mut state, 12, "search_b");
+        let mut third = pending_browse(&mut state, 13, "search_c");
+        let mut load_a = pending_load(&mut state, 14, "search_a");
+        let mut load_b = pending_load(&mut state, 15, "search_b");
+
+        let routing = state.route_browse_rejection(
+            12,
+            Some("search_b"),
+            RoonBrowseErrorKind::InvalidItemKey,
+        );
+
+        assert_eq!(routing, ErrorRouting::Browse);
+        assert_eq!(
+            rejection_kind(&mut rejected),
+            RoonBrowseErrorKind::InvalidItemKey
+        );
+        assert_still_waiting(&mut first, "browse 11");
+        assert_still_waiting(&mut third, "browse 13");
+        assert_still_waiting(&mut load_a, "load 14");
+        // load 15 shares the rejected request's session key: proof that
+        // correlation is by req_id, not by scanning for a session key.
+        assert_still_waiting(&mut load_b, "load 15");
+
+        // Only the resolved entry leaves the map; nothing is stranded.
+        assert!(!state.pending_browses.contains_key(&12));
+        assert_eq!(state.pending_browses.len(), 2);
+        assert_eq!(state.pending_loads.len(), 2);
+    }
+
+    #[test]
+    fn load_rejection_resolves_the_load_not_a_browse_sharing_its_session() {
+        // A browse and a load in the same browse session, both pending. A
+        // session-key scan would resolve whichever the map yielded first; the
+        // req_id in the rejection says exactly which one the Core refused.
+        let mut state = RoonState::default();
+        let mut browse = pending_browse(&mut state, 20, "play_item_1");
+        let mut load = pending_load(&mut state, 21, "play_item_1");
+
+        let routing = state.route_browse_rejection(
+            21,
+            Some("play_item_1"),
+            RoonBrowseErrorKind::InvalidItemKey,
+        );
+
+        assert_eq!(routing, ErrorRouting::Load);
+        assert_eq!(
+            rejection_kind(&mut load),
+            RoonBrowseErrorKind::InvalidItemKey
+        );
+        assert_still_waiting(&mut browse, "browse 20");
+        assert!(state.pending_browses.contains_key(&20));
+        assert!(!state.pending_loads.contains_key(&21));
+    }
+
+    #[test]
+    fn rejection_with_a_mismatched_session_key_leaves_the_waiter_alone() {
+        // `Moo` restarts its request-id counter at 0 on every reconnect, so a
+        // rejection on a new connection can carry a req_id that a stale, not
+        // yet timed-out waiter still occupies. Resolving it would be a
+        // mis-correlation; the waiter is left to its existing timeout instead.
+        let mut state = RoonState::default();
+        let mut stale = pending_browse(&mut state, 7, "browse_old");
+
+        let routing = state.route_browse_rejection(
+            7,
+            Some("browse_new"),
+            RoonBrowseErrorKind::InvalidItemKey,
+        );
+
+        assert_eq!(routing, ErrorRouting::KeyMismatch);
+        assert_still_waiting(&mut stale, "browse 7");
+        assert!(
+            state.pending_browses.contains_key(&7),
+            "the waiter must stay in the map so its own timeout still cleans up"
+        );
+    }
+
+    #[test]
+    fn rejection_for_an_unknown_req_id_is_a_noop() {
+        let mut state = RoonState::default();
+        let mut other = pending_browse(&mut state, 30, "browse_x");
+
+        let routing = state.route_browse_rejection(
+            999,
+            Some("browse_x"),
+            RoonBrowseErrorKind::UnexpectedError,
+        );
+
+        assert_eq!(routing, ErrorRouting::NoWaiter);
+        assert_still_waiting(&mut other, "browse 30");
+        assert_eq!(state.pending_browses.len(), 1);
+    }
+
+    #[test]
+    fn a_second_rejection_for_the_same_req_id_cannot_double_resolve() {
+        let mut state = RoonState::default();
+        let mut rx = pending_browse(&mut state, 40, "browse_y");
+
+        let first = state.route_browse_rejection(
+            40,
+            Some("browse_y"),
+            RoonBrowseErrorKind::InvalidItemKey,
+        );
+        let second = state.route_browse_rejection(
+            40,
+            Some("browse_y"),
+            RoonBrowseErrorKind::InvalidItemKey,
+        );
+
+        assert_eq!(first, ErrorRouting::Browse);
+        assert_eq!(second, ErrorRouting::NoWaiter);
+        assert_eq!(rejection_kind(&mut rx), RoonBrowseErrorKind::InvalidItemKey);
+        assert!(state.pending_browses.is_empty());
+    }
+
+    #[test]
+    fn rejection_after_the_caller_timed_out_is_a_noop() {
+        // `browse()` removes its own entry when BROWSE_TIMEOUT fires. A
+        // rejection arriving afterwards must not panic or resurrect anything.
+        let mut state = RoonState::default();
+        let _rx = pending_browse(&mut state, 50, "browse_z");
+        state.pending_browses.remove(&50);
+
+        let routing =
+            state.route_browse_rejection(50, Some("browse_z"), RoonBrowseErrorKind::InvalidLevels);
+
+        assert_eq!(routing, ErrorRouting::NoWaiter);
+        assert!(state.pending_browses.is_empty());
+    }
+
+    #[test]
+    fn rejection_with_a_dropped_receiver_still_clears_the_entry() {
+        let mut state = RoonState::default();
+        let rx = pending_browse(&mut state, 60, "browse_w");
+        drop(rx);
+
+        let routing = state.route_browse_rejection(
+            60,
+            Some("browse_w"),
+            RoonBrowseErrorKind::InvalidItemKey,
+        );
+
+        assert_eq!(routing, ErrorRouting::ReceiverGone);
+        assert!(
+            state.pending_browses.is_empty(),
+            "a gone receiver must not leave a stranded map entry"
+        );
+    }
+
+    #[test]
+    fn every_browse_rejection_kind_is_routed() {
+        // Routing only InvalidItemKey would leave the other three Core
+        // rejections hanging their callers for the full timeout.
+        for kind in [
+            RoonBrowseErrorKind::InvalidItemKey,
+            RoonBrowseErrorKind::InvalidLevels,
+            RoonBrowseErrorKind::ZoneNotFound,
+            RoonBrowseErrorKind::UnexpectedError,
+        ] {
+            let mut state = RoonState::default();
+            let mut rx = pending_browse(&mut state, 70, "browse_all");
+
+            let routing = state.route_browse_rejection(70, Some("browse_all"), kind);
+
+            assert_eq!(routing, ErrorRouting::Browse, "kind {kind:?} was not routed");
+            assert_eq!(rejection_kind(&mut rx), kind);
+        }
+    }
+
+    #[tokio::test]
+    async fn a_rejected_item_key_resolves_far_inside_the_browse_timeout() {
+        // The point of the issue: promptness. Awaited exactly as `browse()`
+        // awaits it, with the real BROWSE_TIMEOUT.
+        let mut state = RoonState::default();
+        let rx = pending_browse(&mut state, 80, "browse_prompt");
+
+        let started = Instant::now();
+        let routing = state.route_browse_rejection(
+            80,
+            Some("browse_prompt"),
+            RoonBrowseErrorKind::InvalidItemKey,
+        );
+        let result = tokio::time::timeout(BROWSE_TIMEOUT, rx).await;
+        let elapsed = started.elapsed();
+
+        assert_eq!(routing, ErrorRouting::Browse);
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "a rejected item key must not wait out BROWSE_TIMEOUT ({BROWSE_TIMEOUT:?}); \
+             took {elapsed:?}"
+        );
+        let Ok(Ok(Err(err))) = result else {
+            unreachable!("expected a typed rejection inside the timeout");
+        };
+        let Some(rejection) = RoonBrowseError::from_error(&err) else {
+            unreachable!("expected a RoonBrowseError, got: {err}");
+        };
+        assert_eq!(rejection.kind, RoonBrowseErrorKind::InvalidItemKey);
+        assert_eq!(rejection.session_key.as_deref(), Some("browse_prompt"));
+    }
+
+    #[test]
+    fn image_rejection_resolves_the_matching_image_request() {
+        let mut state = RoonState::default();
+        let mut wanted = pending_image(&mut state, 90, "image_a");
+        let mut other = pending_image(&mut state, 91, "image_b");
+
+        let routing = state.route_image_rejection(90, "image_a");
+
+        assert_eq!(routing, ErrorRouting::Image);
+        // `get_image` reads None as "Image not found".
+        assert!(matches!(wanted.try_recv(), Ok(None)));
+        assert!(matches!(other.try_recv(), Err(TryRecvError::Empty)));
+        assert!(!state.pending_images.contains_key(&90));
+        assert!(state.pending_images.contains_key(&91));
+    }
+
+    #[test]
+    fn image_rejection_with_a_mismatched_key_leaves_the_waiter_alone() {
+        let mut state = RoonState::default();
+        let mut rx = pending_image(&mut state, 92, "image_a");
+
+        let routing = state.route_image_rejection(92, "image_somewhere_else");
+
+        assert_eq!(routing, ErrorRouting::KeyMismatch);
+        assert!(matches!(rx.try_recv(), Err(TryRecvError::Empty)));
+        assert!(state.pending_images.contains_key(&92));
+    }
+
+    #[test]
+    fn a_rejection_is_distinguishable_from_a_timeout_and_a_lost_core() {
+        // The three failure classes the issue insists must stay apart.
+        let rejected = anyhow::Error::new(RoonBrowseError::new(
+            RoonBrowseErrorKind::InvalidItemKey,
+            Some("browse_1"),
+        ));
+        let timed_out = anyhow::anyhow!("Browse request timed out");
+        let not_connected =
+            anyhow::anyhow!("Browse service not available - not connected to Roon");
+
+        let Some(rejection) = RoonBrowseError::from_error(&rejected) else {
+            unreachable!("a rejection must be recoverable from the anyhow error");
+        };
+        assert_eq!(rejection.kind, RoonBrowseErrorKind::InvalidItemKey);
+        assert!(rejection.kind.is_recoverable());
+        assert!(RoonBrowseError::from_error(&timed_out).is_none());
+        assert!(RoonBrowseError::from_error(&not_connected).is_none());
+
+        // And the message a caller sees says what to do, without ever reading
+        // like a timeout.
+        let message = rejected.to_string();
+        assert!(message.contains("search or browse again"), "{message}");
+        assert!(!message.contains("timed out"), "{message}");
+        assert!(message.contains("browse_1"), "{message}");
+    }
+
+    #[test]
+    fn only_reference_rejections_are_marked_recoverable() {
+        assert!(RoonBrowseErrorKind::InvalidItemKey.is_recoverable());
+        assert!(RoonBrowseErrorKind::InvalidLevels.is_recoverable());
+        assert!(!RoonBrowseErrorKind::ZoneNotFound.is_recoverable());
+        assert!(!RoonBrowseErrorKind::UnexpectedError.is_recoverable());
+        assert_eq!(
+            RoonBrowseErrorKind::InvalidItemKey.as_str(),
+            "invalid_item_key"
         );
     }
 }

--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -428,16 +428,23 @@ impl RoonState {
     /// so a repeated rejection finds nothing and a waiter can never be resolved
     /// twice. A `KeyMismatch` leaves the entry for the caller's own timeout to
     /// clean up, so no path strands one.
+    ///
+    /// Both maps are searched for an entry where *both* the request id and the
+    /// session key match before any mismatch is reported. A mismatched entry in
+    /// one map must not hide a matching entry in the other - that too is only
+    /// reachable through a reconnect id collision, but reporting a mismatch
+    /// early would cost a legitimate waiter its prompt answer.
     fn route_browse_rejection(
         &mut self,
         req_id: usize,
         session_key: Option<&str>,
         kind: RoonBrowseErrorKind,
     ) -> ErrorRouting {
-        if let Some((pending_key, _)) = self.pending_browses.get(&req_id) {
-            if pending_key.as_deref() != session_key {
-                return ErrorRouting::KeyMismatch;
-            }
+        let browse_matches = matches!(
+            self.pending_browses.get(&req_id),
+            Some((pending_key, _)) if pending_key.as_deref() == session_key
+        );
+        if browse_matches {
             if let Some((_, sender)) = self.pending_browses.remove(&req_id) {
                 return if deliver_browse_rejection(sender, kind, session_key) {
                     ErrorRouting::Browse
@@ -447,10 +454,11 @@ impl RoonState {
             }
         }
 
-        if let Some((pending_key, _)) = self.pending_loads.get(&req_id) {
-            if pending_key.as_deref() != session_key {
-                return ErrorRouting::KeyMismatch;
-            }
+        let load_matches = matches!(
+            self.pending_loads.get(&req_id),
+            Some((pending_key, _)) if pending_key.as_deref() == session_key
+        );
+        if load_matches {
             if let Some((_, sender)) = self.pending_loads.remove(&req_id) {
                 return if deliver_browse_rejection(sender, kind, session_key) {
                     ErrorRouting::Load
@@ -458,6 +466,10 @@ impl RoonState {
                     ErrorRouting::ReceiverGone
                 };
             }
+        }
+
+        if self.pending_browses.contains_key(&req_id) || self.pending_loads.contains_key(&req_id) {
+            return ErrorRouting::KeyMismatch;
         }
 
         ErrorRouting::NoWaiter
@@ -2515,6 +2527,29 @@ mod tests {
             state.pending_browses.contains_key(&7),
             "the waiter must stay in the map so its own timeout still cleans up"
         );
+    }
+
+    #[test]
+    fn a_mismatched_entry_in_one_map_does_not_hide_a_match_in_the_other() {
+        // Only reachable through a reconnect id collision: a stale browse from
+        // the old connection holds req_id 8, and the new connection issues a
+        // load that also gets req_id 8. Reporting the browse's key mismatch
+        // early would cost the load its prompt answer for no safety gain.
+        let mut state = RoonState::default();
+        let mut stale_browse = pending_browse(&mut state, 8, "browse_old");
+        let mut live_load = pending_load(&mut state, 8, "load_new");
+
+        let routing =
+            state.route_browse_rejection(8, Some("load_new"), RoonBrowseErrorKind::InvalidItemKey);
+
+        assert_eq!(routing, ErrorRouting::Load);
+        assert_eq!(
+            rejection_kind(&mut live_load),
+            RoonBrowseErrorKind::InvalidItemKey
+        );
+        assert_still_waiting(&mut stale_browse, "the stale browse");
+        assert!(state.pending_browses.contains_key(&8));
+        assert!(!state.pending_loads.contains_key(&8));
     }
 
     #[test]

--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -422,7 +422,18 @@ impl RoonState {
     ///   connection can carry a request id that an older, not-yet-timed-out
     ///   entry still occupies. On a mismatch the waiter is left alone and falls
     ///   back to `BROWSE_TIMEOUT` - the pre-#405 behavior - because resolving
-    ///   the wrong caller is worse than resolving them late.
+    ///   the wrong caller is worse than resolving them late. Do not remove this
+    ///   check as redundant: `req_id` uniqueness is per-connection only, and
+    ///   nothing near this code says so.
+    ///
+    /// The pair is not a unique key, and this narrows the reconnect window
+    /// rather than closing it. Session keys are not unique either - a caller
+    /// that reuses one across a reconnect (`/roon/browse` accepts a
+    /// caller-supplied `session_key`) can produce a stale entry and a fresh
+    /// request that agree on both. Both callers get an error either way, and
+    /// neither is ever told a wrong *success*; today both simply time out. If a
+    /// long-lived browse tree is ever built on one session key (#399), stamp the
+    /// pending entries with a connection generation instead.
     ///
     /// Resolution is exactly-once: every path removes the entry before sending,
     /// so a repeated rejection finds nothing and a waiter can never be resolved
@@ -480,6 +491,12 @@ impl RoonState {
     /// Same rule as [`RoonState::route_browse_rejection`], with the image key
     /// standing in for the session key. `get_image` reads `None` as "Image not
     /// found", so the caller gets an answer instead of a 10s timeout.
+    ///
+    /// Accepted lossiness: `pending_images` senders carry `Option<ImageData>`,
+    /// so `ImageNotFound` and `ImageUnexpectedError` both arrive at the caller
+    /// as "Image not found". The distinction survives only in the log line the
+    /// event loop writes. Widening `ImageRequest` to a `Result` would carry it
+    /// through, and is not worth the churn for cover art.
     fn route_image_rejection(&mut self, req_id: usize, image_key: &str) -> ErrorRouting {
         if let Some((pending_key, _)) = self.pending_images.get(&req_id) {
             if pending_key != image_key {
@@ -2114,6 +2131,13 @@ async fn run_roon_loop(
                             }
                         }
                     }
+                    // Note the asymmetry with the Parsed::Error arm below: this
+                    // one has to scan by session key because
+                    // `Parsed::BrowseResult` carries no req_id, so it cannot say
+                    // *which* request in a session answered. The error arm is
+                    // given the req_id and correlates exactly. Do not assume the
+                    // two correlate the same way; closing this gap needs a
+                    // change to the pinned fork.
                     Parsed::BrowseResult(result, session_key) => {
                         tracing::debug!(
                             "Roon BrowseResult action={:?}, session_key={:?}",
@@ -2164,6 +2188,11 @@ async fn run_roon_loop(
                     // a result. Route it to the request that is waiting on it -
                     // dropping it here is what made a stale item key look like
                     // an unreachable Core, ten seconds late.
+                    //
+                    // Matched exhaustively on purpose: no wildcard, so a fork
+                    // bump that adds a variant fails to compile here instead of
+                    // silently resuming the swallow this arm exists to end. If
+                    // you are here because of that error, route the new variant.
                     Parsed::Error(err) => {
                         let routing = {
                             let mut s = state_for_events.write().await;
@@ -2483,9 +2512,10 @@ mod tests {
 
     #[test]
     fn load_rejection_resolves_the_load_not_a_browse_sharing_its_session() {
-        // A browse and a load in the same browse session, both pending. A
-        // session-key scan would resolve whichever the map yielded first; the
-        // req_id in the rejection says exactly which one the Core refused.
+        // The positive invariant: the refused request is identified by req_id,
+        // so a sibling sharing its session key in the *other* map is untouched.
+        // (Correlating by session key instead could not even tell a browse from
+        // a load here - it would have to pick a map to scan first.)
         let mut state = RoonState::default();
         let mut browse = pending_browse(&mut state, 20, "play_item_1");
         let mut load = pending_load(&mut state, 21, "play_item_1");

--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -2522,11 +2522,8 @@ mod tests {
         let mut load_a = pending_load(&mut state, 14, "search_a");
         let mut load_b = pending_load(&mut state, 15, "search_b");
 
-        let routing = state.route_browse_rejection(
-            12,
-            Some("search_b"),
-            RoonBrowseErrorKind::InvalidItemKey,
-        );
+        let routing =
+            state.route_browse_rejection(12, Some("search_b"), RoonBrowseErrorKind::InvalidItemKey);
 
         assert_eq!(routing, ErrorRouting::Browse);
         assert_eq!(
@@ -2639,16 +2636,10 @@ mod tests {
         let mut state = RoonState::default();
         let mut rx = pending_browse(&mut state, 40, "browse_y");
 
-        let first = state.route_browse_rejection(
-            40,
-            Some("browse_y"),
-            RoonBrowseErrorKind::InvalidItemKey,
-        );
-        let second = state.route_browse_rejection(
-            40,
-            Some("browse_y"),
-            RoonBrowseErrorKind::InvalidItemKey,
-        );
+        let first =
+            state.route_browse_rejection(40, Some("browse_y"), RoonBrowseErrorKind::InvalidItemKey);
+        let second =
+            state.route_browse_rejection(40, Some("browse_y"), RoonBrowseErrorKind::InvalidItemKey);
 
         assert_eq!(first, ErrorRouting::Browse);
         assert_eq!(second, ErrorRouting::NoWaiter);
@@ -2677,11 +2668,8 @@ mod tests {
         let rx = pending_browse(&mut state, 60, "browse_w");
         drop(rx);
 
-        let routing = state.route_browse_rejection(
-            60,
-            Some("browse_w"),
-            RoonBrowseErrorKind::InvalidItemKey,
-        );
+        let routing =
+            state.route_browse_rejection(60, Some("browse_w"), RoonBrowseErrorKind::InvalidItemKey);
 
         assert_eq!(routing, ErrorRouting::ReceiverGone);
         assert!(
@@ -2705,7 +2693,11 @@ mod tests {
 
             let routing = state.route_browse_rejection(70, Some("browse_all"), kind);
 
-            assert_eq!(routing, ErrorRouting::Browse, "kind {kind:?} was not routed");
+            assert_eq!(
+                routing,
+                ErrorRouting::Browse,
+                "kind {kind:?} was not routed"
+            );
             assert_eq!(rejection_kind(&mut rx), kind);
         }
     }
@@ -2778,8 +2770,7 @@ mod tests {
             Some("browse_1"),
         ));
         let timed_out = anyhow::anyhow!("Browse request timed out");
-        let not_connected =
-            anyhow::anyhow!("Browse service not available - not connected to Roon");
+        let not_connected = anyhow::anyhow!("Browse service not available - not connected to Roon");
 
         let Some(rejection) = RoonBrowseError::from_error(&rejected) else {
             unreachable!("a rejection must be recoverable from the anyhow error");

--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -11,7 +11,7 @@ use roon_api::{
     image::{Args as ImageArgs, Format as ImageFormat, Image, Scale, Scaling},
     status::{self, Status},
     transport::{self, volume, Control, Transport, Zone as RoonZone},
-    CoreEvent, Info, Parsed, RoonApi, Services, Svc,
+    CoreEvent, Info, Parsed, RoonApi, RoonApiError, Services, Svc,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -402,22 +402,86 @@ struct RoonState {
 impl RoonState {
     /// Route a Core browse/load rejection to the exact request waiting on it.
     ///
-    /// TODO(#405): not implemented yet - this reproduces the pre-#405 behavior
-    /// (the rejection is dropped and no waiter is resolved) so the correlation
-    /// tests fail against it.
+    /// Correlation is by `req_id`, cross-checked against the session key:
+    ///
+    /// - `req_id` is authoritative. The fork hands back the same request id
+    ///   that `Browse::browse`/`Browse::load` returned when the request was
+    ///   submitted (fork `src/browse.rs:126-154`, read back off the wire at
+    ///   `:157`), and `Moo` allocates request ids from one monotonic
+    ///   per-connection counter (fork `src/moo.rs:124-135`). So a `req_id`
+    ///   names exactly one submitted request, and `pending_browses` and
+    ///   `pending_loads` cannot both hold it. That is strictly better than the
+    ///   session-key scan the success arms are forced into: a session key is
+    ///   shared by every request in a browse session (`search()` reuses one
+    ///   across six requests, and `/roon/browse` lets a caller supply its own),
+    ///   so scanning for it cannot say *which* request was refused - nor even
+    ///   whether it was a browse or a load.
+    ///
+    /// - The session key is checked because that counter restarts at 0 on every
+    ///   reconnect (fork `src/moo.rs:92`): a rejection arriving on a fresh
+    ///   connection can carry a request id that an older, not-yet-timed-out
+    ///   entry still occupies. On a mismatch the waiter is left alone and falls
+    ///   back to `BROWSE_TIMEOUT` - the pre-#405 behavior - because resolving
+    ///   the wrong caller is worse than resolving them late.
+    ///
+    /// Resolution is exactly-once: every path removes the entry before sending,
+    /// so a repeated rejection finds nothing and a waiter can never be resolved
+    /// twice. A `KeyMismatch` leaves the entry for the caller's own timeout to
+    /// clean up, so no path strands one.
     fn route_browse_rejection(
         &mut self,
-        _req_id: usize,
-        _session_key: Option<&str>,
-        _kind: RoonBrowseErrorKind,
+        req_id: usize,
+        session_key: Option<&str>,
+        kind: RoonBrowseErrorKind,
     ) -> ErrorRouting {
+        if let Some((pending_key, _)) = self.pending_browses.get(&req_id) {
+            if pending_key.as_deref() != session_key {
+                return ErrorRouting::KeyMismatch;
+            }
+            if let Some((_, sender)) = self.pending_browses.remove(&req_id) {
+                return if deliver_browse_rejection(sender, kind, session_key) {
+                    ErrorRouting::Browse
+                } else {
+                    ErrorRouting::ReceiverGone
+                };
+            }
+        }
+
+        if let Some((pending_key, _)) = self.pending_loads.get(&req_id) {
+            if pending_key.as_deref() != session_key {
+                return ErrorRouting::KeyMismatch;
+            }
+            if let Some((_, sender)) = self.pending_loads.remove(&req_id) {
+                return if deliver_browse_rejection(sender, kind, session_key) {
+                    ErrorRouting::Load
+                } else {
+                    ErrorRouting::ReceiverGone
+                };
+            }
+        }
+
         ErrorRouting::NoWaiter
     }
 
     /// Route a Core image rejection to the request waiting on it.
     ///
-    /// TODO(#405): not implemented yet - see `route_browse_rejection`.
-    fn route_image_rejection(&mut self, _req_id: usize, _image_key: &str) -> ErrorRouting {
+    /// Same rule as [`RoonState::route_browse_rejection`], with the image key
+    /// standing in for the session key. `get_image` reads `None` as "Image not
+    /// found", so the caller gets an answer instead of a 10s timeout.
+    fn route_image_rejection(&mut self, req_id: usize, image_key: &str) -> ErrorRouting {
+        if let Some((pending_key, _)) = self.pending_images.get(&req_id) {
+            if pending_key != image_key {
+                return ErrorRouting::KeyMismatch;
+            }
+            if let Some((_, sender)) = self.pending_images.remove(&req_id) {
+                return if sender.send(None).is_ok() {
+                    ErrorRouting::Image
+                } else {
+                    ErrorRouting::ReceiverGone
+                };
+            }
+        }
+
         ErrorRouting::NoWaiter
     }
 }
@@ -2081,6 +2145,66 @@ async fn run_roon_loop(
                                         session_key
                                     );
                                 }
+                            }
+                        }
+                    }
+                    // Issue #405: the Core answered with a rejection rather than
+                    // a result. Route it to the request that is waiting on it -
+                    // dropping it here is what made a stale item key look like
+                    // an unreachable Core, ten seconds late.
+                    Parsed::Error(err) => {
+                        let routing = {
+                            let mut s = state_for_events.write().await;
+                            match &err {
+                                RoonApiError::BrowseInvalidItemKey((req_id, session_key)) => s
+                                    .route_browse_rejection(
+                                        *req_id,
+                                        session_key.as_deref(),
+                                        RoonBrowseErrorKind::InvalidItemKey,
+                                    ),
+                                RoonApiError::BrowseInvalidLevels((req_id, session_key)) => s
+                                    .route_browse_rejection(
+                                        *req_id,
+                                        session_key.as_deref(),
+                                        RoonBrowseErrorKind::InvalidLevels,
+                                    ),
+                                RoonApiError::BrowseZoneNotFound((req_id, session_key)) => s
+                                    .route_browse_rejection(
+                                        *req_id,
+                                        session_key.as_deref(),
+                                        RoonBrowseErrorKind::ZoneNotFound,
+                                    ),
+                                RoonApiError::BrowseUnexpectedError((req_id, session_key)) => s
+                                    .route_browse_rejection(
+                                        *req_id,
+                                        session_key.as_deref(),
+                                        RoonBrowseErrorKind::UnexpectedError,
+                                    ),
+                                RoonApiError::ImageNotFound((req_id, image_key))
+                                | RoonApiError::ImageUnexpectedError((req_id, image_key)) => {
+                                    s.route_image_rejection(*req_id, image_key)
+                                }
+                            }
+                        };
+
+                        match routing {
+                            ErrorRouting::NoWaiter => tracing::debug!(
+                                "Roon reported an error with nothing waiting on it \
+                                 (already resolved or timed out): {}",
+                                err
+                            ),
+                            ErrorRouting::KeyMismatch => tracing::warn!(
+                                "Roon error not routed - a pending request holds that \
+                                 request id under a different session/image key, so it \
+                                 was left for its own timeout: {}",
+                                err
+                            ),
+                            ErrorRouting::ReceiverGone => tracing::debug!(
+                                "Roon error arrived after its caller gave up: {}",
+                                err
+                            ),
+                            ErrorRouting::Browse | ErrorRouting::Load | ErrorRouting::Image => {
+                                tracing::debug!("Roon error routed to its {:?} request: {}", routing, err)
                             }
                         }
                     }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -519,20 +519,19 @@ pub async fn roon_play_handler(
 /// recovery instruction. Everything else - a timed-out or unreachable Core, a
 /// Core-side fault - keeps the 500 it has always had. Browse-not-connected is
 /// still checked before the request is issued and still answers 503.
-fn roon_browse_failure(err: &anyhow::Error, prefix: &str) -> axum::response::Response {
+fn roon_browse_failure(err: &anyhow::Error, prefix: Option<&str>) -> axum::response::Response {
     use crate::adapters::roon::{RoonBrowseError, RoonBrowseErrorKind};
 
     let status = match RoonBrowseError::from_error(err).map(|rejection| rejection.kind) {
-        Some(RoonBrowseErrorKind::InvalidItemKey) | Some(RoonBrowseErrorKind::ZoneNotFound) => {
+        Some(RoonBrowseErrorKind::InvalidItemKey | RoonBrowseErrorKind::ZoneNotFound) => {
             StatusCode::NOT_FOUND
         }
         _ => StatusCode::INTERNAL_SERVER_ERROR,
     };
 
-    let error = if prefix.is_empty() {
-        err.to_string()
-    } else {
-        format!("{}: {}", prefix, err)
+    let error = match prefix {
+        Some(prefix) => format!("{}: {}", prefix, err),
+        None => err.to_string(),
     };
 
     (status, Json(ErrorResponse { error })).into_response()
@@ -576,7 +575,7 @@ pub async fn roon_play_item_handler(
             Json(serde_json::json!({ "message": message })),
         )
             .into_response(),
-        Err(e) => roon_browse_failure(&e, ""),
+        Err(e) => roon_browse_failure(&e, None),
     }
 }
 
@@ -667,7 +666,7 @@ pub async fn roon_browse_handler(
     // Browse to the level
     let browse_result = match state.roon.browse(opts).await {
         Ok(result) => result,
-        Err(e) => return roon_browse_failure(&e, ""),
+        Err(e) => return roon_browse_failure(&e, None),
     };
 
     // Load items at this level
@@ -699,7 +698,7 @@ pub async fn roon_browse_handler(
                         }
                     })
                     .collect(),
-                Err(e) => return roon_browse_failure(&e, "Browse load error"),
+                Err(e) => return roon_browse_failure(&e, Some("Browse load error")),
             }
         } else {
             vec![]

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -501,13 +501,7 @@ pub async fn roon_play_handler(
             Json(serde_json::json!({ "message": message })),
         )
             .into_response(),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse {
-                error: e.to_string(),
-            }),
-        )
-            .into_response(),
+        Err(e) => roon_browse_failure(&e, None),
     }
 }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -511,6 +511,33 @@ pub async fn roon_play_handler(
     }
 }
 
+/// Turn a Roon browse/load failure into an HTTP response, keeping the failure
+/// classes apart (issue #405).
+///
+/// A reference the Core refused is a client-fixable condition that now arrives
+/// immediately, so it answers 404 with the Core's own explanation and the
+/// recovery instruction. Everything else - a timed-out or unreachable Core, a
+/// Core-side fault - keeps the 500 it has always had. Browse-not-connected is
+/// still checked before the request is issued and still answers 503.
+fn roon_browse_failure(err: &anyhow::Error, prefix: &str) -> axum::response::Response {
+    use crate::adapters::roon::{RoonBrowseError, RoonBrowseErrorKind};
+
+    let status = match RoonBrowseError::from_error(err).map(|rejection| rejection.kind) {
+        Some(RoonBrowseErrorKind::InvalidItemKey) | Some(RoonBrowseErrorKind::ZoneNotFound) => {
+            StatusCode::NOT_FOUND
+        }
+        _ => StatusCode::INTERNAL_SERVER_ERROR,
+    };
+
+    let error = if prefix.is_empty() {
+        err.to_string()
+    } else {
+        format!("{}: {}", prefix, err)
+    };
+
+    (status, Json(ErrorResponse { error })).into_response()
+}
+
 /// Play item request body
 #[derive(Deserialize)]
 pub struct PlayItemRequest {
@@ -549,13 +576,7 @@ pub async fn roon_play_item_handler(
             Json(serde_json::json!({ "message": message })),
         )
             .into_response(),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse {
-                error: e.to_string(),
-            }),
-        )
-            .into_response(),
+        Err(e) => roon_browse_failure(&e, ""),
     }
 }
 
@@ -646,15 +667,7 @@ pub async fn roon_browse_handler(
     // Browse to the level
     let browse_result = match state.roon.browse(opts).await {
         Ok(result) => result,
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse {
-                    error: e.to_string(),
-                }),
-            )
-                .into_response()
-        }
+        Err(e) => return roon_browse_failure(&e, ""),
     };
 
     // Load items at this level
@@ -686,15 +699,7 @@ pub async fn roon_browse_handler(
                         }
                     })
                     .collect(),
-                Err(e) => {
-                    return (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(ErrorResponse {
-                            error: format!("Browse load error: {}", e),
-                        }),
-                    )
-                        .into_response();
-                }
+                Err(e) => return roon_browse_failure(&e, "Browse load error"),
             }
         } else {
             vec![]


### PR DESCRIPTION
Fixes #405. Parent epic #392. Unblocks #396.

## What was wrong

Roon Core answers an unusable browse or load with a *named error* instead of a result. The pinned fork turns that into `Parsed::Error(RoonApiError::Browse*)`, carrying the originating `req_id` **and** the request's `multi_session_key` (fork `src/browse.rs:174-188`).

UHC never handled `Parsed::Error`. The event loop's catch-all `_ => {}` swallowed it, the pending oneshot was never resolved, and the caller sat out the full 10s `BROWSE_TIMEOUT` before receiving `"Browse request timed out"` — the same message an unreachable Core produces. A condition the Core reported instantly, and which the caller can recover from, arrived ten seconds late disguised as an outage.

The red commit on this branch shows it as a wall-clock fact: `99b3779` runs the new suite in **10.01s**, because the promptness test's waiter genuinely waits out the timeout. After the fix: **0.00s**.

## Correlation approach — `req_id` primary, session key as the guard

`RoonState::route_browse_rejection` (`src/adapters/roon.rs`) keys on the `req_id` in the rejection and cross-checks the session key before resolving.

**Why `req_id` is authoritative.** `Browse::browse`/`Browse::load` return the request id that UHC stores as its map key (fork `src/browse.rs:126-154`); `Moo::send_req` allocates ids from a single monotonic per-connection counter (fork `src/moo.rs:124-135`); `parse_msg` reads that same id back off the wire (`:157`) and hands it to the error variant. So a `req_id` names exactly one submitted request, and `pending_browses` / `pending_loads` cannot both hold it. Lookup is exact and O(1).

**Why not scan by session key, as the success arms do.** The success arms have no choice — `Parsed::BrowseResult` carries no `req_id`. But a session key is shared by *every* request in a browse session: `search()` reuses one across six requests, and `/roon/browse` lets the caller supply its own. Scanning cannot say which request in a session was refused, or even whether it was a browse or a load. The test `load_rejection_resolves_the_load_not_a_browse_sharing_its_session` pins exactly that case — a scan of `pending_browses` would have resolved the wrong waiter.

**Why the session key is still checked.** `Moo::new` restarts the counter at 0 on every reconnect (fork `src/moo.rs:92`). A rejection arriving on a fresh connection can therefore carry a `req_id` that a stale, not-yet-timed-out entry still occupies. On mismatch the waiter is left alone and falls back to `BROWSE_TIMEOUT` — the pre-#405 behavior — because resolving the wrong caller is worse than resolving them late. `ErrorRouting::KeyMismatch` is logged at `warn`.

**Exactly-once, no strand.** Every delivery path `remove`s the entry before sending, so a repeated rejection finds nothing (`a_second_rejection_for_the_same_req_id_cannot_double_resolve`) and no waiter can be resolved twice. A dropped receiver still clears the entry (`rejection_with_a_dropped_receiver_still_clears_the_entry`). `KeyMismatch` deliberately leaves the entry for the caller's own timeout cleanup — the one path that does not remove, and the only correct one that does not.

**Both maps are searched for a full match before any mismatch is reported** (`b24ae86`, found by this branch's own dissent pass). A stale entry with a colliding `req_id` in `pending_browses` must not short-circuit a matching entry in `pending_loads`; that would cost a legitimate waiter its prompt answer for no safety gain. Pinned by `a_mismatched_entry_in_one_map_does_not_hide_a_match_in_the_other`.

## Failure classes, kept apart

| Condition | Before | After |
|---|---|---|
| Item key refused by Core | 500 `Browse request timed out`, after 10s | **404**, immediately, `Roon Core rejected the item key: it is no longer valid in this browse session - search or browse again to get a fresh key (browse session '…')` |
| Zone unknown to Core | 500 timeout, after 10s | **404**, immediately |
| Bad browse level | 500 timeout, after 10s | 500, immediately, with the Core's reason |
| Core-side unexpected error | 500 timeout, after 10s | 500, immediately, with the Core's reason |
| Core unreachable or slow | 500 timeout, after 10s | unchanged |
| Browse not connected | 503, immediately | unchanged |

Callers classify with `RoonBrowseError::from_error(&err) -> Option<&RoonBrowseError>` — no message-string matching. `RoonBrowseErrorKind::is_recoverable()` marks the two kinds a caller fixes by re-acquiring its reference and retrying. That boundary is a judgment, not a fact: `ZoneNotFound` is also caller-fixable, by naming a different zone. The line drawn here is "retry after re-acquiring your reference" versus "fix your input", and #395's envelope may reasonably want them as one category. The error travels inside the `anyhow::Error` the adapter methods already return, so `browse`, `load`, `search`, `play_item` and `search_and_play` keep their signatures and it survives `?` unchanged.

`RoonBrowseErrorKind::explain()` never contains the word "timeout", and a test asserts it.

## Who this actually reaches today

Worth being precise, because the headline surface is not the one with consumers:

- **`/roon/browse` and `/roon/play_item` — the routes #405 is about — have zero in-repo callers.** The Dioxus UI has no browse page. Their consumers, if any, are external: the iOS app, the knob, the operator's own tooling. `/roon/play_item` may never have been exercised by anything, which is the same evidence that makes its key-portability suspect.
- **`search()` is the path with known callers.** It calls `browse()`/`load()` six times, and MCP's `hifi_search` and `hifi_play` go through it. A rejection anywhere in that sequence used to cost 10s and now returns immediately. This is the change most likely to be noticed.
- **`/roon/image` is used by the web UI.** Cover art the Core refuses now fails fast instead of blocking for its own 10s timeout.

So the fix is worth having on all three counts, but no user-facing timeout is being removed from a route this repo is known to call — the routes named in the issue are external surface.

## Scope decisions

**All four browse rejections are routed, not only `InvalidItemKey`.** `InvalidItemKey` is the traced case; the other three are routed by symmetry, not by observation — nothing here establishes that a Core emits them, or with those exact names. They leak identically through the same catch-all, so routing one and leaving three would have left three 10s hangs behind. #405 lists this as a soft constraint.

**The two image rejections are routed too** — called out separately, as it is beyond the issue's title. `pending_images` has the identical shape (`req_id` key, image key stored) and the identical defect: `ImageNotFound` was dropped, so a missing cover art blocked `get_image` for its own 10s timeout. Routing sends `None`, which `get_image` already reads as `Image not found` (`src/adapters/roon.rs:563`). No type or signature change.

**`RoonApiError` is matched exhaustively, with no wildcard.** If the pinned fork gains a variant, this stops compiling instead of silently resuming the swallow. That is deliberate.

**Success arms untouched.** They cannot be improved without a fork change (no `req_id` on `Parsed::BrowseResult`), and this PR is behavior-additive.

## Test strategy — unit-scoped, deliberately not a Roon mock

Stated explicitly because #405 requires it. **The correlation logic is unit-scoped. No Roon mock was built, and `tests/mock_servers/roon.rs` was not extended.**

`MockRoonCore` holds state and speaks no protocol — nothing in the repo can make the adapter emit a `Parsed::Error`. Building a protocol-level Roon fake is **#408**, which is open and explicitly lists "can emit `Parsed::Error(RoonApiError::BrowseInvalidItemKey)` on demand, so #405 can test error correlation" as its own acceptance criterion. Building one here would duplicate and conflict with that work. #408 had not landed when this was written (no PR on it), so it was not available to use.

18 tests in `src/adapters/roon.rs`'s existing test module (private `RoonState` access), 12 of them new:

- `browse_rejection_resolves_only_the_matching_waiter` — five requests in flight (3 browses, 2 loads), one rejected; asserts the right receiver resolved, the other four still waiting, and only one map entry removed. This is #405's concurrency criterion.
- `load_rejection_resolves_the_load_not_a_browse_sharing_its_session` — the case a session-key scan gets wrong.
- `rejection_with_a_mismatched_session_key_leaves_the_waiter_alone` — the reconnect `req_id`-reuse guard.
- `a_mismatched_entry_in_one_map_does_not_hide_a_match_in_the_other` — the cross-map liveness case above.
- `rejection_for_an_unknown_req_id_is_a_noop`, `rejection_after_the_caller_timed_out_is_a_noop`, `a_second_rejection_for_the_same_req_id_cannot_double_resolve`, `rejection_with_a_dropped_receiver_still_clears_the_entry` — no strand, no double-resolve.
- `every_browse_rejection_kind_is_routed` — all four kinds.
- `a_rejected_item_key_resolves_far_inside_the_browse_timeout` — awaits the real `BROWSE_TIMEOUT` exactly as `browse()` does and asserts it returns in under a second.
- `image_rejection_resolves_the_matching_image_request`, `image_rejection_with_a_mismatched_key_leaves_the_waiter_alone`.
- `a_rejection_is_distinguishable_from_a_timeout_and_a_lost_core`, `only_reference_rejections_are_marked_recoverable`.

**Coverage boundary, stated so nobody over-trusts it** (and repeated in a comment in the test module): these exercise the real routing functions, the real `oneshot` channels and the real `BROWSE_TIMEOUT`. They do **not** exercise the fork's `parse_msg`, nor the three-line result match in `browse()`/`load()` that hands the oneshot payload to the caller. When #408 lands, this suite should gain one end-to-end case through the fake.

## The empirical question: is an `item_key` portable across `multi_session_key`s?

**Not answered. It needs a host with LAN access to the Core — this one does not have it.** Not declared working.

What was established:

- **A live Core is present and answering.** A SOOD query (replicating the fork's `src/sood.rs:120-188` wire format byte for byte, sent from this Mac to `192.168.1.255:9003`) got a reply from `192.168.1.208`: `name=nuc14`, `display_version=2.70 (build 1671) production`, `tcp_port=9150`, `http_port=9330`, `service_id=00720724-5143-4a9b-abac-0e50cba674bb` — the exact extension service id the adapter looks for.
- **But this Mac cannot initiate unicast traffic to it.** `connect()` to `192.168.1.208:9150` and `:9330` returns `EHOSTUNREACH`; `ping` gets no reply; the multicast send to `239.255.90.90` also fails `EHOSTUNREACH`. Identical with the tool sandbox disabled, so it is not the sandbox. Meanwhile `route -n get 192.168.1.208` shows a valid route on `en7` and `arp -n` has the MAC (`88:ae:dd:72:cc:62`) — and the Core's SOOD reply arrived as a *unicast* packet back to this Mac. So inbound unicast works and outbound unicast does not: the shape of a host-level local-network egress restriction, not a broken network. Lifting it means changing a system privacy or security setting, which is the operator's to do, not mine.
- This Mac has also never paired: there is no `~/.config/unified-hifi/roon_state.json`, and no UHC instance is running locally or anywhere reachable.

Even with egress fixed, the first run needs the operator to enable the extension in **Roon Settings → Extensions**, which is theirs to click.

### The exact check, for whoever has the rig

Run UHC against the Core, then:

```bash
UHC=http://localhost:8088

# 1. Mint a key in session A: browse the root, load one level, take an item_key.
curl -s -X POST $UHC/roon/browse -H 'content-type: application/json' \
  -d '{"pop_all":true,"session_key":"portability_A"}' | jq '.items[] | {title, item_key}'

KEY='<paste an item_key from session A>'

# 2. Use it in a *different*, fresh session B - what play_item() does internally.
curl -s -o /tmp/b.json -w 'HTTP %{http_code} in %{time_total}s\n' \
  -X POST $UHC/roon/browse -H 'content-type: application/json' \
  -d "{\"item_key\":\"$KEY\",\"session_key\":\"portability_B\"}"
jq . /tmp/b.json

# 3. Control: the same key re-used in its own session A must still work.
curl -s -X POST $UHC/roon/browse -H 'content-type: application/json' \
  -d "{\"item_key\":\"$KEY\",\"session_key\":\"portability_A\"}" | jq '.list, (.items | length)'
```

Reading the result — and this is only legible *because* of this PR:

- **`HTTP 404` in well under a second**, with `Roon Core rejected the item key`, means **keys are not portable**. Then `/roon/play_item` has never worked (it mints `play_item_<nanos>` and browses the caller's key inside it, `src/adapters/roon.rs:1107-1123`), and **#396's ref record must resolve through the minting session key, not just carry it** — the ref table has to re-drive the browse in the original session, or `play_item` needs a session-key parameter. Say so loudly in #396 before its design is fixed.
- **`HTTP 200` with a `list`** means keys are portable and the existing assumption holds.
- **`HTTP 500` with `Browse request timed out` after 10s** means something else is wrong — with this PR merged, that answer no longer means "stale key".

Before this PR, cases 1 and 3 were indistinguishable, so the question was not answerable from the HTTP surface at all.

Note step 2 uses `/roon/browse`, not `/roon/play_item`: it answers the same question and starts no playback. `/roon/play_item` still has zero in-repo callers and no test.

**That same run also closes this PR's other unverified link.** Nothing on this branch proves that a real Core's error names match the four literals the fork matches on (`InvalidItemKey`, `InvalidLevels`, `UnexpectedError`, `ZoneNotFound` — fork `src/browse.rs:174-188`). If a Core spelled one differently, `parse_msg` would yield `Parsed::None`, the fork would drop it, the caller would time out exactly as before — **and this test suite would still be green.** A fast 404 from step 2 confirms the wire half end to end. Until then, that half rests on a reading of the pinned checkout. It is #408's to pin permanently.

## Verification

**Correction to a premise this PR started with.** The "feature-branch PRs run zero CI" note applies to PRs based on *another feature branch*. This one bases on `v3`, so it gets the full workflow set — **Lint, Build and API Guard all run here, and the checks are meaningful.** The first run caught something local verification had missed: CI's Lint job runs `cargo fmt --check` *before* clippy, and it failed on five hunks in the new test module (`96d3ebd` fixes it). Worth recording, because `cargo clippy -- -D warnings` was clean throughout — clippy is not the whole gate.

**CI on head (`96d3ebd`) is green:** `Lint`, `Test`, `Build Linux x64`, `Build WASM Assets`, `Check API Changes`, `Smoke Test Binary`, `Synology Package Contract`, `Build Summary`. `Check API Changes` passing is independent confirmation that the route contract is untouched.

Everything below was also run locally, on head:

- `cargo fmt --check` — clean (after `96d3ebd`).
- `cargo clippy -- -D warnings` — clean. (Not `--all-targets`: it cannot pass, `src/lib.rs:20-22` denies `unwrap_used`/`expect_used`/`panic` crate-wide and src's own test modules violate it 76 times, pre-existing and untouched here.)
- `cargo test --no-fail-fast` — all suites pass except the two pre-existing `/hqp/discover` failures (`client_harness::shared_endpoints::get_hqp_discover`, `protocol_integration::api_endpoints::hqp_discover_returns_json`), which do live UDP SSDP and are unrelated. They are local-only: CI's `Test` job is green, which is worth knowing before anyone else spends time on them.
- Lint suites named as hard constraints in #405: `spawn_cancellation_lint`, `unbounded_channel_lint`, `await_in_lock_lint` — pass. Also `oneshot_leak_lint`, `ignored_send_lint`, `architecture_lint`, `aggregator_lint`, `arbitrary_find_lint` — pass.
- `cargo test --test api_contract` — passes; `tests/fixtures/api_routes.txt` untouched, so no `api-change-approved` is needed.
- `dx build --release --platform web --features web` — exit 0, both `Client build completed successfully` and `Server build completed successfully`. Two traps worth recording: `make css` must run first in a fresh worktree, and `~/.cargo/config.toml` sets `[build] rustc-wrapper = sccache` — `unset RUSTC_WRAPPER` does not override a config file, `CARGO_BUILD_RUSTC_WRAPPER=""` does. With sccache active the build failed at `exit status: 254`; with it off, clean. rustup's `rustc` (1.97.1) must also precede Homebrew's (1.93.1) on `PATH`.
- Red/green: `99b3779` (tests plus today's behavior behind the new seam) → 9 of 11 new tests fail, suite **10.01s**. Head → **18 pass, suite 0.00s**.

**What each piece of evidence proves.** The 10.01s → 0.00s drop proves *promptness* and nothing else — an implementation that promptly resolved the *wrong* waiter would post the same number. Correlation is proved only by `browse_rejection_resolves_only_the_matching_waiter` and `a_mismatched_entry_in_one_map_does_not_hide_a_match_in_the_other`.

No `.await` is taken while the state lock is held: the routing call is synchronous and the guard is dropped before the logging match. That is also what makes resolution exactly-once — the caller's timeout cleanup and the routing path are serialised by the one state `RwLock`, so they can interleave but never overlap.

## One judgment call the operator may want to veto

`/roon/browse` and `/roon/play_item` now answer **404** instead of 500 when the Core refuses an item key or a zone. Routes, HTTP methods, request bodies and the `{"error": "…"}` response shape are all unchanged, and `tests/fixtures/api_routes.txt` is untouched — but a status code is still observable behavior.

The case for it: 500 says "server bug", which misdirects the caller, and the alternative is making clients match on message text — the fragility this PR exists to remove. And the old 500 only ever arrived *after* a 10s timeout, so any client tuned to this condition was already treating it as an outage; telling it "your reference is stale" is the fix rather than a break. (The stronger claim — that no client could be depending on the old status — would be false: a client can branch on 500 today and would now take a different branch.)

To revert just this: in `src/api/mod.rs`, make `roon_browse_failure` return `StatusCode::INTERNAL_SERVER_ERROR` unconditionally. The adapter fix, the promptness and the precise message all survive that change.

## The neighbouring case, checked and already fine

The obvious sequel would be "a request in flight when the Core connection drops". It is **not** broken: the `CoreEvent::Lost` arm already clears all three pending maps immediately (`src/adapters/roon.rs:1944-1946`), which drops every sender, so each waiting receiver yields `RecvError` and its caller returns `"Browse request cancelled"` / `"Image request cancelled"` promptly — no 10s wait, no strand, and already distinguishable from a timeout. The ship-gate dissent asserted otherwise and was wrong; the retraction is in the comments. Recorded here so nobody else files it.

## Rollback

revert the merge commit, or `git revert 96d3ebd c7acd64 d6b1e1b b24ae86 39c7680 8df4df3 99b3779`. The change is confined to `src/adapters/roon.rs` and `src/api/mod.rs`, adds no dependency, no migration, no config, and no persisted state. Reverting restores the pre-#405 behavior exactly: rejections are dropped and callers time out.

Do not merge without the operator's explicit approval (AGENTS.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Roon browsing and playback requests now return more accurate error responses.
  - Invalid item keys and unavailable zones are reported as “not found” instead of generic server errors.
  - Other Roon Core failures continue to return server-error responses with relevant details preserved.
  - Browse failures are handled more reliably, including request timeouts, disconnected services, and unrelated responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->