### PR TITLE
test(roon): FakeRoonCore, a protocol-level Roon Core fake, and the first Roon success-path assertions (#408)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4607,6 +4607,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-test",
+ "tokio-tungstenite 0.21.0",
  "tokio-util",
  "tower",
  "tower-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,6 +151,10 @@ serial_test = "3"
 syn = { version = "2", features = ["full", "parsing", "visit"] }
 walkdir = "2"
 tempfile = "3"
+# WebSocket *server* for tests/mock_servers/roon_core.rs (the Roon Core protocol fake).
+# Pinned to the same version roon-api uses as its client, so the fake and the real
+# client library share one framing implementation and no new crate is compiled.
+tokio-tungstenite = "0.21"
 
 [profile.release]
 lto = true

--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -334,6 +334,49 @@ impl RoonAdapter {
         Ok(())
     }
 
+    /// Test seam (issue #408): run the Roon event loop against a Core at a known
+    /// address, skipping SOOD multicast discovery.
+    ///
+    /// **Not for production use** — `AdapterLogic::run` is the production entry
+    /// point and always discovers. This exists so `tests/roon_protocol.rs` can
+    /// drive the *real* event loop (including the pending-browse/load correlation
+    /// maps) against `tests/mock_servers/roon_core.rs`. Driving the real loop is
+    /// the whole point: a test that reimplemented the loop would assert nothing
+    /// about this file.
+    ///
+    /// SOOD-based discovery against a fake was rejected deliberately: it needs UDP
+    /// multicast, which is process-global and already the cause of this repo's two
+    /// flaky `/hqp/discover` tests.
+    ///
+    /// Returns when the Core is lost or `stop()` is called.
+    #[doc(hidden)]
+    pub async fn run_event_loop_against_core_for_tests(
+        &self,
+        ip: std::net::IpAddr,
+        port: &str,
+    ) -> Result<()> {
+        let base_url = self
+            .base_url
+            .read()
+            .await
+            .clone()
+            .unwrap_or_else(|| "http://test.invalid".to_string());
+        let shutdown = self.shutdown.read().await.clone();
+
+        run_roon_loop(
+            self.state.clone(),
+            self.bus.clone(),
+            base_url,
+            shutdown,
+            self.knob_store.clone(),
+            CoreConnect::Direct {
+                ip,
+                port: port.to_string(),
+            },
+        )
+        .await
+    }
+
     /// Stop the Roon adapter (internal - use Startable trait)
     async fn stop_internal(&self) {
         use std::sync::atomic::Ordering;
@@ -1301,6 +1344,7 @@ impl AdapterLogic for RoonAdapter {
             base_url,
             ctx.shutdown,
             self.knob_store.clone(),
+            CoreConnect::Discovery,
         )
         .await
     }
@@ -1460,6 +1504,17 @@ fn roon_zone_to_bus_zone(zone: &Zone) -> BusZone {
     }
 }
 
