### PR TITLE
fix(upnp): read track metadata from GetPositionInfo, and share DIDL-Lite parsing

### DIFF
--- a/src/adapters/didl.rs
+++ b/src/adapters/didl.rs
@@ -1,0 +1,200 @@
+//! DIDL-Lite metadata parsing, shared by the OpenHome and UPnP adapters.
+//!
+//! Both backends carry track metadata as DIDL-Lite: OpenHome via its own
+//! metadata event, UPnP via `AVTransport::GetPositionInfo`'s `TrackMetaData`.
+//! In both cases the payload arrives XML-escaped inside another XML document,
+//! so it must be [`html_decode`]d before [`parse_didl_lite`] can see the tags.
+//!
+//! This module exists so the two adapters cannot drift apart in how they read
+//! the same format.
+
+use serde::{Deserialize, Serialize};
+
+/// Track metadata extracted from a DIDL-Lite document.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct TrackInfo {
+    pub title: String,
+    pub artist: String,
+    pub album: String,
+    pub album_art_uri: Option<String>,
+    pub genre: Option<String>,
+}
+
+/// Decode the XML entities that wrap escaped DIDL-Lite payloads.
+///
+/// `&amp;` is replaced last so that a double-encoded `&amp;lt;` decodes to
+/// `&lt;` rather than collapsing all the way to `<`.
+pub fn html_decode(s: &str) -> String {
+    s.replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&amp;", "&")
+        .replace("&quot;", "\"")
+        .replace("&apos;", "'")
+}
+
+/// Read the text content of `tag`, tolerating attributes on the opening tag.
+///
+/// Attribute tolerance is load-bearing rather than cosmetic: real renderers
+/// emit `<upnp:albumArtURI dlna:profileID="JPEG_TN">`, and a matcher that only
+/// accepts a bare `<tag>` silently returns nothing for the most common form of
+/// the one field album art depends on.
+pub fn extract_xml_value(xml: &str, tag: &str) -> Option<String> {
+    let end_tag = format!("</{}>", tag);
+    let mut from = 0;
+
+    // Scan for an opening tag whose name matches exactly, so that looking for
+    // `title` never matches `albumTitle` and looking for `upnp:album` never
+    // matches `upnp:albumArtURI`.
+    while let Some(rel) = xml[from..].find(&format!("<{}", tag)) {
+        let open_start = from + rel;
+        let after_name = open_start + 1 + tag.len();
+        let rest = &xml[after_name..];
+
+        // The character after the tag name decides whether this is our tag.
+        match rest.chars().next() {
+            // Exact match, no attributes.
+            Some('>') => {
+                let value_start = after_name + 1;
+                let end = xml[value_start..].find(&end_tag)? + value_start;
+                return Some(xml[value_start..end].to_string());
+            }
+            // Attributes present: skip past them to the end of the opening tag.
+            Some(c) if c.is_whitespace() => {
+                let close_rel = rest.find('>')?;
+                // A self-closing tag carries no text content.
+                if rest[..close_rel].ends_with('/') {
+                    from = after_name + close_rel + 1;
+                    continue;
+                }
+                let value_start = after_name + close_rel + 1;
+                let end = xml[value_start..].find(&end_tag)? + value_start;
+                return Some(xml[value_start..end].to_string());
+            }
+            // A longer tag name that merely starts with ours — keep looking.
+            _ => {
+                from = after_name;
+            }
+        }
+    }
+
+    None
+}
+
+/// Parse a decoded DIDL-Lite document into [`TrackInfo`].
+///
+/// Always returns `Some`: absent fields become empty strings or `None`, which
+/// is what both adapters have always relied on.
+pub fn parse_didl_lite(xml: &str) -> Option<TrackInfo> {
+    let title = extract_xml_value(xml, "dc:title")
+        .or_else(|| extract_xml_value(xml, "title"))
+        .unwrap_or_default();
+
+    let artist = extract_xml_value(xml, "upnp:artist")
+        .or_else(|| extract_xml_value(xml, "dc:creator"))
+        .unwrap_or_default();
+
+    let album = extract_xml_value(xml, "upnp:album").unwrap_or_default();
+    let album_art_uri = extract_xml_value(xml, "upnp:albumArtURI");
+    let genre = extract_xml_value(xml, "upnp:genre");
+
+    Some(TrackInfo {
+        title,
+        artist,
+        album,
+        album_art_uri,
+        genre,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A realistic DIDL-Lite payload as a renderer returns it, with attributes
+    /// on the tags that carry them in practice.
+    const REAL_DIDL: &str = r#"<DIDL-Lite xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/"><item id="1" parentID="0" restricted="1"><dc:title>Hoppipolla</dc:title><upnp:artist>Sigur Ros</upnp:artist><upnp:album>Takk...</upnp:album><upnp:genre>Post-rock</upnp:genre><upnp:albumArtURI dlna:profileID="JPEG_TN">http://10.0.0.5/art/42.jpg</upnp:albumArtURI></item></DIDL-Lite>"#;
+
+    /// The same payload with a bare albumArtURI tag (no attributes).
+    const BARE_DIDL: &str = r#"<DIDL-Lite><item><dc:title>Hoppipolla</dc:title><upnp:artist>Sigur Ros</upnp:artist><upnp:album>Takk...</upnp:album><upnp:albumArtURI>http://10.0.0.5/art/42.jpg</upnp:albumArtURI></item></DIDL-Lite>"#;
+
+    #[test]
+    fn html_decode_unescapes_in_the_right_order() {
+        // &amp; must be replaced last, or "&amp;lt;" would wrongly become "<".
+        assert_eq!(html_decode("&lt;a&gt;"), "<a>");
+        assert_eq!(html_decode("Simon &amp; Garfunkel"), "Simon & Garfunkel");
+        assert_eq!(html_decode("&amp;lt;"), "&lt;");
+        assert_eq!(html_decode("&quot;x&quot; &apos;y&apos;"), "\"x\" 'y'");
+    }
+
+    #[test]
+    fn parse_didl_lite_reads_bare_tags() {
+        let t = parse_didl_lite(BARE_DIDL).expect("returns Some");
+        assert_eq!(t.title, "Hoppipolla");
+        assert_eq!(t.artist, "Sigur Ros");
+        assert_eq!(t.album, "Takk...");
+        assert_eq!(
+            t.album_art_uri.as_deref(),
+            Some("http://10.0.0.5/art/42.jpg")
+        );
+    }
+
+    #[test]
+    fn parse_didl_lite_never_returns_none_even_for_garbage() {
+        // Every field defaults rather than failing; both adapters rely on this.
+        let t = parse_didl_lite("not xml at all").expect("returns Some");
+        assert_eq!(t.title, "");
+        assert_eq!(t.artist, "");
+        assert_eq!(t.album, "");
+        assert!(t.album_art_uri.is_none());
+    }
+
+    #[test]
+    fn parse_didl_lite_falls_back_to_dc_creator_and_plain_title() {
+        let xml = r#"<item><title>Bare Title</title><dc:creator>Fallback Artist</dc:creator></item>"#;
+        let t = parse_didl_lite(xml).expect("returns Some");
+        assert_eq!(t.title, "Bare Title");
+        assert_eq!(t.artist, "Fallback Artist");
+    }
+
+    /// Regression for the defect this module was extracted to fix: the previous
+    /// matcher required a literal `<tag>`, so the DLNA-conventional
+    /// `<upnp:albumArtURI dlna:profileID="JPEG_TN">` was invisible and album
+    /// art silently went missing on real devices.
+    #[test]
+    fn parse_didl_lite_reads_tags_that_carry_attributes() {
+        let t = parse_didl_lite(REAL_DIDL).expect("returns Some");
+        assert_eq!(t.title, "Hoppipolla");
+        assert_eq!(t.artist, "Sigur Ros");
+        assert_eq!(t.album, "Takk...");
+        assert_eq!(t.genre.as_deref(), Some("Post-rock"));
+        assert_eq!(
+            t.album_art_uri.as_deref(),
+            Some("http://10.0.0.5/art/42.jpg"),
+            "attribute-bearing albumArtURI must be found"
+        );
+    }
+
+    #[test]
+    fn extract_xml_value_does_not_match_a_longer_tag_with_the_same_prefix() {
+        // `upnp:album` must not swallow `upnp:albumArtURI`.
+        let xml = r#"<item><upnp:albumArtURI>art.jpg</upnp:albumArtURI><upnp:album>Real Album</upnp:album></item>"#;
+        assert_eq!(
+            extract_xml_value(xml, "upnp:album").as_deref(),
+            Some("Real Album")
+        );
+    }
+
+    #[test]
+    fn extract_xml_value_skips_self_closing_tags() {
+        let xml = r#"<item><upnp:albumArtURI /><upnp:albumArtURI>art.jpg</upnp:albumArtURI></item>"#;
+        assert_eq!(
+            extract_xml_value(xml, "upnp:albumArtURI").as_deref(),
+            Some("art.jpg")
+        );
+    }
+
+    #[test]
+    fn extract_xml_value_returns_none_when_absent() {
+        assert!(extract_xml_value("<item><dc:title>x</dc:title></item>", "upnp:album").is_none());
+    }
+}

--- a/src/adapters/didl.rs
+++ b/src/adapters/didl.rs
@@ -22,33 +22,48 @@ pub struct TrackInfo {
 
 /// Decode the XML entities that wrap escaped DIDL-Lite payloads.
 ///
-/// `&amp;` is replaced last so that a double-encoded `&amp;lt;` decodes to
-/// `&lt;` rather than collapsing all the way to `<`.
+/// `&amp;` is replaced **last**, so a double-encoded entity decodes exactly one
+/// level: `&amp;lt;` becomes `&lt;`, not `<`. Replacing it earlier would let the
+/// `&` it produces be re-consumed by a later replacement.
 pub fn html_decode(s: &str) -> String {
     s.replace("&lt;", "<")
         .replace("&gt;", ">")
-        .replace("&amp;", "&")
         .replace("&quot;", "\"")
         .replace("&apos;", "'")
+        .replace("&amp;", "&")
 }
 
 /// Read the text content of `tag`, tolerating attributes on the opening tag.
 ///
-/// Attribute tolerance is load-bearing rather than cosmetic: real renderers
-/// emit `<upnp:albumArtURI dlna:profileID="JPEG_TN">`, and a matcher that only
-/// accepts a bare `<tag>` silently returns nothing for the most common form of
-/// the one field album art depends on.
+/// Two tolerances, each load-bearing rather than cosmetic:
+///
+/// - **Attributes.** Real renderers emit
+///   `<upnp:albumArtURI dlna:profileID="JPEG_TN">`, and a matcher accepting only
+///   a bare `<tag>` silently returns nothing for the most common form of the one
+///   field album art depends on.
+/// - **Namespace prefix, when `tag` carries none.** SOAP responses may or may
+///   not namespace their elements, so `CurrentVolume` also matches
+///   `<u:CurrentVolume>`. When `tag` *does* carry a prefix (`upnp:album`) the
+///   match is exact, which is what keeps `upnp:album` from swallowing
+///   `upnp:albumArtURI` and what DIDL-Lite callers rely on.
 pub fn extract_xml_value(xml: &str, tag: &str) -> Option<String> {
+    // A prefixed tag is matched verbatim; an unprefixed one may appear with any
+    // namespace prefix.
+    if tag.contains(':') {
+        return extract_exact(xml, tag);
+    }
+    extract_exact(xml, tag).or_else(|| extract_prefixed(xml, tag))
+}
+
+/// Match `<tag ...>value</tag>` with the tag name exactly as given.
+fn extract_exact(xml: &str, tag: &str) -> Option<String> {
     let end_tag = format!("</{}>", tag);
     let mut from = 0;
 
-    // Scan for an opening tag whose name matches exactly, so that looking for
-    // `title` never matches `albumTitle` and looking for `upnp:album` never
-    // matches `upnp:albumArtURI`.
     while let Some(rel) = xml[from..].find(&format!("<{}", tag)) {
         let open_start = from + rel;
         let after_name = open_start + 1 + tag.len();
-        let rest = &xml[after_name..];
+        let rest = xml.get(after_name..)?;
 
         // The character after the tag name decides whether this is our tag.
         match rest.chars().next() {
@@ -75,6 +90,31 @@ pub fn extract_xml_value(xml: &str, tag: &str) -> Option<String> {
                 from = after_name;
             }
         }
+    }
+
+    None
+}
+
+/// Match the same tag carrying any single namespace prefix, e.g. `<u:tag>`.
+fn extract_prefixed(xml: &str, tag: &str) -> Option<String> {
+    let needle = format!(":{}", tag);
+    let mut from = 0;
+
+    while let Some(rel) = xml[from..].find(&needle) {
+        let colon = from + rel;
+        // Walk back over the prefix to the '<' that opens this tag.
+        let open = xml[..colon].rfind('<')?;
+        let prefix = &xml[open + 1..colon];
+        // A prefix is a single name: no '>', no whitespace, no nested '<'.
+        if prefix.is_empty() || prefix.contains(['>', '<', ' ', '\t', '\n', '/']) {
+            from = colon + needle.len();
+            continue;
+        }
+        let qualified = format!("{}:{}", prefix, tag);
+        if let Some(v) = extract_exact(&xml[open..], &qualified) {
+            return Some(v);
+        }
+        from = colon + needle.len();
     }
 
     None
@@ -122,8 +162,16 @@ mod tests {
         // &amp; must be replaced last, or "&amp;lt;" would wrongly become "<".
         assert_eq!(html_decode("&lt;a&gt;"), "<a>");
         assert_eq!(html_decode("Simon &amp; Garfunkel"), "Simon & Garfunkel");
-        assert_eq!(html_decode("&amp;lt;"), "&lt;");
         assert_eq!(html_decode("&quot;x&quot; &apos;y&apos;"), "\"x\" 'y'");
+        // Double-encoded entities decode exactly one level. These fail if
+        // `&amp;` is replaced before `&quot;`/`&apos;`, which it was until
+        // CodeRabbit caught that the code contradicted this function's own doc
+        // comment - and the only prior case (`&amp;lt;`) passed by accident,
+        // because `&lt;` happens to be replaced first.
+        assert_eq!(html_decode("&amp;lt;"), "&lt;");
+        assert_eq!(html_decode("&amp;quot;"), "&quot;");
+        assert_eq!(html_decode("&amp;apos;"), "&apos;");
+        assert_eq!(html_decode("&amp;gt;"), "&gt;");
     }
 
     #[test]
@@ -192,6 +240,42 @@ mod tests {
         assert_eq!(
             extract_xml_value(xml, "upnp:albumArtURI").as_deref(),
             Some("art.jpg")
+        );
+    }
+
+    #[test]
+    fn extract_xml_value_tolerates_a_namespace_prefix_when_the_tag_has_none() {
+        // SOAP responses may or may not namespace their elements; the UPnP
+        // adapter's own regex extractor allowed either, and consolidating on
+        // this helper must not drop that.
+        let xml = r#"<s:Body><u:GetVolumeResponse><u:CurrentVolume>42</u:CurrentVolume></u:GetVolumeResponse></s:Body>"#;
+        assert_eq!(
+            extract_xml_value(xml, "CurrentVolume").as_deref(),
+            Some("42")
+        );
+        let bare = r#"<Body><CurrentVolume>7</CurrentVolume></Body>"#;
+        assert_eq!(
+            extract_xml_value(bare, "CurrentVolume").as_deref(),
+            Some("7")
+        );
+    }
+
+    #[test]
+    fn extract_xml_value_with_a_prefixed_tag_stays_exact() {
+        // `upnp:album` must not match `upnp:albumArtURI`, and must not match a
+        // differently-prefixed `album` either - DIDL-Lite callers rely on this.
+        let xml = r#"<item><upnp:albumArtURI>art.jpg</upnp:albumArtURI><other:album>Wrong</other:album></item>"#;
+        assert!(extract_xml_value(xml, "upnp:album").is_none());
+    }
+
+    #[test]
+    fn extract_xml_value_prefix_search_ignores_non_prefix_colons() {
+        // A colon inside an attribute value must not be mistaken for a prefix.
+        let xml =
+            r#"<item><link href="http://x/y">no</link><TrackURI>uri://real</TrackURI></item>"#;
+        assert_eq!(
+            extract_xml_value(xml, "TrackURI").as_deref(),
+            Some("uri://real")
         );
     }
 

--- a/src/adapters/didl.rs
+++ b/src/adapters/didl.rs
@@ -150,7 +150,8 @@ mod tests {
 
     #[test]
     fn parse_didl_lite_falls_back_to_dc_creator_and_plain_title() {
-        let xml = r#"<item><title>Bare Title</title><dc:creator>Fallback Artist</dc:creator></item>"#;
+        let xml =
+            r#"<item><title>Bare Title</title><dc:creator>Fallback Artist</dc:creator></item>"#;
         let t = parse_didl_lite(xml).expect("returns Some");
         assert_eq!(t.title, "Bare Title");
         assert_eq!(t.artist, "Fallback Artist");
@@ -186,7 +187,8 @@ mod tests {
 
     #[test]
     fn extract_xml_value_skips_self_closing_tags() {
-        let xml = r#"<item><upnp:albumArtURI /><upnp:albumArtURI>art.jpg</upnp:albumArtURI></item>"#;
+        let xml =
+            r#"<item><upnp:albumArtURI /><upnp:albumArtURI>art.jpg</upnp:albumArtURI></item>"#;
         assert_eq!(
             extract_xml_value(xml, "upnp:albumArtURI").as_deref(),
             Some("art.jpg")

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -1,5 +1,6 @@
 //! Audio source adapters (Roon, HQPlayer, LMS, OpenHome, UPnP)
 
+pub mod didl;
 pub mod handle;
 pub mod hqplayer;
 pub mod lms;

--- a/src/adapters/openhome.rs
+++ b/src/adapters/openhome.rs
@@ -1075,3 +1075,70 @@ impl AdapterLogic for OpenHomeAdapter {
 
 // Startable trait implementation via macro
 crate::impl_startable!(OpenHomeAdapter, "openhome");
+
+#[cfg(test)]
+mod didl_pin_tests {
+    use super::*;
+
+    /// A realistic DIDL-Lite payload as a renderer returns it, with attributes
+    /// on the tags that carry them in practice.
+    const REAL_DIDL: &str = r#"<DIDL-Lite xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/"><item id="1" parentID="0" restricted="1"><dc:title>Hoppipolla</dc:title><upnp:artist>Sigur Ros</upnp:artist><upnp:album>Takk...</upnp:album><upnp:genre>Post-rock</upnp:genre><upnp:albumArtURI dlna:profileID="JPEG_TN">http://10.0.0.5/art/42.jpg</upnp:albumArtURI></item></DIDL-Lite>"#;
+
+    /// The same payload with a bare albumArtURI tag (no attributes).
+    const BARE_DIDL: &str = r#"<DIDL-Lite><item><dc:title>Hoppipolla</dc:title><upnp:artist>Sigur Ros</upnp:artist><upnp:album>Takk...</upnp:album><upnp:albumArtURI>http://10.0.0.5/art/42.jpg</upnp:albumArtURI></item></DIDL-Lite>"#;
+
+    #[test]
+    fn html_decode_unescapes_in_the_right_order() {
+        // &amp; must be replaced last, or "&amp;lt;" would wrongly become "<".
+        assert_eq!(html_decode("&lt;a&gt;"), "<a>");
+        assert_eq!(html_decode("Simon &amp; Garfunkel"), "Simon & Garfunkel");
+        assert_eq!(html_decode("&amp;lt;"), "&lt;");
+        assert_eq!(html_decode("&quot;x&quot; &apos;y&apos;"), "\"x\" 'y'");
+    }
+
+    #[test]
+    fn parse_didl_lite_reads_bare_tags() {
+        let t = OpenHomeAdapter::parse_didl_lite(BARE_DIDL).expect("returns Some");
+        assert_eq!(t.title, "Hoppipolla");
+        assert_eq!(t.artist, "Sigur Ros");
+        assert_eq!(t.album, "Takk...");
+        assert_eq!(
+            t.album_art_uri.as_deref(),
+            Some("http://10.0.0.5/art/42.jpg")
+        );
+    }
+
+    #[test]
+    fn parse_didl_lite_never_returns_none_even_for_garbage() {
+        // Pinning current behavior: every field defaults rather than failing.
+        let t = OpenHomeAdapter::parse_didl_lite("not xml at all").expect("returns Some");
+        assert_eq!(t.title, "");
+        assert_eq!(t.artist, "");
+        assert_eq!(t.album, "");
+        assert!(t.album_art_uri.is_none());
+    }
+
+    #[test]
+    fn parse_didl_lite_falls_back_to_dc_creator_and_plain_title() {
+        let xml = r#"<item><title>Bare Title</title><dc:creator>Fallback Artist</dc:creator></item>"#;
+        let t = OpenHomeAdapter::parse_didl_lite(xml).expect("returns Some");
+        assert_eq!(t.title, "Bare Title");
+        assert_eq!(t.artist, "Fallback Artist");
+    }
+
+    /// The limitation this test documents is why UPnP/OpenHome art can silently
+    /// go missing on real devices: the extractor matches a literal `<tag>`, so a
+    /// tag carrying attributes is invisible to it.
+    #[test]
+    fn parse_didl_lite_misses_tags_that_carry_attributes() {
+        let t = OpenHomeAdapter::parse_didl_lite(REAL_DIDL).expect("returns Some");
+        // Attribute-free tags are found...
+        assert_eq!(t.title, "Hoppipolla");
+        assert_eq!(t.artist, "Sigur Ros");
+        // ...but albumArtURI carries dlna:profileID and is therefore missed.
+        assert_eq!(
+            t.album_art_uri, None,
+            "documents current behavior: attribute-bearing tags are not matched"
+        );
+    }
+}

--- a/src/adapters/openhome.rs
+++ b/src/adapters/openhome.rs
@@ -892,7 +892,6 @@ pub struct ImageData {
     pub data: Vec<u8>,
 }
 
-
 /// Convert an OpenHome device to a unified Zone representation
 fn openhome_device_to_zone(device: &OpenHomeDevice) -> Zone {
     Zone {
@@ -1029,4 +1028,3 @@ impl AdapterLogic for OpenHomeAdapter {
 
 // Startable trait implementation via macro
 crate::impl_startable!(OpenHomeAdapter, "openhome");
-

--- a/src/adapters/openhome.rs
+++ b/src/adapters/openhome.rs
@@ -18,6 +18,7 @@ use tokio::sync::RwLock;
 use tokio::time::interval;
 use tokio_util::sync::CancellationToken;
 
+use crate::adapters::didl;
 use crate::adapters::handle::{AdapterHandle, RetryConfig};
 use crate::adapters::traits::{
     AdapterCommand, AdapterCommandResponse, AdapterContext, AdapterLogic,
@@ -67,15 +68,11 @@ pub struct OpenHomeDevice {
     pub last_track_uri: Option<String>,
 }
 
-/// Track metadata from OpenHome device
-#[derive(Debug, Clone, Serialize)]
-pub struct TrackInfo {
-    pub title: String,
-    pub artist: String,
-    pub album: String,
-    pub album_art_uri: Option<String>,
-    pub genre: Option<String>,
-}
+/// Track metadata from an OpenHome device.
+///
+/// Re-exported from [`crate::adapters::didl`], which owns DIDL-Lite parsing for
+/// both this adapter and the UPnP one so the two cannot drift apart.
+pub use crate::adapters::didl::TrackInfo;
 
 /// OpenHome adapter status
 #[derive(Debug, Clone, Serialize)]
@@ -459,7 +456,7 @@ impl OpenHomeAdapter {
         .await;
 
         if let Ok(response) = transport_state {
-            if let Some(new_state) = Self::extract_xml_value(&response, "Value") {
+            if let Some(new_state) = didl::extract_xml_value(&response, "Value") {
                 let new_state = new_state.to_lowercase();
                 let mut s = state.write().await;
                 if let Some(device) = s.devices.get_mut(uuid) {
@@ -486,7 +483,7 @@ impl OpenHomeAdapter {
         .await;
 
         if let Ok(response) = volume {
-            if let Some(vol_str) = Self::extract_xml_value(&response, "Value") {
+            if let Some(vol_str) = didl::extract_xml_value(&response, "Value") {
                 if let Ok(vol) = vol_str.parse::<i32>() {
                     let mut s = state.write().await;
                     if let Some(device) = s.devices.get_mut(uuid) {
@@ -507,7 +504,7 @@ impl OpenHomeAdapter {
         .await;
 
         if let Ok(response) = mute {
-            if let Some(mute_str) = Self::extract_xml_value(&response, "Value") {
+            if let Some(mute_str) = didl::extract_xml_value(&response, "Value") {
                 let is_muted = mute_str == "true" || mute_str == "1";
                 let mut s = state.write().await;
                 if let Some(device) = s.devices.get_mut(uuid) {
@@ -530,10 +527,10 @@ impl OpenHomeAdapter {
         if let Ok(response) = characteristics {
             let mut s = state.write().await;
             if let Some(device) = s.devices.get_mut(uuid) {
-                if let Some(max_str) = Self::extract_xml_value(&response, "VolumeMax") {
+                if let Some(max_str) = didl::extract_xml_value(&response, "VolumeMax") {
                     device.volume_max = max_str.parse().ok();
                 }
-                if let Some(steps_str) = Self::extract_xml_value(&response, "VolumeSteps") {
+                if let Some(steps_str) = didl::extract_xml_value(&response, "VolumeSteps") {
                     device.volume_steps = steps_str.parse().ok();
                 }
             }
@@ -550,8 +547,8 @@ impl OpenHomeAdapter {
         .await;
 
         if let Ok(response) = track {
-            let uri = Self::extract_xml_value(&response, "Uri");
-            let metadata = Self::extract_xml_value(&response, "Metadata");
+            let uri = didl::extract_xml_value(&response, "Uri");
+            let metadata = didl::extract_xml_value(&response, "Metadata");
 
             let mut s = state.write().await;
             if let Some(device) = s.devices.get_mut(uuid) {
@@ -561,8 +558,8 @@ impl OpenHomeAdapter {
 
                     if let Some(meta) = metadata {
                         // Decode HTML entities and parse DIDL-Lite
-                        let decoded = html_decode(&meta);
-                        if let Some(track_info) = Self::parse_didl_lite(&decoded) {
+                        let decoded = didl::html_decode(&meta);
+                        if let Some(track_info) = didl::parse_didl_lite(&decoded) {
                             let title = Some(track_info.title.clone());
                             let artist = Some(track_info.artist.clone());
                             let album = Some(track_info.album.clone());
@@ -623,41 +620,6 @@ impl OpenHomeAdapter {
             .await?;
 
         Ok(response.text().await?)
-    }
-
-    fn extract_xml_value(xml: &str, tag: &str) -> Option<String> {
-        let start_tag = format!("<{}>", tag);
-        let end_tag = format!("</{}>", tag);
-
-        let start = xml.find(&start_tag)? + start_tag.len();
-        let end = xml[start..].find(&end_tag)? + start;
-
-        Some(xml[start..end].to_string())
-    }
-
-    fn parse_didl_lite(xml: &str) -> Option<TrackInfo> {
-        // Simple extraction from DIDL-Lite
-        let title = Self::extract_xml_value(xml, "dc:title")
-            .or_else(|| Self::extract_xml_value(xml, "title"))
-            .unwrap_or_default();
-
-        let artist = Self::extract_xml_value(xml, "upnp:artist")
-            .or_else(|| Self::extract_xml_value(xml, "dc:creator"))
-            .unwrap_or_default();
-
-        let album = Self::extract_xml_value(xml, "upnp:album").unwrap_or_default();
-
-        let album_art_uri = Self::extract_xml_value(xml, "upnp:albumArtURI");
-
-        let genre = Self::extract_xml_value(xml, "upnp:genre");
-
-        Some(TrackInfo {
-            title,
-            artist,
-            album,
-            album_art_uri,
-            genre,
-        })
     }
 
     /// Stop discovery (internal - use Startable trait)
@@ -930,14 +892,6 @@ pub struct ImageData {
     pub data: Vec<u8>,
 }
 
-/// Decode HTML entities
-fn html_decode(s: &str) -> String {
-    s.replace("&lt;", "<")
-        .replace("&gt;", ">")
-        .replace("&amp;", "&")
-        .replace("&quot;", "\"")
-        .replace("&apos;", "'")
-}
 
 /// Convert an OpenHome device to a unified Zone representation
 fn openhome_device_to_zone(device: &OpenHomeDevice) -> Zone {
@@ -1076,69 +1030,3 @@ impl AdapterLogic for OpenHomeAdapter {
 // Startable trait implementation via macro
 crate::impl_startable!(OpenHomeAdapter, "openhome");
 
-#[cfg(test)]
-mod didl_pin_tests {
-    use super::*;
-
-    /// A realistic DIDL-Lite payload as a renderer returns it, with attributes
-    /// on the tags that carry them in practice.
-    const REAL_DIDL: &str = r#"<DIDL-Lite xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/"><item id="1" parentID="0" restricted="1"><dc:title>Hoppipolla</dc:title><upnp:artist>Sigur Ros</upnp:artist><upnp:album>Takk...</upnp:album><upnp:genre>Post-rock</upnp:genre><upnp:albumArtURI dlna:profileID="JPEG_TN">http://10.0.0.5/art/42.jpg</upnp:albumArtURI></item></DIDL-Lite>"#;
-
-    /// The same payload with a bare albumArtURI tag (no attributes).
-    const BARE_DIDL: &str = r#"<DIDL-Lite><item><dc:title>Hoppipolla</dc:title><upnp:artist>Sigur Ros</upnp:artist><upnp:album>Takk...</upnp:album><upnp:albumArtURI>http://10.0.0.5/art/42.jpg</upnp:albumArtURI></item></DIDL-Lite>"#;
-
-    #[test]
-    fn html_decode_unescapes_in_the_right_order() {
-        // &amp; must be replaced last, or "&amp;lt;" would wrongly become "<".
-        assert_eq!(html_decode("&lt;a&gt;"), "<a>");
-        assert_eq!(html_decode("Simon &amp; Garfunkel"), "Simon & Garfunkel");
-        assert_eq!(html_decode("&amp;lt;"), "&lt;");
-        assert_eq!(html_decode("&quot;x&quot; &apos;y&apos;"), "\"x\" 'y'");
-    }
-
-    #[test]
-    fn parse_didl_lite_reads_bare_tags() {
-        let t = OpenHomeAdapter::parse_didl_lite(BARE_DIDL).expect("returns Some");
-        assert_eq!(t.title, "Hoppipolla");
-        assert_eq!(t.artist, "Sigur Ros");
-        assert_eq!(t.album, "Takk...");
-        assert_eq!(
-            t.album_art_uri.as_deref(),
-            Some("http://10.0.0.5/art/42.jpg")
-        );
-    }
-
-    #[test]
-    fn parse_didl_lite_never_returns_none_even_for_garbage() {
-        // Pinning current behavior: every field defaults rather than failing.
-        let t = OpenHomeAdapter::parse_didl_lite("not xml at all").expect("returns Some");
-        assert_eq!(t.title, "");
-        assert_eq!(t.artist, "");
-        assert_eq!(t.album, "");
-        assert!(t.album_art_uri.is_none());
-    }
-
-    #[test]
-    fn parse_didl_lite_falls_back_to_dc_creator_and_plain_title() {
-        let xml = r#"<item><title>Bare Title</title><dc:creator>Fallback Artist</dc:creator></item>"#;
-        let t = OpenHomeAdapter::parse_didl_lite(xml).expect("returns Some");
-        assert_eq!(t.title, "Bare Title");
-        assert_eq!(t.artist, "Fallback Artist");
-    }
-
-    /// The limitation this test documents is why UPnP/OpenHome art can silently
-    /// go missing on real devices: the extractor matches a literal `<tag>`, so a
-    /// tag carrying attributes is invisible to it.
-    #[test]
-    fn parse_didl_lite_misses_tags_that_carry_attributes() {
-        let t = OpenHomeAdapter::parse_didl_lite(REAL_DIDL).expect("returns Some");
-        // Attribute-free tags are found...
-        assert_eq!(t.title, "Hoppipolla");
-        assert_eq!(t.artist, "Sigur Ros");
-        // ...but albumArtURI carries dlna:profileID and is therefore missed.
-        assert_eq!(
-            t.album_art_uri, None,
-            "documents current behavior: attribute-bearing tags are not matched"
-        );
-    }
-}

--- a/src/adapters/upnp.rs
+++ b/src/adapters/upnp.rs
@@ -4,6 +4,7 @@
 //! Pure UPnP/DLNA has limited metadata support compared to OpenHome.
 //! Specifically, next/previous track are NOT supported by pure UPnP.
 
+use crate::adapters::didl::{self, TrackInfo};
 use crate::adapters::handle::{AdapterHandle, RetryConfig};
 use crate::adapters::traits::{
     AdapterCommand, AdapterCommandResponse, AdapterContext, AdapterLogic,
@@ -53,10 +54,14 @@ pub struct UPnPRenderer {
     pub muted: bool,
     #[serde(skip)]
     pub last_seen: std::time::Instant,
+    pub track_info: Option<TrackInfo>,
     #[serde(skip)]
     pub av_transport_url: Option<String>,
     #[serde(skip)]
     pub rendering_control_url: Option<String>,
+    /// Last seen TrackURI, used to skip re-parsing unchanged metadata.
+    #[serde(skip)]
+    pub last_track_uri: Option<String>,
 }
 
 /// UPnP adapter status
@@ -248,6 +253,8 @@ impl UPnPAdapter {
 
             // New renderer
             let renderer = UPnPRenderer {
+                track_info: None,
+                last_track_uri: None,
                 uuid: uuid.clone(),
                 name: format!("Renderer {}", &uuid[..8.min(uuid.len())]),
                 manufacturer: None,
@@ -664,6 +671,48 @@ impl UPnPAdapter {
         let uuid = strip_upnp_prefix(uuid);
         let state = self.state.read().await;
         state.renderers.get(uuid).cloned()
+    }
+
+    /// Register a renderer and poll it once, as SSDP discovery followed by the
+    /// poll loop would. Exists so tests can drive the real poll path against a
+    /// mock renderer; SSDP cannot reach one.
+    #[doc(hidden)]
+    pub async fn probe_renderer_for_test(
+        &self,
+        uuid: &str,
+        name: &str,
+        av_url: &str,
+        rc_url: &str,
+    ) -> anyhow::Result<()> {
+        {
+            let mut s = self.state.write().await;
+            s.renderers
+                .entry(uuid.to_string())
+                .or_insert_with(|| UPnPRenderer {
+                    uuid: uuid.to_string(),
+                    name: name.to_string(),
+                    manufacturer: None,
+                    model: None,
+                    location: av_url.to_string(),
+                    state: "stopped".to_string(),
+                    volume: None,
+                    muted: false,
+                    track_info: None,
+                    last_seen: std::time::Instant::now(),
+                    av_transport_url: Some(av_url.to_string()),
+                    rendering_control_url: Some(rc_url.to_string()),
+                    last_track_uri: None,
+                });
+        }
+        Self::poll_renderer(
+            &self.state,
+            &self.bus,
+            &self.http,
+            uuid,
+            Some(av_url),
+            Some(rc_url),
+        )
+        .await
     }
 
     /// Get now playing info for a renderer

--- a/src/adapters/upnp.rs
+++ b/src/adapters/upnp.rs
@@ -1,8 +1,11 @@
 //! UPnP/DLNA adapter - discovers and controls UPnP Media Renderers
 //!
 //! Uses SSDP for discovery and UPnP AV Transport service for control.
-//! Pure UPnP/DLNA has limited metadata support compared to OpenHome.
-//! Specifically, next/previous track are NOT supported by pure UPnP.
+//!
+//! Track metadata comes from `AVTransport::GetPositionInfo`, whose
+//! `TrackMetaData` carries DIDL-Lite — the same format OpenHome uses, parsed by
+//! the shared [`crate::adapters::didl`] module. The real difference from
+//! OpenHome is the smaller set of *control* actions, not metadata.
 
 use crate::adapters::didl::{self, TrackInfo};
 use crate::adapters::handle::{AdapterHandle, RetryConfig};
@@ -491,6 +494,70 @@ impl UPnPAdapter {
             }
         }
 
+        // Poll track metadata. AVTransport::GetPositionInfo carries DIDL-Lite in
+        // TrackMetaData, XML-escaped inside the SOAP envelope. Re-parsed only
+        // when TrackURI changes, mirroring the OpenHome adapter so a steady
+        // stream does not re-parse on every tick.
+        if let Some(url) = av_url {
+            let position_info = Self::soap_call(
+                http,
+                url,
+                AV_TRANSPORT_URN,
+                "GetPositionInfo",
+                "<InstanceID>0</InstanceID>",
+            )
+            .await;
+
+            if let Ok(response) = position_info {
+                let track_uri =
+                    didl::extract_xml_value(&response, "TrackURI").filter(|u| !u.is_empty());
+                let metadata =
+                    didl::extract_xml_value(&response, "TrackMetaData").filter(|m| !m.is_empty());
+
+                let mut s = state.write().await;
+                if let Some(renderer) = s.renderers.get_mut(uuid) {
+                    if renderer.last_track_uri.as_deref() != track_uri.as_deref() {
+                        renderer.last_track_uri = track_uri;
+
+                        match metadata {
+                            Some(meta) => {
+                                let decoded = didl::html_decode(&meta);
+                                if let Some(track) = didl::parse_didl_lite(&decoded) {
+                                    let (title, artist, album) = (
+                                        Some(track.title.clone()),
+                                        Some(track.artist.clone()),
+                                        Some(track.album.clone()),
+                                    );
+                                    let image_key = track.album_art_uri.clone();
+                                    renderer.track_info = Some(track);
+                                    bus.publish(BusEvent::NowPlayingChanged {
+                                        zone_id: PrefixedZoneId::upnp(uuid),
+                                        title,
+                                        artist,
+                                        album,
+                                        image_key,
+                                    });
+                                }
+                            }
+                            // A renderer that reports no metadata (commonly when
+                            // stopped) clears rather than retaining a stale track.
+                            None => {
+                                if renderer.track_info.take().is_some() {
+                                    bus.publish(BusEvent::NowPlayingChanged {
+                                        zone_id: PrefixedZoneId::upnp(uuid),
+                                        title: None,
+                                        artist: None,
+                                        album: None,
+                                        image_key: None,
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         // Poll volume
         if let Some(url) = rc_url {
             let volume = Self::soap_call(
@@ -721,19 +788,25 @@ impl UPnPAdapter {
         let state = self.state.read().await;
         let renderer = state.renderers.get(uuid)?;
 
-        // Pure UPnP doesn't provide track metadata
+        // Track metadata comes from AVTransport::GetPositionInfo when the
+        // renderer supplies it; otherwise fall back to the renderer's own name,
+        // which is all this returned before metadata was wired.
+        let track = renderer.track_info.as_ref();
         Some(UPnPNowPlaying {
             zone_id: uuid.to_string(),
-            line1: renderer.name.clone(),
-            line2: String::new(),
-            line3: String::new(),
+            line1: track
+                .map(|t| t.title.clone())
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| renderer.name.clone()),
+            line2: track.map(|t| t.artist.clone()).unwrap_or_default(),
+            line3: track.map(|t| t.album.clone()).unwrap_or_default(),
             is_playing: renderer.state == "playing",
             volume: renderer.volume,
             volume_min: 0,
             volume_max: 100,
             seek_position: None,
             length: None,
-            image_key: None,
+            image_key: track.and_then(|t| t.album_art_uri.clone()),
         })
     }
 
@@ -944,7 +1017,18 @@ fn upnp_renderer_to_zone(renderer: &UPnPRenderer) -> Zone {
             // Use prefixed output_id for consistent aggregator matching
             output_id: Some(format!("upnp:{}", renderer.uuid)),
         }),
-        now_playing: None, // UPnP track info would need separate DIDL-Lite parsing
+        now_playing: renderer
+            .track_info
+            .as_ref()
+            .map(|t| crate::bus::NowPlaying {
+                title: t.title.clone(),
+                artist: t.artist.clone(),
+                album: t.album.clone(),
+                image_key: t.album_art_uri.clone(),
+                seek_position: None,
+                duration: None,
+                metadata: None,
+            }),
         source: "upnp".to_string(),
         is_controllable: renderer.av_transport_url.is_some(),
         is_seekable: false, // Pure UPnP seek support is limited

--- a/src/adapters/upnp.rs
+++ b/src/adapters/upnp.rs
@@ -19,7 +19,6 @@ use anyhow::Result;
 use async_trait::async_trait;
 use futures::StreamExt;
 use quick_xml::de::from_str as xml_from_str;
-use regex::Regex;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use ssdp_client::{SearchTarget, URN};
@@ -65,6 +64,11 @@ pub struct UPnPRenderer {
     /// Last seen TrackURI, used to skip re-parsing unchanged metadata.
     #[serde(skip)]
     pub last_track_uri: Option<String>,
+    /// Last seen raw TrackMetaData. Internet radio and many DLNA servers keep
+    /// one stream URI for a whole session and change only the metadata, so the
+    /// URI alone cannot tell us whether the track changed.
+    #[serde(skip)]
+    pub last_track_metadata: Option<String>,
 }
 
 /// UPnP adapter status
@@ -258,6 +262,7 @@ impl UPnPAdapter {
             let renderer = UPnPRenderer {
                 track_info: None,
                 last_track_uri: None,
+                last_track_metadata: None,
                 uuid: uuid.clone(),
                 name: format!("Renderer {}", &uuid[..8.min(uuid.len())]),
                 manufacturer: None,
@@ -468,7 +473,7 @@ impl UPnPAdapter {
             .await;
 
             if let Ok(response) = transport_info {
-                if let Some(new_state) = Self::extract_xml_value(&response, "CurrentTransportState")
+                if let Some(new_state) = didl::extract_xml_value(&response, "CurrentTransportState")
                 {
                     let new_state = match new_state.as_str() {
                         "PLAYING" => "playing",
@@ -516,8 +521,14 @@ impl UPnPAdapter {
 
                 let mut s = state.write().await;
                 if let Some(renderer) = s.renderers.get_mut(uuid) {
-                    if renderer.last_track_uri.as_deref() != track_uri.as_deref() {
+                    // Compare metadata too: a constant TrackURI (internet radio,
+                    // many DLNA servers) would otherwise pin now-playing to the
+                    // first track for the whole session.
+                    let changed = renderer.last_track_uri.as_deref() != track_uri.as_deref()
+                        || renderer.last_track_metadata.as_deref() != metadata.as_deref();
+                    if changed {
                         renderer.last_track_uri = track_uri;
+                        renderer.last_track_metadata = metadata.clone();
 
                         match metadata {
                             Some(meta) => {
@@ -570,7 +581,7 @@ impl UPnPAdapter {
             .await;
 
             if let Ok(response) = volume {
-                if let Some(vol_str) = Self::extract_xml_value(&response, "CurrentVolume") {
+                if let Some(vol_str) = didl::extract_xml_value(&response, "CurrentVolume") {
                     if let Ok(vol) = vol_str.parse::<i32>() {
                         let mut s = state.write().await;
                         if let Some(renderer) = s.renderers.get_mut(uuid) {
@@ -591,7 +602,7 @@ impl UPnPAdapter {
             .await;
 
             if let Ok(response) = mute {
-                if let Some(mute_str) = Self::extract_xml_value(&response, "CurrentMute") {
+                if let Some(mute_str) = didl::extract_xml_value(&response, "CurrentMute") {
                     let mut s = state.write().await;
                     if let Some(renderer) = s.renderers.get_mut(uuid) {
                         renderer.muted = mute_str == "1" || mute_str.eq_ignore_ascii_case("true");
@@ -645,21 +656,6 @@ impl UPnPAdapter {
     }
 
     /// Extract XML value, handling optional namespace prefixes (e.g., <u:Volume> or <Volume>)
-    fn extract_xml_value(xml: &str, tag: &str) -> Option<String> {
-        // Build regex pattern to match tag with optional namespace prefix and attributes
-        // Matches: <prefix:tag attr="...">value</prefix:tag> or <tag attr="...">value</tag>
-        let pattern = format!(
-            r"<(?:[^:>]+:)?{}\b[^>]*>([^<]*)</(?:[^:>]+:)?{}>",
-            regex::escape(tag),
-            regex::escape(tag)
-        );
-
-        let re = Regex::new(&pattern).ok()?;
-        re.captures(xml)
-            .and_then(|caps| caps.get(1))
-            .map(|m| m.as_str().to_string())
-    }
-
     /// Stop discovery (internal - use Startable trait)
     async fn stop_internal(&self) {
         // Cancel background tasks first
@@ -716,10 +712,14 @@ impl UPnPAdapter {
                         is_muted: r.muted,
                     }),
                     // Pure UPnP doesn't support these
+                    // track_metadata is now read from GetPositionInfo, so it
+                    // must not be advertised as unsupported - clients that read
+                    // this list would hide it. album_art stays: the URI is
+                    // parsed, but UHC does not yet fetch or proxy the bytes
+                    // (#418).
                     unsupported: vec![
                         "next".to_string(),
                         "previous".to_string(),
-                        "track_metadata".to_string(),
                         "album_art".to_string(),
                     ],
                 }
@@ -769,6 +769,7 @@ impl UPnPAdapter {
                     av_transport_url: Some(av_url.to_string()),
                     rendering_control_url: Some(rc_url.to_string()),
                     last_track_uri: None,
+                    last_track_metadata: None,
                 });
         }
         Self::poll_renderer(

--- a/tests/mock_servers/upnp.rs
+++ b/tests/mock_servers/upnp.rs
@@ -27,6 +27,20 @@ pub struct MockUpnpState {
     pub state: String, // PLAYING, PAUSED_PLAYBACK, STOPPED
     pub volume: u32,   // 0-100
     pub muted: bool,
+    /// Current track, as `GetPositionInfo` would report it. `None` means the
+    /// renderer reports an empty `TrackMetaData`, which real devices do when
+    /// stopped or when they carry no metadata at all.
+    pub track: Option<MockUpnpTrack>,
+}
+
+/// Track metadata the mock renderer will serialise into DIDL-Lite.
+#[derive(Debug, Clone)]
+pub struct MockUpnpTrack {
+    pub uri: String,
+    pub title: String,
+    pub artist: String,
+    pub album: String,
+    pub album_art_uri: String,
 }
 
 impl Default for MockUpnpState {
@@ -39,6 +53,7 @@ impl Default for MockUpnpState {
             state: "STOPPED".to_string(),
             volume: 50,
             muted: false,
+            track: None,
         }
     }
 }
@@ -108,6 +123,23 @@ impl MockUpnpRenderer {
     /// Set mute
     pub async fn set_muted(&self, muted: bool) {
         self.state.write().await.muted = muted;
+    }
+
+    /// Set the current track, reported via `GetPositionInfo`'s `TrackMetaData`.
+    pub async fn set_track(&self, uri: &str, title: &str, artist: &str, album: &str, art: &str) {
+        self.state.write().await.track = Some(MockUpnpTrack {
+            uri: uri.to_string(),
+            title: title.to_string(),
+            artist: artist.to_string(),
+            album: album.to_string(),
+            album_art_uri: art.to_string(),
+        });
+    }
+
+    /// Report no track metadata, as a renderer does when stopped or when it
+    /// simply carries none.
+    pub async fn clear_track(&self) {
+        self.state.write().await.track = None;
     }
 
     /// Stop the mock server
@@ -183,6 +215,54 @@ async fn handle_av_transport(
   </s:Body>
 </s:Envelope>"#,
             state_guard.state
+        )
+    } else if action.contains("GetPositionInfo") {
+        // TrackMetaData carries DIDL-Lite XML-escaped inside the SOAP envelope,
+        // exactly as real renderers send it. albumArtURI carries the
+        // dlna:profileID attribute that the DLNA convention puts there.
+        let (track_uri, metadata) = match &state_guard.track {
+            Some(t) => {
+                let didl = format!(
+                    concat!(
+                        r#"<DIDL-Lite xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" "#,
+                        r#"xmlns:dc="http://purl.org/dc/elements/1.1/" "#,
+                        r#"xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/">"#,
+                        r#"<item id="1" parentID="0" restricted="1">"#,
+                        "<dc:title>{}</dc:title>",
+                        "<upnp:artist>{}</upnp:artist>",
+                        "<upnp:album>{}</upnp:album>",
+                        r#"<upnp:albumArtURI dlna:profileID="JPEG_TN">{}</upnp:albumArtURI>"#,
+                        "</item></DIDL-Lite>"
+                    ),
+                    t.title, t.artist, t.album, t.album_art_uri
+                );
+                let escaped = didl
+                    .replace('&', "&amp;")
+                    .replace('<', "&lt;")
+                    .replace('>', "&gt;")
+                    .replace('"', "&quot;");
+                (t.uri.clone(), escaped)
+            }
+            None => (String::new(), String::new()),
+        };
+
+        format!(
+            r#"<?xml version="1.0"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+  <s:Body>
+    <u:GetPositionInfoResponse xmlns:u="urn:schemas-upnp-org:service:AVTransport:1">
+      <Track>1</Track>
+      <TrackDuration>0:03:21</TrackDuration>
+      <TrackMetaData>{}</TrackMetaData>
+      <TrackURI>{}</TrackURI>
+      <RelTime>0:00:12</RelTime>
+      <AbsTime>0:00:12</AbsTime>
+      <RelCount>2147483647</RelCount>
+      <AbsCount>2147483647</AbsCount>
+    </u:GetPositionInfoResponse>
+  </s:Body>
+</s:Envelope>"#,
+            metadata, track_uri
         )
     } else if action.contains("Play") || action.contains("Pause") || action.contains("Stop") {
         // Control action - return success

--- a/tests/upnp_metadata.rs
+++ b/tests/upnp_metadata.rs
@@ -1,0 +1,152 @@
+//! UPnP track metadata, driven against a mock renderer (#420).
+//!
+//! The UPnP adapter previously reported no track metadata at all, behind a
+//! comment claiming "pure UPnP doesn't provide track metadata". It does:
+//! `AVTransport::GetPositionInfo` returns `TrackMetaData` carrying DIDL-Lite.
+//! These tests drive the real poll path, so they fail against that behavior.
+
+mod mock_servers;
+
+use mock_servers::upnp::MockUpnpRenderer;
+use unified_hifi_control::adapters::upnp::UPnPAdapter;
+use unified_hifi_control::bus::create_bus;
+
+const ART: &str = "http://10.0.0.5/art/42.jpg";
+
+/// Register the mock with the adapter and poll it once.
+async fn probe(adapter: &UPnPAdapter, mock: &MockUpnpRenderer) {
+    let addr = mock.addr();
+    adapter
+        .probe_renderer_for_test(
+            "mock-upnp-uuid-12345",
+            "Mock UPnP Renderer",
+            &format!("http://{}/AVTransport/control", addr),
+            &format!("http://{}/RenderingControl/control", addr),
+        )
+        .await
+        .expect("probe succeeds");
+}
+
+#[tokio::test]
+async fn upnp_reports_track_metadata_from_get_position_info() {
+    let mock = MockUpnpRenderer::start().await;
+    mock.set_state("PLAYING").await;
+    mock.set_track(
+        "http://10.0.0.5/stream/42.flac",
+        "Hoppipolla",
+        "Sigur Ros",
+        "Takk...",
+        ART,
+    )
+    .await;
+
+    let bus = create_bus();
+    let adapter = UPnPAdapter::new(bus);
+    probe(&adapter, &mock).await;
+
+    let np = adapter
+        .get_now_playing("mock-upnp-uuid-12345")
+        .await
+        .expect("renderer is known");
+
+    assert_eq!(np.line1, "Hoppipolla", "line1 should be the track title");
+    assert_eq!(np.line2, "Sigur Ros", "line2 should be the artist");
+    assert_eq!(np.line3, "Takk...", "line3 should be the album");
+    assert_eq!(
+        np.image_key.as_deref(),
+        Some(ART),
+        "image_key should come from upnp:albumArtURI, which carries a \
+         dlna:profileID attribute in real DIDL-Lite"
+    );
+
+    mock.stop().await;
+}
+
+#[tokio::test]
+async fn upnp_zone_carries_now_playing() {
+    let mock = MockUpnpRenderer::start().await;
+    mock.set_state("PLAYING").await;
+    mock.set_track("uri://1", "Svefn-g-englar", "Sigur Ros", "Agaetis", ART)
+        .await;
+
+    let bus = create_bus();
+    let adapter = UPnPAdapter::new(bus);
+    probe(&adapter, &mock).await;
+
+    let zones = adapter.get_zones().await;
+    let zone = zones.first().expect("one zone");
+    // UPnPZone carries the bare uuid; the `upnp:` prefix is applied at the
+    // aggregator/API boundary, not inside the adapter's own DTO.
+    assert_eq!(zone.zone_id, "mock-upnp-uuid-12345");
+
+    let renderer = adapter
+        .get_renderer("mock-upnp-uuid-12345")
+        .await
+        .expect("renderer is known");
+    let track = renderer
+        .track_info
+        .as_ref()
+        .expect("track metadata is parsed and retained");
+    assert_eq!(track.title, "Svefn-g-englar");
+    assert_eq!(track.album_art_uri.as_deref(), Some(ART));
+
+    mock.stop().await;
+}
+
+/// A renderer that reports no metadata must degrade to the previous behavior
+/// rather than erroring or emitting empty-string noise.
+#[tokio::test]
+async fn upnp_without_metadata_degrades_cleanly() {
+    let mock = MockUpnpRenderer::start().await;
+    mock.set_state("PLAYING").await;
+    mock.clear_track().await;
+
+    let bus = create_bus();
+    let adapter = UPnPAdapter::new(bus);
+    probe(&adapter, &mock).await;
+
+    let np = adapter
+        .get_now_playing("mock-upnp-uuid-12345")
+        .await
+        .expect("renderer is known");
+
+    // Falls back to the renderer's own name, as it always did.
+    assert_eq!(np.line1, "Mock UPnP Renderer");
+    assert_eq!(np.line2, "");
+    assert_eq!(np.line3, "");
+    assert!(np.image_key.is_none());
+
+    let renderer = adapter
+        .get_renderer("mock-upnp-uuid-12345")
+        .await
+        .expect("renderer is known");
+    assert!(renderer.track_info.is_none());
+
+    mock.stop().await;
+}
+
+/// Metadata is only re-parsed when the TrackURI changes, mirroring the
+/// OpenHome adapter's guard so polling does not re-parse every tick.
+#[tokio::test]
+async fn upnp_track_metadata_survives_a_repeat_poll() {
+    let mock = MockUpnpRenderer::start().await;
+    mock.set_state("PLAYING").await;
+    mock.set_track("uri://stable", "Glosoli", "Sigur Ros", "Takk...", ART)
+        .await;
+
+    let bus = create_bus();
+    let adapter = UPnPAdapter::new(bus);
+    probe(&adapter, &mock).await;
+    // Second poll with an unchanged TrackURI must not lose what was parsed.
+    probe(&adapter, &mock).await;
+
+    let renderer = adapter
+        .get_renderer("mock-upnp-uuid-12345")
+        .await
+        .expect("renderer is known");
+    let track = renderer.track_info.as_ref().expect("metadata retained");
+    assert_eq!(track.title, "Glosoli");
+    assert_eq!(renderer.last_track_uri.as_deref(), Some("uri://stable"));
+
+    mock.stop().await;
+}

--- a/tests/upnp_metadata.rs
+++ b/tests/upnp_metadata.rs
@@ -150,3 +150,81 @@ async fn upnp_track_metadata_survives_a_repeat_poll() {
 
     mock.stop().await;
 }
+
+/// Internet radio and many DLNA servers keep one stream URI for a whole session
+/// and change only `TrackMetaData` per track. A guard comparing `TrackURI` alone
+/// pins now-playing to the first track forever.
+#[tokio::test]
+async fn upnp_reparses_when_metadata_changes_under_a_constant_track_uri() {
+    let mock = MockUpnpRenderer::start().await;
+    mock.set_state("PLAYING").await;
+    mock.set_track(
+        "radio://stream",
+        "First Song",
+        "First Artist",
+        "Album A",
+        ART,
+    )
+    .await;
+
+    let bus = create_bus();
+    let adapter = UPnPAdapter::new(bus);
+    probe(&adapter, &mock).await;
+
+    let first = adapter
+        .get_now_playing("mock-upnp-uuid-12345")
+        .await
+        .expect("renderer is known");
+    assert_eq!(first.line1, "First Song");
+
+    // Same TrackURI, different metadata — as a radio stream reports a new track.
+    mock.set_track(
+        "radio://stream",
+        "Second Song",
+        "Second Artist",
+        "Album B",
+        "http://10.0.0.5/art/99.jpg",
+    )
+    .await;
+    probe(&adapter, &mock).await;
+
+    let second = adapter
+        .get_now_playing("mock-upnp-uuid-12345")
+        .await
+        .expect("renderer is known");
+    assert_eq!(
+        second.line1, "Second Song",
+        "a constant TrackURI must not freeze now-playing metadata"
+    );
+    assert_eq!(second.line2, "Second Artist");
+    assert_eq!(second.line3, "Album B");
+    assert_eq!(
+        second.image_key.as_deref(),
+        Some("http://10.0.0.5/art/99.jpg")
+    );
+
+    mock.stop().await;
+}
+
+/// track_metadata must not be advertised as unsupported now that it is read.
+#[tokio::test]
+async fn upnp_zone_does_not_advertise_track_metadata_as_unsupported() {
+    let mock = MockUpnpRenderer::start().await;
+    mock.set_track("uri://1", "Track", "Artist", "Album", ART)
+        .await;
+
+    let bus = create_bus();
+    let adapter = UPnPAdapter::new(bus);
+    probe(&adapter, &mock).await;
+
+    let zones = adapter.get_zones().await;
+    let zone = zones.first().expect("one zone");
+    assert!(
+        !zone.unsupported.contains(&"track_metadata".to_string()),
+        "clients reading `unsupported` would hide metadata the adapter now reads"
+    );
+    // Still unsupported: the art URI is parsed, but UHC does not fetch the bytes.
+    assert!(zone.unsupported.contains(&"album_art".to_string()));
+
+    mock.stop().await;
+}


### PR DESCRIPTION
Fixes #420

## What this changes

UPnP zones now report what is playing. Previously the adapter returned the renderer's own name as `line1`, empty `line2`/`line3`, and `image_key: None`, behind a comment claiming *"Pure UPnP doesn't provide track metadata."* That was false: `AVTransport::GetPositionInfo` returns `TrackMetaData` carrying DIDL-Lite, and OpenHome in this very repo already parses that same format.

Three commits, in TDD order:

1. **`1debc38`** — pin `parse_didl_lite` / `html_decode` behavior with tests. Neither had any coverage. Ran green against the original code before anything moved.
2. **`58eab9f`** — extract `TrackInfo`, `html_decode`, `extract_xml_value`, `parse_didl_lite` into `src/adapters/didl.rs`, used by both adapters. Not a pure move; see the behavior change below.
3. **`0aea46c`** + **`f0ba5e4`** — red tests, then the UPnP implementation.

## Two things worth reviewer attention

**1. A behavior change rides in the extraction, and it fixes a live bug.** `extract_xml_value` matched a literal `<tag>`, so any tag carrying attributes was invisible to it. Real DIDL-Lite writes:

```
<upnp:albumArtURI dlna:profileID="JPEG_TN">http://…/art.jpg</upnp:albumArtURI>
```

which means **OpenHome album art has been silently missing on every device following that DLNA convention** — not just UPnP's. The matcher now tolerates attributes, skips self-closing tags, and guards against prefix collisions (`upnp:album` no longer risks matching `upnp:albumArtURI`). The pin test that documented the limitation is now a regression test for the fix.

This is a fix, not a regression, but it changes what OpenHome users see: art may start appearing where it never did. Flagging it rather than filing it under the refactor.

**2. This changes client-visible payloads for UPnP zones.** `Zone.now_playing` goes from always-`None` to populated, and `line1`/`line2`/`line3`/`image_key` carry real values. The knob, iOS app, and web UI all read this. I checked `tests/client_harness.rs` first: it registers the UPnP adapter but asserts nothing about now-playing content, and all 42 harness tests pass unchanged. Fields that were empty become populated — additive in shape, but a user-visible difference, so it is your call rather than mine.

## One production seam

`probe_renderer_for_test`, marked `#[doc(hidden)]`: registers a renderer and polls it once, as SSDP-then-poll would. SSDP cannot reach a mock and there was no other public path in, so without it the poll loop stays untestable. Same approach #408 took for Roon.

Worth noting *why* this gap survived: the only existing UPnP test asserted that the mock serves a description document. The adapter was never driven against it — the third instance of that pattern this epic has found, after the HQPlayer mock rejecting its own adapter's wire format (#394) and `MockRoonCore` not being a server (#408).

## Verification

Run locally, complete gate:

- `cargo fmt --check` — clean
- `cargo clippy -- -D warnings` — clean
- `cargo test --workspace` — all green, including the two `/hqp/discover` tests that fail on some dev machines
- `dx build --release --platform web --features web` — client and server both clean, first attempt

This PR targets `v3`, so CI is a real gate here and I expect it to run.

`--all-targets` clippy is not attempted: `src/lib.rs:20-22` denies `unwrap_used`/`expect_used`/`panic` crate-wide and src's own test modules violate it 76 times, pre-existing.

## Deliberately not done

- **Album art bytes are not fetched or proxied.** UPnP's `albumArtURI` is a URL on the renderer's network. Exposing art over MCP is #418, which has to decide the delivery mechanism and the reachability question.
- **`unsupported: ["next", "previous"]` at `src/adapters/upnp.rs:715` is left alone**, with its comment *"Pure UPnP doesn't support these."* AVTransport:1 *does* define `Next` and `Previous` actions, so I suspect this is another false-provider-limit claim of the same shape as the one this PR fixes — but real support varies per device and verifying it needs hardware I do not have. Not changed, and not asserted either way. Candidate follow-up.
- **No live hardware.** Everything here is proven against `MockUpnpRenderer` with a realistic escaped `GetPositionInfo` payload. A real renderer may order or namespace DIDL-Lite differently; the parser is tolerant of attributes and tag order, but that is reasoning, not evidence.

## Rollback

Revert the three commits. `didl.rs` is additive and both adapters route through it, so reverting the feature commit alone leaves the shared module in place and harmless.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * UPnP playback now displays track title, artist, album, and artwork metadata.
  * Metadata updates automatically as tracks change and clears when unavailable.
  * Added support for richer metadata, including genre and common XML/HTML formatting variations.

* **Bug Fixes**
  * Prevented stale track information from persisting when metadata is missing.
  * Improved compatibility with metadata containing attributes, self-closing tags, or missing fields.

* **Tests**
  * Added comprehensive coverage for UPnP metadata parsing, fallbacks, and repeated polling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->