+/// How the event loop obtains its connection to a Roon Core.
+///
+/// Production always uses [`CoreConnect::Discovery`]; `Direct` exists only for
+/// `RoonAdapter::run_event_loop_against_core_for_tests` (issue #408).
+enum CoreConnect {
+    /// SOOD multicast discovery, then WebSocket to whatever answers.
+    Discovery,
+    /// WebSocket straight to a known address, no discovery.
+    Direct { ip: std::net::IpAddr, port: String },
+}
+
 /// Main Roon event loop
 async fn run_roon_loop(
     state: Arc<RwLock<RoonState>>,
@@ -1467,6 +1522,7 @@ async fn run_roon_loop(
     base_url: String,
     shutdown: CancellationToken,
     knob_store: Option<KnobStore>,
+    connect: CoreConnect,
 ) -> Result<()> {
     tracing::info!("Starting Roon discovery...");
 
@@ -1518,15 +1574,29 @@ async fn run_roon_loop(
     let state_path_clone = state_path_str.clone();
     let get_roon_state = move || RoonApi::load_roon_state(&state_path_clone);
 
-    // Start discovery
-    let (mut handles, mut core_rx) = roon
-        .start_discovery(Box::new(get_roon_state), provided, Some(services))
-        .await
-        .ok_or_else(|| anyhow::anyhow!("Failed to start Roon discovery"))?;
-
-    tracing::info!(
-        "Roon discovery started, waiting for core (authorize in Roon → Settings → Extensions)..."
-    );
+    // Start discovery (or, for tests, connect straight to a known Core)
+    let (mut handles, mut core_rx) = match connect {
+        CoreConnect::Discovery => {
+            let started = roon
+                .start_discovery(Box::new(get_roon_state), provided, Some(services))
+                .await
+                .ok_or_else(|| anyhow::anyhow!("Failed to start Roon discovery"))?;
+            tracing::info!(
+                "Roon discovery started, waiting for core (authorize in Roon → Settings → Extensions)..."
+            );
+            started
+        }
+        CoreConnect::Direct { ip, ref port } => {
+            let connected = roon
+                .ws_connect(Box::new(get_roon_state), provided, Some(services), &ip, port)
+                .await
+                .ok_or_else(|| {
+                    anyhow::anyhow!("Failed to connect to Roon Core at {}:{}", ip, port)
+                })?;
+            tracing::info!("Connected directly to Roon Core at {}:{}", ip, port);
+            connected
+        }
+    };
 
     // Event processing task
     let state_for_events = state.clone();

--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -1588,7 +1588,13 @@ async fn run_roon_loop(
         }
         CoreConnect::Direct { ip, ref port } => {
             let connected = roon
-                .ws_connect(Box::new(get_roon_state), provided, Some(services), &ip, port)
+                .ws_connect(
+                    Box::new(get_roon_state),
+                    provided,
+                    Some(services),
+                    &ip,
+                    port,
+                )
                 .await
                 .ok_or_else(|| {
                     anyhow::anyhow!("Failed to connect to Roon Core at {}:{}", ip, port)

--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -345,8 +345,9 @@ impl RoonAdapter {
     /// about this file.
     ///
     /// SOOD-based discovery against a fake was rejected deliberately: it needs UDP
-    /// multicast, which is process-global and already the cause of this repo's two
-    /// flaky `/hqp/discover` tests.
+    /// multicast, which is process-global, cannot be scoped to one test, and is why
+    /// this repo's `/hqp/discover` tests already pass in CI while failing on a
+    /// developer machine.
     ///
     /// Returns when the Core is lost or `stop()` is called.
     #[doc(hidden)]

--- a/tests/mock_servers/README.md
+++ b/tests/mock_servers/README.md
@@ -68,7 +68,7 @@ adapter.
 | Load | offset/count paging, short final page, total count vs page size, past-the-end returns empty |
 | play_item | an `item_key` resolves through the item's action list to `Play Now`; the `roon:` prefix is stripped before it reaches the Core |
 | search_and_play | navigates into a search hit to find a playable action; `play` / `queue` invoke different actions; a missing action reports what *is* available |
-| Errors on demand | `InvalidItemKey` and `InvalidLevels`, correlated to the right request id and session key, including with several requests in flight and responses arriving out of order |
+| Errors on demand | `InvalidItemKey` and `InvalidLevels`, correlated to the right request id and session key, including with several requests in flight and responses arriving out of order; and an *unrecognised* error name, to pin what happens when the fork's four literals are wrong |
 | Drift | every request name the adapter sends is a closed set; anything else is recorded as unhandled and answered `InvalidRequest` |
 
 ### Does NOT cover — do not assume otherwise
@@ -127,7 +127,19 @@ that each contains a `Search` item, that an action list contains
 | `action: "none"` in reply to invoking an action item | the adapter discards this BrowseResult | none today; would matter if a caller started reading it |
 | `InvalidItemKey` carries no body | the fork keys only off the name | none for the fork; a real body that parsed as a `BrowseResult` would be read as success |
 | `item_key` format | opacity is all this repo needs | none |
+| **the four browse error *names*** | only evidence is the fork's own literals | **a Core that spells one differently is dropped inside the dependency, and the caller times out as if unreachable — with every test here still green** |
 | **`item_key` portability across `multi_session_key`s** | **this is the epic's open question** | if keys are *not* portable, `/roon/play_item` is broken and #396's ref design changes |
+
+The error-name row is the one #405's PR (#412) explicitly handed to this issue: the
+fork matches `"InvalidItemKey"`, `"InvalidLevels"`, `"UnexpectedError"` and
+`"ZoneNotFound"` against `msg["name"]`, and anything else becomes `Parsed::None`,
+which it drops. This fake sends the fork's own literals, so it can never catch a
+mismatch. What it *can* do — and does — is pin the consequence:
+`an_unrecognised_error_name_degrades_to_an_indistinguishable_timeout` makes the Core
+answer instantly with an unrecognised name and asserts the caller still times out.
+`FakeRoonCore::FORK_ERROR_NAMES` pins the four literals so a fork bump that renames
+one fails here rather than as a mysterious timeout. **Verifying the names needs a
+real Core.**
 
 That last row is the one that matters. `RoonAdapter::play_item` mints a fresh,
 unrelated session key and browses the caller's key inside it, so the repo already
@@ -137,19 +149,60 @@ Core reject a foreign key, so a test can pin either answer. #405 must settle it
 against the operator's rig — see
 `a_foreign_item_key_is_rejected_when_keys_are_session_scoped`.
 
-### Tests that deliberately pin defects
+### Rejection tests work on both sides of #405, by design
 
-Two tests assert today's *wrong* behaviour, and say so at the assertion:
+Four tests drive a Core rejection: a bad item key, a foreign key under
+`ItemKeyScope::PerSession`, a load with no browse, and one rejection among three
+concurrent browses. None of them asserts "it hangs".
 
-* `browse_error_is_delivered_but_the_adapter_drops_it`
-* `concurrent_browses_one_rejected_leaves_the_rejected_caller_hanging`
+`classify_rejection()` in `tests/roon_protocol.rs` enforces what must hold whether
+or not #405 (PR #412) has landed — a rejected request **never** resolves as success,
+and if it resolves at all it resolves promptly, with a message that neither reads as
+a timeout nor omits the browse session — and reports which of the two it observed.
+Verified both ways:
 
-The adapter's event loop discards `Parsed::Error` in its catch-all, so a
-Core-rejected item key resolves nothing and the caller waits out the 10s
-`BROWSE_TIMEOUT`. The fake proves the Core answered immediately — that is what
-`FakeRoonCore::responses()` is for — so the ten seconds are demonstrably UHC's, not
-Roon's. **#405 fixes this. When it lands, invert the assertions; do not delete the
-tests.**
+```
+$ # on v3 (c47d36a), #405 not present
+load without a browse: DroppedByAdapter
+rejected browse: DroppedByAdapter
+rejected browse among three in flight: DroppedByAdapter
+play_item against a foreign key: DroppedByAdapter
+ok. 49 passed
+
+$ # same file, merged with fix/issue-405-roon-browse-errors
+load without a browse: RoutedToCaller
+rejected browse: RoutedToCaller
+rejected browse among three in flight: RoutedToCaller
+play_item against a foreign key: RoutedToCaller
+ok. 49 passed
+```
+
+So this is the end-to-end proof #412 asked for — its own correlation tests are
+unit-scoped precisely because nothing could drive the wire path — and it does not
+have to be inverted on merge. What is pinned unconditionally is the wire half: the
+Core answered, named the error, and correlated it to the rejected request's own
+`req_id` **and** session key, which is exactly the `Parsed::Error` payload.
+
+### One test does pin a defect: same-session cross-delivery
+
+`concurrent_browses_in_one_session_cross_deliver_their_results` asserts a bug is
+**present**, and it survives #405.
+
+Two browses in flight under the *same* `multi_session_key` cross-deliver their
+results. `pending_browses` is keyed by `req_id` but the `Parsed::BrowseResult` arm
+scans by session key — `Parsed::BrowseResult` carries no `req_id`, so it cannot say
+which request in a session answered — and `.find()` returns an arbitrary match.
+Measured: seven trials in eight hand the caller someone else's list, with no error.
+
+`search`, `search_and_play` and `play_item` each mint a private session key and run
+sequentially, so they are safe. `POST /roon/browse` takes a **caller-supplied**
+session key and has no in-repo callers today — but any external client can trigger
+it, and #399's navigation handle will give clients a reusable session identity,
+which is exactly the shape that triggers it. #412's own comment says closing the gap
+needs a change to the pinned fork.
+
+When that assertion starts failing, the bug is fixed: invert it to compare each
+trial against `expected`.
 
 ### Adding to the fake
 

--- a/tests/mock_servers/README.md
+++ b/tests/mock_servers/README.md
@@ -1,0 +1,163 @@
+# Mock backends
+
+Test doubles for the backends UHC talks to. They exist so adapter behaviour can be
+asserted without hardware, a network, or the operator's rig.
+
+**Read the "does not cover" column before you trust one.** A mock nothing asserts
+*against* is worse than no mock, because it reads as coverage: `MockHqpServer`
+rejected its own adapter's wire format until #394 noticed
+(`HqpAdapter::build_command` sends the XML declaration and the command on one line;
+the mock discarded any line starting with `<?xml`).
+
+| Module | Kind | Drives the real adapter? |
+|---|---|---|
+| `roon_core.rs` — `FakeRoonCore` | WebSocket server, MOO protocol | **yes** |
+| `roon.rs` — `MockRoonCore` | in-memory state holder, no protocol | no — and no test uses it |
+| `lms.rs` — `MockLmsServer` | HTTP server, JSON-RPC `slim.request` | yes |
+| `hqplayer.rs` — `MockHqpServer` | TCP server, XML lines | yes |
+| `openhome.rs` — `MockOpenHomeDevice` | HTTP server, SOAP | discovery only |
+| `upnp.rs` — `MockUpnpRenderer` | HTTP server, SOAP | discovery only |
+
+---
+
+## `FakeRoonCore` (issue #408)
+
+A real WebSocket server that speaks Roon's MOO framing and enough of
+`com.roonlabs.registry:1` / `transport:2` / `browse:1` for `RoonAdapter` to run
+against it end to end. Tests live in `tests/roon_protocol.rs`.
+
+`MockRoonCore` in `roon.rs` is **not** this. It is an in-memory zone-state holder
+that nothing speaks a protocol to — which is why, before #408, no test asserted a
+Roon success path. It is left in place unchanged, but note what a grep shows:
+
+```
+$ grep -rn "MockRoonCore" tests/ | grep -v tests/mock_servers/roon.rs
+tests/mock_servers/mod.rs:19:pub use roon::MockRoonCore;
+```
+
+**Its only callers are its own six unit tests.** No adapter test uses it. Prefer
+`FakeRoonCore` for anything new; `MockRoonCore` is a removal candidate, filed
+separately rather than deleted here.
+
+### How a test uses it
+
+```rust
+let core = FakeRoonCore::start().await;              // random loopback port
+let adapter = connected(&core).await;                // real event loop, no SOOD
+let hits = adapter.search("kind of blue", None, Some(10), SearchSource::Library).await?;
+core.assert_no_unhandled_requests().await;           // drift guard
+```
+
+`connected()` calls `RoonAdapter::run_event_loop_against_core_for_tests`, the one
+production-code seam this added: `run_roon_loop` gained a `CoreConnect` parameter so
+tests can connect to a known address instead of doing SOOD multicast discovery.
+Everything after the connection — the event loop, the `pending_browses` /
+`pending_loads` maps, the zone conversion — is the code production runs. That is
+the point. A test that reimplemented the loop would assert nothing about the
+adapter.
+
+### Covered
+
+| Area | What is asserted |
+|---|---|
+| Handshake | `registry:1/info` at request id 0, then `register`; `CoreEvent::Registered`; Browse becomes available |
+| Zones | a `Subscribed` payload survives the fork's deserializer and reaches `get_zones()` — a missing required field would otherwise be swallowed silently |
+| Search | full six-request sequence, one `search_{nanos}` session key throughout, query carried as `input`, source selection (Library / TIDAL / Qobuz), empty result sets, `hierarchy=browse` on every request |
+| **title / subtitle mapping** | asymmetric values at three layers: adapter return value, `GET /roon/search`, `POST /roon/browse`. This is the hole #408 exists to close |
+| Browse | two levels down and `pop_all` back to the root; per-session level stacks proven independent; `input_prompt` advertised; unkeyed rows |
+| Load | offset/count paging, short final page, total count vs page size, past-the-end returns empty |
+| play_item | an `item_key` resolves through the item's action list to `Play Now`; the `roon:` prefix is stripped before it reaches the Core |
+| search_and_play | navigates into a search hit to find a playable action; `play` / `queue` invoke different actions; a missing action reports what *is* available |
+| Errors on demand | `InvalidItemKey` and `InvalidLevels`, correlated to the right request id and session key, including with several requests in flight and responses arriving out of order |
+| Drift | every request name the adapter sends is a closed set; anything else is recorded as unhandled and answered `InvalidRequest` |
+
+### Does NOT cover — do not assume otherwise
+
+* **It cannot prove the adapter matches a real Roon Core.** The fake's semantics
+  came from the pinned fork's deserializers and from this repo's own adapter, so
+  green means *unchanged*, not *correct*. Both were derived from the same source of
+  truth, and that source has never been checked against Roon.
+* **Category-grouped search results.** A real Core returns search hits grouped
+  under `Albums` / `Tracks` / `Artists` rows. The default library returns hits
+  flat, so `is_category`, `try_category_playable` and the second half of
+  `try_navigate_to_playable` (`src/adapters/roon.rs`) are **untested**. A test
+  can build a grouped library itself — `FakeLibrary`'s fields and the `FakeItem`
+  builders are public — but nobody has verified what the real grouping looks like,
+  so the fake does not ship a guess.
+* **Transport control.** `play` / `pause` / `next` / volume / mute go through
+  `com.roonlabs.transport:2/control` and `change_volume`; the fake does not model
+  them. It answers `InvalidRequest` and records the call as unhandled — those
+  adapter methods do not await a reply, so they would appear to succeed; only
+  `assert_no_unhandled_requests()` catches it. Call that assertion in any test you
+  add.
+* **Images.** `com.roonlabs.image:1/get_image` is not modelled.
+* **Queue.** `subscribe_queue` / `play_from_here` (which #400 needs) are not
+  modelled.
+* **Zone updates over time.** Zones are sent once at subscribe. No `Changed`,
+  `zones_added`, `zones_removed` or `zones_seek_changed` events.
+* **Reconnection and Core loss.** Dropping the connection is not exercised.
+* **Roon's real error bodies.** The fake sends error names with no body.
+* **Authorization.** A real extension must be authorized in Roon → Settings →
+  Extensions before `register` succeeds. The fake always registers, so the
+  unauthorized state is untested.
+
+### Which shapes are inferred rather than recorded
+
+**No live Roon Core was reachable when this was written** — this machine's config
+directory has no `roon_state.json`, so there is no pairing token, and obtaining one
+requires a human to authorize the extension in Roon's UI. So nothing here is
+recorded from a Core. Two pedigrees, unequal confidence:
+
+*From the pinned fork* (`~/.cargo/git/checkouts/rust-roon-api-*/06dd807`) — which
+fields exist, which are required, enum spellings, the four browse error names, the
+handshake order. High confidence: a shape the fork accepts is a shape the adapter
+can consume.
+
+*From this repo's adapter* — that the root contains `Library` / `TIDAL` / `Qobuz`,
+that each contains a `Search` item, that an action list contains
+`Play Now` / `Queue` / `Start Radio`. High confidence as *expectations*:
+`src/adapters/roon.rs` will not work against anything else.
+
+*Inferred, unverified* — each marked `INFERRED:` at its use site in `roon_core.rs`:
+
+| Shape | Why it is a guess | Consequence if wrong |
+|---|---|---|
+| root list title `"Explore"` | never read by this repo | none — cosmetic |
+| `list.level` numbered from 0 at the root | plausible, unchecked | #399's "report your position" would be off by one |
+| `action: "none"` in reply to invoking an action item | the adapter discards this BrowseResult | none today; would matter if a caller started reading it |
+| `InvalidItemKey` carries no body | the fork keys only off the name | none for the fork; a real body that parsed as a `BrowseResult` would be read as success |
+| `item_key` format | opacity is all this repo needs | none |
+| **`item_key` portability across `multi_session_key`s** | **this is the epic's open question** | if keys are *not* portable, `/roon/play_item` is broken and #396's ref design changes |
+
+That last row is the one that matters. `RoonAdapter::play_item` mints a fresh,
+unrelated session key and browses the caller's key inside it, so the repo already
+assumes keys are global. The fake refuses to decide: `ItemKeyScope::Global` is the
+default (matching the repo's assumption) and `ItemKeyScope::PerSession` makes the
+Core reject a foreign key, so a test can pin either answer. #405 must settle it
+against the operator's rig — see
+`a_foreign_item_key_is_rejected_when_keys_are_session_scoped`.
+
+### Tests that deliberately pin defects
+
+Two tests assert today's *wrong* behaviour, and say so at the assertion:
+
+* `browse_error_is_delivered_but_the_adapter_drops_it`
+* `concurrent_browses_one_rejected_leaves_the_rejected_caller_hanging`
+
+The adapter's event loop discards `Parsed::Error` in its catch-all, so a
+Core-rejected item key resolves nothing and the caller waits out the 10s
+`BROWSE_TIMEOUT`. The fake proves the Core answered immediately — that is what
+`FakeRoonCore::responses()` is for — so the ten seconds are demonstrably UHC's, not
+Roon's. **#405 fixes this. When it lands, invert the assertions; do not delete the
+tests.**
+
+### Adding to the fake
+
+* Do not encode a Roon semantic this repo does not already depend on. If a shape
+  is uncertain, make it configurable and mark it `INFERRED:`, the way
+  `ItemKeyScope` is.
+* Library *shape* is data a test supplies (`FakeLibrary`, `FakeItem`); protocol
+  behaviour is the fake's. Keep that line.
+* If you teach it a new request, `the_fake_models_everything_the_adapter_sends`
+  pins the closed set of request names — update it deliberately, and never by
+  deleting the assertion.

--- a/tests/mock_servers/README.md
+++ b/tests/mock_servers/README.md
@@ -62,7 +62,7 @@ adapter.
 |---|---|
 | Handshake | `registry:1/info` at request id 0, then `register`; `CoreEvent::Registered`; Browse becomes available |
 | Zones | a `Subscribed` payload survives the fork's deserializer and reaches `get_zones()` — a missing required field would otherwise be swallowed silently |
-| Search | full six-request sequence, one `search_{nanos}` session key throughout, query carried as `input`, source selection (Library / TIDAL / Qobuz), empty result sets, `hierarchy=browse` on every request |
+| Search | full six-request sequence, one `search_{nanos}` session key throughout, query carried as `input`, source selection (Library / TIDAL / Qobuz), empty result sets, `hierarchy=browse` on every request. **Flat results only** — see the category-grouping entry below — and against a hierarchy taken from the adapter's own expectations, so this cannot detect the adapter expecting the wrong hierarchy |
 | **title / subtitle mapping** | asymmetric values at three layers: adapter return value, `GET /roon/search`, `POST /roon/browse`. This is the hole #408 exists to close |
 | Browse | two levels down and `pop_all` back to the root; per-session level stacks proven independent; `input_prompt` advertised; unkeyed rows |
 | Load | offset/count paging, short final page, total count vs page size, past-the-end returns empty |
@@ -77,13 +77,19 @@ adapter.
   came from the pinned fork's deserializers and from this repo's own adapter, so
   green means *unchanged*, not *correct*. Both were derived from the same source of
   truth, and that source has never been checked against Roon.
-* **Category-grouped search results.** A real Core returns search hits grouped
-  under `Albums` / `Tracks` / `Artists` rows. The default library returns hits
-  flat, so `is_category`, `try_category_playable` and the second half of
-  `try_navigate_to_playable` (`src/adapters/roon.rs`) are **untested**. A test
-  can build a grouped library itself — `FakeLibrary`'s fields and the `FakeItem`
+* **Category-grouped search results — probably the most-travelled real path.** A
+  real Core returns search hits grouped under `Albums` / `Tracks` / `Artists` rows;
+  `is_category` and `try_category_playable` exist in `src/adapters/roon.rs` because
+  someone saw that. The default library returns hits flat, so those two and the
+  second half of `try_navigate_to_playable` are **untested**, which means the
+  branch a real search most likely takes is the one with no coverage. A test can
+  build a grouped library itself — `FakeLibrary`'s fields and the `FakeItem`
   builders are public — but nobody has verified what the real grouping looks like,
-  so the fake does not ship a guess.
+  so the fake ships no guess.
+* **The hierarchy itself.** `Library` / `TIDAL` / `Qobuz` → `Search` → results is
+  taken from what `src/adapters/roon.rs` requires, so a fake built from it can never
+  disagree with the adapter about navigation. If Roon renamed `Search`, `search()`
+  would break in production and this suite would stay green.
 * **Transport control.** `play` / `pause` / `next` / volume / mute go through
   `com.roonlabs.transport:2/control` and `change_volume`; the fake does not model
   them. It answers `InvalidRequest` and records the call as unhandled — those
@@ -203,6 +209,21 @@ needs a change to the pinned fork.
 
 When that assertion starts failing, the bug is fixed: invert it to compare each
 trial against `expected`.
+
+### Two scheduled edits — do these, do not skip them
+
+1. **When #405 (PR #412) is on `v3`:** tighten `classify_rejection` so
+   `RejectionOutcome::DroppedByAdapter` is a hard failure, and replace the string
+   checks with `RoonBrowseError::from_error(&e)` asserting
+   `kind == RoonBrowseErrorKind::InvalidItemKey` and the session key. As written the
+   helper accepts both outcomes, which means it cannot catch a regression *back* to
+   dropping the error — the exact bug #405 fixed.
+2. **`concurrent_browses_in_one_session_cross_deliver_their_results` will rot.** It
+   asserts a defect is present, so it turns red when the defect is fixed, and the
+   person who sees that red will not know it is good news. The instruction is at the
+   assertion site: invert it, compare each trial against `expected`. It is also the
+   only probabilistic assertion in this repo's suite (eight trials, roughly 1 in
+   10^7 for a false failure).
 
 ### Adding to the fake
 

--- a/tests/mock_servers/README.md
+++ b/tests/mock_servers/README.md
@@ -109,43 +109,98 @@ adapter.
 
 ### Which shapes are inferred rather than recorded
 
-**No live Roon Core was reachable when this was written** — this machine's config
-directory has no `roon_state.json`, so there is no pairing token, and obtaining one
-requires a human to authorize the extension in Roon's UI. So nothing here is
-recorded from a Core. Two pedigrees, unequal confidence:
+**No live Roon Core was reachable** — this machine's config directory has no
+`roon_state.json`, so there is no pairing token, and obtaining one requires a human
+to authorize the extension in Roon's UI. So nothing here was recorded off a Core *by
+this work*.
 
-*From the pinned fork* (`~/.cargo/git/checkouts/rust-roon-api-*/06dd807`) — which
-fields exist, which are required, enum spellings, the four browse error names, the
-handshake order. High confidence: a shape the fork accepts is a shape the adapter
-can consume.
+The alternative to recording is not hand-writing shapes and letting the fake agree
+with its author — that is exactly the failure #408 exists to end, and #407 found a
+real client-visible bug precisely because it recorded rather than assumed. So the
+uncertain shapes were chased into published sources instead. **Five pedigrees,
+unequal confidence:**
 
-*From this repo's adapter* — that the root contains `Library` / `TIDAL` / `Qobuz`,
-that each contains a `Search` item, that an action list contains
-`Play Now` / `Queue` / `Start Radio`. High confidence as *expectations*:
-`src/adapters/roon.rs` will not work against anything else.
+**1. From the pinned fork** (`~/.cargo/git/checkouts/rust-roon-api-*/06dd807`) —
+which fields exist, which are required, the handshake order, the 10s read timeout. A
+shape the fork's `serde` accepts is a shape the adapter can consume.
 
-*Inferred, unverified* — each marked `INFERRED:` at its use site in `roon_core.rs`:
+**2. From RoonLabs' own published API** (`RoonLabs/node-roon-api-browse`,
+`RoonLabs/node-roon-api`) — quoted at the use sites:
 
-| Shape | Why it is a guess | Consequence if wrong |
-|---|---|---|
-| root list title `"Explore"` | never read by this repo | none — cosmetic |
-| `list.level` numbered from 0 at the root | plausible, unchecked | #399's "report your position" would be off by one |
-| `action: "none"` in reply to invoking an action item | the adapter discards this BrowseResult | none today; would matter if a caller started reading it |
-| `InvalidItemKey` carries no body | the fork keys only off the name | none for the fork; a real body that parsed as a `BrowseResult` would be read as success |
-| `item_key` format | opacity is all this repo needs | none |
-| **the four browse error *names*** | only evidence is the fork's own literals | **a Core that spells one differently is dropped inside the dependency, and the caller times out as if unreachable — with every test here still green** |
-| **`item_key` portability across `multi_session_key`s** | **this is the epic's open question** | if keys are *not* portable, `/roon/play_item` is broken and #396's ref design changes |
+| Shape | RoonLabs' words |
+|---|---|
+| `list.level` | "increases from 0" — so root = 0 is **documented**, not inferred |
+| `action` values | `message`, `none` ("No action is required"), `list`, `replace_item`, `remove_item` |
+| `hint` values | `null` ("Unknown"), `action`, `action_list`, `list`, `header` |
+| `input_prompt` | `prompt`, `action` ("The verb that goes with this action"), `value`, `is_password` |
+| `InvalidRequest` | what `node-roon-api` itself sends for "unknown service" / "unknown request name" — the shape this fake uses for unmodelled calls |
 
-The error-name row is the one #405's PR (#412) explicitly handed to this issue: the
-fork matches `"InvalidItemKey"`, `"InvalidLevels"`, `"UnexpectedError"` and
-`"ZoneNotFound"` against `msg["name"]`, and anything else becomes `Parsed::None`,
-which it drops. This fake sends the fork's own literals, so it can never catch a
-mismatch. What it *can* do — and does — is pin the consequence:
+**3. Recorded off real Cores, by third parties** — real Cores, but other people's
+logs rather than a controlled run:
+
+* `MOO/1 COMPLETE InvalidItemKey`, verbatim, in `home-assistant/core#137605`:
+  `Could not play id:122:4, result: MOO/1 COMPLETE InvalidItemKey` (also `130:12`,
+  `133:13`, `109:7`, `135:5`). Confirms the name **and** that the reply is just verb
+  and name.
+* Real `item_key`s are two colon-separated integers and "change with each refresh" —
+  `"115:0"` becoming `"116:0"` (Roon Labs community thread 23129).
+
+**4. From this repo's adapter** — the `Library`/`TIDAL`/`Qobuz` → `Search` hierarchy
+and the `Play Now`/`Queue`/`Start Radio` action titles. High confidence as
+*expectations*; `src/adapters/roon.rs` will not work against anything else. **That is
+not the same as Roon being that way.**
+
+**5. Inferred and unverified** — each marked `INFERRED:` at its use site:
+
+| Shape | Consequence if wrong |
+|---|---|
+| root list title `"Explore"` | none — never read |
+| a real Core sends *no body* with an error | none for the fork; a real body that parsed as a `BrowseResult` would read as success |
+| `action: "none"` is the reply a Core picks for an invoked action | none today — the adapter discards that `BrowseResult` |
+| **`InvalidLevels` / `UnexpectedError` / `ZoneNotFound` spellings** | **dropped inside the dependency; the caller times out as if the Core were unreachable, with every test here still green** |
+| search results are flat rather than category-grouped | `is_category` / `try_category_playable` untested |
+| **`item_key` portability across `multi_session_key`s** | if keys are *not* portable, `/roon/play_item` is broken and #396's ref design changes |
+
+### The error names: one corroborated, three not
+
+#405's PR (#412) handed this issue the wire half it could not reach. Result:
+
+* `InvalidItemKey` — **corroborated verbatim off real Cores** (above).
+* `InvalidLevels`, `UnexpectedError`, `ZoneNotFound` — **unverified.** RoonLabs'
+  published browse API documents errors only as "an error code or false if no error"
+  and never enumerates them; none of the three appears anywhere in `node-roon-api`.
+  A community thread shows the prose "Zone not found", which is not evidence of a
+  wire spelling.
+
+This fake sends the fork's literals, so it can never catch a mismatch. What it does
+instead is pin the consequence:
 `an_unrecognised_error_name_degrades_to_an_indistinguishable_timeout` makes the Core
-answer instantly with an unrecognised name and asserts the caller still times out.
-`FakeRoonCore::FORK_ERROR_NAMES` pins the four literals so a fork bump that renames
-one fails here rather than as a mysterious timeout. **Verifying the names needs a
-real Core.**
+answer instantly with an unrecognised name and asserts the caller still times out —
+and it passes with #405 applied, because the fix does not help when the name is
+unrecognised. `FakeRoonCore::FORK_ERROR_NAMES` pins the literals so a fork bump that
+renames one fails here rather than as a mysterious timeout.
+
+### Third-party evidence contradicts the repo's `item_key` assumption
+
+`RoonAdapter::play_item` mints a *fresh* session key and browses the caller's key
+inside it, so the repo assumes keys are global. Two recorded observations point the
+other way:
+
+* `home-assistant/core#137605` — playing a Roon playlist from a script "works
+  successfully on the first attempt but fails on the second", with
+  `MOO/1 COMPLETE InvalidItemKey`. Same shape as UHC's `play_item`: hold a key from
+  an earlier lookup, browse it later.
+* Community thread 23129 — item keys "change with each refresh".
+
+That is `ItemKeyScope::PerSession` behaviour. **Neither source states the rule**, and
+Home Assistant is not UHC, so this is evidence rather than proof — but it is enough
+that #396 should not design on the assumption keys are portable, and enough that
+`/roon/play_item` should be assumed broken until the rig says otherwise.
+
+The default stays `Global` because that is what the adapter's code assumes and these
+tests describe the adapter. **Do not read the default as a claim about Roon.**
+`a_foreign_item_key_is_rejected_when_keys_are_session_scoped` exercises the other
+setting; flip the default once the rig settles it.
 
 That last row is the one that matters. `RoonAdapter::play_item` mints a fresh,
 unrelated session key and browses the caller's key inside it, so the repo already

--- a/tests/mock_servers/mod.rs
+++ b/tests/mock_servers/mod.rs
@@ -3,14 +3,19 @@
 //! These mock servers simulate real backend services (Roon, LMS, HQPlayer, UPnP, OpenHome)
 //! allowing full integration testing without real hardware.
 
+//!
+//! See `README.md` in this directory for what each mock does and does not cover.
+
 pub mod hqplayer;
 pub mod lms;
 pub mod openhome;
 pub mod roon;
+pub mod roon_core;
 pub mod upnp;
 
 pub use hqplayer::MockHqpServer;
 pub use lms::MockLmsServer;
 pub use openhome::MockOpenHomeDevice;
 pub use roon::MockRoonCore;
+pub use roon_core::FakeRoonCore;
 pub use upnp::MockUpnpRenderer;

--- a/tests/mock_servers/roon_core.rs
+++ b/tests/mock_servers/roon_core.rs
@@ -1,0 +1,1337 @@
+//! `FakeRoonCore` — a Roon Core that actually speaks Roon's protocol.
+//!
+//! Issue #408. This is **not** [`super::roon::MockRoonCore`], which is an in-memory
+//! state holder with no wire protocol. This is a real WebSocket server that speaks
+//! the MOO framing and the `com.roonlabs.*` request/response surface that
+//! `roon_api` (the pinned fork) expects, so `RoonAdapter` can be driven end to end
+//! without a Roon Core and without a network.
+//!
+//! # What it is for
+//!
+//! Before this existed, no test asserted a Roon *success* path: if the adapter had
+//! swapped `title` and `subtitle` on the way out of a search, nothing would have
+//! failed. See `tests/roon_protocol.rs` for the tests that close that hole.
+//!
+//! # Wire protocol
+//!
+//! Everything below is read off the pinned fork
+//! (`open-horizon-labs/rust-roon-api@ohc/main`, checkout `06dd807`), not invented:
+//!
+//! * Transport: WebSocket at `ws://<ip>:<port>/api`, binary frames (`moo.rs::Moo::new`).
+//! * Frame: `MOO/1 <VERB> <NAME>\n` then `Request-Id: <n>\n`, optional
+//!   `Content-Length` / `Content-Type: application/json`, a blank line, then the
+//!   body (`moo.rs::Moo::create_msg_string`, `moo.rs::MooReceiver::parse`).
+//! * Handshake: client sends `REQUEST com.roonlabs.registry:1/info` as
+//!   request id 0. The Core answers with a body carrying `core_id`,
+//!   `display_name`, `display_version`; the client then sends
+//!   `REQUEST com.roonlabs.registry:1/register` and the Core answers
+//!   `COMPLETE Registered` with a `token`. Only then does `CoreEvent::Registered`
+//!   fire and `state.browse` become available (`lib.rs:405-524`).
+//! * Zones: `COMPLETE`/`CONTINUE Subscribed` with `{"zones": [...]}` in reply to
+//!   `com.roonlabs.transport:2/subscribe_zones` (`transport.rs:479-482`).
+//! * Browse/load: `COMPLETE Success` with a `BrowseResult` or `LoadResult` body
+//!   (`browse.rs:159-167`).
+//! * Browse errors: a body-less `COMPLETE InvalidItemKey` (or `InvalidLevels`,
+//!   `UnexpectedError`, `ZoneNotFound`) — the fork keys purely off the message
+//!   *name* (`browse.rs:169-183`) and emits
+//!   `Parsed::Error(RoonApiError::BrowseInvalidItemKey((req_id, session_key)))`.
+//! * Keepalive: the fork's `MooReceiver::receive_response` gives up after 10s of
+//!   silence and the connection is then reported as a lost Core
+//!   (`moo.rs:245-249`, `lib.rs:646-660`), so this fake sends a
+//!   `com.roonlabs.ping:1/ping` request every 3s, which the client's built-in
+//!   Ping service answers (`lib.rs:857-871`).
+//!
+//! # PROVENANCE — read this before trusting a shape
+//!
+//! **No live Roon Core was reachable when this was written** (no pairing token
+//! exists in this machine's config dir, and pairing requires a human to authorize
+//! the extension in Roon → Settings → Extensions). So the shapes here have two
+//! different pedigrees, and they are not equally trustworthy:
+//!
+//! | Pedigree | What it covers | Confidence |
+//! |---|---|---|
+//! | **From the fork** | which fields exist, which are required vs optional, enum spellings (`"action_list"`, `"list"`, …), the four browse error names, the handshake order | high — a shape the fork's `serde` accepts is a shape the adapter can consume |
+//! | **From this repo's adapter** | that the browse root contains `Library` / `TIDAL` / `Qobuz`, that each contains a `Search` item, that an action list contains `Play Now` / `Queue` / `Start Radio` | high as *expectations* — `src/adapters/roon.rs` will not work against anything else |
+//! | **INFERRED** | root list title (`Explore`), `level` numbering from 0, `action: "none"` as the reply to invoking an action item, whether a real Core sends a body with `InvalidItemKey`, whether an `item_key` minted under one `multi_session_key` resolves under another | **unverified** — every one is marked `INFERRED:` at its use site |
+//!
+//! The last row is the dangerous one. In particular the `item_key` portability
+//! question is the empirical unknown #405 must answer against the operator's rig;
+//! this fake makes it *configurable* ([`ItemKeyScope`]) rather than pretending to
+//! know, so a test can pin either answer and be re-pointed once it is known.
+//!
+//! # What this fake does NOT prove
+//!
+//! It proves the adapter is self-consistent and that it drives `roon_api` correctly.
+//! It **cannot** prove the adapter matches a real Roon Core, because the fake's
+//! semantics were derived from the same repo the adapter lives in. Green here means
+//! "unchanged", not "correct". See `tests/mock_servers/README.md` for the full
+//! covered/not-covered table.
+//!
+//! # Failing loudly rather than looking like coverage
+//!
+//! The `MockHqpServer` lesson (#394) was that a mock nothing asserts *against* is
+//! worse than no mock — it had been rejecting its own adapter's wire format for
+//! months and read as coverage. Three defences here:
+//!
+//! 1. Every request the adapter sends is recorded ([`FakeRoonCore::requests`]), so
+//!    tests assert what went *out*, not only what came back.
+//! 2. Anything this fake does not understand is recorded as unhandled and answered
+//!    with `InvalidRequest`; [`FakeRoonCore::assert_no_unhandled_requests`] turns
+//!    adapter drift into a test failure instead of a silent hang.
+//! 3. The fake is validated by the real client library, never by a hand-written
+//!    client: if its framing breaks, `roon_core_completes_handshake` fails first.
+
+#![allow(dead_code)] // a shared test module: each test binary uses a subset
+
+use std::collections::{HashMap, HashSet};
+use std::net::{IpAddr, SocketAddr};
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::{SinkExt, StreamExt};
+use serde_json::{json, Value};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::{Mutex, RwLock};
+use tokio::task::JoinHandle;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::WebSocketStream;
+
+// =============================================================================
+// Library model
+// =============================================================================
+
+/// Roon item hints, spelled as the fork deserializes them (`browse.rs::ItemHint`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Hint {
+    List,
+    Action,
+    ActionList,
+    Header,
+}
+
+impl Hint {
+    fn wire(self) -> &'static str {
+        match self {
+            // FROM FORK: browse.rs::ItemHint, #[serde(rename_all = "snake_case")]
+            Hint::List => "list",
+            Hint::Action => "action",
+            Hint::ActionList => "action_list",
+            Hint::Header => "header",
+        }
+    }
+}
+
+/// One node of the fake Core's browse tree.
+#[derive(Debug, Clone)]
+pub struct FakeItem {
+    pub title: String,
+    pub subtitle: Option<String>,
+    pub hint: Option<Hint>,
+    pub image_key: Option<String>,
+    /// `Some(prompt)` marks an item that accepts `BrowseOpts::input` — Roon's
+    /// `Search` entries. Browsing it *with* input yields search results;
+    /// browsing it without yields `children`.
+    pub input_prompt: Option<String>,
+    /// Items served when this node is entered.
+    pub children: Vec<FakeItem>,
+    /// When false the Core mints no `item_key` for this item, which is how a real
+    /// Core presents non-navigable rows (headers). Lets tests cover the adapter's
+    /// "has no item_key" paths.
+    pub keyed: bool,
+}
+
+impl FakeItem {
+    pub fn new(title: &str) -> Self {
+        Self {
+            title: title.to_string(),
+            subtitle: None,
+            hint: None,
+            image_key: None,
+            input_prompt: None,
+            children: Vec::new(),
+            keyed: true,
+        }
+    }
+
+    pub fn list(title: &str) -> Self {
+        Self::new(title).with_hint(Hint::List)
+    }
+
+    pub fn action(title: &str) -> Self {
+        Self::new(title).with_hint(Hint::Action)
+    }
+
+    pub fn action_list(title: &str) -> Self {
+        Self::new(title).with_hint(Hint::ActionList)
+    }
+
+    pub fn with_hint(mut self, hint: Hint) -> Self {
+        self.hint = Some(hint);
+        self
+    }
+
+    pub fn with_subtitle(mut self, subtitle: &str) -> Self {
+        self.subtitle = Some(subtitle.to_string());
+        self
+    }
+
+    pub fn with_image_key(mut self, key: &str) -> Self {
+        self.image_key = Some(key.to_string());
+        self
+    }
+
+    pub fn searchable(mut self, prompt: &str) -> Self {
+        self.input_prompt = Some(prompt.to_string());
+        self
+    }
+
+    pub fn unkeyed(mut self) -> Self {
+        self.keyed = false;
+        self
+    }
+
+    pub fn with_children(mut self, children: Vec<FakeItem>) -> Self {
+        self.children = children;
+        self
+    }
+}
+
+/// The three standard play actions, as an [`FakeItem`] list.
+///
+/// Titles come from `RoonAdapter::PlayAction::action_title()`
+/// (`src/adapters/roon.rs:82-88`) — this repo's own expectation, not a guess.
+pub fn play_actions() -> Vec<FakeItem> {
+    vec![
+        FakeItem::action("Play Now"),
+        FakeItem::action("Queue"),
+        FakeItem::action("Start Radio"),
+    ]
+}
+
+/// An album whose page carries an action list, the way the adapter expects to
+/// find playable content one level below a search hit.
+pub fn album(title: &str, artist: &str, tracks: &[&str]) -> FakeItem {
+    let mut children = vec![FakeItem::action_list("Play Album").with_children(play_actions())];
+    for track in tracks {
+        children.push(
+            FakeItem::list(track)
+                .with_subtitle(artist)
+                .with_children(vec![
+                    FakeItem::action_list("Play Track").with_children(play_actions())
+                ]),
+        );
+    }
+    FakeItem::list(title)
+        .with_subtitle(artist)
+        .with_children(children)
+}
+
+/// The fake Core's library: a browse root plus a flat set of searchable items.
+#[derive(Debug, Clone)]
+pub struct FakeLibrary {
+    /// INFERRED: a real Core's browse root list is titled "Explore". Cosmetic —
+    /// nothing in this repo reads it.
+    pub root_title: String,
+    /// Top-level rows. `RoonAdapter::search` requires one titled `Library`,
+    /// `TIDAL` or `Qobuz` (`src/adapters/roon.rs:686-700`).
+    pub root_items: Vec<FakeItem>,
+    /// Candidate results, matched by case-insensitive substring against title and
+    /// subtitle. Keyed by the source name they are reachable through.
+    pub search_results: HashMap<String, Vec<FakeItem>>,
+}
+
+impl FakeLibrary {
+    /// A library big enough for search, two-level browse, paging and play_item.
+    pub fn standard() -> Self {
+        let mut search_results = HashMap::new();
+        search_results.insert(
+            "Library".to_string(),
+            vec![
+                album(
+                    "Kind of Blue",
+                    "Miles Davis",
+                    &["So What", "Blue in Green", "Flamenco Sketches"],
+                ),
+                album("Blue Train", "John Coltrane", &["Blue Train", "Moment's Notice"]),
+            ],
+        );
+        search_results.insert(
+            "TIDAL".to_string(),
+            vec![album("Blue Note Reimagined", "Various Artists", &["Footprints"])],
+        );
+
+        Self {
+            root_title: "Explore".to_string(),
+            root_items: vec![
+                FakeItem::list("Library").with_children(vec![
+                    FakeItem::list("Search").searchable("Search"),
+                    FakeItem::list("Artists").with_children(
+                        (1..=25)
+                            .map(|n| FakeItem::list(&format!("Artist {n:02}")))
+                            .collect(),
+                    ),
+                    // Deliberately not one of the search results, so that every
+                    // title in this library is unambiguous.
+                    FakeItem::list("Albums").with_children(vec![album(
+                        "Sketches of Spain",
+                        "Miles Davis",
+                        &["Solea"],
+                    )]),
+                ]),
+                FakeItem::list("TIDAL")
+                    .with_children(vec![FakeItem::list("Search").searchable("Search TIDAL")]),
+                FakeItem::list("Qobuz")
+                    .with_children(vec![FakeItem::list("Search").searchable("Search Qobuz")]),
+                FakeItem::new("Settings").unkeyed(),
+            ],
+            search_results,
+        }
+    }
+}
+
+// =============================================================================
+// Behaviour knobs
+// =============================================================================
+
+/// Whether an `item_key` minted inside one `multi_session_key` resolves inside
+/// another.
+///
+/// **This is the epic's open empirical question** (#392, #405):
+/// `RoonAdapter::play_item` mints a fresh, unrelated session key and browses the
+/// caller's key inside it (`src/adapters/roon.rs:1105-1122`), so the repo already
+/// assumes [`ItemKeyScope::Global`] — but `/roon/play_item` has no in-repo callers
+/// and no test, so it may never have worked. The fake refuses to decide.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ItemKeyScope {
+    /// Any session may use any key. Matches what this repo assumes today. Default.
+    Global,
+    /// A key only resolves in the session that minted it; elsewhere the Core
+    /// answers `InvalidItemKey`.
+    PerSession,
+}
+
+/// One MOO request as it arrived, for assertions about what the adapter sent.
+#[derive(Debug, Clone)]
+pub struct RecordedRequest {
+    pub req_id: usize,
+    /// e.g. `com.roonlabs.browse:1/browse`
+    pub name: String,
+    pub body: Value,
+    /// True when this fake had no handler for `name`.
+    pub unhandled: bool,
+}
+
+impl RecordedRequest {
+    pub fn session_key(&self) -> Option<&str> {
+        self.body.get("multi_session_key")?.as_str()
+    }
+
+    pub fn item_key(&self) -> Option<&str> {
+        self.body.get("item_key")?.as_str()
+    }
+
+    pub fn input(&self) -> Option<&str> {
+        self.body.get("input")?.as_str()
+    }
+
+    pub fn pop_all(&self) -> bool {
+        self.body
+            .get("pop_all")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+    }
+}
+
+// =============================================================================
+// Internals
+// =============================================================================
+
+/// Flattened library. `item_key` is an index into `nodes`, wrapped in a
+/// per-Core-instance nonce so tests cannot hardcode keys — they must read them
+/// out of a load result, exactly as a client does.
+struct Arena {
+    nodes: Vec<ArenaNode>,
+    root_children: Vec<usize>,
+    /// source name -> candidate result indices
+    search_results: HashMap<String, Vec<usize>>,
+    nonce: u32,
+}
+
+struct ArenaNode {
+    title: String,
+    subtitle: Option<String>,
+    hint: Option<Hint>,
+    image_key: Option<String>,
+    input_prompt: Option<String>,
+    children: Vec<usize>,
+    keyed: bool,
+}
+
+impl Arena {
+    fn build(library: &FakeLibrary, nonce: u32) -> Self {
+        let mut nodes = Vec::new();
+        let root_children = library
+            .root_items
+            .iter()
+            .map(|item| arena_insert(&mut nodes, item))
+            .collect();
+        let mut search_results = HashMap::new();
+        for (source, items) in &library.search_results {
+            let indices = items
+                .iter()
+                .map(|item| arena_insert(&mut nodes, item))
+                .collect();
+            search_results.insert(source.clone(), indices);
+        }
+        Self {
+            nodes,
+            root_children,
+            search_results,
+            nonce,
+        }
+    }
+
+    fn key_of(&self, index: usize) -> String {
+        // INFERRED: real Roon item keys look like short opaque colon-separated
+        // strings. Only their opacity matters to this repo.
+        format!("{}:{}", self.nonce, index)
+    }
+
+    fn index_of(&self, key: &str) -> Option<usize> {
+        let (nonce, index) = key.split_once(':')?;
+        if nonce.parse::<u32>().ok()? != self.nonce {
+            return None;
+        }
+        let index = index.parse::<usize>().ok()?;
+        if index < self.nodes.len() {
+            Some(index)
+        } else {
+            None
+        }
+    }
+
+    fn find_by_title(&self, title: &str) -> Option<usize> {
+        self.nodes.iter().position(|n| n.title == title)
+    }
+}
+
+fn arena_insert(nodes: &mut Vec<ArenaNode>, item: &FakeItem) -> usize {
+    let children = item
+        .children
+        .iter()
+        .map(|child| arena_insert(nodes, child))
+        .collect();
+    nodes.push(ArenaNode {
+        title: item.title.clone(),
+        subtitle: item.subtitle.clone(),
+        hint: item.hint,
+        image_key: item.image_key.clone(),
+        input_prompt: item.input_prompt.clone(),
+        children,
+        keyed: item.keyed,
+    });
+    nodes.len() - 1
+}
+
+/// One browse level: the list a subsequent `load` returns.
+#[derive(Debug, Clone)]
+struct Level {
+    title: String,
+    items: Vec<usize>,
+}
+
+#[derive(Default)]
+struct Session {
+    levels: Vec<Level>,
+}
+
+struct CoreState {
+    arena: Arena,
+    sessions: HashMap<String, Session>,
+    /// item_key -> sessions that have been served that key
+    minted: HashMap<String, HashSet<String>>,
+    item_key_scope: ItemKeyScope,
+    /// item_keys the Core will reject with `InvalidItemKey`
+    rejected_keys: HashSet<String>,
+    /// One-shot: the next browse, whatever it is, is rejected.
+    reject_next_browse: bool,
+    /// Applied before every response.
+    delay: Duration,
+    /// Per-item_key delay override, so a test can force responses to arrive out
+    /// of order and prove correlation is by request, not by arrival.
+    key_delays: HashMap<String, Duration>,
+    zones: Vec<Value>,
+    log: Vec<RecordedRequest>,
+    /// What this Core answered, in send order: (request id, message name).
+    /// Without this, "the adapter hung" and "the Core never replied" are
+    /// indistinguishable — and that ambiguity is exactly what #405 is about.
+    sent: Vec<(usize, String)>,
+    core_id: String,
+    display_name: String,
+    display_version: String,
+}
+
+// =============================================================================
+// The fake
+// =============================================================================
+
+pub struct FakeRoonCore {
+    addr: SocketAddr,
+    state: Arc<RwLock<CoreState>>,
+    handle: JoinHandle<()>,
+}
+
+impl FakeRoonCore {
+    /// Start a fake Core on a random loopback port with the standard library.
+    pub async fn start() -> Self {
+        Self::start_with(FakeLibrary::standard()).await
+    }
+
+    pub async fn start_with(library: FakeLibrary) -> Self {
+        // Nonce derived from the port keeps keys distinct between concurrently
+        // running fakes without pulling in a RNG.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let nonce = u32::from(addr.port());
+
+        let state = Arc::new(RwLock::new(CoreState {
+            arena: Arena::build(&library, nonce),
+            sessions: HashMap::new(),
+            minted: HashMap::new(),
+            item_key_scope: ItemKeyScope::Global,
+            rejected_keys: HashSet::new(),
+            reject_next_browse: false,
+            delay: Duration::ZERO,
+            key_delays: HashMap::new(),
+            zones: vec![default_zone("zone_fake_1", "Fake Living Room")],
+            log: Vec::new(),
+            sent: Vec::new(),
+            core_id: "fake-core-408".to_string(),
+            display_name: "Fake Roon Core".to_string(),
+            display_version: "2.0.408".to_string(),
+        }));
+        let root_title = library.root_title.clone();
+
+        let state_for_task = state.clone();
+        let handle = tokio::spawn(async move {
+            while let Ok((stream, _)) = listener.accept().await {
+                let state = state_for_task.clone();
+                let root_title = root_title.clone();
+                tokio::spawn(async move {
+                    serve_connection(stream, state, root_title).await;
+                });
+            }
+        });
+
+        Self {
+            addr,
+            state,
+            handle,
+        }
+    }
+
+    pub fn addr(&self) -> SocketAddr {
+        self.addr
+    }
+
+    pub fn ip(&self) -> IpAddr {
+        self.addr.ip()
+    }
+
+    pub fn port(&self) -> String {
+        self.addr.port().to_string()
+    }
+
+    // ---- behaviour knobs ---------------------------------------------------
+
+    /// Delay every response by `delay`, so several adapter requests are genuinely
+    /// in flight at once.
+    pub async fn set_delay(&self, delay: Duration) {
+        self.state.write().await.delay = delay;
+    }
+
+    /// Delay only browses carrying `item_key`, so responses can be forced to
+    /// arrive out of order.
+    pub async fn set_delay_for_item_key(&self, item_key: &str, delay: Duration) {
+        self.state
+            .write()
+            .await
+            .key_delays
+            .insert(item_key.to_string(), delay);
+    }
+
+    /// Answer `InvalidItemKey` for every browse carrying this key.
+    pub async fn reject_item_key(&self, item_key: &str) {
+        self.state
+            .write()
+            .await
+            .rejected_keys
+            .insert(item_key.to_string());
+    }
+
+    /// Answer `InvalidItemKey` for the next browse, whatever it carries.
+    pub async fn reject_next_browse(&self) {
+        self.state.write().await.reject_next_browse = true;
+    }
+
+    pub async fn set_item_key_scope(&self, scope: ItemKeyScope) {
+        self.state.write().await.item_key_scope = scope;
+    }
+
+    pub async fn set_zones(&self, zones: Vec<Value>) {
+        self.state.write().await.zones = zones;
+    }
+
+    pub async fn core_name(&self) -> String {
+        self.state.read().await.display_name.clone()
+    }
+
+    // ---- observation -------------------------------------------------------
+
+    /// The `item_key` this Core mints for the (first) item with this title.
+    /// Tests use it to name a key for [`Self::reject_item_key`]; they must not
+    /// construct keys themselves.
+    pub async fn key_for_title(&self, title: &str) -> Option<String> {
+        let state = self.state.read().await;
+        state.arena.find_by_title(title).map(|i| state.arena.key_of(i))
+    }
+
+    /// The title of the item a given `item_key` points at.
+    ///
+    /// Prefer this over [`Self::key_for_title`] when a title is not unique — a
+    /// library has one `Play Now` per action list, so asserting on the *key* the
+    /// adapter sent is ambiguous while asserting on the title it resolves to is not.
+    pub async fn title_for_key(&self, item_key: &str) -> Option<String> {
+        let state = self.state.read().await;
+        let index = state.arena.index_of(item_key)?;
+        Some(state.arena.nodes[index].title.clone())
+    }
+
+    /// Titles of the items the adapter browsed into, in order. Browses that carry
+    /// no `item_key` (a `pop_all` to the root) are omitted.
+    pub async fn browsed_titles(&self) -> Vec<String> {
+        let state = self.state.read().await;
+        state
+            .log
+            .iter()
+            .filter(|r| r.name == "com.roonlabs.browse:1/browse")
+            .filter_map(|r| r.item_key())
+            .filter_map(|key| {
+                let index = state.arena.index_of(key)?;
+                Some(state.arena.nodes[index].title.clone())
+            })
+            .collect()
+    }
+
+    /// Every MOO request the adapter sent, in arrival order.
+    pub async fn requests(&self) -> Vec<RecordedRequest> {
+        self.state.read().await.log.clone()
+    }
+
+    /// Requests to `com.roonlabs.browse:1/browse`, in arrival order.
+    pub async fn browse_requests(&self) -> Vec<RecordedRequest> {
+        self.requests_named("com.roonlabs.browse:1/browse").await
+    }
+
+    /// Requests to `com.roonlabs.browse:1/load`, in arrival order.
+    pub async fn load_requests(&self) -> Vec<RecordedRequest> {
+        self.requests_named("com.roonlabs.browse:1/load").await
+    }
+
+    pub async fn requests_named(&self, name: &str) -> Vec<RecordedRequest> {
+        self.state
+            .read()
+            .await
+            .log
+            .iter()
+            .filter(|r| r.name == name)
+            .cloned()
+            .collect()
+    }
+
+    /// Every response this Core sent, as `(request id, message name)`.
+    ///
+    /// This is what distinguishes "the Core never answered" from "the Core
+    /// answered and the adapter dropped it" — the exact ambiguity #405 exists to
+    /// remove. Without it, a hang looks the same either way.
+    pub async fn responses(&self) -> Vec<(usize, String)> {
+        self.state.read().await.sent.clone()
+    }
+
+    /// Names of the responses sent, in order.
+    pub async fn response_names(&self) -> Vec<String> {
+        self.state
+            .read()
+            .await
+            .sent
+            .iter()
+            .map(|(_, name)| name.clone())
+            .collect()
+    }
+
+    /// Requests this fake did not understand. Non-empty means the adapter has
+    /// grown a call this fake does not model — drift, and a test failure, rather
+    /// than a silent hang.
+    pub async fn unhandled_requests(&self) -> Vec<RecordedRequest> {
+        self.state
+            .read()
+            .await
+            .log
+            .iter()
+            .filter(|r| r.unhandled)
+            .cloned()
+            .collect()
+    }
+
+    /// Fail if the adapter sent anything this fake does not model.
+    pub async fn assert_no_unhandled_requests(&self) {
+        let unhandled = self.unhandled_requests().await;
+        assert!(
+            unhandled.is_empty(),
+            "FakeRoonCore received request(s) it does not model: {:?}\n\
+             The adapter's protocol surface changed. Teach this fake the new call \
+             rather than deleting the assertion.",
+            unhandled
+                .iter()
+                .map(|r| r.name.as_str())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    /// Session keys the adapter has opened, in first-seen order.
+    pub async fn session_keys(&self) -> Vec<String> {
+        let mut seen = Vec::new();
+        for req in &self.state.read().await.log {
+            if let Some(key) = req.session_key() {
+                if !seen.iter().any(|k| k == key) {
+                    seen.push(key.to_string());
+                }
+            }
+        }
+        seen
+    }
+
+    /// Titles of the levels currently stacked in a session, root first. Lets a
+    /// test assert that `pop_all` really reset the stack.
+    pub async fn session_levels(&self, session_key: &str) -> Vec<String> {
+        self.state
+            .read()
+            .await
+            .sessions
+            .get(session_key)
+            .map(|s| s.levels.iter().map(|l| l.title.clone()).collect())
+            .unwrap_or_default()
+    }
+
+    pub async fn stop(self) {
+        self.handle.abort();
+    }
+}
+
+/// A zone with every field `roon_api`'s `transport::Zone` requires.
+///
+/// FROM FORK: the required-field list is `transport.rs:94-107` (`Zone`),
+/// `:112-120` (`Output`), `:127-131` (`Settings`), `:36-47` (`Volume`). If a
+/// required field is missing the fork's deserializer errors and the client library
+/// swallows the zone, so this is asserted by `roon_core_publishes_zones`.
+pub fn default_zone(zone_id: &str, display_name: &str) -> Value {
+    json!({
+        "zone_id": zone_id,
+        "display_name": display_name,
+        "state": "stopped",
+        "is_next_allowed": true,
+        "is_previous_allowed": true,
+        "is_pause_allowed": false,
+        "is_play_allowed": true,
+        "is_seek_allowed": false,
+        "queue_items_remaining": 0,
+        "queue_time_remaining": 0,
+        "now_playing": null,
+        "settings": { "loop": "disabled", "shuffle": false, "auto_radio": false },
+        "outputs": [{
+            "output_id": format!("{zone_id}_output"),
+            "zone_id": zone_id,
+            "can_group_with_output_ids": [],
+            "display_name": display_name,
+            "source_controls": null,
+            "volume": {
+                "type": "number",
+                "min": 0.0,
+                "max": 100.0,
+                "value": 50.0,
+                "step": 1.0,
+                "is_muted": false
+            }
+        }]
+    })
+}
+
+// =============================================================================
+// MOO framing
+// =============================================================================
+
+/// A parsed inbound MOO message.
+struct MooRequest {
+    req_id: usize,
+    /// `service/name`, e.g. `com.roonlabs.browse:1/browse`
+    name: String,
+    body: Value,
+}
+
+/// Mirror of `moo.rs::MooReceiver::parse` for the server side.
+fn parse_moo(data: &[u8]) -> Option<MooRequest> {
+    let split = data.windows(2).position(|w| w == b"\n\n")?;
+    let header = std::str::from_utf8(&data[..split]).ok()?;
+    let body_bytes = &data[split + 2..];
+
+    let mut lines = header.split('\n');
+    let first = lines.next()?;
+    let rest = first.strip_prefix("MOO/1 ")?;
+    let (verb, name) = rest.split_once(' ')?;
+    if verb != "REQUEST" {
+        return None;
+    }
+
+    let mut req_id = None;
+    let mut content_type = None;
+    for line in lines {
+        if let Some((key, value)) = line.split_once(':') {
+            match key.trim() {
+                "Request-Id" => req_id = value.trim().parse::<usize>().ok(),
+                "Content-Type" => content_type = Some(value.trim().to_string()),
+                _ => {}
+            }
+        }
+    }
+
+    let body = if content_type.as_deref() == Some("application/json") {
+        serde_json::from_slice(body_bytes).unwrap_or(Value::Null)
+    } else {
+        Value::Null
+    };
+
+    Some(MooRequest {
+        req_id: req_id?,
+        name: name.to_string(),
+        body,
+    })
+}
+
+/// Mirror of `moo.rs::Moo::create_msg_string`.
+fn encode_moo(verb: &str, name: &str, req_id: usize, body: Option<&Value>) -> Vec<u8> {
+    let mut out = format!("MOO/1 {verb} {name}\nRequest-Id: {req_id}\n");
+    match body {
+        Some(body) => {
+            let body = body.to_string();
+            out.push_str(&format!(
+                "Content-Length: {}\nContent-Type: application/json\n\n",
+                body.len()
+            ));
+            out.push_str(&body);
+        }
+        None => out.push('\n'),
+    }
+    out.into_bytes()
+}
+
+type Writer = Arc<Mutex<futures::stream::SplitSink<WebSocketStream<TcpStream>, Message>>>;
+
+async fn send(writer: &Writer, verb: &str, name: &str, req_id: usize, body: Option<&Value>) {
+    let frame = encode_moo(verb, name, req_id, body);
+    let _ = writer.lock().await.send(Message::Binary(frame)).await;
+}
+
+/// Send a response *and record it*, so a test can tell "the Core answered
+/// `InvalidItemKey`" apart from "the Core never answered".
+async fn respond(
+    state: &Arc<RwLock<CoreState>>,
+    writer: &Writer,
+    verb: &str,
+    name: &str,
+    req_id: usize,
+    body: Option<&Value>,
+) {
+    state.write().await.sent.push((req_id, name.to_string()));
+    send(writer, verb, name, req_id, body).await;
+}
+
+// =============================================================================
+// Connection handling
+// =============================================================================
+
+async fn serve_connection(stream: TcpStream, state: Arc<RwLock<CoreState>>, root_title: String) {
+    let ws = match tokio_tungstenite::accept_async(stream).await {
+        Ok(ws) => ws,
+        Err(_) => return,
+    };
+    let (write, mut read) = ws.split();
+    let writer: Writer = Arc::new(Mutex::new(write));
+
+    // Keepalive: the fork's reader times out after 10s of silence and the client
+    // then reports a lost Core (moo.rs:245-249). The client answers ping with its
+    // built-in Ping service (lib.rs:857-871).
+    let ping_writer = writer.clone();
+    let ping = tokio::spawn(async move {
+        let mut req_id = 1_000_000;
+        loop {
+            tokio::time::sleep(Duration::from_secs(3)).await;
+            req_id += 1;
+            send(
+                &ping_writer,
+                "REQUEST",
+                "com.roonlabs.ping:1/ping",
+                req_id,
+                None,
+            )
+            .await;
+        }
+    });
+
+    while let Some(Ok(msg)) = read.next().await {
+        let data = match msg {
+            Message::Binary(data) => data,
+            Message::Text(text) => text.into_bytes(),
+            Message::Close(_) => break,
+            _ => continue,
+        };
+        let Some(request) = parse_moo(&data) else {
+            continue;
+        };
+
+        // One task per request: a real Core pipelines, and serialising here would
+        // make it impossible to have several adapter requests in flight, which is
+        // exactly what #405's correlation tests need.
+        let state = state.clone();
+        let writer = writer.clone();
+        let root_title = root_title.clone();
+        tokio::spawn(async move {
+            handle_request(request, state, writer, root_title).await;
+        });
+    }
+
+    ping.abort();
+}
+
+async fn handle_request(
+    request: MooRequest,
+    core: Arc<RwLock<CoreState>>,
+    writer: Writer,
+    root_title: String,
+) {
+    let MooRequest { req_id, name, body } = request;
+
+    let (delay, kind) = {
+        let mut st = core.write().await;
+        let kind = RequestKind::of(&name);
+        st.log.push(RecordedRequest {
+            req_id,
+            name: name.clone(),
+            body: body.clone(),
+            unhandled: kind == RequestKind::Unknown,
+        });
+        let delay = body
+            .get("item_key")
+            .and_then(Value::as_str)
+            .and_then(|k| st.key_delays.get(k).copied())
+            .unwrap_or(st.delay);
+        (delay, kind)
+    };
+
+    if !delay.is_zero() {
+        tokio::time::sleep(delay).await;
+    }
+
+    match kind {
+        RequestKind::RegistryInfo => {
+            // FROM FORK: lib.rs:405 keys registration off request id 0 plus a
+            // string `core_id`; display_name / display_version are read at :460.
+            let body = {
+                let st = core.read().await;
+                json!({
+                    "core_id": st.core_id,
+                    "display_name": st.display_name,
+                    "display_version": st.display_version,
+                })
+            };
+            respond(&core, &writer, "COMPLETE", "Success", req_id, Some(&body)).await;
+        }
+        RequestKind::RegistryRegister => {
+            // FROM FORK: lib.rs:479 requires the message name "Registered" and a
+            // string `token`. A real Core returns more; the fork reads nothing
+            // else, so nothing else is invented here.
+            let body = json!({ "token": "fake-token-408" });
+            respond(&core, &writer, "COMPLETE", "Registered", req_id, Some(&body)).await;
+        }
+        RequestKind::SubscribeZones => {
+            let body = json!({ "zones": core.read().await.zones.clone() });
+            // FROM FORK: transport.rs:479 accepts name "Subscribed"; a
+            // subscription stays open, hence CONTINUE.
+            respond(&core, &writer, "CONTINUE", "Subscribed", req_id, Some(&body)).await;
+        }
+        RequestKind::UnsubscribeZones | RequestKind::Ping => {
+            respond(&core, &writer, "COMPLETE", "Success", req_id, None).await;
+        }
+        RequestKind::Browse => handle_browse(req_id, &body, &core, &writer, &root_title).await,
+        RequestKind::Load => handle_load(req_id, &body, &core, &writer).await,
+        RequestKind::Unknown => {
+            // Mirrors the fork's own reply to an unknown service (lib.rs:588-592)
+            // so an unmodelled call fails fast instead of hanging for 10s.
+            let body = json!({ "error": format!("FakeRoonCore does not model {name}") });
+            respond(
+                &core,
+                &writer,
+                "COMPLETE",
+                "InvalidRequest",
+                req_id,
+                Some(&body),
+            )
+            .await;
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+enum RequestKind {
+    RegistryInfo,
+    RegistryRegister,
+    SubscribeZones,
+    UnsubscribeZones,
+    Browse,
+    Load,
+    Ping,
+    Unknown,
+}
+
+impl RequestKind {
+    fn of(name: &str) -> Self {
+        match name {
+            "com.roonlabs.registry:1/info" => Self::RegistryInfo,
+            "com.roonlabs.registry:1/register" => Self::RegistryRegister,
+            "com.roonlabs.transport:2/subscribe_zones" => Self::SubscribeZones,
+            "com.roonlabs.transport:2/unsubscribe_zones" => Self::UnsubscribeZones,
+            "com.roonlabs.browse:1/browse" => Self::Browse,
+            "com.roonlabs.browse:1/load" => Self::Load,
+            "com.roonlabs.ping:1/ping" => Self::Ping,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+// =============================================================================
+// Browse / load semantics
+// =============================================================================
+
+fn session_key_of(body: &Value) -> String {
+    // The adapter always sets multi_session_key; a real Core tolerates its
+    // absence by using a single default session.
+    body.get("multi_session_key")
+        .and_then(Value::as_str)
+        .unwrap_or("__default__")
+        .to_string()
+}
+
+async fn handle_browse(
+    req_id: usize,
+    body: &Value,
+    core: &Arc<RwLock<CoreState>>,
+    writer: &Writer,
+    root_title: &str,
+) {
+    let session_key = session_key_of(body);
+    let item_key = body.get("item_key").and_then(Value::as_str);
+    let input = body.get("input").and_then(Value::as_str);
+    let pop_all = body
+        .get("pop_all")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let pop_levels = body.get("pop_levels").and_then(Value::as_u64);
+
+    let mut state = core.write().await;
+
+    // --- error injection ---------------------------------------------------
+    let rejected = state.reject_next_browse
+        || item_key.is_some_and(|k| state.rejected_keys.contains(k))
+        || match (state.item_key_scope, item_key) {
+            (ItemKeyScope::PerSession, Some(key)) => !state
+                .minted
+                .get(key)
+                .is_some_and(|sessions| sessions.contains(&session_key)),
+            _ => false,
+        }
+        || item_key.is_some_and(|k| state.arena.index_of(k).is_none());
+    if rejected {
+        state.reject_next_browse = false;
+        drop(state);
+        // FROM FORK: browse.rs:170-172 keys purely off the message name, and
+        // yields Parsed::Error(RoonApiError::BrowseInvalidItemKey((req_id, key))).
+        // INFERRED: whether a real Core attaches a body. None is sent, because a
+        // body that parsed as BrowseResult/LoadResult would be taken for success.
+        respond(core, writer, "COMPLETE", "InvalidItemKey", req_id, None).await;
+        return;
+    }
+
+    // --- level stack -------------------------------------------------------
+    let root_level = Level {
+        title: root_title.to_string(),
+        items: state.arena.root_children.clone(),
+    };
+
+    let session = state.sessions.entry(session_key.clone()).or_default();
+    if pop_all || session.levels.is_empty() {
+        session.levels = vec![root_level];
+    }
+    if let Some(n) = pop_levels {
+        let keep = session.levels.len().saturating_sub(n as usize).max(1);
+        session.levels.truncate(keep);
+    }
+
+    if let Some(key) = item_key {
+        let Some(index) = state.arena.index_of(key) else {
+            drop(state);
+            respond(core, writer, "COMPLETE", "InvalidItemKey", req_id, None).await;
+            return;
+        };
+        let node_hint = state.arena.nodes[index].hint;
+        let accepts_input = state.arena.nodes[index].input_prompt.is_some();
+        let node_title = state.arena.nodes[index].title.clone();
+
+        // Invoking an action does not produce a list.
+        if node_hint == Some(Hint::Action) {
+            drop(state);
+            // INFERRED: a real Core answers an invoked action with action "none"
+            // or a "message". Nothing in this repo reads it — `execute_play_action`
+            // discards the BrowseResult (src/adapters/roon.rs:1276-1284) — so the
+            // load-bearing assertion is that the request arrived, which the
+            // request log carries.
+            let body = json!({ "action": "none" });
+            respond(core, writer, "COMPLETE", "Success", req_id, Some(&body)).await;
+            return;
+        }
+
+        let (title, items) = if accepts_input {
+            match input {
+                Some(query) => {
+                    let source = search_source_for(&state, index);
+                    let matches = search(&state, &source, query);
+                    (format!("Search results for \"{query}\""), matches)
+                }
+                // Browsing a Search item without input: a real Core returns the
+                // item's own list so the client can read `input_prompt`.
+                None => (node_title, state.arena.nodes[index].children.clone()),
+            }
+        } else {
+            (node_title, state.arena.nodes[index].children.clone())
+        };
+
+        let session = state.sessions.entry(session_key.clone()).or_default();
+        session.levels.push(Level { title, items });
+    }
+
+    let list = current_list(&state, &session_key);
+    drop(state);
+
+    // FROM FORK: browse.rs:85-91 BrowseResult { action, item, list, message,
+    // is_error }; only `action` is required. Action::List spells as "list"
+    // (browse.rs:10-17).
+    let body = json!({ "action": "list", "list": list });
+    respond(core, writer, "COMPLETE", "Success", req_id, Some(&body)).await;
+}
+
+async fn handle_load(req_id: usize, body: &Value, core: &Arc<RwLock<CoreState>>, writer: &Writer) {
+    let session_key = session_key_of(body);
+    let offset = body
+        .get("offset")
+        .and_then(Value::as_u64)
+        .unwrap_or(0) as usize;
+    let count = body
+        .get("count")
+        .and_then(Value::as_u64)
+        .map(|c| c as usize);
+    let requested_level = body.get("level").and_then(Value::as_u64);
+
+    let mut state = core.write().await;
+
+    // `LoadOpts::level` selects a level in the stack; the adapter never sets it,
+    // so the default is the top of the stack.
+    let selected = state.sessions.get(&session_key).and_then(|session| {
+        let index = match requested_level {
+            Some(level) => level as usize,
+            None => session.levels.len().saturating_sub(1),
+        };
+        session.levels.get(index).cloned().map(|level| (index, level))
+    });
+    let Some((level_index, level)) = selected else {
+        drop(state);
+        // FROM FORK: browse.rs:173-175 — loading a session with no browse level.
+        respond(core, writer, "COMPLETE", "InvalidLevels", req_id, None).await;
+        return;
+    };
+
+    let total = level.items.len();
+    let start = offset.min(total);
+    let end = count.map_or(total, |c| (start + c).min(total));
+
+    let mut items = Vec::with_capacity(end - start);
+    for &index in &level.items[start..end] {
+        let key = state.arena.key_of(index);
+        let node = &state.arena.nodes[index];
+        let mut item = json!({ "title": node.title });
+        if let Some(subtitle) = &node.subtitle {
+            item["subtitle"] = json!(subtitle);
+        }
+        if let Some(image_key) = &node.image_key {
+            item["image_key"] = json!(image_key);
+        }
+        if let Some(hint) = node.hint {
+            item["hint"] = json!(hint.wire());
+        }
+        if let Some(prompt) = &node.input_prompt {
+            // FROM FORK: browse.rs:70-75 InputPrompt { prompt, action, value,
+            // is_password }.
+            item["input_prompt"] = json!({ "prompt": prompt, "action": "Search" });
+        }
+        let keyed = node.keyed;
+        if keyed {
+            item["item_key"] = json!(key);
+            state
+                .minted
+                .entry(key)
+                .or_default()
+                .insert(session_key.clone());
+        }
+        items.push(item);
+    }
+
+    let list = list_json(&level.title, total, level_index as u32);
+    drop(state);
+
+    // FROM FORK: browse.rs:93-98 LoadResult { items, offset, list } — all required.
+    let body = json!({ "items": items, "offset": offset, "list": list });
+    respond(core, writer, "COMPLETE", "Success", req_id, Some(&body)).await;
+}
+
+fn current_list(state: &CoreState, session_key: &str) -> Value {
+    let Some(session) = state.sessions.get(session_key) else {
+        return list_json("", 0, 0);
+    };
+    let level_index = session.levels.len().saturating_sub(1);
+    match session.levels.last() {
+        Some(level) => list_json(&level.title, level.items.len(), level_index as u32),
+        None => list_json("", 0, 0),
+    }
+}
+
+fn list_json(title: &str, count: usize, level: u32) -> Value {
+    // FROM FORK: browse.rs:57-65 List { title, count, level, subtitle?,
+    // image_key?, display_offset?, hint? }.
+    // INFERRED: levels numbered from 0 at the browse root.
+    json!({ "title": title, "count": count, "level": level })
+}
+
+/// Which search source an input-accepting node sits under, so `Library`, `TIDAL`
+/// and `Qobuz` can return different results.
+fn search_source_for(state: &CoreState, search_index: usize) -> String {
+    for &root in &state.arena.root_children {
+        if contains(state, root, search_index) {
+            return state.arena.nodes[root].title.clone();
+        }
+    }
+    "Library".to_string()
+}
+
+fn contains(state: &CoreState, parent: usize, needle: usize) -> bool {
+    if parent == needle {
+        return true;
+    }
+    state.arena.nodes[parent]
+        .children
+        .iter()
+        .any(|&child| contains(state, child, needle))
+}
+
+fn search(state: &CoreState, source: &str, query: &str) -> Vec<usize> {
+    let query = query.to_lowercase();
+    state
+        .arena
+        .search_results
+        .get(source)
+        .map(|candidates| {
+            candidates
+                .iter()
+                .copied()
+                .filter(|&index| {
+                    let node = &state.arena.nodes[index];
+                    node.title.to_lowercase().contains(&query)
+                        || node
+                            .subtitle
+                            .as_deref()
+                            .is_some_and(|s| s.to_lowercase().contains(&query))
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+// =============================================================================
+// Self-tests: the framing codec, independent of the adapter
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encodes_and_parses_a_body_less_request() {
+        let frame = encode_moo("REQUEST", "com.roonlabs.registry:1/info", 0, None);
+        let parsed = parse_moo(&frame).expect("body-less frame should parse");
+        assert_eq!(parsed.req_id, 0);
+        assert_eq!(parsed.name, "com.roonlabs.registry:1/info");
+        assert_eq!(parsed.body, Value::Null);
+    }
+
+    #[test]
+    fn encodes_and_parses_a_json_body() {
+        let body = json!({ "multi_session_key": "s1", "pop_all": true });
+        let frame = encode_moo("REQUEST", "com.roonlabs.browse:1/browse", 7, Some(&body));
+        let parsed = parse_moo(&frame).expect("json frame should parse");
+        assert_eq!(parsed.req_id, 7);
+        assert_eq!(parsed.body, body);
+    }
+
+    #[test]
+    fn content_length_counts_bytes_not_chars() {
+        // moo.rs uses body.as_bytes().len(); a multibyte title must not desync.
+        let body = json!({ "title": "Björk – Homogénic" });
+        let frame = encode_moo("COMPLETE", "Success", 1, Some(&body));
+        let text = String::from_utf8(frame.clone()).unwrap();
+        let declared: usize = text
+            .lines()
+            .find_map(|l| l.strip_prefix("Content-Length: "))
+            .unwrap()
+            .parse()
+            .unwrap();
+        // String::len() is a byte count, which is what moo.rs declares
+        // (body.as_bytes().len()); a char count would be 17 here, not 20.
+        assert_eq!(declared, body.to_string().len());
+        assert!(declared > body.to_string().chars().count());
+        assert!(parse_moo(&frame).is_none()); // COMPLETE is a response, not a request
+    }
+
+    #[test]
+    fn rejects_non_request_verbs() {
+        let frame = encode_moo("COMPLETE", "Success", 1, None);
+        assert!(parse_moo(&frame).is_none());
+    }
+
+    #[test]
+    fn item_keys_are_scoped_to_the_core_instance() {
+        let arena = Arena::build(&FakeLibrary::standard(), 4242);
+        let key = arena.key_of(0);
+        assert_eq!(arena.index_of(&key), Some(0));
+        // A key minted by a different Core instance must not resolve here.
+        let other = Arena::build(&FakeLibrary::standard(), 99);
+        assert_eq!(arena.index_of(&other.key_of(0)), None);
+        assert_eq!(arena.index_of("garbage"), None);
+        assert_eq!(arena.index_of("4242:999999"), None);
+    }
+}

--- a/tests/mock_servers/roon_core.rs
+++ b/tests/mock_servers/roon_core.rs
@@ -15,7 +15,9 @@
 //! # Wire protocol
 //!
 //! Everything below is read off the pinned fork
-//! (`open-horizon-labs/rust-roon-api@ohc/main`, checkout `06dd807`), not invented:
+//! (`open-horizon-labs/rust-roon-api@ohc/main`, checkout `06dd807`), not invented.
+//! Where a shape is also documented by RoonLabs or recorded off a real Core, the
+//! PROVENANCE section below says so and the use site cites it:
 //!
 //! * Transport: WebSocket at `ws://<ip>:<port>/api`, binary frames (`moo.rs::Moo::new`).
 //! * Frame: `MOO/1 <VERB> <NAME>\n` then `Request-Id: <n>\n`, optional
@@ -77,10 +79,13 @@
 //! # What this fake does NOT prove
 //!
 //! It proves the adapter is self-consistent and that it drives `roon_api` correctly.
-//! It **cannot** prove the adapter matches a real Roon Core, because the fake's
-//! semantics were derived from the same repo the adapter lives in. Green here means
-//! "unchanged", not "correct". See `tests/mock_servers/README.md` for the full
-//! covered/not-covered table.
+//! It **cannot** prove the adapter matches a real Roon Core. Individual shapes are
+//! now backed by RoonLabs' published API or by logs off real Cores, which is better
+//! than nothing — but the *navigation model* (a `Search` item under
+//! `Library`/`TIDAL`/`Qobuz`, flat search results, an action list holding
+//! `Play Now`) came from `src/adapters/roon.rs` itself, so on that the fake cannot
+//! disagree with the adapter. Green here means "unchanged", not "correct". See
+//! `tests/mock_servers/README.md` for the full covered/not-covered table.
 //!
 //! # Failing loudly rather than looking like coverage
 //!

--- a/tests/mock_servers/roon_core.rs
+++ b/tests/mock_servers/roon_core.rs
@@ -43,30 +43,36 @@
 //!
 //! # PROVENANCE — read this before trusting a shape
 //!
-//! **No live Roon Core was reachable when this was written** (no pairing token
+//! **No live Roon Core was reachable when this was written** — no pairing token
 //! exists in this machine's config dir, and pairing requires a human to authorize
-//! the extension in Roon → Settings → Extensions). So the shapes here have two
-//! different pedigrees, and they are not equally trustworthy:
+//! the extension in Roon → Settings → Extensions. So nothing here was recorded off
+//! a Core *by this work*. Rather than hand-write shapes and let the fake agree with
+//! its author, the uncertain ones were chased down in published sources. Four
+//! pedigrees, and they are not equally trustworthy:
 //!
 //! | Pedigree | What it covers | Confidence |
 //! |---|---|---|
-//! | **From the fork** | which fields exist, which are required vs optional, enum spellings (`"action_list"`, `"list"`, …), the four browse error names, the handshake order | high — a shape the fork's `serde` accepts is a shape the adapter can consume |
-//! | **From this repo's adapter** | that the browse root contains `Library` / `TIDAL` / `Qobuz`, that each contains a `Search` item, that an action list contains `Play Now` / `Queue` / `Start Radio` | high as *expectations* — `src/adapters/roon.rs` will not work against anything else |
-//! | **INFERRED** | root list title (`Explore`), `level` numbering from 0, `action: "none"` as the reply to invoking an action item, whether a real Core sends a body with `InvalidItemKey`, **whether a real Core spells the four error names the way the fork matches them**, whether an `item_key` minted under one `multi_session_key` resolves under another | **unverified** — every one is marked `INFERRED:` at its use site |
+//! | **From the fork** (`06dd807`) | which fields exist, required vs optional, the handshake order, the 10s read timeout | high — a shape the fork's `serde` accepts is a shape the adapter can consume |
+//! | **From RoonLabs' published API** (`RoonLabs/node-roon-api-browse`, `node-roon-api`) | `list.level` "increases from 0"; `action` ∈ `message`/`none`/`list`/`replace_item`/`remove_item`; `hint` ∈ `null`/`action`/`action_list`/`list`/`header`; the `input_prompt` shape; `InvalidRequest` as a real reply to an unknown service | high — RoonLabs' own JSDoc, quoted at the use sites below |
+//! | **Recorded off real Cores by third parties** | `MOO/1 COMPLETE InvalidItemKey` as a verbatim wire frame, and the `"<int>:<int>"` shape of a real `item_key` — see the `ItemKeyScope` docs for the citations | good — real Cores, but other people's logs, not a controlled run |
+//! | **From this repo's adapter** | that the browse root contains `Library` / `TIDAL` / `Qobuz`, that each contains a `Search` item, that an action list contains `Play Now` / `Queue` / `Start Radio` | high as *expectations* — `src/adapters/roon.rs` will not work against anything else, and **that is not the same as Roon being that way** |
+//! | **INFERRED** | root list title (`Explore`); whether a real Core sends a *body* with an error; whether the *other three* error names are spelled as the fork matches them; whether search results are category-grouped | **unverified** — each marked `INFERRED:` at its use site |
 //!
-//! The last row is the dangerous one. Two entries in it are load-bearing:
+//! Two entries are load-bearing:
 //!
-//! * **The four error names.** The fork matches string literals, and anything else
+//! * **The error names.** The fork matches four string literals; anything else
 //!   becomes `Parsed::None`, which it drops — so a Core that spells one differently
 //!   makes the caller time out as if unreachable, with every test here still green.
-//!   #405's PR flagged this as #408's to pin, and it is pinned as far as it can be:
-//!   [`FakeRoonCore::reject_item_key_with_name`] and
-//!   [`FakeRoonCore::FORK_ERROR_NAMES`] make the *consequence* testable. Verifying
-//!   the names themselves needs a real Core.
-//! * **`item_key` portability across sessions.** The empirical unknown #405 must
-//!   answer against the operator's rig; this fake makes it *configurable*
-//!   ([`ItemKeyScope`]) rather than pretending to know, so a test can pin either
-//!   answer and be re-pointed once it is known.
+//!   #405's PR flagged this as #408's to pin. `InvalidItemKey` is now **corroborated
+//!   verbatim** from real Cores (see [`ItemKeyScope`]); `InvalidLevels`,
+//!   `UnexpectedError` and `ZoneNotFound` are **not** — RoonLabs' published browse
+//!   API documents errors only as "an error code or false if no error" and never
+//!   enumerates them, and the three names appear nowhere in `node-roon-api`. So the
+//!   consequence is pinned instead: [`FakeRoonCore::reject_item_key_with_name`] and
+//!   [`FakeRoonCore::FORK_ERROR_NAMES`] make it testable.
+//! * **`item_key` portability across sessions.** Configurable ([`ItemKeyScope`])
+//!   rather than decided — and third-party evidence now points *against* the
+//!   assumption this repo makes. See that type's docs.
 //!
 //! # What this fake does NOT prove
 //!
@@ -121,7 +127,9 @@ pub enum Hint {
 impl Hint {
     fn wire(self) -> &'static str {
         match self {
-            // FROM FORK: browse.rs::ItemHint, #[serde(rename_all = "snake_case")]
+            // FROM FORK: browse.rs::ItemHint, #[serde(rename_all = "snake_case")].
+            // Corroborated by RoonLabs' published JSDoc, which documents exactly
+            // these five: null "Unknown", "action", "action_list", "list", "header".
             Hint::List => "list",
             Hint::Action => "action",
             Hint::ActionList => "action_list",
@@ -318,9 +326,36 @@ impl FakeLibrary {
 /// caller's key inside it (`src/adapters/roon.rs:1105-1122`), so the repo already
 /// assumes [`ItemKeyScope::Global`] — but `/roon/play_item` has no in-repo callers
 /// and no test, so it may never have worked. The fake refuses to decide.
+///
+/// # Third-party evidence points against the repo's assumption
+///
+/// Not a controlled experiment, and not this repo's code path — but recorded off
+/// real Roon Cores, which is more than anything else here has:
+///
+/// * Home Assistant issue `home-assistant/core#137605`: playing a Roon playlist
+///   from a script "works successfully on the first attempt but fails on the second
+///   attempt", logging `Could not play id:122:4, result: MOO/1 COMPLETE
+///   InvalidItemKey` (and the same for `130:12`, `133:13`, `109:7`, `135:5`). Same
+///   shape as UHC's `play_item`: hold a key from an earlier lookup, browse it later.
+/// * Roon Labs community thread 23129: `item_key`s "change with each refresh" —
+///   `"115:0"` becoming `"116:0"`.
+///
+/// Read together: a key from an earlier lookup does **not** reliably resolve later.
+/// That is [`ItemKeyScope::PerSession`] behaviour, and if it is right then
+/// `/roon/play_item` is broken as #405 feared and #396's ref design changes.
+///
+/// The default here stays `Global` because that is what the adapter's code assumes,
+/// and these tests describe the adapter. **Do not read the default as a claim about
+/// Roon.** `a_foreign_item_key_is_rejected_when_keys_are_session_scoped` exercises
+/// the other setting; flip the default once the operator's rig settles it.
+///
+/// Two caveats against over-reading the citations: Home Assistant's integration is
+/// not UHC and may reuse keys differently, and neither source states the *rule* —
+/// only that reuse fails in practice.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ItemKeyScope {
-    /// Any session may use any key. Matches what this repo assumes today. Default.
+    /// Any session may use any key. Matches what this repo assumes today. Default —
+    /// see the type docs: that is the adapter's assumption, not a fact about Roon.
     Global,
     /// A key only resolves in the session that minted it; elsewhere the Core
     /// answers `InvalidItemKey`.
@@ -409,8 +444,10 @@ impl Arena {
     }
 
     fn key_of(&self, index: usize) -> String {
-        // INFERRED: real Roon item keys look like short opaque colon-separated
-        // strings. Only their opacity matters to this repo.
+        // RECORDED (third-party): real keys are two colon-separated integers —
+        // `122:4`, `130:12`, `115:0` — from home-assistant/core#137605 logs and
+        // Roon Labs community thread 23129. Same shape as this. Only their opacity
+        // matters to the adapter; the nonce keeps tests from hardcoding them.
         format!("{}:{}", self.nonce, index)
     }
 
@@ -626,6 +663,15 @@ impl FakeRoonCore {
     /// The four browse error names the pinned fork recognises, in the order they
     /// appear in `browse.rs`. Pinned by a test so a fork bump that renames one is
     /// visible here rather than as a mysterious timeout.
+    ///
+    /// Corroboration status, because they are not equal:
+    /// * `InvalidItemKey` — **recorded verbatim** off real Cores as
+    ///   `MOO/1 COMPLETE InvalidItemKey` (home-assistant/core#137605).
+    /// * `InvalidLevels`, `UnexpectedError`, `ZoneNotFound` — **unverified.**
+    ///   RoonLabs' published browse API documents errors only as "an error code or
+    ///   false if no error" and never enumerates them; none of the three appears in
+    ///   `node-roon-api`. A Roon Labs community thread shows the prose "Zone not
+    ///   found", which is not evidence of the wire spelling.
     pub const FORK_ERROR_NAMES: [&'static str; 4] = [
         "InvalidItemKey",
         "InvalidLevels",
@@ -948,8 +994,11 @@ async fn refuse(
             .push((req_id, name.to_string(), session_key.to_string()));
     }
     // FROM FORK: browse.rs:169-183 keys purely off the message name.
-    // INFERRED: whether a real Core attaches a body. None is sent, because a body
-    // that parsed as BrowseResult/LoadResult would be taken for success.
+    // RECORDED (third-party): home-assistant/core#137605 logs the whole reply as
+    // `MOO/1 COMPLETE InvalidItemKey` — verb, name, and nothing else — which is
+    // exactly this frame.
+    // INFERRED: that a real Core attaches no body at all. None is sent here, since
+    // a body that parsed as BrowseResult/LoadResult would be taken for success.
     send(writer, "COMPLETE", name, req_id, None).await;
 }
 
@@ -1088,8 +1137,11 @@ async fn handle_request(
         RequestKind::Browse => handle_browse(req_id, &body, &core, &writer, &root_title).await,
         RequestKind::Load => handle_load(req_id, &body, &core, &writer).await,
         RequestKind::Unknown => {
-            // Mirrors the fork's own reply to an unknown service (lib.rs:588-592)
-            // so an unmodelled call fails fast instead of hanging for 10s.
+            // Mirrors the fork's own reply to an unknown service (lib.rs:588-592).
+            // FROM ROONLABS' PUBLISHED API: `InvalidRequest` with an `error` string
+            // is what node-roon-api itself sends for "unknown service" and "unknown
+            // request name", so this is the real shape, not an invention. It also
+            // means an unmodelled call fails fast instead of hanging for 10s.
             let body = json!({ "error": format!("FakeRoonCore does not model {name}") });
             respond(
                 &core,
@@ -1211,8 +1263,11 @@ async fn handle_browse(
         // Invoking an action does not produce a list.
         if node_hint == Some(Hint::Action) {
             drop(state);
-            // INFERRED: a real Core answers an invoked action with action "none"
-            // or a "message". Nothing in this repo reads it — `execute_play_action`
+            // FROM ROONLABS' PUBLISHED API: `action: "none"` is documented as "No
+            // action is required" (node-roon-api-browse JSDoc), so this is a legal
+            // reply rather than a guess. INFERRED: that it is the one a real Core
+            // picks for an invoked action, rather than "message".
+            // Nothing in this repo reads it — `execute_play_action`
             // discards the BrowseResult (src/adapters/roon.rs:1276-1284) — so the
             // load-bearing assertion is that the request arrived, which the
             // request log carries.
@@ -1301,7 +1356,8 @@ async fn handle_load(req_id: usize, body: &Value, core: &Arc<RwLock<CoreState>>,
         }
         if let Some(prompt) = &node.input_prompt {
             // FROM FORK: browse.rs:70-75 InputPrompt { prompt, action, value,
-            // is_password }.
+            // is_password } — matching RoonLabs' published JSDoc, where `action` is
+            // "The verb that goes with this action".
             item["input_prompt"] = json!({ "prompt": prompt, "action": "Search" });
         }
         let keyed = node.keyed;
@@ -1338,7 +1394,8 @@ fn current_list(state: &CoreState, session_key: &str) -> Value {
 fn list_json(title: &str, count: usize, level: u32) -> Value {
     // FROM FORK: browse.rs:57-65 List { title, count, level, subtitle?,
     // image_key?, display_offset?, hint? }.
-    // INFERRED: levels numbered from 0 at the browse root.
+    // FROM ROONLABS' PUBLISHED API: `level` is documented as "increases from 0"
+    // (node-roon-api-browse JSDoc), so root = 0 is documented, not inferred.
     json!({ "title": title, "count": count, "level": level })
 }
 

--- a/tests/mock_servers/roon_core.rs
+++ b/tests/mock_servers/roon_core.rs
@@ -52,12 +52,21 @@
 //! |---|---|---|
 //! | **From the fork** | which fields exist, which are required vs optional, enum spellings (`"action_list"`, `"list"`, …), the four browse error names, the handshake order | high — a shape the fork's `serde` accepts is a shape the adapter can consume |
 //! | **From this repo's adapter** | that the browse root contains `Library` / `TIDAL` / `Qobuz`, that each contains a `Search` item, that an action list contains `Play Now` / `Queue` / `Start Radio` | high as *expectations* — `src/adapters/roon.rs` will not work against anything else |
-//! | **INFERRED** | root list title (`Explore`), `level` numbering from 0, `action: "none"` as the reply to invoking an action item, whether a real Core sends a body with `InvalidItemKey`, whether an `item_key` minted under one `multi_session_key` resolves under another | **unverified** — every one is marked `INFERRED:` at its use site |
+//! | **INFERRED** | root list title (`Explore`), `level` numbering from 0, `action: "none"` as the reply to invoking an action item, whether a real Core sends a body with `InvalidItemKey`, **whether a real Core spells the four error names the way the fork matches them**, whether an `item_key` minted under one `multi_session_key` resolves under another | **unverified** — every one is marked `INFERRED:` at its use site |
 //!
-//! The last row is the dangerous one. In particular the `item_key` portability
-//! question is the empirical unknown #405 must answer against the operator's rig;
-//! this fake makes it *configurable* ([`ItemKeyScope`]) rather than pretending to
-//! know, so a test can pin either answer and be re-pointed once it is known.
+//! The last row is the dangerous one. Two entries in it are load-bearing:
+//!
+//! * **The four error names.** The fork matches string literals, and anything else
+//!   becomes `Parsed::None`, which it drops — so a Core that spells one differently
+//!   makes the caller time out as if unreachable, with every test here still green.
+//!   #405's PR flagged this as #408's to pin, and it is pinned as far as it can be:
+//!   [`FakeRoonCore::reject_item_key_with_name`] and
+//!   [`FakeRoonCore::FORK_ERROR_NAMES`] make the *consequence* testable. Verifying
+//!   the names themselves needs a real Core.
+//! * **`item_key` portability across sessions.** The empirical unknown #405 must
+//!   answer against the operator's rig; this fake makes it *configurable*
+//!   ([`ItemKeyScope`]) rather than pretending to know, so a test can pin either
+//!   answer and be re-pointed once it is known.
 //!
 //! # What this fake does NOT prove
 //!
@@ -252,12 +261,20 @@ impl FakeLibrary {
                     "Miles Davis",
                     &["So What", "Blue in Green", "Flamenco Sketches"],
                 ),
-                album("Blue Train", "John Coltrane", &["Blue Train", "Moment's Notice"]),
+                album(
+                    "Blue Train",
+                    "John Coltrane",
+                    &["Blue Train", "Moment's Notice"],
+                ),
             ],
         );
         search_results.insert(
             "TIDAL".to_string(),
-            vec![album("Blue Note Reimagined", "Various Artists", &["Footprints"])],
+            vec![album(
+                "Blue Note Reimagined",
+                "Various Artists",
+                &["Footprints"],
+            )],
         );
 
         Self {
@@ -453,6 +470,8 @@ struct CoreState {
     item_key_scope: ItemKeyScope,
     /// item_keys the Core will reject with `InvalidItemKey`
     rejected_keys: HashSet<String>,
+    /// Per-key override of the rejection's message *name*.
+    rejection_names: HashMap<String, String>,
     /// One-shot: the next browse, whatever it is, is rejected.
     reject_next_browse: bool,
     /// Applied before every response.
@@ -466,6 +485,11 @@ struct CoreState {
     /// Without this, "the adapter hung" and "the Core never replied" are
     /// indistinguishable — and that ambiguity is exactly what #405 is about.
     sent: Vec<(usize, String)>,
+    /// Responses that were browse/load errors, as (request id, name, session key).
+    /// The fork's `Parsed::Error` payload carries exactly this pair, so a test can
+    /// assert the Core correlated its refusal to the right request and session even
+    /// though today's adapter throws the payload away.
+    errors: Vec<(usize, String, String)>,
     core_id: String,
     display_name: String,
     display_version: String,
@@ -474,6 +498,9 @@ struct CoreState {
 // =============================================================================
 // The fake
 // =============================================================================
+
+/// Token handed out by `com.roonlabs.registry:1/register`.
+const REGISTRATION_TOKEN: &str = "fake-token-408";
 
 pub struct FakeRoonCore {
     addr: SocketAddr,
@@ -500,13 +527,17 @@ impl FakeRoonCore {
             minted: HashMap::new(),
             item_key_scope: ItemKeyScope::Global,
             rejected_keys: HashSet::new(),
+            rejection_names: HashMap::new(),
             reject_next_browse: false,
             delay: Duration::ZERO,
             key_delays: HashMap::new(),
             zones: vec![default_zone("zone_fake_1", "Fake Living Room")],
             log: Vec::new(),
             sent: Vec::new(),
-            core_id: "fake-core-408".to_string(),
+            errors: Vec::new(),
+            // Per-instance, so two fakes running concurrently are distinct Cores.
+            // Tests read it back via `core_id()` rather than hardcoding it.
+            core_id: format!("fake-core-408-{}", addr.port()),
             display_name: "Fake Roon Core".to_string(),
             display_version: "2.0.408".to_string(),
         }));
@@ -574,6 +605,34 @@ impl FakeRoonCore {
         self.state.write().await.reject_next_browse = true;
     }
 
+    /// Answer browses carrying `item_key` with an arbitrary error *name*.
+    ///
+    /// The four names the fork recognises are `InvalidItemKey`, `InvalidLevels`,
+    /// `UnexpectedError` and `ZoneNotFound` (`browse.rs:169-183`). **Whether a real
+    /// Roon Core spells them that way is unverified** — the fork's own literals are
+    /// the only evidence, and #405's PR flags the same gap. Any other name yields
+    /// `Parsed::None`, which the fork drops, so the caller times out exactly as it
+    /// did before #405 — with every test still green. This knob exists so that
+    /// consequence can be pinned rather than merely described; see
+    /// `an_unrecognised_error_name_degrades_to_an_indistinguishable_timeout`.
+    pub async fn reject_item_key_with_name(&self, item_key: &str, error_name: &str) {
+        let mut state = self.state.write().await;
+        state.rejected_keys.insert(item_key.to_string());
+        state
+            .rejection_names
+            .insert(item_key.to_string(), error_name.to_string());
+    }
+
+    /// The four browse error names the pinned fork recognises, in the order they
+    /// appear in `browse.rs`. Pinned by a test so a fork bump that renames one is
+    /// visible here rather than as a mysterious timeout.
+    pub const FORK_ERROR_NAMES: [&'static str; 4] = [
+        "InvalidItemKey",
+        "InvalidLevels",
+        "UnexpectedError",
+        "ZoneNotFound",
+    ];
+
     pub async fn set_item_key_scope(&self, scope: ItemKeyScope) {
         self.state.write().await.item_key_scope = scope;
     }
@@ -586,6 +645,16 @@ impl FakeRoonCore {
         self.state.read().await.display_name.clone()
     }
 
+    /// The `core_id` this Core reports, unique per instance.
+    pub async fn core_id(&self) -> String {
+        self.state.read().await.core_id.clone()
+    }
+
+    /// The token this Core hands out on `register`.
+    pub fn token(&self) -> &'static str {
+        REGISTRATION_TOKEN
+    }
+
     // ---- observation -------------------------------------------------------
 
     /// The `item_key` this Core mints for the (first) item with this title.
@@ -593,7 +662,10 @@ impl FakeRoonCore {
     /// construct keys themselves.
     pub async fn key_for_title(&self, title: &str) -> Option<String> {
         let state = self.state.read().await;
-        state.arena.find_by_title(title).map(|i| state.arena.key_of(i))
+        state
+            .arena
+            .find_by_title(title)
+            .map(|i| state.arena.key_of(i))
     }
 
     /// The title of the item a given `item_key` points at.
@@ -656,6 +728,11 @@ impl FakeRoonCore {
     /// remove. Without it, a hang looks the same either way.
     pub async fn responses(&self) -> Vec<(usize, String)> {
         self.state.read().await.sent.clone()
+    }
+
+    /// Browse/load refusals this Core sent, as `(request id, name, session key)`.
+    pub async fn errors_sent(&self) -> Vec<(usize, String, String)> {
+        self.state.read().await.errors.clone()
     }
 
     /// Names of the responses sent, in order.
@@ -855,6 +932,27 @@ async fn respond(
     send(writer, verb, name, req_id, body).await;
 }
 
+/// Refuse a browse/load, recording the `(req_id, name, session_key)` triple the
+/// fork's `Parsed::Error` payload carries.
+async fn refuse(
+    state: &Arc<RwLock<CoreState>>,
+    writer: &Writer,
+    name: &str,
+    req_id: usize,
+    session_key: &str,
+) {
+    {
+        let mut st = state.write().await;
+        st.sent.push((req_id, name.to_string()));
+        st.errors
+            .push((req_id, name.to_string(), session_key.to_string()));
+    }
+    // FROM FORK: browse.rs:169-183 keys purely off the message name.
+    // INFERRED: whether a real Core attaches a body. None is sent, because a body
+    // that parsed as BrowseResult/LoadResult would be taken for success.
+    send(writer, "COMPLETE", name, req_id, None).await;
+}
+
 // =============================================================================
 // Connection handling
 // =============================================================================
@@ -959,14 +1057,30 @@ async fn handle_request(
             // FROM FORK: lib.rs:479 requires the message name "Registered" and a
             // string `token`. A real Core returns more; the fork reads nothing
             // else, so nothing else is invented here.
-            let body = json!({ "token": "fake-token-408" });
-            respond(&core, &writer, "COMPLETE", "Registered", req_id, Some(&body)).await;
+            let body = json!({ "token": REGISTRATION_TOKEN });
+            respond(
+                &core,
+                &writer,
+                "COMPLETE",
+                "Registered",
+                req_id,
+                Some(&body),
+            )
+            .await;
         }
         RequestKind::SubscribeZones => {
             let body = json!({ "zones": core.read().await.zones.clone() });
             // FROM FORK: transport.rs:479 accepts name "Subscribed"; a
             // subscription stays open, hence CONTINUE.
-            respond(&core, &writer, "CONTINUE", "Subscribed", req_id, Some(&body)).await;
+            respond(
+                &core,
+                &writer,
+                "CONTINUE",
+                "Subscribed",
+                req_id,
+                Some(&body),
+            )
+            .await;
         }
         RequestKind::UnsubscribeZones | RequestKind::Ping => {
             respond(&core, &writer, "COMPLETE", "Success", req_id, None).await;
@@ -1061,12 +1175,11 @@ async fn handle_browse(
         || item_key.is_some_and(|k| state.arena.index_of(k).is_none());
     if rejected {
         state.reject_next_browse = false;
+        let name = item_key
+            .and_then(|k| state.rejection_names.get(k).cloned())
+            .unwrap_or_else(|| "InvalidItemKey".to_string());
         drop(state);
-        // FROM FORK: browse.rs:170-172 keys purely off the message name, and
-        // yields Parsed::Error(RoonApiError::BrowseInvalidItemKey((req_id, key))).
-        // INFERRED: whether a real Core attaches a body. None is sent, because a
-        // body that parsed as BrowseResult/LoadResult would be taken for success.
-        respond(core, writer, "COMPLETE", "InvalidItemKey", req_id, None).await;
+        refuse(core, writer, &name, req_id, &session_key).await;
         return;
     }
 
@@ -1088,7 +1201,7 @@ async fn handle_browse(
     if let Some(key) = item_key {
         let Some(index) = state.arena.index_of(key) else {
             drop(state);
-            respond(core, writer, "COMPLETE", "InvalidItemKey", req_id, None).await;
+            refuse(core, writer, "InvalidItemKey", req_id, &session_key).await;
             return;
         };
         let node_hint = state.arena.nodes[index].hint;
@@ -1139,10 +1252,7 @@ async fn handle_browse(
 
 async fn handle_load(req_id: usize, body: &Value, core: &Arc<RwLock<CoreState>>, writer: &Writer) {
     let session_key = session_key_of(body);
-    let offset = body
-        .get("offset")
-        .and_then(Value::as_u64)
-        .unwrap_or(0) as usize;
+    let offset = body.get("offset").and_then(Value::as_u64).unwrap_or(0) as usize;
     let count = body
         .get("count")
         .and_then(Value::as_u64)
@@ -1158,12 +1268,16 @@ async fn handle_load(req_id: usize, body: &Value, core: &Arc<RwLock<CoreState>>,
             Some(level) => level as usize,
             None => session.levels.len().saturating_sub(1),
         };
-        session.levels.get(index).cloned().map(|level| (index, level))
+        session
+            .levels
+            .get(index)
+            .cloned()
+            .map(|level| (index, level))
     });
     let Some((level_index, level)) = selected else {
         drop(state);
         // FROM FORK: browse.rs:173-175 — loading a session with no browse level.
-        respond(core, writer, "COMPLETE", "InvalidLevels", req_id, None).await;
+        refuse(core, writer, "InvalidLevels", req_id, &session_key).await;
         return;
     };
 

--- a/tests/roon_protocol.rs
+++ b/tests/roon_protocol.rs
@@ -23,9 +23,7 @@ mod mock_servers;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use mock_servers::roon_core::{
-    album, FakeItem, FakeLibrary, FakeRoonCore, Hint, ItemKeyScope,
-};
+use mock_servers::roon_core::{album, FakeItem, FakeLibrary, FakeRoonCore, Hint, ItemKeyScope};
 use roon_api::browse::{BrowseOpts, LoadOpts};
 use unified_hifi_control::adapters::roon::{PlayAction, RoonAdapter, SearchSource};
 use unified_hifi_control::bus::create_bus;
@@ -118,6 +116,63 @@ fn load_all(session: &str) -> LoadOpts {
     }
 }
 
+/// What the adapter did with a rejection the Core definitely sent.
+#[derive(Debug, PartialEq, Eq)]
+enum RejectionOutcome {
+    /// The rejection was routed to the waiting caller, promptly (#405 / PR #412).
+    RoutedToCaller,
+    /// The rejection was dropped; the caller is still waiting for its 10s timeout.
+    /// This is `v3` before #405.
+    DroppedByAdapter,
+}
+
+/// Await a browse-backed call that the Core has been told to reject, and classify
+/// what the adapter did — enforcing, in both cases, the invariants that hold
+/// regardless of whether #405 has landed.
+///
+/// This is deliberately not "assert it hangs". #405 (PR #412) routes
+/// `Parsed::Error` into the pending maps, and this suite has to be correct on
+/// `v3` both before and after that merges — a test that pinned the hang would
+/// turn red the moment the defect was fixed, which is the wrong signal from a
+/// test whose whole job is to be the end-to-end proof of the fix.
+///
+/// What is enforced either way:
+/// * a rejected request **never** resolves as success;
+/// * if it does resolve, it resolves *promptly* (well inside `BROWSE_TIMEOUT`),
+///   the message does not read as a timeout, and it names the browse session.
+///
+/// The `session` argument is asserted against the message because #405 carries
+/// the `multi_session_key` from the Core's error payload. When #412 is on the
+/// base branch, tighten this to `RoonBrowseError::from_error(&e)` and assert
+/// `kind == InvalidItemKey` directly; the string checks are the strongest
+/// assertions expressible without that type.
+async fn classify_rejection<T: std::fmt::Debug>(
+    fut: impl std::future::Future<Output = anyhow::Result<T>>,
+    session: &str,
+) -> RejectionOutcome {
+    const BOUND: Duration = Duration::from_millis(750);
+    match tokio::time::timeout(BOUND, fut).await {
+        Ok(Ok(unexpected)) => {
+            panic!("a Core-rejected item key must never resolve as success, got {unexpected:?}")
+        }
+        Ok(Err(e)) => {
+            let msg = e.to_string();
+            assert!(
+                !msg.to_lowercase().contains("timed out")
+                    && !msg.to_lowercase().contains("timeout"),
+                "a Core rejection must be distinguishable from an unreachable Core, \
+                 got {msg:?}"
+            );
+            assert!(
+                msg.contains(session),
+                "the rejection should name the browse session it happened in, got {msg:?}"
+            );
+            RejectionOutcome::RoutedToCaller
+        }
+        Err(_) => RejectionOutcome::DroppedByAdapter,
+    }
+}
+
 // =============================================================================
 // The fake is validated by the real client library, not by a hand-written client
 // =============================================================================
@@ -134,7 +189,12 @@ async fn roon_core_completes_handshake() {
 
     // The handshake order is the fork's, not ours: info (request id 0) then
     // register. If the fake's framing ever breaks, this test fails first.
-    let names: Vec<String> = core.requests().await.iter().map(|r| r.name.clone()).collect();
+    let names: Vec<String> = core
+        .requests()
+        .await
+        .iter()
+        .map(|r| r.name.clone())
+        .collect();
     assert_eq!(names[0], "com.roonlabs.registry:1/info");
     assert_eq!(core.requests().await[0].req_id, 0);
     assert!(names.contains(&"com.roonlabs.registry:1/register".to_string()));
@@ -153,13 +213,25 @@ async fn roon_core_completes_handshake() {
         state_file.exists(),
         "expected pairing state at {state_file:?}"
     );
-    let saved: serde_json::Value =
-        serde_json::from_str(&std::fs::read_to_string(&state_file).unwrap()).unwrap();
-    assert_eq!(
-        saved["roonstate"]["tokens"]["fake-core-408"],
-        "fake-token-408",
-        "the token from the fake's Registered reply should be persisted: {saved}"
-    );
+    // Every test in this binary shares the one config directory, so the file is
+    // rewritten concurrently and a read can catch it mid-truncate. Retry until it
+    // parses and carries this Core's own id.
+    let core_id = core.core_id().await;
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let saved = loop {
+        let parsed = std::fs::read_to_string(&state_file)
+            .ok()
+            .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
+            .filter(|v| v["roonstate"]["tokens"][&core_id].is_string());
+        match parsed {
+            Some(v) => break v,
+            None if Instant::now() < deadline => {
+                tokio::time::sleep(Duration::from_millis(20)).await
+            }
+            None => panic!("pairing state never carried a token for {core_id}"),
+        }
+    };
+    assert_eq!(saved["roonstate"]["tokens"][&core_id], core.token());
 
     core.assert_no_unhandled_requests().await;
     core.stop().await;
@@ -241,7 +313,10 @@ async fn search_maps_title_and_subtitle_without_swapping_them() {
 
     // An item_key came back, and it is opaque: nothing in it is derivable from the
     // title. #396 will wrap this in a ref; today it is what /roon/play_item takes.
-    let key = hit.item_key.as_deref().expect("search hit should carry a key");
+    let key = hit
+        .item_key
+        .as_deref()
+        .expect("search hit should carry a key");
     assert!(!key.is_empty());
     assert!(!key.to_lowercase().contains("kind of blue"));
 
@@ -264,7 +339,7 @@ async fn search_results_survive_the_http_boundary() {
 
     let core = FakeRoonCore::start().await;
     let adapter = connected(&core).await;
-    let state = app_state_with(adapter);
+    let state = app_state_with(adapter).await;
 
     let app = Router::new()
         .route(
@@ -311,7 +386,7 @@ async fn browse_items_survive_the_http_boundary() {
 
     let core = FakeRoonCore::start().await;
     let adapter = connected(&core).await;
-    let state = app_state_with(adapter);
+    let state = app_state_with(adapter).await;
 
     let app = Router::new()
         .route(
@@ -357,7 +432,10 @@ async fn browse_items_survive_the_http_boundary() {
         serde_json::json!({ "session_key": "http_browse", "item_key": library_key }),
     )
     .await;
-    let albums_key = library["items"][2]["item_key"].as_str().unwrap().to_string();
+    let albums_key = library["items"][2]["item_key"]
+        .as_str()
+        .unwrap()
+        .to_string();
 
     let albums = post_browse(
         app,
@@ -392,7 +470,11 @@ async fn search_mints_one_session_key_and_uses_it_throughout() {
         .expect("search should succeed");
 
     let sessions = core.session_keys().await;
-    assert_eq!(sessions.len(), 1, "search should mint exactly one session key");
+    assert_eq!(
+        sessions.len(),
+        1,
+        "search should mint exactly one session key"
+    );
     assert!(
         sessions[0].starts_with("search_"),
         "session key should be search-scoped, got {:?}",
@@ -412,7 +494,10 @@ async fn search_mints_one_session_key_and_uses_it_throughout() {
     assert!(browses[0].pop_all(), "first browse must pop to the root");
     assert_eq!(browses[0].item_key(), None);
     // Request 2: enter the source by the key the Core minted for it.
-    assert_eq!(browses[1].item_key(), core.key_for_title("Library").await.as_deref());
+    assert_eq!(
+        browses[1].item_key(),
+        core.key_for_title("Library").await.as_deref()
+    );
     assert!(!browses[1].pop_all());
     // Request 3: the query is carried as `input` on the Search item, not as a
     // path or a filter.
@@ -467,7 +552,12 @@ async fn search_with_no_matches_returns_empty_not_an_error() {
     let adapter = connected(&core).await;
 
     let results = adapter
-        .search("no such album anywhere", None, Some(10), SearchSource::Library)
+        .search(
+            "no such album anywhere",
+            None,
+            Some(10),
+            SearchSource::Library,
+        )
         .await
         .expect("an empty result set is not an error");
     assert!(results.is_empty());
@@ -490,7 +580,10 @@ async fn browse_walks_two_levels_and_pop_all_returns_to_the_root() {
     let session = "browse_test_session";
 
     // Level 0: the browse root.
-    let root = adapter.browse(browse_root(session)).await.expect("root browse");
+    let root = adapter
+        .browse(browse_root(session))
+        .await
+        .expect("root browse");
     let root_list = root.list.expect("root browse should carry a list");
     assert_eq!(root_list.level, 0);
     assert_eq!(root_list.count, 4);
@@ -647,24 +740,16 @@ async fn load_without_a_browse_is_refused_not_answered_with_stale_items() {
     let core = FakeRoonCore::start().await;
     let adapter = connected(&core).await;
 
-    // The fake answers InvalidLevels. Today the adapter's catch-all drops that,
-    // so the caller waits out BROWSE_TIMEOUT; #405 covers the routing fix. What
-    // this test pins is that the *Core* refused, which is visible in its
-    // response log even though the adapter cannot see it yet.
-    let pending = tokio::time::timeout(
-        Duration::from_millis(750),
-        adapter.load(load_all("never_browsed")),
-    )
-    .await;
-    assert!(
-        pending.is_err(),
-        "expected the load to still be pending: today's adapter drops Parsed::Error"
-    );
-    assert!(
-        core.response_names().await.contains(&"InvalidLevels".to_string()),
-        "the fake Core must have refused: {:?}",
-        core.response_names().await
-    );
+    // The fake answers InvalidLevels, correlated to the load's own req_id and
+    // session. Whether the caller ever hears about it depends on #405.
+    let outcome =
+        classify_rejection(adapter.load(load_all("never_browsed")), "never_browsed").await;
+    println!("load without a browse: {outcome:?}");
+
+    let errors = core.errors_sent().await;
+    assert_eq!(errors.len(), 1, "exactly one refusal: {errors:?}");
+    assert_eq!(errors[0].1, "InvalidLevels");
+    assert_eq!(errors[0].2, "never_browsed");
 
     core.stop().await;
 }
@@ -702,7 +787,13 @@ async fn play_item_resolves_an_item_key_to_a_play_action() {
     let walked = core.browsed_titles().await;
     assert_eq!(
         walked,
-        vec!["Library", "Search", "Kind of Blue", "Play Album", "Play Now"],
+        vec![
+            "Library",
+            "Search",
+            "Kind of Blue",
+            "Play Album",
+            "Play Now"
+        ],
         "play_item should enter the item, find its action list, and invoke Play Now"
     );
 
@@ -746,7 +837,11 @@ async fn play_item_mints_a_session_key_unrelated_to_the_one_that_minted_the_key(
         .unwrap();
 
     let sessions = core.session_keys().await;
-    assert_eq!(sessions.len(), 2, "search and play_item use separate sessions");
+    assert_eq!(
+        sessions.len(),
+        2,
+        "search and play_item use separate sessions"
+    );
     assert!(sessions[0].starts_with("search_"));
     assert!(sessions[1].starts_with("play_item_"));
 }
@@ -768,20 +863,20 @@ async fn a_foreign_item_key_is_rejected_when_keys_are_session_scoped() {
 
     core.set_item_key_scope(ItemKeyScope::PerSession).await;
 
-    let outcome = tokio::time::timeout(
-        Duration::from_millis(750),
+    // play_item mints its own session, so the rejection lands in that one.
+    let outcome = classify_rejection(
         adapter.play_item(&key, "roon:zone_fake_1", PlayAction::Play),
+        "play_item_",
     )
     .await;
+    println!("play_item against a foreign key: {outcome:?}");
+
+    let errors = core.errors_sent().await;
+    assert_eq!(errors.len(), 1, "exactly one refusal: {errors:?}");
+    assert_eq!(errors[0].1, "InvalidItemKey");
     assert!(
-        outcome.is_err(),
-        "today a rejected key hangs until BROWSE_TIMEOUT rather than failing fast"
-    );
-    assert!(
-        core.response_names()
-            .await
-            .contains(&"InvalidItemKey".to_string()),
-        "the Core should have rejected the foreign key"
+        errors[0].2.starts_with("play_item_"),
+        "the refusal should name play_item's own session: {errors:?}"
     );
 
     core.stop().await;
@@ -805,7 +900,13 @@ async fn search_and_play_navigates_into_a_result_to_find_a_playable_action() {
 
     assert_eq!(
         core.browsed_titles().await,
-        vec!["Library", "Search", "Kind of Blue", "Play Album", "Play Now"],
+        vec![
+            "Library",
+            "Search",
+            "Kind of Blue",
+            "Play Album",
+            "Play Now"
+        ],
         "search_and_play should navigate into the hit before invoking an action"
     );
 
@@ -871,7 +972,10 @@ async fn an_action_the_core_does_not_offer_is_reported_with_what_is_available() 
         .expect_err("Start Radio is not offered");
     let text = error.to_string();
     assert!(text.contains("Start Radio"), "got {text}");
-    assert!(text.contains("Play Now"), "should list what is available: {text}");
+    assert!(
+        text.contains("Play Now"),
+        "should list what is available: {text}"
+    );
 
     core.stop().await;
 }
@@ -883,16 +987,20 @@ async fn an_action_the_core_does_not_offer_is_reported_with_what_is_available() 
 /// The fake emits `InvalidItemKey` on demand and the fork turns it into
 /// `Parsed::Error(RoonApiError::BrowseInvalidItemKey((req_id, session_key)))`.
 ///
-/// **This test pins a defect.** `src/adapters/roon.rs`'s event-loop catch-all
-/// (`_ => {}`) discards `Parsed::Error`, so the pending oneshot is never resolved
-/// and the caller waits out the 10s `BROWSE_TIMEOUT`. The assertions below say
-/// "still pending after 750ms" and "the Core did reply" — together they prove the
-/// error was delivered and dropped, which no test could show before.
+/// This is the end-to-end proof #405 (PR #412) asked for: #412's own correlation
+/// tests are unit-scoped precisely because nothing could drive the wire path.
 ///
-/// When #405 lands, invert this: the browse should return a typed, recoverable
-/// error promptly. Do not delete the test; change the assertion.
+/// On `v3` before #405 the event-loop catch-all discards `Parsed::Error`, so the
+/// caller waits out the 10s `BROWSE_TIMEOUT`; with #405 it gets a typed rejection
+/// promptly. `classify_rejection` enforces what must hold either way — never a
+/// silent success, and if it does resolve, promptly and not looking like a timeout —
+/// and reports which of the two it saw. So this test is correct on both bases and
+/// does not have to be inverted on merge.
+///
+/// What it pins unconditionally is the wire half: the Core answered, named the
+/// error, and correlated it to the rejected request's own `req_id` and session key.
 #[tokio::test]
-async fn browse_error_is_delivered_but_the_adapter_drops_it() {
+async fn a_rejected_item_key_is_answered_immediately_and_correlated() {
     let core = FakeRoonCore::start().await;
     let adapter = connected(&core).await;
 
@@ -904,44 +1012,49 @@ async fn browse_error_is_delivered_but_the_adapter_drops_it() {
     core.reject_item_key(&library_key).await;
 
     let started = Instant::now();
-    let pending = tokio::time::timeout(
-        Duration::from_millis(750),
+    let outcome = classify_rejection(
         adapter.browse(browse_at(session, Some(&library_key))),
+        session,
     )
     .await;
-
-    assert!(
-        pending.is_err(),
-        "TODAY: a Core-rejected item key hangs until BROWSE_TIMEOUT (10s). \
-         When #405 routes Parsed::Error, flip this to assert a prompt typed error."
-    );
+    println!("rejected browse: {outcome:?}");
     assert!(started.elapsed() < Duration::from_secs(2));
 
-    // The Core answered immediately, and named the error. So the 10s the caller
-    // waits is entirely UHC's, not Roon's.
-    assert!(
-        core.response_names()
-            .await
-            .contains(&"InvalidItemKey".to_string()),
-        "the fake must have emitted InvalidItemKey: {:?}",
-        core.response_names().await
+    // The Core answered immediately, named the error, and correlated it to the
+    // right request id *and* the right session key — which is precisely the
+    // `Parsed::Error(BrowseInvalidItemKey((req_id, multi_session_key)))` payload the
+    // adapter throws away. So the 10s the caller waits is entirely UHC's.
+    let rejected_req_id = core
+        .browse_requests()
+        .await
+        .into_iter()
+        .find(|r| r.item_key() == Some(library_key.as_str()) && r.session_key() == Some(session))
+        .expect("the rejected browse should be in the request log")
+        .req_id;
+    assert_eq!(
+        core.errors_sent().await,
+        vec![(
+            rejected_req_id,
+            "InvalidItemKey".to_string(),
+            session.to_string()
+        )],
+        "the refusal must carry the rejected request's own id and session key"
     );
 
     core.stop().await;
 }
 
-/// #405's acceptance criterion: "a test with several in-flight browse/load
-/// requests, where one is rejected, proves the right waiter is resolved and the
-/// others complete normally."
+/// #405's acceptance criterion, end to end: "a test with several in-flight
+/// browse/load requests, where one is rejected, proves the right waiter is resolved
+/// and the others complete normally."
 ///
-/// The instrument for that is here. The rejected waiter's *current* fate is a
-/// hang, and that is what is asserted — but the two healthy requests are proven
-/// to complete, in their own sessions, while the rejected one is outstanding.
-/// The pending maps are keyed by `req_id` and scanned by session key
-/// (`src/adapters/roon.rs`), so a correlation bug in #405's error arm would show
-/// up here as a healthy browse resolving with the wrong list, or not at all.
+/// Three browses in three sessions, the rejected one answered *first* (via a
+/// per-key delay) so its error cannot be mistaken for "whatever arrived last".
+/// The two healthy ones must resolve with their own correct lists whether or not
+/// #405 has landed — a correlation bug in #412's error arm shows up here as a
+/// healthy browse resolving with the wrong list, or not at all.
 #[tokio::test]
-async fn concurrent_browses_one_rejected_leaves_the_rejected_caller_hanging() {
+async fn concurrent_browses_with_one_rejected_do_not_disturb_the_others() {
     let core = FakeRoonCore::start().await;
     let adapter = connected(&core).await;
 
@@ -963,9 +1076,9 @@ async fn concurrent_browses_one_rejected_leaves_the_rejected_caller_hanging() {
 
     let a = adapter.browse(browse_at("c_a", Some(&library_key)));
     let b = adapter.browse(browse_at("c_b", Some(&library_key)));
-    let bad = tokio::time::timeout(
-        Duration::from_millis(1_500),
+    let bad = classify_rejection(
         adapter.browse(browse_at("c_bad", Some(&tidal_key))),
+        "c_bad",
     );
 
     let (a, b, bad) = tokio::join!(a, b, bad);
@@ -982,20 +1095,90 @@ async fn concurrent_browses_one_rejected_leaves_the_rejected_caller_hanging() {
         "the rejected browse must not have advanced its session"
     );
 
+    println!("rejected browse among three in flight: {bad:?}");
+
+    // Exactly one refusal, and it named the rejected request's own session — not
+    // one of the two healthy ones. That pairing is the whole correlation claim.
+    let errors = core.errors_sent().await;
+    assert_eq!(errors.len(), 1, "exactly one refusal: {errors:?}");
+    assert_eq!(errors[0].1, "InvalidItemKey");
+    assert_eq!(errors[0].2, "c_bad");
+
+    core.stop().await;
+}
+
+/// **The unverified assumption #405's PR handed to this issue.** The fork matches
+/// four literal error names against `msg["name"]`; anything else becomes
+/// `Parsed::None`, which the fork drops. So if a real Roon Core spells an error
+/// differently, the caller times out exactly as it did before #405 — and every
+/// test in this file stays green, because this fake sends the fork's own literals.
+///
+/// **No live Core was reachable, so whether Roon really uses these four spellings
+/// is unverified.** This test pins the *consequence* of being wrong rather than
+/// pretending to have checked: with an unrecognised name, the Core answered
+/// instantly and the caller still waits out `BROWSE_TIMEOUT`.
+///
+/// If someone reaches a real Core: confirm the four names below, and if any differs,
+/// this is the failure you will be looking at.
+#[tokio::test]
+async fn an_unrecognised_error_name_degrades_to_an_indistinguishable_timeout() {
+    let core = FakeRoonCore::start().await;
+    let adapter = connected(&core).await;
+
+    let session = "unknown_error_name";
+    adapter.browse(browse_root(session)).await.unwrap();
+    let root = adapter.load(load_all(session)).await.unwrap();
+    let library_key = root.items[0].item_key.clone().unwrap();
+
+    core.reject_item_key_with_name(&library_key, "ItemKeyNoLongerValid")
+        .await;
+
+    let pending = tokio::time::timeout(
+        Duration::from_millis(750),
+        adapter.browse(browse_at(session, Some(&library_key))),
+    )
+    .await;
     assert!(
-        bad.is_err(),
-        "TODAY: the rejected browse hangs. #405 must make this a prompt typed \
-         error while leaving the other two exactly as asserted above."
+        pending.is_err(),
+        "an error name the fork does not recognise is dropped inside the dependency, \
+         so the caller can only time out. This is the cost of the four literals in \
+         browse.rs being unverified against a real Core."
     );
 
-    let names = core.response_names().await;
+    // The Core did answer, instantly, with that name.
     assert_eq!(
-        names.iter().filter(|n| *n == "InvalidItemKey").count(),
-        1,
-        "exactly one request should have been rejected: {names:?}"
+        core.errors_sent().await,
+        vec![(
+            core.browse_requests()
+                .await
+                .into_iter()
+                .find(|r| r.item_key() == Some(library_key.as_str())
+                    && r.session_key() == Some(session))
+                .expect("the rejected browse should be logged")
+                .req_id,
+            "ItemKeyNoLongerValid".to_string(),
+            session.to_string()
+        )]
     );
 
     core.stop().await;
+}
+
+/// The four names are a contract with the pinned fork. If a fork bump renames one,
+/// fail here rather than as an unexplained timeout somewhere else.
+#[test]
+fn the_forks_browse_error_names_are_pinned() {
+    assert_eq!(
+        FakeRoonCore::FORK_ERROR_NAMES,
+        [
+            "InvalidItemKey",
+            "InvalidLevels",
+            "UnexpectedError",
+            "ZoneNotFound"
+        ],
+        "these are the literals roon_api's browse.rs matches on; whether a real Roon \
+         Core uses them is UNVERIFIED"
+    );
 }
 
 // =============================================================================
@@ -1067,9 +1250,10 @@ async fn a_custom_library_is_browsable() {
             FakeItem::list("Ambient"),
         ]),
     ])];
-    library
-        .search_results
-        .insert("Library".to_string(), vec![album("Music for Airports", "Brian Eno", &["1/1"])]);
+    library.search_results.insert(
+        "Library".to_string(),
+        vec![album("Music for Airports", "Brian Eno", &["1/1"])],
+    );
 
     let core = FakeRoonCore::start_with(library).await;
     let adapter = connected(&core).await;
@@ -1107,7 +1291,7 @@ async fn a_custom_library_is_browsable() {
 // AppState for the HTTP-boundary test
 // =============================================================================
 
-fn app_state_with(roon: Arc<RoonAdapter>) -> unified_hifi_control::api::AppState {
+async fn app_state_with(roon: Arc<RoonAdapter>) -> unified_hifi_control::api::AppState {
     use unified_hifi_control::adapters::hqplayer::{HqpInstanceManager, HqpZoneLinkService};
     use unified_hifi_control::adapters::lms::LmsAdapter;
     use unified_hifi_control::adapters::openhome::OpenHomeAdapter;
@@ -1119,7 +1303,7 @@ fn app_state_with(roon: Arc<RoonAdapter>) -> unified_hifi_control::api::AppState
 
     let bus = create_bus();
     let hqp_instances = Arc::new(HqpInstanceManager::new(bus.clone()));
-    let hqplayer = futures::executor::block_on(hqp_instances.get_default());
+    let hqplayer = hqp_instances.get_default().await;
     let hqp_zone_links = Arc::new(HqpZoneLinkService::new(hqp_instances.clone()));
     let lms = Arc::new(LmsAdapter::new(bus.clone()));
     let openhome = Arc::new(OpenHomeAdapter::new(bus.clone()));
@@ -1142,4 +1326,81 @@ fn app_state_with(roon: Arc<RoonAdapter>) -> unified_hifi_control::api::AppState
         Instant::now(),
         tokio_util::sync::CancellationToken::new(),
     )
+}
+
+/// **Found by this instrument.** Two browses in flight under the *same*
+/// `multi_session_key` cross-deliver their results, silently.
+///
+/// `pending_browses` is keyed by `req_id` but scanned by session key
+/// (`src/adapters/roon.rs`, the `Parsed::BrowseResult` arm):
+/// `.iter().find(|(_, (key, _))| key == &session_key)` returns an *arbitrary*
+/// matching entry when more than one request shares a session. So the caller that
+/// asked for `Library` is handed `TIDAL`'s list, with no error and no way to tell.
+///
+/// #405's issue text calls the req_id / session-key mismatch "the whole problem" but
+/// frames it as error routing. It is already a **success-path correctness bug**.
+///
+/// Reachability: the adapter's own callers (`search`, `search_and_play`, `play_item`)
+/// each mint a private key and run sequentially, so they are safe. `POST /roon/browse`
+/// takes a **caller-supplied** `session_key` and has no in-repo callers today, so
+/// nothing here triggers it — but any external client can, and #399's navigation
+/// handle will hand clients a reusable session identity, which is exactly the shape
+/// that triggers it.
+///
+/// This test asserts the defect is **present**, over eight trials, because a single
+/// trial gets the right answer by luck about one time in eight. When it starts
+/// failing, the bug is fixed: invert it to compare each trial against `expected`.
+#[tokio::test]
+async fn concurrent_browses_in_one_session_cross_deliver_their_results() {
+    let core = FakeRoonCore::start().await;
+    let adapter = connected(&core).await;
+
+    const TRIALS: usize = 8;
+    let expected = ["Library", "TIDAL", "Qobuz"];
+    let mut crossed = 0;
+    let mut observed = Vec::new();
+
+    for trial in 0..TRIALS {
+        let session = format!("shared_session_{trial}");
+        adapter.browse(browse_root(&session)).await.unwrap();
+        let root = adapter.load(load_all(&session)).await.unwrap();
+        let keys: Vec<String> = (0..3)
+            .map(|i| root.items[i].item_key.clone().unwrap())
+            .collect();
+
+        // Responses arrive in the reverse of the request order, so a correlation
+        // that goes by arrival rather than by request is visible.
+        for (i, key) in keys.iter().enumerate() {
+            core.set_delay_for_item_key(key, Duration::from_millis(60 * (3 - i) as u64))
+                .await;
+        }
+
+        let got: Vec<String> = futures::future::join_all(
+            keys.iter()
+                .map(|k| adapter.browse(browse_at(&session, Some(k)))),
+        )
+        .await
+        .into_iter()
+        .map(|r| {
+            r.expect("every browse resolves; only the payload is wrong")
+                .list
+                .map(|l| l.title)
+                .unwrap_or_default()
+        })
+        .collect();
+
+        if got != expected {
+            crossed += 1;
+        }
+        observed.push(got);
+    }
+
+    assert!(
+        crossed > 0,
+        "TODAY: same-session concurrency cross-delivers browse results. If this \
+assertion fails, the defect is fixed - invert it to assert each caller got the \
+list it asked for. Asked {expected:?} in every trial; got {observed:?}"
+    );
+
+    core.stop().await;
 }

--- a/tests/roon_protocol.rs
+++ b/tests/roon_protocol.rs
@@ -1,0 +1,1145 @@
+//! Roon protocol integration tests (issue #408).
+//!
+//! These are the first tests in this repo to assert a Roon **success** path. They
+//! drive the real `RoonAdapter` event loop — the same code production runs,
+//! including the `pending_browses` / `pending_loads` correlation maps — against
+//! `tests/mock_servers/roon_core.rs`, a WebSocket server that speaks Roon's MOO
+//! protocol. No Roon Core, no network, no multicast.
+//!
+//! Read `tests/mock_servers/README.md` before adding to this file. In particular:
+//! **green here means "unchanged", not "correct".** The fake's semantics were
+//! derived from the pinned `roon_api` fork and from this repo's own adapter, so
+//! these tests cannot prove the adapter matches a real Roon Core. What they can and
+//! do prove is that a change to the wire mapping is visible.
+//!
+//! Two tests deliberately pin *defects* rather than desired behaviour, and say so
+//! at the assertion: `browse_error_is_delivered_but_the_adapter_drops_it` and
+//! `concurrent_browses_one_rejected_leaves_the_rejected_caller_hanging`. Both are
+//! #405's subject. When #405 lands, they flip from "hangs" to "returns a typed,
+//! recoverable error promptly" — the instrument is here so that flip is provable.
+
+mod mock_servers;
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use mock_servers::roon_core::{
+    album, FakeItem, FakeLibrary, FakeRoonCore, Hint, ItemKeyScope,
+};
+use roon_api::browse::{BrowseOpts, LoadOpts};
+use unified_hifi_control::adapters::roon::{PlayAction, RoonAdapter, SearchSource};
+use unified_hifi_control::bus::create_bus;
+use unified_hifi_control::knobs::KnobStore;
+
+// =============================================================================
+// Harness
+// =============================================================================
+
+/// Point the adapter's state-file writes at a throwaway directory, and return it.
+///
+/// `run_roon_loop` persists Roon pairing state via `get_config_file_path`, which
+/// honours `UHC_CONFIG_DIR`. Without this, registering against the fake would write
+/// `roon_state.json` into the operator's real config directory.
+///
+/// The `set_var` happens *inside* the `OnceLock` initializer, so it runs exactly
+/// once and every later read of the variable is ordered after it by the `OnceLock`'s
+/// own acquire/release. Calling `set_var` per test would race with concurrent
+/// `getenv` from the other test threads.
+fn isolate_config_dir() -> &'static std::path::Path {
+    use std::sync::OnceLock;
+    static DIR: OnceLock<tempfile::TempDir> = OnceLock::new();
+    DIR.get_or_init(|| {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("UHC_CONFIG_DIR", dir.path());
+        dir
+    })
+    .path()
+}
+
+/// Start a fake Core and a `RoonAdapter` connected to it, and wait until the
+/// adapter reports Browse as available.
+async fn connected(core: &FakeRoonCore) -> Arc<RoonAdapter> {
+    let _ = isolate_config_dir();
+
+    let bus = create_bus();
+    let adapter = Arc::new(RoonAdapter::new_configured(
+        bus,
+        "http://test.invalid:8088".to_string(),
+        KnobStore::new(),
+    ));
+
+    let runner = adapter.clone();
+    let ip = core.ip();
+    let port = core.port();
+    tokio::spawn(async move {
+        let _ = runner
+            .run_event_loop_against_core_for_tests(ip, &port)
+            .await;
+    });
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        if adapter.is_browse_connected().await {
+            return adapter;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!(
+        "adapter never reported Browse connected; requests seen by the fake: {:?}",
+        core.requests()
+            .await
+            .iter()
+            .map(|r| r.name.clone())
+            .collect::<Vec<_>>()
+    );
+}
+
+fn browse_at(session: &str, item_key: Option<&str>) -> BrowseOpts {
+    BrowseOpts {
+        multi_session_key: Some(session.to_string()),
+        item_key: item_key.map(str::to_string),
+        ..Default::default()
+    }
+}
+
+fn browse_root(session: &str) -> BrowseOpts {
+    BrowseOpts {
+        multi_session_key: Some(session.to_string()),
+        pop_all: true,
+        ..Default::default()
+    }
+}
+
+fn load_all(session: &str) -> LoadOpts {
+    LoadOpts {
+        multi_session_key: Some(session.to_string()),
+        count: Some(100),
+        ..Default::default()
+    }
+}
+
+// =============================================================================
+// The fake is validated by the real client library, not by a hand-written client
+// =============================================================================
+
+#[tokio::test]
+async fn roon_core_completes_handshake() {
+    let core = FakeRoonCore::start().await;
+    let adapter = connected(&core).await;
+
+    let status = adapter.get_status().await;
+    assert!(status.connected);
+    assert_eq!(status.core_name.as_deref(), Some("Fake Roon Core"));
+    assert_eq!(status.core_version.as_deref(), Some("2.0.408"));
+
+    // The handshake order is the fork's, not ours: info (request id 0) then
+    // register. If the fake's framing ever breaks, this test fails first.
+    let names: Vec<String> = core.requests().await.iter().map(|r| r.name.clone()).collect();
+    assert_eq!(names[0], "com.roonlabs.registry:1/info");
+    assert_eq!(core.requests().await[0].req_id, 0);
+    assert!(names.contains(&"com.roonlabs.registry:1/register".to_string()));
+
+    // Registering makes the adapter persist pairing state. Prove it landed in the
+    // throwaway directory: if this ever fails, the suite is writing into the
+    // operator's real config directory.
+    let state_file = isolate_config_dir()
+        .join("unified-hifi")
+        .join("roon_state.json");
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while !state_file.exists() && Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(
+        state_file.exists(),
+        "expected pairing state at {state_file:?}"
+    );
+    let saved: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&state_file).unwrap()).unwrap();
+    assert_eq!(
+        saved["roonstate"]["tokens"]["fake-core-408"],
+        "fake-token-408",
+        "the token from the fake's Registered reply should be persisted: {saved}"
+    );
+
+    core.assert_no_unhandled_requests().await;
+    core.stop().await;
+}
+
+#[tokio::test]
+async fn roon_core_publishes_zones() {
+    // A missing required field in the zone JSON makes the fork's deserializer
+    // error and the client library swallow the zone silently, so this test is
+    // what keeps `default_zone()` honest.
+    let core = FakeRoonCore::start().await;
+    let adapter = connected(&core).await;
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let zones = loop {
+        let zones = adapter.get_zones().await;
+        if !zones.is_empty() || Instant::now() > deadline {
+            break zones;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    };
+
+    assert_eq!(zones.len(), 1, "fake zone was not accepted by roon_api");
+    assert_eq!(zones[0].zone_id, "zone_fake_1");
+    assert_eq!(zones[0].display_name, "Fake Living Room");
+    assert_eq!(zones[0].state, "stopped");
+    let volume = zones[0].outputs[0]
+        .volume
+        .as_ref()
+        .expect("output volume should survive deserialization");
+    assert_eq!(volume.value, Some(50.0));
+    assert_eq!(volume.max, Some(100.0));
+
+    core.stop().await;
+}
+
+// =============================================================================
+// THE REGRESSION TEST THIS ISSUE EXISTS FOR (#408 acceptance criterion)
+// =============================================================================
+
+/// #394's gate: "if the module split had swapped `title` and `subtitle` in Roon's
+/// search mapping, none of its 48 contract tests would have noticed."
+///
+/// This is that test. Every value below is *asymmetric* — the title is never a
+/// plausible subtitle and vice versa — so any swap, at any layer between the wire
+/// and the adapter's return value, changes an asserted string.
+///
+/// Verified to bite: swapping the two fields in `SearchResultItem::from`
+/// (`src/api/mod.rs:402`) fails `search_results_survive_the_http_boundary`, and
+/// swapping them in the adapter fails this test. See the PR body.
+#[tokio::test]
+async fn search_maps_title_and_subtitle_without_swapping_them() {
+    let core = FakeRoonCore::start().await;
+    let adapter = connected(&core).await;
+
+    let results = adapter
+        .search("kind of blue", None, Some(10), SearchSource::Library)
+        .await
+        .expect("search against the fake Core should succeed");
+
+    assert_eq!(results.len(), 1, "expected exactly one match");
+    let hit = &results[0];
+
+    // The album name is the title. The artist is the subtitle. Not the reverse.
+    assert_eq!(
+        hit.title, "Kind of Blue",
+        "title must carry the item's title, not its subtitle"
+    );
+    assert_eq!(
+        hit.subtitle.as_deref(),
+        Some("Miles Davis"),
+        "subtitle must carry the item's subtitle, not its title"
+    );
+
+    // The two are distinguishable by shape as well as by value, so a swap cannot
+    // pass by coincidence.
+    assert_ne!(hit.title, "Miles Davis");
+    assert_ne!(hit.subtitle.as_deref(), Some("Kind of Blue"));
+
+    // An item_key came back, and it is opaque: nothing in it is derivable from the
+    // title. #396 will wrap this in a ref; today it is what /roon/play_item takes.
+    let key = hit.item_key.as_deref().expect("search hit should carry a key");
+    assert!(!key.is_empty());
+    assert!(!key.to_lowercase().contains("kind of blue"));
+
+    core.assert_no_unhandled_requests().await;
+    core.stop().await;
+}
+
+/// The same anti-swap assertion one layer up, over HTTP, so the mapping in
+/// `SearchResultItem::from` (`src/api/mod.rs:402-421`) is covered too.
+///
+/// The MCP projection in `src/mcp/` is a third, structurally identical `.map()`
+/// (`item.title -> title`, `item.subtitle -> subtitle`). It is deliberately NOT
+/// covered here: #394 (PR #404) is rewriting that whole module and owns its
+/// harness. With this fake in place that harness can add the same assertion in a
+/// few lines. Stated as a gap rather than papered over.
+#[tokio::test]
+async fn search_results_survive_the_http_boundary() {
+    use axum::{body::Body, http::Request, routing::get, Router};
+    use tower::ServiceExt;
+
+    let core = FakeRoonCore::start().await;
+    let adapter = connected(&core).await;
+    let state = app_state_with(adapter);
+
+    let app = Router::new()
+        .route(
+            "/roon/search",
+            get(unified_hifi_control::api::roon_search_handler),
+        )
+        .with_state(state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/roon/search?q=kind%20of%20blue")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let results = json["results"].as_array().expect("results array");
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0]["title"], "Kind of Blue");
+    assert_eq!(results[0]["subtitle"], "Miles Davis");
+    assert_eq!(results[0]["hint"], "list");
+    assert!(results[0]["item_key"].is_string());
+
+    core.stop().await;
+}
+
+/// The third projection of the same two fields:
+/// `roon_browse_handler`'s inline `BrowseItemResponse` map (`src/api/mod.rs:672-687`),
+/// which is what the web UI reads. Also the end-to-end proof that
+/// `POST /roon/browse` works against something that answers like Roon — the route
+/// #399 builds its MCP browse contract on top of.
+#[tokio::test]
+async fn browse_items_survive_the_http_boundary() {
+    use axum::{body::Body, http::Request, routing::post, Router};
+    use tower::ServiceExt;
+
+    let core = FakeRoonCore::start().await;
+    let adapter = connected(&core).await;
+    let state = app_state_with(adapter);
+
+    let app = Router::new()
+        .route(
+            "/roon/browse",
+            post(unified_hifi_control::api::roon_browse_handler),
+        )
+        .with_state(state);
+
+    // Root, then into Library > Albums, over HTTP with a caller-supplied session
+    // key — the flow the web UI uses.
+    let post_browse = |app: Router, body: serde_json::Value| async move {
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/roon/browse")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 200);
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        serde_json::from_slice::<serde_json::Value>(&bytes).unwrap()
+    };
+
+    let root = post_browse(
+        app.clone(),
+        serde_json::json!({ "session_key": "http_browse", "pop_all": true }),
+    )
+    .await;
+    assert_eq!(root["action"], "list");
+    assert_eq!(root["session_key"], "http_browse");
+    assert_eq!(root["list"]["level"], 0);
+    let library_key = root["items"][0]["item_key"].as_str().unwrap().to_string();
+    assert_eq!(root["items"][0]["title"], "Library");
+
+    let library = post_browse(
+        app.clone(),
+        serde_json::json!({ "session_key": "http_browse", "item_key": library_key }),
+    )
+    .await;
+    let albums_key = library["items"][2]["item_key"].as_str().unwrap().to_string();
+
+    let albums = post_browse(
+        app,
+        serde_json::json!({ "session_key": "http_browse", "item_key": albums_key }),
+    )
+    .await;
+    assert_eq!(albums["list"]["title"], "Albums");
+    assert_eq!(albums["list"]["level"], 2);
+    // The anti-swap assertion, again with asymmetric values.
+    assert_eq!(albums["items"][0]["title"], "Sketches of Spain");
+    assert_eq!(albums["items"][0]["subtitle"], "Miles Davis");
+    assert_eq!(albums["items"][0]["hint"], "list");
+
+    core.stop().await;
+}
+
+// =============================================================================
+// Search: the multi_session_key mint/consume sequence
+// =============================================================================
+
+/// The epic needs this pinned: `search()` mints one `search_{nanos}` session key,
+/// uses it for all six requests, and drops it — leaving the returned `item_key`s
+/// outliving the only thing that scopes them (#396's third acceptance criterion).
+#[tokio::test]
+async fn search_mints_one_session_key_and_uses_it_throughout() {
+    let core = FakeRoonCore::start().await;
+    let adapter = connected(&core).await;
+
+    adapter
+        .search("kind of blue", None, Some(10), SearchSource::Library)
+        .await
+        .expect("search should succeed");
+
+    let sessions = core.session_keys().await;
+    assert_eq!(sessions.len(), 1, "search should mint exactly one session key");
+    assert!(
+        sessions[0].starts_with("search_"),
+        "session key should be search-scoped, got {:?}",
+        sessions[0]
+    );
+
+    // Six requests, alternating browse and load, all in that one session.
+    let browses = core.browse_requests().await;
+    let loads = core.load_requests().await;
+    assert_eq!(browses.len(), 3, "root, into source, search with input");
+    assert_eq!(loads.len(), 3, "one load after each browse");
+    for req in browses.iter().chain(loads.iter()) {
+        assert_eq!(req.session_key(), Some(sessions[0].as_str()));
+    }
+
+    // Request 1: reset to the root. No item key, pop_all set.
+    assert!(browses[0].pop_all(), "first browse must pop to the root");
+    assert_eq!(browses[0].item_key(), None);
+    // Request 2: enter the source by the key the Core minted for it.
+    assert_eq!(browses[1].item_key(), core.key_for_title("Library").await.as_deref());
+    assert!(!browses[1].pop_all());
+    // Request 3: the query is carried as `input` on the Search item, not as a
+    // path or a filter.
+    assert_eq!(browses[2].input(), Some("kind of blue"));
+    assert!(browses[2].item_key().is_some());
+
+    // The fork injects hierarchy=browse on every browse/load (browse.rs:124).
+    for req in browses.iter().chain(loads.iter()) {
+        assert_eq!(req.body["hierarchy"], "browse");
+    }
+
+    core.assert_no_unhandled_requests().await;
+    core.stop().await;
+}
+
+#[tokio::test]
+async fn search_source_selects_a_different_branch() {
+    let core = FakeRoonCore::start().await;
+    let adapter = connected(&core).await;
+
+    let tidal = adapter
+        .search("blue", None, Some(10), SearchSource::Tidal)
+        .await
+        .expect("TIDAL search should succeed");
+    assert_eq!(tidal.len(), 1);
+    assert_eq!(tidal[0].title, "Blue Note Reimagined");
+
+    let library = adapter
+        .search("blue", None, Some(10), SearchSource::Library)
+        .await
+        .expect("library search should succeed");
+    assert_eq!(library.len(), 2, "Kind of Blue and Blue Train");
+
+    // The source is chosen by entering the matching root row, so the second
+    // browse of each search carries a different item key.
+    let browses = core.browse_requests().await;
+    assert_eq!(
+        browses[1].item_key(),
+        core.key_for_title("TIDAL").await.as_deref()
+    );
+    assert_eq!(
+        browses[4].item_key(),
+        core.key_for_title("Library").await.as_deref()
+    );
+
+    core.stop().await;
+}
+
+#[tokio::test]
+async fn search_with_no_matches_returns_empty_not_an_error() {
+    let core = FakeRoonCore::start().await;
+    let adapter = connected(&core).await;
+
+    let results = adapter
+        .search("no such album anywhere", None, Some(10), SearchSource::Library)
+        .await
+        .expect("an empty result set is not an error");
+    assert!(results.is_empty());
+
+    // list.count == 0 short-circuits before the final load, so only three loads
+    // happen for a hit and two for a miss.
+    assert_eq!(core.load_requests().await.len(), 2);
+
+    core.stop().await;
+}
+
+// =============================================================================
+// Browse and load across levels, including pop_all
+// =============================================================================
+
+#[tokio::test]
+async fn browse_walks_two_levels_and_pop_all_returns_to_the_root() {
+    let core = FakeRoonCore::start().await;
+    let adapter = connected(&core).await;
+    let session = "browse_test_session";
+
+    // Level 0: the browse root.
+    let root = adapter.browse(browse_root(session)).await.expect("root browse");
+    let root_list = root.list.expect("root browse should carry a list");
+    assert_eq!(root_list.level, 0);
+    assert_eq!(root_list.count, 4);
+
+    let root_items = adapter.load(load_all(session)).await.expect("root load");
+    let titles: Vec<&str> = root_items.items.iter().map(|i| i.title.as_str()).collect();
+    assert_eq!(titles, vec!["Library", "TIDAL", "Qobuz", "Settings"]);
+    // A row a real Core presents as non-navigable has no key, and the adapter
+    // must cope with that rather than assume every row is enterable.
+    assert!(root_items.items[3].item_key.is_none());
+
+    let library_key = root_items.items[0].item_key.clone().expect("Library key");
+
+    // Level 1: inside Library.
+    let library = adapter
+        .browse(browse_at(session, Some(&library_key)))
+        .await
+        .expect("browse into Library");
+    let library_list = library.list.expect("list");
+    assert_eq!(library_list.title, "Library");
+    assert_eq!(library_list.level, 1);
+
+    let library_items = adapter.load(load_all(session)).await.expect("library load");
+    let titles: Vec<&str> = library_items
+        .items
+        .iter()
+        .map(|i| i.title.as_str())
+        .collect();
+    assert_eq!(titles, vec!["Search", "Artists", "Albums"]);
+    // The Search row advertises that it takes input; that is how a client knows
+    // to send `input` rather than just entering it.
+    assert_eq!(
+        library_items.items[0]
+            .input_prompt
+            .as_ref()
+            .map(|p| p.prompt.as_str()),
+        Some("Search")
+    );
+
+    // Level 2: inside Library > Albums.
+    let albums_key = library_items.items[2].item_key.clone().expect("Albums key");
+    let albums = adapter
+        .browse(browse_at(session, Some(&albums_key)))
+        .await
+        .expect("browse into Albums");
+    assert_eq!(albums.list.expect("list").level, 2);
+    assert_eq!(
+        core.session_levels(session).await,
+        vec!["Explore", "Library", "Albums"]
+    );
+
+    // pop_all discards every level but the root — the thing #399's back/pop
+    // contract rests on.
+    let back = adapter.browse(browse_root(session)).await.expect("pop_all");
+    assert_eq!(back.list.expect("list").level, 0);
+    assert_eq!(core.session_levels(session).await, vec!["Explore"]);
+
+    core.assert_no_unhandled_requests().await;
+    core.stop().await;
+}
+
+#[tokio::test]
+async fn browse_sessions_are_independent() {
+    let core = FakeRoonCore::start().await;
+    let adapter = connected(&core).await;
+
+    adapter.browse(browse_root("session_a")).await.unwrap();
+    adapter.browse(browse_root("session_b")).await.unwrap();
+    let root = adapter.load(load_all("session_a")).await.unwrap();
+    let library_key = root.items[0].item_key.clone().unwrap();
+
+    adapter
+        .browse(browse_at("session_a", Some(&library_key)))
+        .await
+        .unwrap();
+
+    // Descending in one session must not move the other; this is the collision
+    // the adapter's `multi_session_key` requirement exists to prevent.
+    assert_eq!(
+        core.session_levels("session_a").await,
+        vec!["Explore", "Library"]
+    );
+    assert_eq!(core.session_levels("session_b").await, vec!["Explore"]);
+
+    core.stop().await;
+}
+
+#[tokio::test]
+async fn load_pages_within_a_level_and_reports_the_total() {
+    let core = FakeRoonCore::start().await;
+    let adapter = connected(&core).await;
+    let session = "paging_session";
+
+    adapter.browse(browse_root(session)).await.unwrap();
+    let root = adapter.load(load_all(session)).await.unwrap();
+    let library_key = root.items[0].item_key.clone().unwrap();
+    adapter
+        .browse(browse_at(session, Some(&library_key)))
+        .await
+        .unwrap();
+    let library = adapter.load(load_all(session)).await.unwrap();
+    let artists_key = library.items[1].item_key.clone().unwrap();
+    adapter
+        .browse(browse_at(session, Some(&artists_key)))
+        .await
+        .unwrap();
+
+    // 25 artists, requested ten at a time.
+    let first = adapter
+        .load(LoadOpts {
+            multi_session_key: Some(session.to_string()),
+            count: Some(10),
+            offset: 0,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(first.items.len(), 10);
+    assert_eq!(first.offset, 0);
+    assert_eq!(first.list.count, 25, "total count, not page size");
+    assert_eq!(first.items[0].title, "Artist 01");
+
+    let third = adapter
+        .load(LoadOpts {
+            multi_session_key: Some(session.to_string()),
+            count: Some(10),
+            offset: 20,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(third.items.len(), 5, "last page is short, not padded");
+    assert_eq!(third.offset, 20);
+    assert_eq!(third.items[0].title, "Artist 21");
+    assert_eq!(third.list.count, 25);
+
+    // Off the end is empty, not an error and not a wrap-around.
+    let past_end = adapter
+        .load(LoadOpts {
+            multi_session_key: Some(session.to_string()),
+            count: Some(10),
+            offset: 99,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert!(past_end.items.is_empty());
+
+    core.stop().await;
+}
+
+#[tokio::test]
+async fn load_without_a_browse_is_refused_not_answered_with_stale_items() {
+    let core = FakeRoonCore::start().await;
+    let adapter = connected(&core).await;
+
+    // The fake answers InvalidLevels. Today the adapter's catch-all drops that,
+    // so the caller waits out BROWSE_TIMEOUT; #405 covers the routing fix. What
+    // this test pins is that the *Core* refused, which is visible in its
+    // response log even though the adapter cannot see it yet.
+    let pending = tokio::time::timeout(
+        Duration::from_millis(750),
+        adapter.load(load_all("never_browsed")),
+    )
+    .await;
+    assert!(
+        pending.is_err(),
+        "expected the load to still be pending: today's adapter drops Parsed::Error"
+    );
+    assert!(
+        core.response_names().await.contains(&"InvalidLevels".to_string()),
+        "the fake Core must have refused: {:?}",
+        core.response_names().await
+    );
+
+    core.stop().await;
+}
+
+// =============================================================================
+// play_item and search_and_play resolve to a playable action
+// =============================================================================
+
+#[tokio::test]
+async fn play_item_resolves_an_item_key_to_a_play_action() {
+    let core = FakeRoonCore::start().await;
+    let adapter = connected(&core).await;
+
+    // A client's real flow: search, hold the key, play it.
+    let results = adapter
+        .search("kind of blue", None, Some(10), SearchSource::Library)
+        .await
+        .unwrap();
+    let key = results[0].item_key.clone().unwrap();
+
+    let message = adapter
+        .play_item(&key, "roon:zone_fake_1", PlayAction::Play)
+        .await
+        .expect("play_item should resolve to a playable action");
+
+    // Recorded behaviour, not desired behaviour: the message names the action
+    // container ("Play Album") rather than the album, because `play_item` takes
+    // its title from the playable item it lands on
+    // (src/adapters/roon.rs:1140-1147). Cosmetic, and filed separately rather
+    // than fixed here — this issue builds the instrument.
+    assert_eq!(message, "Play Now: Play Album");
+
+    // The load-bearing assertion: the Core was actually asked to invoke Play Now,
+    // reached by entering the album and then its action list.
+    let walked = core.browsed_titles().await;
+    assert_eq!(
+        walked,
+        vec!["Library", "Search", "Kind of Blue", "Play Album", "Play Now"],
+        "play_item should enter the item, find its action list, and invoke Play Now"
+    );
+
+    // The zone id reached the Core with the "roon:" prefix stripped.
+    let browses = core.browse_requests().await;
+    let zone_ids: Vec<Option<String>> = browses
+        .iter()
+        .map(|r| {
+            r.body
+                .get("zone_or_output_id")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string)
+        })
+        .collect();
+    assert!(zone_ids.contains(&Some("zone_fake_1".to_string())));
+    assert!(!zone_ids.contains(&Some("roon:zone_fake_1".to_string())));
+
+    core.assert_no_unhandled_requests().await;
+    core.stop().await;
+}
+
+#[tokio::test]
+async fn play_item_mints_a_session_key_unrelated_to_the_one_that_minted_the_key() {
+    // This is the empirical unknown #405 must settle against the operator's rig:
+    // `play_item` browses a caller's item_key inside a *fresh* session, so the
+    // repo already assumes keys are portable across `multi_session_key`s. The
+    // fake defaults to ItemKeyScope::Global, i.e. it assumes the same thing —
+    // so this test documents the assumption, it does not verify it.
+    let core = FakeRoonCore::start().await;
+    let adapter = connected(&core).await;
+
+    let results = adapter
+        .search("kind of blue", None, Some(10), SearchSource::Library)
+        .await
+        .unwrap();
+    let key = results[0].item_key.clone().unwrap();
+
+    adapter
+        .play_item(&key, "roon:zone_fake_1", PlayAction::Play)
+        .await
+        .unwrap();
+
+    let sessions = core.session_keys().await;
+    assert_eq!(sessions.len(), 2, "search and play_item use separate sessions");
+    assert!(sessions[0].starts_with("search_"));
+    assert!(sessions[1].starts_with("play_item_"));
+}
+
+#[tokio::test]
+async fn a_foreign_item_key_is_rejected_when_keys_are_session_scoped() {
+    // Flip the unverified assumption and the failure is instant and specific:
+    // the Core answers InvalidItemKey. If the operator's rig says Roon keys are
+    // session-scoped, `/roon/play_item` is broken and this is the shape of the
+    // break.
+    let core = FakeRoonCore::start().await;
+    let adapter = connected(&core).await;
+
+    let results = adapter
+        .search("kind of blue", None, Some(10), SearchSource::Library)
+        .await
+        .unwrap();
+    let key = results[0].item_key.clone().unwrap();
+
+    core.set_item_key_scope(ItemKeyScope::PerSession).await;
+
+    let outcome = tokio::time::timeout(
+        Duration::from_millis(750),
+        adapter.play_item(&key, "roon:zone_fake_1", PlayAction::Play),
+    )
+    .await;
+    assert!(
+        outcome.is_err(),
+        "today a rejected key hangs until BROWSE_TIMEOUT rather than failing fast"
+    );
+    assert!(
+        core.response_names()
+            .await
+            .contains(&"InvalidItemKey".to_string()),
+        "the Core should have rejected the foreign key"
+    );
+
+    core.stop().await;
+}
+
+#[tokio::test]
+async fn search_and_play_navigates_into_a_result_to_find_a_playable_action() {
+    let core = FakeRoonCore::start().await;
+    let adapter = connected(&core).await;
+
+    let message = adapter
+        .search_and_play(
+            "kind of blue",
+            "roon:zone_fake_1",
+            SearchSource::Library,
+            PlayAction::Play,
+        )
+        .await
+        .expect("search_and_play should find a playable action");
+    assert_eq!(message, "Play Now: Kind of Blue");
+
+    assert_eq!(
+        core.browsed_titles().await,
+        vec!["Library", "Search", "Kind of Blue", "Play Album", "Play Now"],
+        "search_and_play should navigate into the hit before invoking an action"
+    );
+
+    let sessions = core.session_keys().await;
+    assert_eq!(sessions.len(), 1);
+    assert!(sessions[0].starts_with("play_"));
+
+    core.assert_no_unhandled_requests().await;
+    core.stop().await;
+}
+
+#[tokio::test]
+async fn queue_and_radio_invoke_different_actions_than_play() {
+    let core = FakeRoonCore::start().await;
+    let adapter = connected(&core).await;
+
+    let queued = adapter
+        .search_and_play(
+            "kind of blue",
+            "roon:zone_fake_1",
+            SearchSource::Library,
+            PlayAction::Queue,
+        )
+        .await
+        .unwrap();
+    assert_eq!(queued, "Queue: Kind of Blue");
+
+    let invoked = core.browsed_titles().await;
+    assert!(invoked.contains(&"Queue".to_string()), "got {invoked:?}");
+    assert!(
+        !invoked.contains(&"Play Now".to_string()),
+        "action='queue' must not invoke Play Now: {invoked:?}"
+    );
+
+    core.stop().await;
+}
+
+#[tokio::test]
+async fn an_action_the_core_does_not_offer_is_reported_with_what_is_available() {
+    // A library whose album page offers only Play Now: asking to queue must fail
+    // with a message that lists the real options, because that text is what a
+    // caller (and an AI client) reads to recover.
+    let mut library = FakeLibrary::standard();
+    library.search_results.insert(
+        "Library".to_string(),
+        vec![FakeItem::list("Solo Album")
+            .with_subtitle("Some Artist")
+            .with_children(vec![FakeItem::action_list("Play Album")
+                .with_children(vec![FakeItem::action("Play Now")])])],
+    );
+
+    let core = FakeRoonCore::start_with(library).await;
+    let adapter = connected(&core).await;
+
+    let error = adapter
+        .search_and_play(
+            "solo",
+            "roon:zone_fake_1",
+            SearchSource::Library,
+            PlayAction::Radio,
+        )
+        .await
+        .expect_err("Start Radio is not offered");
+    let text = error.to_string();
+    assert!(text.contains("Start Radio"), "got {text}");
+    assert!(text.contains("Play Now"), "should list what is available: {text}");
+
+    core.stop().await;
+}
+
+// =============================================================================
+// On-demand Parsed::Error(BrowseInvalidItemKey) — what #405 needs
+// =============================================================================
+
+/// The fake emits `InvalidItemKey` on demand and the fork turns it into
+/// `Parsed::Error(RoonApiError::BrowseInvalidItemKey((req_id, session_key)))`.
+///
+/// **This test pins a defect.** `src/adapters/roon.rs`'s event-loop catch-all
+/// (`_ => {}`) discards `Parsed::Error`, so the pending oneshot is never resolved
+/// and the caller waits out the 10s `BROWSE_TIMEOUT`. The assertions below say
+/// "still pending after 750ms" and "the Core did reply" — together they prove the
+/// error was delivered and dropped, which no test could show before.
+///
+/// When #405 lands, invert this: the browse should return a typed, recoverable
+/// error promptly. Do not delete the test; change the assertion.
+#[tokio::test]
+async fn browse_error_is_delivered_but_the_adapter_drops_it() {
+    let core = FakeRoonCore::start().await;
+    let adapter = connected(&core).await;
+
+    let session = "error_session";
+    adapter.browse(browse_root(session)).await.unwrap();
+    let root = adapter.load(load_all(session)).await.unwrap();
+    let library_key = root.items[0].item_key.clone().unwrap();
+
+    core.reject_item_key(&library_key).await;
+
+    let started = Instant::now();
+    let pending = tokio::time::timeout(
+        Duration::from_millis(750),
+        adapter.browse(browse_at(session, Some(&library_key))),
+    )
+    .await;
+
+    assert!(
+        pending.is_err(),
+        "TODAY: a Core-rejected item key hangs until BROWSE_TIMEOUT (10s). \
+         When #405 routes Parsed::Error, flip this to assert a prompt typed error."
+    );
+    assert!(started.elapsed() < Duration::from_secs(2));
+
+    // The Core answered immediately, and named the error. So the 10s the caller
+    // waits is entirely UHC's, not Roon's.
+    assert!(
+        core.response_names()
+            .await
+            .contains(&"InvalidItemKey".to_string()),
+        "the fake must have emitted InvalidItemKey: {:?}",
+        core.response_names().await
+    );
+
+    core.stop().await;
+}
+
+/// #405's acceptance criterion: "a test with several in-flight browse/load
+/// requests, where one is rejected, proves the right waiter is resolved and the
+/// others complete normally."
+///
+/// The instrument for that is here. The rejected waiter's *current* fate is a
+/// hang, and that is what is asserted — but the two healthy requests are proven
+/// to complete, in their own sessions, while the rejected one is outstanding.
+/// The pending maps are keyed by `req_id` and scanned by session key
+/// (`src/adapters/roon.rs`), so a correlation bug in #405's error arm would show
+/// up here as a healthy browse resolving with the wrong list, or not at all.
+#[tokio::test]
+async fn concurrent_browses_one_rejected_leaves_the_rejected_caller_hanging() {
+    let core = FakeRoonCore::start().await;
+    let adapter = connected(&core).await;
+
+    // Prime three independent sessions and learn two distinct keys.
+    for session in ["c_a", "c_b", "c_bad"] {
+        adapter.browse(browse_root(session)).await.unwrap();
+    }
+    let root = adapter.load(load_all("c_a")).await.unwrap();
+    let library_key = root.items[0].item_key.clone().unwrap();
+    let tidal_key = root.items[1].item_key.clone().unwrap();
+
+    core.reject_item_key(&tidal_key).await;
+    // Hold every response back so all three browses really are in flight, and
+    // make the rejected one answer *first* so the error cannot be mistaken for
+    // "whatever arrived last".
+    core.set_delay(Duration::from_millis(300)).await;
+    core.set_delay_for_item_key(&tidal_key, Duration::from_millis(50))
+        .await;
+
+    let a = adapter.browse(browse_at("c_a", Some(&library_key)));
+    let b = adapter.browse(browse_at("c_b", Some(&library_key)));
+    let bad = tokio::time::timeout(
+        Duration::from_millis(1_500),
+        adapter.browse(browse_at("c_bad", Some(&tidal_key))),
+    );
+
+    let (a, b, bad) = tokio::join!(a, b, bad);
+
+    // The healthy requests resolved, each with its own level, unaffected by the
+    // rejection that landed between them.
+    assert_eq!(a.expect("session c_a").list.expect("list").title, "Library");
+    assert_eq!(b.expect("session c_b").list.expect("list").title, "Library");
+    assert_eq!(core.session_levels("c_a").await, vec!["Explore", "Library"]);
+    assert_eq!(core.session_levels("c_b").await, vec!["Explore", "Library"]);
+    assert_eq!(
+        core.session_levels("c_bad").await,
+        vec!["Explore"],
+        "the rejected browse must not have advanced its session"
+    );
+
+    assert!(
+        bad.is_err(),
+        "TODAY: the rejected browse hangs. #405 must make this a prompt typed \
+         error while leaving the other two exactly as asserted above."
+    );
+
+    let names = core.response_names().await;
+    assert_eq!(
+        names.iter().filter(|n| *n == "InvalidItemKey").count(),
+        1,
+        "exactly one request should have been rejected: {names:?}"
+    );
+
+    core.stop().await;
+}
+
+// =============================================================================
+// Drift guard
+// =============================================================================
+
+/// The fake answers `InvalidRequest` to anything it does not model and records it,
+/// so an adapter that grows a new Roon call fails a test instead of hanging for
+/// ten seconds. This is the `MockHqpServer` lesson from #394: a mock that quietly
+/// mismatches its adapter reads as coverage.
+#[tokio::test]
+async fn the_fake_models_everything_the_adapter_sends() {
+    let core = FakeRoonCore::start().await;
+    let adapter = connected(&core).await;
+
+    adapter
+        .search("kind of blue", None, Some(10), SearchSource::Library)
+        .await
+        .unwrap();
+    adapter
+        .search_and_play(
+            "blue train",
+            "roon:zone_fake_1",
+            SearchSource::Library,
+            PlayAction::Play,
+        )
+        .await
+        .unwrap();
+    let session = "drift";
+    adapter.browse(browse_root(session)).await.unwrap();
+    adapter.load(load_all(session)).await.unwrap();
+
+    core.assert_no_unhandled_requests().await;
+
+    // And the set of request names is closed: exactly these, nothing else.
+    let mut names: Vec<String> = core
+        .requests()
+        .await
+        .iter()
+        .map(|r| r.name.clone())
+        .collect();
+    names.sort();
+    names.dedup();
+    assert_eq!(
+        names,
+        vec![
+            "com.roonlabs.browse:1/browse",
+            "com.roonlabs.browse:1/load",
+            "com.roonlabs.registry:1/info",
+            "com.roonlabs.registry:1/register",
+            "com.roonlabs.transport:2/subscribe_zones",
+        ],
+        "the adapter's Roon protocol surface changed"
+    );
+
+    core.stop().await;
+}
+
+/// Sanity: `album()` and the `FakeItem` builders compose a tree the adapter can
+/// walk, so a test needing a different library shape can build one without
+/// touching the fake's protocol code.
+#[tokio::test]
+async fn a_custom_library_is_browsable() {
+    let mut library = FakeLibrary::standard();
+    library.root_items = vec![FakeItem::list("Library").with_children(vec![
+        FakeItem::list("Search").searchable("Search"),
+        FakeItem::list("Genres").with_children(vec![
+            FakeItem::list("Jazz").with_hint(Hint::List),
+            FakeItem::list("Ambient"),
+        ]),
+    ])];
+    library
+        .search_results
+        .insert("Library".to_string(), vec![album("Music for Airports", "Brian Eno", &["1/1"])]);
+
+    let core = FakeRoonCore::start_with(library).await;
+    let adapter = connected(&core).await;
+
+    let session = "custom";
+    adapter.browse(browse_root(session)).await.unwrap();
+    let root = adapter.load(load_all(session)).await.unwrap();
+    assert_eq!(root.items.len(), 1);
+    let library_key = root.items[0].item_key.clone().unwrap();
+    adapter
+        .browse(browse_at(session, Some(&library_key)))
+        .await
+        .unwrap();
+    let inner = adapter.load(load_all(session)).await.unwrap();
+    assert_eq!(
+        inner
+            .items
+            .iter()
+            .map(|i| i.title.as_str())
+            .collect::<Vec<_>>(),
+        vec!["Search", "Genres"]
+    );
+
+    let hits = adapter
+        .search("airports", None, Some(10), SearchSource::Library)
+        .await
+        .unwrap();
+    assert_eq!(hits[0].title, "Music for Airports");
+    assert_eq!(hits[0].subtitle.as_deref(), Some("Brian Eno"));
+
+    core.stop().await;
+}
+
+// =============================================================================
+// AppState for the HTTP-boundary test
+// =============================================================================
+
+fn app_state_with(roon: Arc<RoonAdapter>) -> unified_hifi_control::api::AppState {
+    use unified_hifi_control::adapters::hqplayer::{HqpInstanceManager, HqpZoneLinkService};
+    use unified_hifi_control::adapters::lms::LmsAdapter;
+    use unified_hifi_control::adapters::openhome::OpenHomeAdapter;
+    use unified_hifi_control::adapters::upnp::UPnPAdapter;
+    use unified_hifi_control::adapters::Startable;
+    use unified_hifi_control::aggregator::ZoneAggregator;
+    use unified_hifi_control::api::AppState;
+    use unified_hifi_control::coordinator::AdapterCoordinator;
+
+    let bus = create_bus();
+    let hqp_instances = Arc::new(HqpInstanceManager::new(bus.clone()));
+    let hqplayer = futures::executor::block_on(hqp_instances.get_default());
+    let hqp_zone_links = Arc::new(HqpZoneLinkService::new(hqp_instances.clone()));
+    let lms = Arc::new(LmsAdapter::new(bus.clone()));
+    let openhome = Arc::new(OpenHomeAdapter::new(bus.clone()));
+    let upnp = Arc::new(UPnPAdapter::new(bus.clone()));
+    let startable: Vec<Arc<dyn Startable>> = vec![roon.clone()];
+
+    AppState::new(
+        roon,
+        hqplayer,
+        hqp_instances,
+        hqp_zone_links,
+        lms,
+        openhome,
+        upnp,
+        KnobStore::new(),
+        bus.clone(),
+        Arc::new(ZoneAggregator::new(bus.clone())),
+        Arc::new(AdapterCoordinator::new(bus)),
+        startable,
+        Instant::now(),
+        tokio_util::sync::CancellationToken::new(),
+    )
+}

--- a/tests/roon_protocol.rs
+++ b/tests/roon_protocol.rs
@@ -1113,12 +1113,19 @@ async fn concurrent_browses_with_one_rejected_do_not_disturb_the_others() {
 /// differently, the caller times out exactly as it did before #405 — and every
 /// test in this file stays green, because this fake sends the fork's own literals.
 ///
-/// **No live Core was reachable, so whether Roon really uses these four spellings
-/// is unverified.** This test pins the *consequence* of being wrong rather than
-/// pretending to have checked: with an unrecognised name, the Core answered
-/// instantly and the caller still waits out `BROWSE_TIMEOUT`.
+/// Corroboration, chased rather than assumed: `InvalidItemKey` **is** real, recorded
+/// verbatim off Roon Cores as `MOO/1 COMPLETE InvalidItemKey`
+/// (`home-assistant/core#137605`). `InvalidLevels`, `UnexpectedError` and
+/// `ZoneNotFound` are **not** corroborated anywhere — RoonLabs' published browse API
+/// documents errors only as "an error code or false if no error", and none of the
+/// three appears in `node-roon-api`.
 ///
-/// If someone reaches a real Core: confirm the four names below, and if any differs,
+/// So this test pins the *consequence* of being wrong rather than pretending to have
+/// checked: with an unrecognised name the Core answers instantly and the caller still
+/// waits out `BROWSE_TIMEOUT`. It passes with #405 applied too — routing the error
+/// does not help when the fork never recognises it.
+///
+/// If someone reaches a real Core: confirm the other three names, and if any differs,
 /// this is the failure you will be looking at.
 #[tokio::test]
 async fn an_unrecognised_error_name_degrades_to_an_indistinguishable_timeout() {


### PR DESCRIPTION
Fixes #408

Parent epic: #392. OH: 80222d6d

`MockRoonCore` is not a server. **`FakeRoonCore` is.** It speaks Roon's MOO protocol over a real WebSocket, so `RoonAdapter` can be driven end to end without a Core, a network, or multicast — and for the first time a test asserts a Roon *success* path.

**Do not merge** — awaiting operator approval per AGENTS.md and #392. No labels added, no force-push.

---

## CI is a real gate on this PR

An earlier draft of this section said feature-branch PRs run zero CI. **That was wrong, and it is worth saying why:** the workflow triggers on `pull_request: branches: [master, v3]`, which keys on the PR's **base**, not on the head being a feature branch. This PR targets `v3`, so it gets the full Lint / Test / Build set and a red check is blocking.

The correction cost a real failure: the first push was green on local `cargo clippy -- -D warnings` and still failed CI's **Lint** job on `cargo fmt --check` alone, which clippy does not catch. Both are now run locally before every push.

Consequence for the `/hqp/discover` failures below: they fail on a dev Mac because they do live UDP SSDP, and CI's Test job passes them. So they are a **local-environment artifact**, not pre-existing failures — an earlier draft of this body wrote them off as the latter, which was a second version of the same mistake.

The full gate, now run locally before every push: **Lint** = `cargo fmt --check` + `cargo clippy -- -D warnings`; **Test** = `cargo test --workspace`; `make css` first in both.

Settled on this PR: **Lint pass · Test pass · Plan pass · Build WASM Assets pass · Synology Package Contract pass · CodeRabbit pass.**

## The hole, and the proof it is closed

#394's execute gate found it: *"if the module split had swapped `title` and `subtitle` in Roon's search mapping, none of its 48 contract tests would have noticed."* #396's design gate hit the same wall from the other side — no browse mock, so it could not state an honest Roon test strategy.

There are **four** structurally identical `item.title -> title, item.subtitle -> subtitle` projections in this repo. Three are now covered with asymmetric values, and each was verified to fail when swapped.

### 1. `SearchResultItem::from` — `src/api/mod.rs:402`

```
$ # title: item.subtitle.clone().unwrap_or_default(),  subtitle: Some(item.title),
$ cargo test --test roon_protocol search_results_survive
test search_results_survive_the_http_boundary ... FAILED

thread 'search_results_survive_the_http_boundary' panicked at tests/roon_protocol.rs:263:5:
assertion `left == right` failed
  left: String("Miles Davis")
 right: "Kind of Blue"
```

### 2. `BrowseItemResponse` in `roon_browse_handler` — `src/api/mod.rs:681`

```
$ # same swap
$ cargo test --test roon_protocol browse_items_survive
test browse_items_survive_the_http_boundary ... FAILED

thread 'browse_items_survive_the_http_boundary' panicked at tests/roon_protocol.rs:322:5:
assertion `left == right` failed
  left: String("")
 right: "Library"
```

### 3. The adapter's own navigation — `src/adapters/roon.rs:766`

Not a field swap but the same class of silent-wrong-data bug: a refactor that returns the wrong browse level. `search()` changed to return `source_items.items` instead of `load_result.items`:

```
$ cargo test --test roon_protocol search_maps_title
test search_maps_title_and_subtitle_without_swapping_them ... FAILED

thread 'search_maps_title_and_subtitle_without_swapping_them' panicked at tests/roon_protocol.rs:192:5:
assertion `left == right` failed: expected exactly one match
  left: 3
 right: 1
```

All three reverted; `git diff` clean; 46/46 green again.

### 4. `McpSearchResult` — `src/mcp/mod.rs:483` — **deliberately not covered**

#394 (PR #404) is rewriting all of `src/mcp/` and owns `tests/mcp_contract.rs`. Covering it here would either duplicate that harness or conflict with it. With this fake merged, the assertion is a few lines in #394's harness: start a `FakeRoonCore`, point the harness's existing `AppState` at an adapter connected to it, and assert `hifi_search`'s Roon branch returns `title: "Kind of Blue"`, `subtitle: "Miles Davis"`.

Stated as a gap rather than papered over. It is the only one of the four still uncovered, and every layer beneath it is now covered — so that one `.map()` is the sole remaining place this bug can hide.

## What the fake covers

`tests/mock_servers/roon_core.rs` (1337 lines), `tests/roon_protocol.rs` (25 tests), plus 6 unit tests in the fake and the pre-existing mock self-tests — 49 in the binary, **1.7s**.

| Area | Asserted |
|---|---|
| Handshake | `registry:1/info` at request id 0 → `register` → `CoreEvent::Registered`; Browse becomes available; the pairing token is persisted — and the test proves it landed in a temp dir, not the operator's config |
| Zones | a `Subscribed` payload survives the fork's deserializer and reaches `get_zones()` with volume intact |
| Search | the full six-request sequence; **one** `search_{nanos}` session key throughout; query carried as `input`; `hierarchy=browse` on every request; Library/TIDAL/Qobuz select different branches; empty results are not an error |
| **title/subtitle** | asymmetric values at three layers (above) |
| Browse | two levels down and `pop_all` back to the root, asserted against the Core's own level stack; sessions proven independent; `input_prompt` advertised; unkeyed rows |
| Load | offset/count paging, short final page, total count vs page size, past-the-end empty |
| `play_item` | an `item_key` resolves through the item's action list to `Play Now`; the exact walk is pinned (`Library → Search → Kind of Blue → Play Album → Play Now`); the `roon:` prefix is stripped before it reaches the Core |
| `search_and_play` | navigates into a hit to find a playable action; `play`/`queue` invoke different actions; a missing action reports what *is* available |
| **Errors on demand** | `InvalidItemKey` and `InvalidLevels`, correlated to the right request id and session key, including with three requests in flight and responses arriving out of order |
| Drift | the set of request names the adapter sends is closed; anything else is answered `InvalidRequest` and fails an assertion |

## What it deliberately does NOT cover

Written up in full in `tests/mock_servers/README.md` so the next agent does not over-trust it. The load-bearing entries:

- **It cannot prove the adapter matches a real Roon Core.** The fake's semantics came from the pinned fork's deserializers and from this repo's own adapter — the same source of truth the adapter was written against, and one that has never itself been checked against Roon. **Green means "unchanged", not "correct."**
- **Category-grouped search results.** A real Core groups hits under `Albums`/`Tracks`/`Artists` rows. The default library returns them flat, so `is_category`, `try_category_playable` and the second half of `try_navigate_to_playable` are **untested**. `FakeLibrary` and the `FakeItem` builders are public so a test can build a grouped library — but nobody has verified what the real grouping looks like, so the fake ships no guess.
- **Transport control, images, queue** (`subscribe_queue` / `play_from_here`, which #400 needs), **zone updates over time** (`Changed`, `zones_added`, seek), **reconnection / Core loss**, **the unauthorized-extension state**.
- **Roon's real error bodies.** The fake sends error names with no body.

## Which shapes are recorded, which are documented, and which are still guesses

**No live Roon Core was reachable**, so nothing here was recorded off a Core by this work:

```
$ ls ~/Library/Application\ Support/unified-hifi-control/unified-hifi/
hqp-config.json   knobs.json   lms-config.json          # no roon_state.json
```

No pairing token exists on this machine, and getting one needs a human in Roon's UI.

That is where an earlier draft of this PR stopped, and stopping there was the weak point. **#407 found a real client-visible bug precisely because it recorded a response instead of hand-writing what it expected** — a mock that agrees with a wrong premise is the exact failure #408 exists to end. So the uncertain shapes were chased into published sources rather than left as author-flavoured guesses. Six of them moved out of INFERRED.

### Documented by RoonLabs themselves

From `RoonLabs/node-roon-api-browse` and `RoonLabs/node-roon-api`, quoted at the use sites:

| Shape | RoonLabs' words | Was |
|---|---|---|
| `list.level` | **"increases from 0"** | INFERRED |
| `action` | `message`, `none` ("No action is required"), `list`, `replace_item`, `remove_item` | INFERRED |
| `hint` | `null` ("Unknown"), `action`, `action_list`, `list`, `header` — exactly the fork's five | fork-only |
| `input_prompt` | `prompt`, `action` ("The verb that goes with this action"), `value`, `is_password` | fork-only |
| `InvalidRequest` + `error` string | what `node-roon-api` itself sends for "unknown service" / "unknown request name" | fork-only |

`list.level` mattered: #399's "every browse page reports its position" rests on it, and it is now documented rather than assumed.

### Recorded off real Cores — by third parties, not by me

| Observation | Source |
|---|---|
| `MOO/1 COMPLETE InvalidItemKey` **verbatim** — `Could not play id:122:4, result: MOO/1 COMPLETE InvalidItemKey` (also `130:12`, `133:13`, `109:7`, `135:5`) | `home-assistant/core#137605` |
| real `item_key`s are two colon-separated integers that **"change with each refresh"** — `"115:0"` → `"116:0"` | Roon Labs community thread 23129 |

The first confirms both the error name **and** that the reply is verb-and-name with no body — which is exactly the frame this fake sends. The second confirms the key shape the fake mints. These are real Cores, but other people's logs rather than a controlled run, and they are labelled that way.

### Still guesses, and now with a source saying so

| Shape | Consequence if wrong |
|---|---|
| root list title `"Explore"` | none — never read |
| a real Core sends *no body* with an error | none for the fork; a real body parsing as a `BrowseResult` would read as success |
| `action: "none"` is what a Core picks for an invoked action | none today — the adapter discards it |
| **`InvalidLevels` / `UnexpectedError` / `ZoneNotFound` spellings** | **dropped inside the dependency; caller times out as if the Core were unreachable, every test here still green** |
| search results flat rather than category-grouped | `is_category` / `try_category_playable` untested |
| **`item_key` portability across `multi_session_key`s** | see below — this one now has contrary evidence |

**Only `InvalidItemKey` of the fork's four names is corroborated.** RoonLabs' published browse API documents errors solely as "an error code or false if no error" and never enumerates them; the other three appear nowhere in `node-roon-api`. A community thread shows the prose "Zone not found", which is not evidence of a wire spelling. **#408 does not close the verification #412 assigned it — it narrows it from four unknowns to three and pins the consequence.**

### The epic's `item_key` question: third-party evidence points against the repo's assumption

`RoonAdapter::play_item` mints a *fresh, unrelated* session key and browses the caller's key inside it, so the repo assumes keys are portable across sessions. Two recorded observations point the other way:

* `home-assistant/core#137605` — playing a Roon playlist from a script "works successfully on the first attempt but fails on the second", with `MOO/1 COMPLETE InvalidItemKey`. **That is the same shape as UHC's `play_item`:** hold a key from an earlier lookup, browse it later.
* Community 23129 — item keys "change with each refresh".

That is `ItemKeyScope::PerSession` behaviour. **Not proof** — Home Assistant is not UHC and neither source states the rule — but it is enough that **#396 should not design on the assumption keys are portable**, and enough that `/roon/play_item` should be assumed broken until the operator's rig says otherwise. This is the epic's empirical unknown #1, and it now has evidence rather than only a question mark.

The fake's default stays `ItemKeyScope::Global` because that is what the adapter's code assumes and these tests describe the adapter. The default is explicitly not a claim about Roon, and `a_foreign_item_key_is_rejected_when_keys_are_session_scoped` exercises the other setting.

## Production-code change — one commit, review it as a behaviour change

`707833e`, `src/adapters/roon.rs`, +79/−9, three hunks:

1. `CoreConnect { Discovery, Direct { ip, port } }` — a private enum.
2. `run_roon_loop` takes it; `AdapterLogic::run` passes `Discovery` and the discovery call is otherwise unchanged.
3. `#[doc(hidden)] pub async fn run_event_loop_against_core_for_tests(ip, port)` — no production callers.

**None of it touches the `Parsed::` match arms at `:1860-1915`**, which is what #405 modifies. The hunks are at `:334`, `:1344` and `:1504-1600`. Conflict risk with #405 is a context-line rename at most; if #405 lands first I will rebase.

Why a seam at all: the whole value of the fake is that it drives the **real** event loop and its pending-request correlation maps. A test that stood up its own loop would assert nothing about `roon.rs` — precisely the failure mode that makes mocks dangerous. Rejected alternative: have the fake answer SOOD so no seam is needed. SOOD is UDP multicast, process-global, and already the cause of this repo's two flaky `/hqp/discover` tests.

## Dependency added

`tokio-tungstenite = "0.21"` under `[dev-dependencies]` — the exact version `roon-api` already uses, so the fake and the real client library share one framing implementation. **No new crate enters the tree:**

```
$ git diff v3 -- Cargo.lock
+  "tokio-tungstenite 0.21.0",     # one line, in this package's own dep list
```

## This is #405 / PR #412's end-to-end proof, and it was verified as such

#412's own correlation tests are unit-scoped *precisely* because nothing could drive the wire path. An earlier draft of this PR pinned the pre-#405 hang; that was the wrong instrument, because it would have turned red the moment the defect was fixed.

Four tests drive a Core rejection — bad item key, foreign key under `ItemKeyScope::PerSession`, load with no browse, and one rejection among three concurrent browses. None asserts "it hangs". `classify_rejection()` enforces what must hold on either base:

* a rejected request **never** resolves as success;
* if it resolves at all, it resolves promptly, its message does not read as a timeout, and it names the browse session.

…and reports which adapter it saw. **Verified both ways — same file, same assertions, both green:**

```
$ # on v3 (c47d36a), #405 not present
load without a browse: DroppedByAdapter
rejected browse: DroppedByAdapter
rejected browse among three in flight: DroppedByAdapter
play_item against a foreign key: DroppedByAdapter
test result: ok. 49 passed

$ git merge origin/fix/issue-405-roon-browse-errors      # local, throwaway branch
$ cargo test --test roon_protocol -- --nocapture
load without a browse: RoutedToCaller
rejected browse: RoutedToCaller
rejected browse among three in flight: RoutedToCaller
play_item against a foreign key: RoutedToCaller
test result: ok. 49 passed
$ cargo test --lib && cargo clippy -- -D warnings && cargo fmt --check
100 passed; clippy clean; fmt clean
```

So the fake genuinely drives #412's `Parsed::Error` arm, and this suite needs no inversion on merge.

Pinned unconditionally, on both bases: the Core answered, named the error, and correlated it to the rejected request's own `req_id` **and** session key — exactly the `Parsed::Error(BrowseInvalidItemKey((req_id, multi_session_key)))` payload. `FakeRoonCore::errors_sent()` records refusals as that triple.

**Base stays `v3`, deliberately.** Rebasing onto `fix/issue-405-roon-browse-errors` would make the PR's base a non-`v3` branch, and CI keys on the base — I would lose the entire Lint/Test/Build set. A suite that is correct on both bases is strictly better than one that trades CI for a tighter type assertion. When #412 is on `v3`, tighten `classify_rejection`'s `Ok(Err(_))` arm to `RoonBrowseError::from_error(&e)` and assert `kind == InvalidItemKey` directly; the string checks are the strongest assertions expressible without that type.

## The gap #412 handed to this issue, and what I could and could not do about it

#412's module comment says it plainly:

> `Browse::parse_msg` matches four literal error names against `msg["name"]` (fork `src/browse.rs:174-188`). A Core that spells one differently yields `Parsed::None`, which the fork drops, and the caller times out as it did before — with this module's tests still green. That half is wire-level and is #408's to pin.

**I cannot pin it, and neither can any fake.** This fake sends the fork's own literals, so it agrees with the fork by construction. Verifying `"InvalidItemKey"` / `"InvalidLevels"` / `"UnexpectedError"` / `"ZoneNotFound"` against a real Core is the only way, and no Core was reachable.

What I did instead — pin the *consequence*, so the risk is a test rather than a paragraph:

* `FakeRoonCore::reject_item_key_with_name()` emits an arbitrary error name.
* `an_unrecognised_error_name_degrades_to_an_indistinguishable_timeout` makes the Core answer instantly with `"ItemKeyNoLongerValid"` and asserts the caller still waits out `BROWSE_TIMEOUT`, and that the Core's refusal *was* correlated and logged. It passes on `v3` **and** with #412 merged — the fix does not help when the name is unrecognised.
* `FakeRoonCore::FORK_ERROR_NAMES` plus `the_forks_browse_error_names_are_pinned` make a fork bump that renames one fail here rather than as a mysterious timeout somewhere else.

**Open, needs the operator's rig:** do a real Core's error names match those four literals? If any differs, `an_unrecognised_error_name_degrades_to_an_indistinguishable_timeout` is the failure you will be looking at.

## Designed to fail loudly instead of reading as coverage

The `MockHqpServer` precedent is the whole reason this section exists: it rejected its own adapter's wire format for months and read as coverage. Three defences:

1. **Request log** — tests assert what the adapter *sent*, not only what came back. Same fix #394 applied to `MockLmsServer`.
2. **Response log** — `FakeRoonCore::responses()`, so "the Core never answered" and "the Core answered and the adapter dropped it" are distinguishable.
3. **Closed request set** — anything unmodelled is answered `InvalidRequest`, recorded as unhandled, and `assert_no_unhandled_requests()` fails. `the_fake_models_everything_the_adapter_sends` additionally pins the exact set of five request names, so a new adapter call is a visible edit rather than a silent hang.

And the fake is never validated by a hand-written client — only by the real `roon_api`. If its framing breaks, `roon_core_completes_handshake` fails first.

## Found by the instrument, not fixed here

Per the epic ("anything it finds gets its own issue"):

### 1. Concurrent browses in one session cross-deliver their results — silently

**This one needs its own issue.** Two browses in flight under the same `multi_session_key` hand each caller the *other's* list, with no error. Measured, seven trials in eight:

```
SCRATCH trial 0: asked ["Library", "TIDAL", "Qobuz"] got ["TIDAL", "Qobuz", "Library"]
SCRATCH trial 1: asked ["Library", "TIDAL", "Qobuz"] got ["Library", "TIDAL", "Qobuz"]
SCRATCH trial 2: asked ["Library", "TIDAL", "Qobuz"] got ["Qobuz", "TIDAL", "Library"]
SCRATCH trial 3: asked ["Library", "TIDAL", "Qobuz"] got ["TIDAL", "Library", "Qobuz"]
...
SCRATCH crossed 7/8
```

`pending_browses` is keyed by `req_id`, but the `Parsed::BrowseResult` arm scans by session key — because `Parsed::BrowseResult` carries no `req_id` — and `.find()` returns an arbitrary match. **It survives #405**: #412 fixes the *error* arm's correlation and its own comment says the success arm's gap needs a change to the pinned fork.

Reachability: `search`, `search_and_play` and `play_item` each mint a private key and run sequentially, so they are safe. `POST /roon/browse` takes a **caller-supplied** `session_key` and has no in-repo callers today, so nothing here triggers it — but any external client can, and **#399's navigation handle will hand clients a reusable session identity, which is exactly the shape that triggers it.** Worth resolving before #399 designs around it.

`concurrent_browses_in_one_session_cross_deliver_their_results` asserts the defect is present over eight trials (one trial is right by luck about one time in eight). When it starts failing, the bug is fixed — invert it.

### 2. **`play_item` reports the wrong title.** It returns `"Play Now: Play Album"` — the action container's title, not the album's — because it takes `title` from the playable item it lands on (`src/adapters/roon.rs:1140-1147`). `search_and_play` gets this right (`"Play Now: Kind of Blue"`). Cosmetic, user-visible, recorded in the test rather than corrected.
### 3. **`MockRoonCore` has no callers.** Not "used by a few tests" — none:
   ```
   $ grep -rn "MockRoonCore" tests/ | grep -v tests/mock_servers/roon.rs
   tests/mock_servers/mod.rs:19:pub use roon::MockRoonCore;
   ```
Its only exercisers are its own six unit tests. Left in place; flagged as a removal candidate.

## What I ran locally

```
$ cargo test --test roon_protocol
test result: ok. 49 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.72s

$ cargo clippy -- -D warnings            # CI's Lint job, part 1
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.59s      (exit 0)

$ cargo fmt --check                      # CI's Lint job, part 2 - clippy does not catch this
(no output)

$ make css && cargo test --workspace     # CI's Test job, exactly
... one failure: client_harness shared_endpoints::get_hqp_discover (live UDP SSDP)
    CI's Test job passes it - see the CI note at the top

$ cargo clippy --test roon_protocol      # zero findings in either new file
(only the pre-existing unused-re-export warnings in tests/mock_servers/mod.rs)

$ cargo test --lib
test result: ok. 86 passed; 0 failed

$ make css && dx build --release --platform web --features web
#   rustup toolchain ahead of Homebrew's on PATH, RUSTC_WRAPPER unset
 62.99s  INFO Client build completed successfully! 🚀
189.45s  INFO Server build completed successfully! 🚀
```

Every other test target, run individually — all green, all unchanged:

```
adapter_integration    47      protocol_schema        41
zones_sha_integration  25      volume_safety          14
volume_step             9      architecture_lint       8
arch_packaging          6      await_in_lock_lint      4
ignored_send_lint       4      arbitrary_find_lint     3
release_hardening       3      aggregator_lint         2
api_contract            2      oneshot_leak_lint       1
spawn_cancellation_lint 1      unbounded_channel_lint  1
client_harness         41  (+1 local-only failure)
protocol_integration   32  (+1 local-only failure)
```

The two failures are the `/hqp/discover` ones, which do live UDP SSDP broadcast and fail on a dev Mac. **They are a local-environment artifact, not this branch's and not pre-existing repo breakage** — CI's Test job passes them, including on this PR. Confirmed unrelated to the branch by stashing it and reproducing at `c47d36a`:

```
$ git stash push --include-untracked
$ cargo test --test protocol_integration api_endpoints::hqp_discover_returns_json
test result: FAILED. 0 passed; 1 failed; 32 filtered out
$ cargo test --test client_harness shared_endpoints::get_hqp_discover
test result: FAILED. 0 passed; 1 failed; 41 filtered out
```

Flakiness check, because these are timing- and socket-dependent:

```
$ for i in 1 2 3 4 5; do cargo test --test roon_protocol; done
ok  (1.60s / 1.61s / 1.58s / 1.59s / 1.93s)

$ cargo test --test roon_protocol -- --test-threads=1     # ok, 9.65s
$ cargo test --test roon_protocol -- --test-threads=16    # ok, 1.86s
```

`tests/fixtures/api_routes.txt` untouched — no `api-change-approved` label needed.

## Deliberate calls I made

- **Base stays `v3`, and the rejection tests are written to be correct with or without #405.** Rebasing onto `fix/issue-405-roon-browse-errors` would have let me assert `RoonBrowseError` by type, but the PR's base determines whether CI runs at all — so that trade buys a stronger assertion with the entire Lint/Test/Build gate. Verified against both bases instead.
- **A separate fake, not an extended `MockRoonCore`.** #408 left this open. `MockRoonCore`'s state model is a different shape, it has no callers whose compatibility needs preserving, and conflating "in-memory state holder" with "protocol server" is how the confusion arose. Both now exist side by side, with the README saying which is which.
- **The library is data the test supplies; only the protocol is the fake's.** `FakeLibrary` and `FakeItem` are public builders. This is what keeps the fake from becoming a second implementation of Roon's semantics that can drift from the fork — the constraint #408 named.
- **The unverifiable question is configurable, not decided.** `ItemKeyScope` exists so #405 can pin either answer rather than inheriting my guess.
- **Item keys are minted by the Core and unguessable by the test.** Nonce-scoped, so a test must read keys out of a load result the way a client does. `key_for_title` / `title_for_key` exist for assertions; a test cannot construct a key. A key from one fake instance does not resolve in another, and that is asserted.
- **Errors are injected by key, not by call count.** `reject_item_key` survives concurrency; "fail the Nth call" would not.
- **Per-request tasks and per-key delays.** A real Core pipelines. Serialising responses would make it impossible to have several requests genuinely in flight, which is the only way to test correlation.
- **A 3s keepalive ping.** The fork's reader times out after 10s of silence and the client then reports a lost Core, so without this any test slower than 10s would fail for the wrong reason. The client's built-in Ping service answers it, which exercises the provided-service path for free.
- **Assertions against the Core's own level stack**, not only against adapter return values. `pop_all` is only really tested if you can see the stack it emptied.
- **`UHC_CONFIG_DIR` set once inside a `OnceLock` initializer**, so `set_var` runs exactly once and every later read is ordered after it. And the handshake test asserts the state file landed in the temp dir — if a refactor starts writing to the operator's real config, a test fails.

## Rollback

Self-contained. Nothing outside `src/adapters/roon.rs` (one reviewable commit), two new test files, one README, and a dev-dependency line.

- **Whole branch:** revert `a550674`, `cc74ca0`, `a64b745`, `19bed47`, `707833e`, `e604c0c` — or don't merge. No migration, no config, no persisted state, no HTTP surface, no route changes.
- **Production seam only, keeping the fake:** revert `707833e`. `tests/roon_protocol.rs` then fails to compile, so that is not a useful intermediate state — the fake and its seam belong together.
- **Runtime:** nothing ships. The seam has no production callers and is `#[doc(hidden)]`.

## Residual risk

1. **The fake's semantics are derived from the same repo as the adapter.** This is the ceiling on what any of it proves. It is stated at the top of both new files and in the README, and it cannot be lifted without the operator's Core. If the fork's understanding of Roon is wrong, these tests agree with it confidently.
2. **`#[doc(hidden)] pub` is not enforcement.** Nothing stops production code calling `run_event_loop_against_core_for_tests`. A cargo feature gate would remove the risk but also remove the function from `cargo test` and from `cargo clippy -- -D warnings`, which is worse. An `architecture_lint` rule asserting zero non-test callers would close it properly; follow-up, not this PR.
3. **One test asserts a defect is present** (`concurrent_browses_in_one_session_cross_deliver_their_results`) and is probabilistic — eight trials, each right by luck about one time in eight, so a false failure is around 1 in 10^7. If someone "fixes" it by deleting rather than inverting, the evidence for the cross-delivery bug is lost. Says so at the assertion and in the README.
4. **Three of the four browse error names remain unverified.** `InvalidItemKey` is corroborated off real Cores; `InvalidLevels`, `UnexpectedError` and `ZoneNotFound` are not, and RoonLabs does not publish them. If Roon spells one differently, every rejection test here stays green and real callers still time out. Mitigated only by pinning the consequence.
5. **`std::env::set_var` in a threaded test binary** is correctly ordered for its own reads but still races with unrelated `getenv` from other threads in principle. Unavoidable while `get_roon_state_path()` reads the environment.
6. **The category-grouped search shape is untested and unverified**, so `try_category_playable` remains dead as far as tests are concerned — and a real Core probably exercises it on every search.

## Gate reports

Solution / execute / ship, each with a review and a dissent, in the comments.
