### PR TITLE
feat(mcp): expose readable bridge state as MCP resources (#397)

### DIFF
--- a/src/mcp/handler.rs
+++ b/src/mcp/handler.rs
@@ -1,8 +1,8 @@
-//! The MCP `ServerHandler`: advertise tools, and dispatch calls to them.
+//! The MCP `ServerHandler`: advertise tools, dispatch calls to them, and (#397)
+//! advertise and serve resources.
 //!
-//! Dispatch only. Every arm delegates to a handler in
-//! [`crate::mcp::tools`]; no tool behavior lives here. #397 extends this impl
-//! with the resource methods.
+//! Dispatch only. Every arm delegates to a handler in [`crate::mcp::tools`] or
+//! [`crate::mcp::resources`]; no tool or resource behavior lives here.
 
 use crate::api::{load_app_settings, AppState};
 use crate::mcp::envelope::{Envelope, Refusal};
@@ -11,8 +11,9 @@ use async_trait::async_trait;
 use rust_mcp_sdk::{
     mcp_server::ServerHandler,
     schema::{
-        schema_utils::CallToolError, CallToolRequestParams, CallToolResult, ListToolsResult,
-        PaginatedRequestParams, RpcError,
+        schema_utils::CallToolError, CallToolRequestParams, CallToolResult,
+        ListResourceTemplatesResult, ListResourcesResult, ListToolsResult, PaginatedRequestParams,
+        ReadResourceRequestParams, ReadResourceResult, RpcError,
     },
     McpServer,
 };
@@ -31,6 +32,19 @@ impl HifiMcpHandler {
 
 #[async_trait]
 impl ServerHandler for HifiMcpHandler {
+    /// Fires once per session, when the client sends `notifications/initialized`
+    /// — the SDK hands us that session's own `runtime` here, which is the only
+    /// place a per-session background notifier can be started. See
+    /// [`crate::mcp::resources::spawn_list_changed_notifier`] for what this
+    /// notifier does and does not promise.
+    async fn on_initialized(&self, runtime: Arc<dyn McpServer>) {
+        crate::mcp::resources::spawn_list_changed_notifier(
+            self.state.bus.clone(),
+            runtime,
+            self.state.shutdown.clone(),
+        );
+    }
+
     async fn handle_list_tools_request(
         &self,
         _params: Option<PaginatedRequestParams>,
@@ -99,6 +113,52 @@ impl ServerHandler for HifiMcpHandler {
                 tools::capabilities::handle_capabilities(state, args).await
             }
         }
+    }
+
+    /// Same settings-based gate as `handle_list_tools_request`: the HQPlayer
+    /// resources are hidden when the adapter is disabled, exactly like the
+    /// HQPlayer tools.
+    async fn handle_list_resources_request(
+        &self,
+        _params: Option<PaginatedRequestParams>,
+        _runtime: Arc<dyn McpServer>,
+    ) -> Result<ListResourcesResult, RpcError> {
+        let settings = load_app_settings();
+        Ok(ListResourcesResult {
+            meta: None,
+            next_cursor: None,
+            resources: crate::mcp::resources::list_resources(
+                &self.state,
+                settings.adapters.hqplayer,
+            )
+            .await,
+        })
+    }
+
+    /// No resource template is advertised — #397's solution-space gate chose
+    /// live per-zone enumeration in `resources/list` instead (a newly
+    /// discovered zone needs no restart there either). This returns a fixed
+    /// empty list rather than the SDK's generic `method_not_found`, because
+    /// resources genuinely exist here; there is just no template shape for any
+    /// of them.
+    async fn handle_list_resource_templates_request(
+        &self,
+        _params: Option<PaginatedRequestParams>,
+        _runtime: Arc<dyn McpServer>,
+    ) -> Result<ListResourceTemplatesResult, RpcError> {
+        Ok(ListResourceTemplatesResult {
+            meta: None,
+            next_cursor: None,
+            resource_templates: vec![],
+        })
+    }
+
+    async fn handle_read_resource_request(
+        &self,
+        params: ReadResourceRequestParams,
+        _runtime: Arc<dyn McpServer>,
+    ) -> Result<ReadResourceResult, RpcError> {
+        crate::mcp::resources::read_resource(&self.state, &params.uri).await
     }
 }
 

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -19,6 +19,7 @@
 //! | [`envelope`] | the structured result envelope every tool fills           |
 //! | [`routing`]  | zone-prefix -> adapter, in exactly one place              |
 //! | [`capabilities`] | per-provider capability truth, in three states        |
+//! | [`resources`] | readable bridge state addressable by URI (#397)          |
 //!
 //! # The MCP surface is pinned by tests
 //!
@@ -34,6 +35,7 @@
 pub mod capabilities;
 pub mod envelope;
 pub mod handler;
+pub mod resources;
 pub mod routing;
 pub mod server;
 pub mod tools;

--- a/src/mcp/resources.rs
+++ b/src/mcp/resources.rs
@@ -1,0 +1,384 @@
+//! MCP resources: readable bridge state addressable by URI (issue #397).
+//!
+//! # What this is, and is not
+//!
+//! Every value here is already reachable through a `read_only_hint` tool —
+//! that tool keeps working exactly as it does today. Resources are a second,
+//! address-based path to the *same* state, for clients that model ambient
+//! state (what is playing, is the bridge connected) as something to read
+//! rather than something to ask for by calling a tool. This is the least
+//! load-bearing issue in epic #392: nothing here is new capability, only a new
+//! shape for capability that already exists.
+//!
+//! # URI scheme
+//!
+//! | URI                        | Equivalent tool           |
+//! |-----------------------------|---------------------------|
+//! | `hifi://zones`              | `hifi_zones`               |
+//! | `hifi://zones/{zone_id}`    | `hifi_now_playing`         |
+//! | `hifi://status`             | `hifi_status`              |
+//! | `hifi://hqplayer/status`    | `hifi_hqplayer_status`     |
+//! | `hifi://hqplayer/profiles`  | `hifi_hqplayer_profiles`   |
+//!
+//! `zone_id` already carries its own provider prefix (`roon:`, `lms:`, ...), so
+//! `hifi://zones/roon:1601a5d4` is a valid URI despite the second colon — no
+//! escaping is applied or required, because URIs are matched by prefix-stripping
+//! rather than parsed as RFC 3986 authority/path components.
+//!
+//! # No second source of truth
+//!
+//! Each resource's payload is built by the exact function its equivalent tool
+//! calls — [`crate::mcp::tools::zones::zones_payload`],
+//! [`crate::mcp::tools::zones::now_playing_payload`],
+//! [`crate::mcp::tools::status::status_payload`],
+//! [`crate::mcp::tools::hqplayer::hqp_status_payload`] and
+//! [`crate::mcp::tools::hqplayer::hqp_profiles_payload`]. There is exactly one
+//! place that reads the aggregator or the adapter accessors for each kind of
+//! state, so a resource and its tool cannot compute different answers for the
+//! same underlying state. `tests/mcp_contract.rs` asserts this directly for
+//! zones and now-playing (including a live LMS zone, not just the empty case).
+//!
+//! # Live per-zone enumeration, not a template
+//!
+//! [`list_resources`] reads `ZoneAggregator` fresh on every call, so a zone
+//! discovered after a client's last `resources/list` is addressable on the very
+//! next one — no restart, no resource template needed. A single `hifi://zones`
+//! document was rejected in the solution-space gate: a zone inside a bigger
+//! document has no URI of its own, which fails addressability outright.
+//!
+//! # HQPlayer resources respect the same settings gate as HQPlayer tools
+//!
+//! [`list_resources`] takes the same `hqplayer_enabled` flag
+//! [`crate::mcp::tools::list_tools`] does, and hides the two HQPlayer resources
+//! on the same condition. As with tools, this only gates *advertisement* —
+//! [`read_resource`] does not re-check settings, matching how a HQPlayer tool
+//! called directly (unlisted) still executes.
+//!
+//! # `listChanged`: best-effort, wired off the events the aggregator already
+//! consumes
+//!
+//! [`spawn_list_changed_notifier`] subscribes to the same bus
+//! [`crate::aggregator::ZoneAggregator`] already consumes and sends
+//! `notifications/resources/list_changed` on any event that changes the *set*
+//! of zones (`ZoneDiscovered`, `ZoneRemoved`, `ZonesFlushed`) — not on every
+//! `NowPlayingChanged`, which would be noise for a signal that only means "the
+//! zone list changed, re-list". This is genuinely best-effort: with
+//! `event_store: None` (`src/mcp/mod.rs`), a client with no open GET/SSE stream
+//! simply does not receive it, and there is no replay. That is why `subscribe`
+//! is not advertised at all — see [`crate::mcp::server::server_details`].
+//!
+//! # Reading an unknown or stale URI
+//!
+//! [`read_resource`] never panics and never returns an empty success for a URI
+//! it does not recognise or a zone the aggregator no longer holds. Both produce
+//! a JSON-RPC error with the MCP-conventional "resource not found" code
+//! (`-32002`), carrying the offending URI in `data` so a client can log which
+//! one it asked for.
+
+use crate::api::AppState;
+use crate::bus::{BusEvent, SharedBus};
+use crate::mcp::tools::{hqplayer, status, zones};
+use rust_mcp_sdk::{
+    schema::{ReadResourceContent, ReadResourceResult, Resource, RpcError, TextResourceContents},
+    McpServer,
+};
+use serde::Serialize;
+use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
+
+/// `hifi_zones`'s resource equivalent: every zone, in one document.
+const ZONES_URI: &str = "hifi://zones";
+/// Prefix for a per-zone `hifi_now_playing` equivalent. The full URI appends the
+/// zone id verbatim, e.g. `hifi://zones/roon:1601a5d4`.
+const ZONE_PREFIX: &str = "hifi://zones/";
+/// `hifi_status`'s resource equivalent.
+const STATUS_URI: &str = "hifi://status";
+/// `hifi_hqplayer_status`'s resource equivalent. Listed only when the HQPlayer
+/// adapter is enabled in settings.
+const HQP_STATUS_URI: &str = "hifi://hqplayer/status";
+/// `hifi_hqplayer_profiles`'s resource equivalent. Listed only when the
+/// HQPlayer adapter is enabled in settings.
+const HQP_PROFILES_URI: &str = "hifi://hqplayer/profiles";
+
+/// The MIME type every resource here declares: each payload is exactly what the
+/// equivalent tool's structured content carries, rendered as JSON text.
+const JSON_MIME_TYPE: &str = "application/json";
+
+/// Render `payload` as the resource's one content entry.
+///
+/// Uses [`serde_json::to_string_pretty`] rather than `to_value`'s `BTreeMap`
+/// ordering, for the same reason [`crate::mcp::envelope::Envelope::json_result`]
+/// does: the payload struct serializes in declaration order, so the resource's
+/// text matches what a human (or a model) reading the equivalent tool's text
+/// would see, key for key.
+fn text_resource(uri: &str, payload: &impl Serialize) -> ReadResourceContent {
+    let text = serde_json::to_string_pretty(payload).unwrap_or_else(|_| "{}".to_string());
+    ReadResourceContent::TextResourceContents(TextResourceContents {
+        meta: None,
+        mime_type: Some(JSON_MIME_TYPE.to_string()),
+        text,
+        uri: uri.to_string(),
+    })
+}
+
+/// The MCP-conventional "Resource not found" error (`-32002`), carrying the
+/// offending URI so a client can tell which of possibly several requests failed.
+///
+/// `RpcError` (the type every `ServerHandler` resource method returns) has no
+/// built-in constructor for this code — only `SdkError`, a different type used
+/// internally by the transport, does — so this builds the struct directly. Its
+/// three fields are public for exactly this reason.
+fn resource_not_found(uri: &str) -> RpcError {
+    RpcError {
+        code: -32002,
+        message: "Resource not found".to_string(),
+        data: Some(serde_json::json!({ "uri": uri })),
+    }
+}
+
+fn zone_resource(zone_id: &str, zone_name: &str) -> Resource {
+    Resource {
+        annotations: None,
+        description: Some(format!(
+            "Current playback state for zone '{zone_id}' ({zone_name}): track, artist, \
+             album, play state, volume. Same payload as the hifi_now_playing tool."
+        )),
+        icons: vec![],
+        meta: None,
+        mime_type: Some(JSON_MIME_TYPE.to_string()),
+        name: format!("now_playing:{zone_id}"),
+        size: None,
+        title: Some(format!("Now playing: {zone_name}")),
+        uri: format!("{ZONE_PREFIX}{zone_id}"),
+    }
+}
+
+/// Every resource UHC advertises right now, enumerated live so a zone
+/// discovered since the last call is included without a restart.
+///
+/// `hqplayer_enabled` gates the two HQPlayer resources exactly as
+/// [`crate::mcp::tools::list_tools`] gates the four HQPlayer tools; the caller
+/// (`HifiMcpHandler::handle_list_resources_request`) supplies it from the same
+/// `load_app_settings()` read.
+pub async fn list_resources(state: &AppState, hqplayer_enabled: bool) -> Vec<Resource> {
+    let mut resources = vec![
+        Resource {
+            annotations: None,
+            description: Some(
+                "All available playback zones (Roon, LMS, OpenHome, UPnP, HQPlayer), with \
+                 state, volume and mute. Same payload as the hifi_zones tool."
+                    .to_string(),
+            ),
+            icons: vec![],
+            meta: None,
+            mime_type: Some(JSON_MIME_TYPE.to_string()),
+            name: "zones".to_string(),
+            size: None,
+            title: Some("All zones".to_string()),
+            uri: ZONES_URI.to_string(),
+        },
+        Resource {
+            annotations: None,
+            description: Some(
+                "Overall bridge status (Roon connection, HQPlayer config). Same payload as \
+                 the hifi_status tool."
+                    .to_string(),
+            ),
+            icons: vec![],
+            meta: None,
+            mime_type: Some(JSON_MIME_TYPE.to_string()),
+            name: "status".to_string(),
+            size: None,
+            title: Some("Bridge status".to_string()),
+            uri: STATUS_URI.to_string(),
+        },
+    ];
+
+    for zone in state.aggregator.get_zones().await {
+        resources.push(zone_resource(&zone.zone_id, &zone.zone_name));
+    }
+
+    if hqplayer_enabled {
+        resources.push(Resource {
+            annotations: None,
+            description: Some(
+                "HQPlayer Embedded status and current pipeline settings. Same payload as \
+                 the hifi_hqplayer_status tool."
+                    .to_string(),
+            ),
+            icons: vec![],
+            meta: None,
+            mime_type: Some(JSON_MIME_TYPE.to_string()),
+            name: "hqplayer_status".to_string(),
+            size: None,
+            title: Some("HQPlayer status".to_string()),
+            uri: HQP_STATUS_URI.to_string(),
+        });
+        resources.push(Resource {
+            annotations: None,
+            description: Some(
+                "Available HQPlayer Embedded configurations. Same payload as the \
+                 hifi_hqplayer_profiles tool."
+                    .to_string(),
+            ),
+            icons: vec![],
+            meta: None,
+            mime_type: Some(JSON_MIME_TYPE.to_string()),
+            name: "hqplayer_profiles".to_string(),
+            size: None,
+            title: Some("HQPlayer profiles".to_string()),
+            uri: HQP_PROFILES_URI.to_string(),
+        });
+    }
+
+    resources
+}
+
+/// Read one resource by URI.
+///
+/// An unknown scheme, an unknown fixed URI, or a `hifi://zones/{zone_id}` whose
+/// zone the aggregator does not (or no longer) hold all produce
+/// [`resource_not_found`] rather than a panic or an empty success.
+pub async fn read_resource(state: &AppState, uri: &str) -> Result<ReadResourceResult, RpcError> {
+    let content = match uri {
+        ZONES_URI => text_resource(uri, &zones::zones_payload(state).await),
+        STATUS_URI => text_resource(uri, &status::status_payload(state).await),
+        HQP_STATUS_URI => text_resource(uri, &hqplayer::hqp_status_payload(state).await),
+        HQP_PROFILES_URI => text_resource(uri, &hqplayer::hqp_profiles_payload(state).await),
+        _ => {
+            let zone_id = uri
+                .strip_prefix(ZONE_PREFIX)
+                .filter(|id| !id.is_empty())
+                .ok_or_else(|| resource_not_found(uri))?;
+            let payload = zones::now_playing_payload(state, zone_id)
+                .await
+                .ok_or_else(|| resource_not_found(uri))?;
+            text_resource(uri, &payload)
+        }
+    };
+
+    Ok(ReadResourceResult {
+        contents: vec![content],
+        meta: None,
+    })
+}
+
+/// Whether a bus event changes the *set* of zones, and therefore what
+/// `resources/list` would return next.
+///
+/// `NowPlayingChanged`, `VolumeChanged` and friends change a resource's
+/// *contents*, not the *list* — and since `subscribe` is not advertised, this
+/// server has no channel for content-level staleness at all. Only listing
+/// changes get a signal.
+fn changes_the_zone_list(event: &BusEvent) -> bool {
+    matches!(
+        event,
+        BusEvent::ZoneDiscovered { .. }
+            | BusEvent::ZoneRemoved { .. }
+            | BusEvent::ZonesFlushed { .. }
+    )
+}
+
+/// Best-effort `notifications/resources/list_changed`, for one session.
+///
+/// Spawned from [`crate::mcp::handler::HifiMcpHandler::on_initialized`], which
+/// fires once per session with that session's own `runtime` — so this
+/// subscribes to the bus once per connected client and stops when sending to
+/// that client starts failing (session torn down, stream gone), or when the
+/// server itself shuts down (`shutdown`, the same [`CancellationToken`] every
+/// other background loop in this crate selects on — see
+/// `tests/spawn_cancellation_lint.rs`, which fails a `tokio::spawn` loop with no
+/// cancellation arm).
+///
+/// This is deliberately best-effort and undocumented as anything stronger: with
+/// `event_store: None`, a client with no open GET/SSE stream never receives
+/// this notification and there is no way to replay it later. A client that
+/// wants to be sure it has the current zone list should still call
+/// `resources/list` itself; this notification is only ever a hint to do so
+/// sooner.
+pub fn spawn_list_changed_notifier(
+    bus: SharedBus,
+    runtime: Arc<dyn McpServer>,
+    shutdown: CancellationToken,
+) {
+    let mut rx = bus.subscribe();
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                _ = shutdown.cancelled() => break,
+                event = rx.recv() => match event {
+                    Ok(event) if changes_the_zone_list(&event) => {
+                        if runtime.notify_resource_list_changed(None).await.is_err() {
+                            // The client's stream is gone (or never existed); best-effort
+                            // means giving up quietly rather than looping forever against
+                            // a session nothing is listening on.
+                            break;
+                        }
+                    }
+                    Ok(_) => continue,
+                    // Missed events under load: keep going, the next one may still
+                    // matter. A closed bus means the server is shutting down.
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                },
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zone_list_events_are_recognised_and_state_events_are_not() {
+        use crate::bus::{PlaybackState, Zone};
+
+        let zone = Zone {
+            zone_id: "roon:x".to_string(),
+            zone_name: "Test".to_string(),
+            state: PlaybackState::Stopped,
+            volume_control: None,
+            now_playing: None,
+            source: "roon".to_string(),
+            is_controllable: true,
+            is_seekable: false,
+            last_updated: 0,
+            is_play_allowed: true,
+            is_pause_allowed: true,
+            is_next_allowed: true,
+            is_previous_allowed: true,
+        };
+
+        assert!(changes_the_zone_list(&BusEvent::ZoneDiscovered { zone }));
+        assert!(changes_the_zone_list(&BusEvent::ZoneRemoved {
+            zone_id: crate::bus::PrefixedZoneId::parse("roon:x").expect("valid prefix"),
+        }));
+        assert!(changes_the_zone_list(&BusEvent::ZonesFlushed {
+            adapter: "roon".to_string(),
+            zone_ids: vec!["roon:x".to_string()],
+        }));
+        assert!(!changes_the_zone_list(&BusEvent::VolumeChanged {
+            output_id: "roon:x".to_string(),
+            value: 50.0,
+            is_muted: false,
+        }));
+    }
+
+    /// The parsing rule the resource reader relies on: a zone id is recovered
+    /// by stripping the prefix, and an empty remainder (`hifi://zones/`) is
+    /// treated as absent rather than as a valid, empty zone id.
+    #[test]
+    fn zone_uri_parsing_rejects_an_empty_zone_id() {
+        assert_eq!(
+            "hifi://zones/roon:x".strip_prefix(ZONE_PREFIX),
+            Some("roon:x")
+        );
+        assert_eq!(
+            "hifi://zones/"
+                .strip_prefix(ZONE_PREFIX)
+                .filter(|id| !id.is_empty()),
+            None
+        );
+    }
+}

--- a/src/mcp/resources.rs
+++ b/src/mcp/resources.rs
@@ -122,7 +122,11 @@ fn text_resource(uri: &str, payload: &impl Serialize) -> ReadResourceContent {
 }
 
 /// The MCP-conventional "Resource not found" error (`-32002`), carrying the
-/// offending URI so a client can tell which of possibly several requests failed.
+/// offending URI and a discovery hint, so a client can tell which of possibly
+/// several requests failed and how to recover — the resource-side equivalent of
+/// [`crate::mcp::envelope::Refusal::UnknownTarget`]'s `discover_with`, which
+/// names `hifi_zones` for the same underlying fact (an unrecognised or stale
+/// zone id) when a tool hits it instead of a resource read.
 ///
 /// `RpcError` (the type every `ServerHandler` resource method returns) has no
 /// built-in constructor for this code — only `SdkError`, a different type used
@@ -132,7 +136,10 @@ fn resource_not_found(uri: &str) -> RpcError {
     RpcError {
         code: -32002,
         message: "Resource not found".to_string(),
-        data: Some(serde_json::json!({ "uri": uri })),
+        data: Some(serde_json::json!({
+            "uri": uri,
+            "hint": "call resources/list for the current set of valid URIs",
+        })),
     }
 }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -7,18 +7,30 @@
 //! # Declared capabilities gate request dispatch
 //!
 //! rust-mcp-sdk checks the declared capability set *before* any handler runs. So
-//! declaring only `tools` is not merely "resources are unimplemented" — every
-//! resource method returns JSON-RPC `-32603 Server does not support resources`.
-//! That refusal is pinned by
-//! `tests/mcp_contract.rs::resource_methods_are_refused_while_only_tools_is_declared`,
-//! so #397 shows up as a visible refusal-to-success diff rather than as a silent
-//! change. The SDK gate keys only on the *presence* of `resources`; it never
-//! inspects `subscribe` or `listChanged`.
+//! before #397, declaring only `tools` was not merely "resources are
+//! unimplemented" — every resource method returned JSON-RPC
+//! `-32603 Server does not support resources`. That refusal was pinned by
+//! `tests/mcp_contract.rs` (previously
+//! `resource_methods_are_refused_while_only_tools_is_declared`, now
+//! `resource_methods_dispatch_now_that_resources_is_declared`), so #397 shows up
+//! as a visible refusal-to-success diff rather than as a silent change. The SDK
+//! gate keys only on the *presence* of `resources`; it never inspects
+//! `subscribe` or `listChanged`.
 //!
-//! This function is #397's primary target.
+//! # What #397 declares, and why not more
+//!
+//! `resources.list_changed: Some(true)` — implemented, see
+//! [`crate::mcp::resources::spawn_list_changed_notifier`]. `resources.subscribe`
+//! is left `None`: the pinned SDK has no subscription registry and no event
+//! replay (`event_store: None` in [`crate::mcp::create_mcp_extension`]), so
+//! advertising `subscribe` would claim something this server cannot honor —
+//! exactly the capability-honesty problem this epic exists to fix everywhere
+//! else. A client that calls `resources/subscribe` anyway reaches the SDK's own
+//! default handler, a plain `method_not_found`, which is a truthful answer.
 
 use rust_mcp_sdk::schema::{
-    Implementation, InitializeResult, ProtocolVersion, ServerCapabilities, ServerCapabilitiesTools,
+    Implementation, InitializeResult, ProtocolVersion, ServerCapabilities,
+    ServerCapabilitiesResources, ServerCapabilitiesTools,
 };
 
 /// The `initialize` result this server advertises.
@@ -42,6 +54,12 @@ pub fn server_details() -> InitializeResult {
         },
         capabilities: ServerCapabilities {
             tools: Some(ServerCapabilitiesTools { list_changed: None }),
+            // #397: only the sub-features actually implemented. See the module
+            // docs for why `subscribe` stays unset.
+            resources: Some(ServerCapabilitiesResources {
+                list_changed: Some(true),
+                subscribe: None,
+            }),
             ..Default::default()
         },
         meta: None,

--- a/src/mcp/tools/hqplayer.rs
+++ b/src/mcp/tools/hqplayer.rs
@@ -95,11 +95,13 @@ fn canonical_setting(setting: &str) -> Option<&'static str> {
     }
 }
 
-pub async fn handle_status(state: &AppState) -> Result<CallToolResult, CallToolError> {
+/// Shared by [`handle_status`] and the `hifi://hqplayer/status` resource
+/// ([`crate::mcp::resources`]), so the two cannot disagree.
+pub async fn hqp_status_payload(state: &AppState) -> McpHqpStatus {
     let status = state.hqplayer.get_status().await;
     let pipeline = state.hqplayer.get_pipeline_status().await.ok();
 
-    let mcp_status = McpHqpStatus {
+    McpHqpStatus {
         connected: status.connected,
         host: status.host,
         pipeline: pipeline.map(|p| McpPipelineStatus {
@@ -108,18 +110,31 @@ pub async fn handle_status(state: &AppState) -> Result<CallToolResult, CallToolE
             shaper: p.status.active_shaper,
             rate: p.status.active_rate,
         }),
-    };
+    }
+}
+
+/// Shared by [`handle_profiles`] and the `hifi://hqplayer/profiles` resource
+/// ([`crate::mcp::resources`]), so the two cannot disagree.
+pub async fn hqp_profiles_payload(state: &AppState) -> Vec<String> {
+    state
+        .hqplayer
+        .get_cached_profiles()
+        .await
+        .into_iter()
+        .map(|p| p.title)
+        .collect()
+}
+
+pub async fn handle_status(state: &AppState) -> Result<CallToolResult, CallToolError> {
     Ok(Envelope::read("hifi_hqplayer_status", "get_status")
         .scope(Scope::provider_only(Provider::HqPlayer))
-        .json_result(&mcp_status))
+        .json_result(&hqp_status_payload(state).await))
 }
 
 pub async fn handle_profiles(state: &AppState) -> Result<CallToolResult, CallToolError> {
-    let profiles = state.hqplayer.get_cached_profiles().await;
-    let profile_names: Vec<String> = profiles.into_iter().map(|p| p.title).collect();
     Ok(Envelope::read("hifi_hqplayer_profiles", "list_profiles")
         .scope(Scope::provider_only(Provider::HqPlayer))
-        .json_result(&profile_names))
+        .json_result(&hqp_profiles_payload(state).await))
 }
 
 pub async fn handle_load_profile(

--- a/src/mcp/tools/status.rs
+++ b/src/mcp/tools/status.rs
@@ -26,11 +26,14 @@ pub struct HifiStatusTool {}
 ///
 /// `tests/mcp_contract.rs::hifi_status_shape_is_pinned` asserts the ordering, so
 /// the mistake is caught — but it is cheaper to not make it.
-pub async fn handle_status(state: &AppState) -> Result<CallToolResult, CallToolError> {
+/// Shared by [`handle_status`] and the `hifi://status` resource
+/// ([`crate::mcp::resources`]), so the tool and the resource read exactly the
+/// same adapter accessors and cannot disagree.
+pub async fn status_payload(state: &AppState) -> serde_json::Value {
     let roon_status = state.roon.get_status().await;
     let hqp_status = state.hqplayer.get_status().await;
 
-    let status = serde_json::json!({
+    serde_json::json!({
         "roon": {
             "connected": roon_status.connected,
             "core_name": roon_status.core_name,
@@ -39,9 +42,12 @@ pub async fn handle_status(state: &AppState) -> Result<CallToolResult, CallToolE
             "connected": hqp_status.connected,
             "host": hqp_status.host,
         }
-    });
+    })
+}
+
+pub async fn handle_status(state: &AppState) -> Result<CallToolResult, CallToolError> {
     // No scope: this tool reports on the bridge, spanning every provider. The
     // `json!` value is already a map, so `data` and the text agree exactly here —
     // the declaration-order/BTreeMap divergence only applies to struct payloads.
-    Ok(Envelope::read("hifi_status", "get_status").json_result(&status))
+    Ok(Envelope::read("hifi_status", "get_status").json_result(&status_payload(state).await))
 }

--- a/src/mcp/tools/zones.rs
+++ b/src/mcp/tools/zones.rs
@@ -20,7 +20,7 @@
 
 use crate::api::AppState;
 use crate::mcp::envelope::{Envelope, Refusal, Scope};
-use crate::mcp::types::{now_playing_from_zone, McpZone};
+use crate::mcp::types::{now_playing_from_zone, McpNowPlaying, McpZone};
 use rust_mcp_sdk::{
     macros::{mcp_tool, JsonSchema},
     schema::{schema_utils::CallToolError, CallToolResult},
@@ -48,9 +48,20 @@ pub struct HifiNowPlayingTool {
     pub zone_id: String,
 }
 
-pub async fn handle_zones(state: &AppState) -> Result<CallToolResult, CallToolError> {
-    let zones = state.aggregator.get_zones().await;
-    let mcp_zones: Vec<McpZone> = zones
+/// The `hifi_zones` / `hifi://zones` resource payload, read straight from the
+/// aggregator.
+///
+/// Shared by the tool and by [`crate::mcp::resources`] so the two can never
+/// disagree — there is exactly one place that turns aggregator [`Zone`]s into
+/// [`McpZone`]s. `tests/mcp_contract.rs::zones_resource_agrees_with_hifi_zones_tool`
+/// asserts the two paths still produce the same JSON value.
+///
+/// [`Zone`]: crate::bus::Zone
+pub async fn zones_payload(state: &AppState) -> Vec<McpZone> {
+    state
+        .aggregator
+        .get_zones()
+        .await
         .into_iter()
         .map(|z| McpZone {
             zone_id: z.zone_id,
@@ -59,7 +70,30 @@ pub async fn handle_zones(state: &AppState) -> Result<CallToolResult, CallToolEr
             volume: z.volume_control.as_ref().map(|v| v.value as f64),
             is_muted: z.volume_control.as_ref().map(|v| v.is_muted),
         })
-        .collect();
+        .collect()
+}
+
+/// The `hifi_now_playing` / `hifi://zones/{zone_id}` resource payload for one
+/// zone, or `None` when the aggregator holds no such zone.
+///
+/// Used by [`crate::mcp::resources`] for the per-zone resource reader, so a
+/// stale or never-existed zone id produces a proper "not found" there rather
+/// than a panic or an empty success. `handle_now_playing` below reads the same
+/// aggregator through the same [`now_playing_from_zone`] transform, so the two
+/// cannot disagree about what a zone's state is — only about whether a missing
+/// zone is reported as a resource-not-found or as an `hifi_now_playing` refusal,
+/// which is deliberate: a resource URI and a tool's `zone_id` parameter warrant
+/// different error shapes for the same underlying fact.
+pub async fn now_playing_payload(state: &AppState, zone_id: &str) -> Option<McpNowPlaying> {
+    state
+        .aggregator
+        .get_zone(zone_id)
+        .await
+        .map(now_playing_from_zone)
+}
+
+pub async fn handle_zones(state: &AppState) -> Result<CallToolResult, CallToolError> {
+    let mcp_zones = zones_payload(state).await;
 
     // No scope: this tool spans every provider, so naming one would be a lie.
     Ok(Envelope::read("hifi_zones", "list_zones").json_result(&mcp_zones))

--- a/tests/fixtures/mcp_initialize.json
+++ b/tests/fixtures/mcp_initialize.json
@@ -1,5 +1,8 @@
 {
   "capabilities": {
+    "resources": {
+      "listChanged": true
+    },
     "tools": {}
   },
   "instructions": "Unified Hi-Fi Control MCP Server - Control Your Music System\n\nUse hifi_zones to list available zones, hifi_now_playing to see what's playing, hifi_control for playback control, hifi_search to find music, and hifi_play to play it.\n\nNote: hifi_search and hifi_play currently work with Roon and LMS zones only. Transport controls (play/pause/next/volume) work with all zones (Roon, LMS, OpenHome, UPnP).\n\nTo build a playlist: call hifi_play multiple times with action='queue'. The first track can use action='play' to start playback, then subsequent tracks use action='queue' to add to the queue.",

--- a/tests/mcp_contract.rs
+++ b/tests/mcp_contract.rs
@@ -391,6 +391,40 @@ impl TestApp {
             .cloned()
             .unwrap_or_else(|| panic!("tools/call {name} returned no result: {response}"))
     }
+
+    /// `resources/list` against an initialized session. Returns the `result`
+    /// object.
+    async fn list_resources(&self) -> Value {
+        let (session_id, _) = self.initialize().await;
+        let (_, response) = self
+            .post(
+                Some(&session_id),
+                json!({ "jsonrpc": "2.0", "id": 20, "method": "resources/list", "params": {} }),
+            )
+            .await;
+        let response = response.expect("resources/list must return a JSON-RPC response");
+        response
+            .get("result")
+            .cloned()
+            .unwrap_or_else(|| panic!("resources/list returned no result: {response}"))
+    }
+
+    /// `resources/read` against an initialized session. Returns the full
+    /// JSON-RPC response (not just `result`), so a caller can inspect `error`
+    /// for the unknown/stale-uri cases without a separate code path.
+    async fn read_resource(&self, uri: &str) -> Value {
+        let (session_id, _) = self.initialize().await;
+        let (_, response) = self
+            .post(
+                Some(&session_id),
+                json!({
+                    "jsonrpc": "2.0", "id": 21, "method": "resources/read",
+                    "params": { "uri": uri }
+                }),
+            )
+            .await;
+        response.expect("resources/read must return a JSON-RPC response")
+    }
 }
 
 /// Extract the first `data:` payload from an SSE body, or parse the body as
@@ -626,14 +660,31 @@ fn declared_protocol_version_and_capabilities_are_pinned() {
     );
 
     // Capabilities gate request dispatch in the SDK, so the declared set decides
-    // which methods are reachable at all. #397 adds `resources`; #394 must not.
+    // which methods are reachable at all.
     assert!(
         details.capabilities.tools.is_some(),
         "tools capability must be declared"
     );
-    assert!(
-        details.capabilities.resources.is_none(),
-        "#394 must not declare a resources capability — that is #397's work"
+
+    // #397: `resources` is now declared, but only the sub-features actually
+    // implemented. `listChanged` is wired off the aggregator's own zone-discovery
+    // bus events (best-effort: undelivered with no open stream, since
+    // `event_store: None` gives no replay). `subscribe` is deliberately omitted —
+    // the SDK has no subscription registry and no replay, so advertising it would
+    // oblige honoring something this server cannot.
+    let resources = details
+        .capabilities
+        .resources
+        .as_ref()
+        .expect("#397 must declare a resources capability");
+    assert_eq!(
+        resources.list_changed,
+        Some(true),
+        "listChanged must be advertised: it is implemented"
+    );
+    assert_eq!(
+        resources.subscribe, None,
+        "subscribe must not be advertised: the SDK cannot honor it (no registry, no replay)"
     );
     assert!(
         details.capabilities.prompts.is_none(),
@@ -947,68 +998,131 @@ async fn get_and_delete_are_wired_and_session_aware() {
 // 4. Capabilities gate: what the server refuses today
 // =============================================================================
 
-/// `create_mcp_extension` declares only `tools`, and rust-mcp-sdk 0.8.3 gates
-/// request dispatch on the *declared* capability before any handler runs
-/// (`ServerCapabilities::can_handle_request`, which rejects all five resource
-/// methods when `resources.is_none()`). So the resource methods are not merely
-/// unimplemented — they return a concrete JSON-RPC error, and that error is part
-/// of today's surface.
+/// Before #397, `create_mcp_extension` declared only `tools`, and rust-mcp-sdk
+/// 0.8.3 gates request dispatch on the *declared* capability before any handler
+/// runs (`ServerCapabilities::can_handle_request`, which rejects all five
+/// resource methods when `resources.is_none()`). #397 declares `resources`, so
+/// the same three methods that used to be refused with a capability error now
+/// dispatch to real handlers.
 ///
-/// Pinned here so #397 shows up as a visible diff (refusal -> success) rather
-/// than as a silent change from one behavior to another. The SDK gate keys only
-/// on the *presence* of `resources`; it never inspects `subscribe` or
-/// `listChanged`.
-///
-/// This test records current behavior. It does not endorse it, and #394 must not
-/// declare a `resources` capability — that is #397's work.
+/// This is the visible diff #397's PR body calls out: refusal -> success, on the
+/// same three methods `tests/mcp_contract.rs` pinned in FOUNDATION (#394). The
+/// SDK gate keys only on the *presence* of `resources`; it never inspects
+/// `subscribe` or `listChanged`, which is why `resources/templates/list`
+/// dispatches too even though no template is ever advertised — see
+/// `crate::mcp::resources` for why live enumeration was chosen over templates.
 #[tokio::test]
 #[serial_test::serial(uhc_config_dir)]
-async fn resource_methods_are_refused_while_only_tools_is_declared() {
+async fn resource_methods_dispatch_now_that_resources_is_declared() {
     let _settings = SettingsFixture::with_hqplayer(true);
     let app = TestApp::new().await;
     let (session_id, init) = app.initialize().await;
 
-    // Precondition: the declared capability set contains tools and not resources.
+    // Precondition: the declared capability set contains both tools and
+    // resources.
     assert!(
         init.pointer("/capabilities/tools").is_some(),
         "tools capability must be declared: {init}"
     );
     assert!(
-        init.pointer("/capabilities/resources").is_none(),
-        "#394 must not declare a resources capability — that is #397's work: {init}"
+        init.pointer("/capabilities/resources").is_some(),
+        "#397 must declare a resources capability: {init}"
     );
 
-    for (id, method, params) in [
-        (10, "resources/list", json!({})),
-        (11, "resources/read", json!({ "uri": "hifi://zones" })),
-        (12, "resources/templates/list", json!({})),
-    ] {
-        let (_, response) = app
-            .post(
-                Some(&session_id),
-                json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params }),
-            )
-            .await;
-        let response =
-            response.unwrap_or_else(|| panic!("{method} must return a JSON-RPC response"));
+    let (_, list_response) = app
+        .post(
+            Some(&session_id),
+            json!({ "jsonrpc": "2.0", "id": 10, "method": "resources/list", "params": {} }),
+        )
+        .await;
+    let list_response =
+        list_response.expect("resources/list must return a JSON-RPC response");
+    assert!(
+        list_response.get("error").is_none(),
+        "resources/list must no longer be refused: {list_response}"
+    );
+    assert!(
+        list_response
+            .pointer("/result/resources")
+            .and_then(Value::as_array)
+            .is_some(),
+        "resources/list must return a resources array: {list_response}"
+    );
 
-        let error = response
-            .get("error")
-            .unwrap_or_else(|| panic!("{method} must be refused today, got: {response}"));
-        assert_eq!(
-            error.get("code").and_then(Value::as_i64),
-            Some(-32603),
-            "{method}: expected the capability gate's internal-error code, got {error}"
-        );
-        let message = error
-            .get("message")
-            .and_then(Value::as_str)
-            .unwrap_or_default();
-        assert!(
-            message.contains("does not support resources"),
-            "{method}: the refusal must name the missing capability, got {message:?}"
-        );
-    }
+    let (_, read_response) = app
+        .post(
+            Some(&session_id),
+            json!({
+                "jsonrpc": "2.0", "id": 11, "method": "resources/read",
+                "params": { "uri": "hifi://zones" }
+            }),
+        )
+        .await;
+    let read_response = read_response.expect("resources/read must return a JSON-RPC response");
+    assert!(
+        read_response.get("error").is_none(),
+        "resources/read on a known uri must no longer be refused: {read_response}"
+    );
+    assert!(
+        read_response
+            .pointer("/result/contents")
+            .and_then(Value::as_array)
+            .is_some(),
+        "resources/read must return contents: {read_response}"
+    );
+
+    // No templates are advertised (#397 chose live enumeration over templates),
+    // so this returns an empty list rather than the SDK's generic refusal.
+    let (_, templates_response) = app
+        .post(
+            Some(&session_id),
+            json!({ "jsonrpc": "2.0", "id": 12, "method": "resources/templates/list", "params": {} }),
+        )
+        .await;
+    let templates_response =
+        templates_response.expect("resources/templates/list must return a JSON-RPC response");
+    assert_eq!(
+        templates_response.pointer("/result/resourceTemplates"),
+        Some(&json!([])),
+        "no resource templates are implemented, so this must be an empty list, not an \
+         error: {templates_response}"
+    );
+}
+
+/// `subscribe` is declared absent, and the SDK's own default handler (a plain
+/// `method_not_found`) is what actually answers a client that tries anyway —
+/// UHC does not claim to implement something the SDK cannot honor (no
+/// subscription registry, no replay).
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn resources_subscribe_is_not_advertised_and_not_implemented() {
+    let _settings = SettingsFixture::with_hqplayer(true);
+    let app = TestApp::new().await;
+    let (session_id, init) = app.initialize().await;
+
+    assert!(
+        init.pointer("/capabilities/resources/subscribe").is_none(),
+        "subscribe must not be advertised: {init}"
+    );
+
+    let (_, response) = app
+        .post(
+            Some(&session_id),
+            json!({
+                "jsonrpc": "2.0", "id": 13, "method": "resources/subscribe",
+                "params": { "uri": "hifi://zones" }
+            }),
+        )
+        .await;
+    let response = response.expect("resources/subscribe must return a JSON-RPC response");
+    let error = response
+        .get("error")
+        .unwrap_or_else(|| panic!("resources/subscribe must be refused, got: {response}"));
+    assert_eq!(
+        error.get("code").and_then(Value::as_i64),
+        Some(-32601),
+        "expected a plain method-not-found, not a capability-gate error: {error}"
+    );
 }
 
 // =============================================================================
@@ -4674,6 +4788,247 @@ async fn agents_md_capability_matrix_matches_the_derived_data() {
              produced the ❌ against OpenHome/UPnP volume that #398 was filed to correct.\n\n\
              Regenerate with UPDATE_AGENTS_MATRIX=1 cargo test --test mcp_contract agents_md\n\n\
              --- AGENTS.md has ---\n{current}\n--- the derived data renders ---\n{expected}"
+        );
+    }
+}
+
+// =============================================================================
+// 8. Resources (#397)
+// =============================================================================
+//
+// `resources/list` and `resources/read` project the same read-only state the
+// `read_only_hint` tools already expose, addressable by URI instead of by tool
+// call. The two hard requirements the tests below check: a resource's payload
+// can never disagree with its equivalent tool's (no second source of truth),
+// and a client can never get a panic or an empty success for a URI that does
+// not (or no longer) exists.
+
+/// The minimum resource set the issue's acceptance criteria name: all zones,
+/// bridge status, and — adapter enabled — the two HQPlayer resources. Per-zone
+/// now-playing resources are asserted live, separately, in
+/// `a_newly_discovered_zone_is_addressable_without_a_restart` and
+/// `now_playing_resource_agrees_with_hifi_now_playing_tool_for_a_live_zone`.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn resources_list_includes_the_minimum_set_when_hqplayer_enabled() {
+    let _settings = SettingsFixture::with_hqplayer(true);
+    let app = TestApp::new().await;
+
+    let result = app.list_resources().await;
+    let resources = result
+        .get("resources")
+        .and_then(Value::as_array)
+        .expect("resources/list result must contain a resources array");
+    let uris: Vec<&str> = resources
+        .iter()
+        .filter_map(|r| r.get("uri").and_then(Value::as_str))
+        .collect();
+
+    for expected in [
+        "hifi://zones",
+        "hifi://status",
+        "hifi://hqplayer/status",
+        "hifi://hqplayer/profiles",
+    ] {
+        assert!(
+            uris.contains(&expected),
+            "resources/list must include {expected}, got {uris:?}"
+        );
+    }
+}
+
+/// The HQPlayer-tool filter (`hqplayer_tools_filtered_when_adapter_disabled`)
+/// has a resource equivalent: the two HQPlayer resources must not be listed
+/// when the adapter is disabled in settings, and nothing else may change.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn hqplayer_resources_are_absent_when_adapter_disabled() {
+    let _settings = SettingsFixture::with_hqplayer(false);
+    let app = TestApp::new().await;
+
+    let result = app.list_resources().await;
+    let resources = result
+        .get("resources")
+        .and_then(Value::as_array)
+        .expect("resources/list result must contain a resources array");
+    let uris: Vec<&str> = resources
+        .iter()
+        .filter_map(|r| r.get("uri").and_then(Value::as_str))
+        .collect();
+
+    assert_eq!(
+        uris,
+        vec!["hifi://zones", "hifi://status"],
+        "HQPlayer disabled must yield exactly the two non-HQPlayer resources, in order"
+    );
+}
+
+/// `hifi://zones` must carry exactly what `hifi_zones` returns for the same
+/// state — the tool/resource agreement the acceptance criteria require.
+/// Trivially true with no zones connected; the live-zone case is asserted in
+/// `now_playing_resource_agrees_with_hifi_now_playing_tool_for_a_live_zone`,
+/// which would fail if the two payloads were ever computed differently.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn zones_resource_agrees_with_hifi_zones_tool() {
+    let _settings = SettingsFixture::with_hqplayer(true);
+    let app = TestApp::new().await;
+
+    let tool_text = result_text(&app.call_tool("hifi_zones", json!({})).await);
+    let tool_value: Value = serde_json::from_str(&tool_text).expect("hifi_zones must return JSON");
+
+    let read = app.read_resource("hifi://zones").await;
+    let resource_text = read
+        .pointer("/result/contents/0/text")
+        .and_then(Value::as_str)
+        .expect("hifi://zones must return text contents");
+    let resource_value: Value =
+        serde_json::from_str(resource_text).expect("hifi://zones contents must be JSON");
+
+    assert_eq!(
+        tool_value, resource_value,
+        "hifi://zones must carry exactly the hifi_zones tool's payload"
+    );
+}
+
+/// A live zone through a real mock LMS server and adapter — the strongest form
+/// of the tool/resource agreement test, because it fails if the resource path
+/// and the tool path ever compute the now-playing payload differently for a
+/// zone that actually has state (title, artist, album).
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn now_playing_resource_agrees_with_hifi_now_playing_tool_for_a_live_zone() {
+    let h = LmsHarness::start().await;
+    let zone_id = h.zone_id();
+
+    let tool_text = result_text(
+        &h.app
+            .call_tool("hifi_now_playing", json!({ "zone_id": zone_id }))
+            .await,
+    );
+    let tool_value: Value =
+        serde_json::from_str(&tool_text).expect("hifi_now_playing must return JSON");
+    assert_eq!(
+        tool_value.get("title").and_then(Value::as_str),
+        Some("So What"),
+        "sanity: the mock's now-playing must reach the tool at all: {tool_value}"
+    );
+
+    let uri = format!("hifi://zones/{zone_id}");
+    let read = h.app.read_resource(&uri).await;
+    let resource_text = read
+        .pointer("/result/contents/0/text")
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("{uri} must return text contents: {read}"));
+    let resource_value: Value =
+        serde_json::from_str(resource_text).expect("resource contents must be JSON");
+
+    assert_eq!(
+        tool_value, resource_value,
+        "hifi://zones/{{zone_id}} must carry exactly the hifi_now_playing tool's payload"
+    );
+
+    h.stop().await;
+}
+
+/// The design's central claim: a zone discovered *after* a client's last
+/// `resources/list` is addressable on the very next call, with no restart,
+/// because per-zone resources are enumerated live from `ZoneAggregator` rather
+/// than fixed at startup or behind a resource template.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn a_newly_discovered_zone_is_addressable_without_a_restart() {
+    let _settings = SettingsFixture::with_hqplayer(true);
+    let bus = create_bus();
+    let state = build_state_with_bus(bus.clone(), None).await;
+
+    let aggregator = state.aggregator.clone();
+    let aggregator_task = tokio::spawn(async move { aggregator.run().await });
+
+    let app = TestApp::with_state(state.clone());
+
+    let before = app.list_resources().await;
+    let before_uris: Vec<String> = before
+        .get("resources")
+        .and_then(Value::as_array)
+        .expect("resources array")
+        .iter()
+        .filter_map(|r| r.get("uri").and_then(Value::as_str))
+        .map(str::to_string)
+        .collect();
+    assert!(
+        !before_uris.iter().any(|u| u.starts_with("hifi://zones/")),
+        "no zone-specific resource must exist before any zone is discovered: {before_uris:?}"
+    );
+
+    let zone_id = "roon:injected-zone".to_string();
+    bus.publish(unified_hifi_control::bus::BusEvent::ZoneDiscovered {
+        zone: unified_hifi_control::bus::Zone {
+            zone_id: zone_id.clone(),
+            zone_name: "Injected Zone".to_string(),
+            state: unified_hifi_control::bus::PlaybackState::Stopped,
+            volume_control: None,
+            now_playing: None,
+            source: "roon".to_string(),
+            is_controllable: true,
+            is_seekable: false,
+            last_updated: 0,
+            is_play_allowed: true,
+            is_pause_allowed: true,
+            is_next_allowed: true,
+            is_previous_allowed: true,
+        },
+    });
+
+    let mut found = false;
+    for _ in 0..100 {
+        if state.aggregator.get_zone(&zone_id).await.is_some() {
+            found = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+    assert!(found, "the injected zone never reached the aggregator");
+
+    let after = app.list_resources().await;
+    let after_uris: Vec<String> = after
+        .get("resources")
+        .and_then(Value::as_array)
+        .expect("resources array")
+        .iter()
+        .filter_map(|r| r.get("uri").and_then(Value::as_str))
+        .map(str::to_string)
+        .collect();
+    let expected_uri = format!("hifi://zones/{zone_id}");
+    assert!(
+        after_uris.contains(&expected_uri),
+        "the newly discovered zone must be addressable with no restart: {after_uris:?}"
+    );
+
+    aggregator_task.abort();
+}
+
+/// An unknown scheme, and a zone id the aggregator has never held, must both
+/// yield a proper JSON-RPC error — never a panic, and never an empty success a
+/// client could mistake for "this resource has no content".
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn unknown_or_stale_resource_uri_is_a_proper_error() {
+    let _settings = SettingsFixture::with_hqplayer(true);
+    let app = TestApp::new().await;
+
+    for uri in ["hifi://nonsense", "hifi://zones/does-not-exist"] {
+        let response = app.read_resource(uri).await;
+        let error = response
+            .get("error")
+            .unwrap_or_else(|| panic!("{uri}: must be refused, got {response}"));
+        assert!(
+            error.get("code").and_then(Value::as_i64).is_some(),
+            "{uri}: error must carry a JSON-RPC code: {error}"
+        );
+        assert!(
+            response.get("result").is_none(),
+            "{uri}: must not also carry a result: {response}"
         );
     }
 }

--- a/tests/mcp_contract.rs
+++ b/tests/mcp_contract.rs
@@ -1035,8 +1035,7 @@ async fn resource_methods_dispatch_now_that_resources_is_declared() {
             json!({ "jsonrpc": "2.0", "id": 10, "method": "resources/list", "params": {} }),
         )
         .await;
-    let list_response =
-        list_response.expect("resources/list must return a JSON-RPC response");
+    let list_response = list_response.expect("resources/list must return a JSON-RPC response");
     assert!(
         list_response.get("error").is_none(),
         "resources/list must no longer be refused: {list_response}"

--- a/tests/mcp_contract.rs
+++ b/tests/mcp_contract.rs
@@ -5021,9 +5021,23 @@ async fn unknown_or_stale_resource_uri_is_a_proper_error() {
         let error = response
             .get("error")
             .unwrap_or_else(|| panic!("{uri}: must be refused, got {response}"));
+        assert_eq!(
+            error.get("code").and_then(Value::as_i64),
+            Some(-32002),
+            "{uri}: expected the MCP-conventional resource-not-found code: {error}"
+        );
+        assert_eq!(
+            error.pointer("/data/uri").and_then(Value::as_str),
+            Some(uri),
+            "{uri}: the offending uri must be echoed in the error data: {error}"
+        );
         assert!(
-            error.get("code").and_then(Value::as_i64).is_some(),
-            "{uri}: error must carry a JSON-RPC code: {error}"
+            error
+                .pointer("/data/hint")
+                .and_then(Value::as_str)
+                .is_some_and(|h| h.contains("resources/list")),
+            "{uri}: a stale/unknown resource must point at resources/list to recover, \
+             the way hifi_now_playing's UnknownTarget refusal names hifi_zones: {error}"
         );
         assert!(
             response.get("result").is_none(),

--- a/tests/mcp_contract.rs
+++ b/tests/mcp_contract.rs
@@ -5045,3 +5045,126 @@ async fn unknown_or_stale_resource_uri_is_a_proper_error() {
         );
     }
 }
+
+/// The issue's hard constraint — "a resource and its equivalent tool must
+/// never be able to disagree" — is enforced structurally for all five
+/// resources (`hqp_status_payload`/`hqp_profiles_payload` are the single
+/// function each of the tool and the resource call), but the acceptance
+/// criteria only require a *test* for zones and now-playing. This closes that
+/// gap for HQPlayer status specifically, reusing
+/// `hqplayer_round_trip_reports_a_live_connection`'s mock-server harness so the
+/// payload is non-trivial (`connected: true`, a real `host`), not just the
+/// vacuously-equal all-`None`/disconnected case.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn hqplayer_status_resource_agrees_with_the_tool_for_a_live_connection() {
+    let _settings = SettingsFixture::with_hqplayer(true);
+    let mock = MockHqpServer::start().await;
+
+    let state = build_state(None).await;
+    state
+        .hqplayer
+        .configure(
+            mock.addr().ip().to_string(),
+            Some(mock.addr().port()),
+            None,
+            None,
+            None,
+        )
+        .await;
+    state
+        .hqplayer
+        .connect()
+        .await
+        .expect("HQPlayer must connect to the mock");
+
+    let app = TestApp::with_state(state.clone());
+
+    let mut connected = false;
+    for _ in 0..50 {
+        if state.hqplayer.get_status().await.connected {
+            connected = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    assert!(connected, "HQPlayer adapter never connected to the mock");
+
+    let tool_text = result_text(&app.call_tool("hifi_hqplayer_status", json!({})).await);
+    let tool_value: Value = serde_json::from_str(&tool_text)
+        .unwrap_or_else(|e| panic!("hifi_hqplayer_status must return JSON: {e}\n{tool_text}"));
+    assert_eq!(
+        tool_value.get("connected"),
+        Some(&json!(true)),
+        "sanity: the mock's connection must reach the tool at all: {tool_value}"
+    );
+
+    let read = app.read_resource("hifi://hqplayer/status").await;
+    let resource_text = read
+        .pointer("/result/contents/0/text")
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("hifi://hqplayer/status must return text contents: {read}"));
+    let resource_value: Value =
+        serde_json::from_str(resource_text).expect("resource contents must be JSON");
+
+    assert_eq!(
+        tool_value, resource_value,
+        "hifi://hqplayer/status must carry exactly the hifi_hqplayer_status tool's payload"
+    );
+
+    mock.stop().await;
+}
+
+/// The profiles counterpart to the status test above. Trivially equal with no
+/// profiles cached (both are `[]`), which is honest: `get_cached_profiles`
+/// needs a `list_profiles` round-trip the mock doesn't drive here, and the
+/// point of this test is the shared-function property (`hqp_profiles_payload`
+/// is the one place either path reads from), not a specific profile list.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn hqplayer_profiles_resource_agrees_with_hifi_hqplayer_profiles_tool() {
+    let _settings = SettingsFixture::with_hqplayer(true);
+    let app = TestApp::new().await;
+
+    let tool_text = result_text(&app.call_tool("hifi_hqplayer_profiles", json!({})).await);
+    let tool_value: Value =
+        serde_json::from_str(&tool_text).expect("hifi_hqplayer_profiles must return JSON");
+
+    let read = app.read_resource("hifi://hqplayer/profiles").await;
+    let resource_text = read
+        .pointer("/result/contents/0/text")
+        .and_then(Value::as_str)
+        .expect("hifi://hqplayer/profiles must return text contents");
+    let resource_value: Value =
+        serde_json::from_str(resource_text).expect("resource contents must be JSON");
+
+    assert_eq!(
+        tool_value, resource_value,
+        "hifi://hqplayer/profiles must carry exactly the hifi_hqplayer_profiles tool's payload"
+    );
+}
+
+/// `hifi://status`'s counterpart. Both paths call `status_payload` directly, so
+/// this is the last of the five resources without a dedicated agreement test.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn status_resource_agrees_with_hifi_status_tool() {
+    let _settings = SettingsFixture::with_hqplayer(true);
+    let app = TestApp::new().await;
+
+    let tool_text = result_text(&app.call_tool("hifi_status", json!({})).await);
+    let tool_value: Value = serde_json::from_str(&tool_text).expect("hifi_status must return JSON");
+
+    let read = app.read_resource("hifi://status").await;
+    let resource_text = read
+        .pointer("/result/contents/0/text")
+        .and_then(Value::as_str)
+        .expect("hifi://status must return text contents");
+    let resource_value: Value =
+        serde_json::from_str(resource_text).expect("resource contents must be JSON");
+
+    assert_eq!(
+        tool_value, resource_value,
+        "hifi://status must carry exactly the hifi_status tool's payload"
+    );
+}


### PR DESCRIPTION
## Summary

Implements #397 (RESOURCES) in epic #392: exposes readable bridge state as MCP resources, addressable by URI, alongside the existing `read_only_hint` tools — which keep working unchanged.

Base: `v3` at `5996af5` (includes #394 FOUNDATION, #395 ENVELOPE, #398 CAPABILITIES). This PR targets `v3` directly, so the full CI Lint/Test/Build set applies — see CI status below, not just local verification.

## Solution space: already resolved, not relitigated

Per the issue and #392, the solution-space gate for this issue was resolved before implementation started (see the issue body's "SDK findings" and "Decisions taken" sections). Confirming briefly rather than re-deriving:

- **Live per-zone enumeration**, not one big document or a resource template. `resources/list` reads `ZoneAggregator` fresh on every call, so a zone discovered after a client's last list is addressable on the very next one, with no restart — see `a_newly_discovered_zone_is_addressable_without_a_restart` in `tests/mcp_contract.rs`.
- **`listChanged`: advertised and implemented.** Wired off the same bus zone-discovery events (`ZoneDiscovered`, `ZoneRemoved`, `ZonesFlushed`) `ZoneAggregator` already consumes. Documented as best-effort: with `event_store: None` (`src/mcp/mod.rs`), a client with no open GET/SSE stream never receives it and there is no replay.
- **`subscribe`: not advertised.** The pinned SDK has no subscription registry and no replay, so advertising it would claim something this server cannot honor. A client that calls `resources/subscribe` anyway reaches the SDK's own default handler — a plain `method_not_found` (`-32601`), not a capability-gate refusal — asserted by `resources_subscribe_is_not_advertised_and_not_implemented`.
- **Declaring the `resources` capability at all is what makes the five resource hooks on `ServerHandler` reachable** — the SDK's dispatch gate keys only on capability *presence*, never on `subscribe`/`listChanged` sub-fields, confirmed directly by `declared_protocol_version_and_capabilities_are_pinned`.
- **Payload shape equals the tool's envelope `data`.** No parallel shape was invented — see "No second source of truth" below.
- Left room for #418 (album art / `BlobResourceContents`) without building for it speculatively — the URI scheme and `ReadResourceContent` enum (`TextResourceContents | BlobResourceContents`) both already accommodate a future blob resource; nothing here forecloses it.

## What's covered

`resources/list` and `resources/read`, for:

| URI | Equivalent tool |
|---|---|
| `hifi://zones` | `hifi_zones` |
| `hifi://zones/{zone_id}` (one per live zone) | `hifi_now_playing` |
| `hifi://status` | `hifi_status` |
| `hifi://hqplayer/status` (HQPlayer enabled only) | `hifi_hqplayer_status` |
| `hifi://hqplayer/profiles` (HQPlayer enabled only) | `hifi_hqplayer_profiles` |

- **No second source of truth.** `src/mcp/tools/{zones,status,hqplayer}.rs` had their payload-building logic extracted into functions (`zones_payload`, `now_playing_payload`, `status_payload`, `hqp_status_payload`, `hqp_profiles_payload`) that both the tool handler and `src/mcp/resources.rs` call. There is exactly one place that reads the aggregator or an adapter accessor for each kind of state — a resource and its tool cannot compute different answers. No behavior change to the tools themselves (same fixtures, same tests, still green).
- **Tool/resource agreement is tested, not just asserted in prose**, for all five resources (the acceptance criteria require it for at least zones and now-playing): `zones_resource_agrees_with_hifi_zones_tool`, `now_playing_resource_agrees_with_hifi_now_playing_tool_for_a_live_zone` (a real mock LMS server + adapter + bus + aggregator, non-trivial payload with title/artist/album, not just the empty case), `status_resource_agrees_with_hifi_status_tool`, `hqplayer_status_resource_agrees_with_the_tool_for_a_live_connection` (mock HQPlayer server, real `connected: true`/`host`), and `hqplayer_profiles_resource_agrees_with_hifi_hqplayer_profiles_tool`. The last three were added after this PR's own dissent pass found that satisfying the acceptance criteria's literal minimum ("at least zones and now-playing") had left three of five resources' tool/resource agreement enforced only structurally (shared payload functions) and unverified by any test.
- **HQPlayer resources are gated exactly like HQPlayer tools.** `hqplayer_resources_are_absent_when_adapter_disabled` mirrors the existing `hqplayer_tools_filtered_when_adapter_disabled`, same settings fixture, same assertion shape. As with tools, this only gates *advertisement* — `read_resource` doesn't re-check settings, matching how a HQPlayer tool called directly (unlisted) still executes.
- **Unknown/stale URIs are a proper JSON-RPC error, never a panic or empty success.** `unknown_or_stale_resource_uri_is_a_proper_error` covers both an unrecognised scheme and a `hifi://zones/{zone_id}` for a zone the aggregator has never held. Uses the MCP-conventional "Resource not found" code (`-32002`), since the SDK's `RpcError` (returned by every `ServerHandler` resource method) has no built-in constructor for it — only a different type, `SdkError`, used internally by the transport, does — so the struct is built directly (its fields are public for exactly this). The error's `data` also carries a `hint` pointing at `resources/list` — the resource-side equivalent of `hifi_now_playing`'s `Refusal::UnknownTarget` naming `hifi_zones` as `discover_with` for the same underlying fact. (Added in a follow-up commit after self-review flagged the first version as less actionable than the tool's equivalent refusal — see commit `4ea6f17`.)
- **`resources/templates/list` returns an empty list**, not the SDK's generic refusal — resources genuinely exist here, there's just no template shape for any of them (live enumeration was chosen instead).

## The capability delta (#394's snapshot, updated deliberately)

`tests/fixtures/mcp_initialize.json`:

```diff
   "capabilities": {
+    "resources": {
+      "listChanged": true
+    },
     "tools": {}
   },
```

`tests/mcp_contract.rs::declared_protocol_version_and_capabilities_are_pinned` now asserts `resources.list_changed == Some(true)` and `resources.subscribe == None` directly off `server_details()`.

`tests/mcp_contract.rs::resource_methods_are_refused_while_only_tools_is_declared` (the test #394 was asked to write specifically so this diff would show up) is renamed to `resource_methods_dispatch_now_that_resources_is_declared` and rewritten to assert the new behavior: `resources/list` and `resources/read` on a known URI now succeed (previously `-32603 Server does not support resources`), and `resources/templates/list` returns `{"resourceTemplates": []}` rather than an error.

## Execute gate: genuine red before green

Commit `525924c` updates/adds the acceptance-criteria tests against **today's** (pre-#397) code and is red for real — 8 failures, all with the expected `-32603 Server does not support resources` shape or the still-missing capability. Commit `47cfbff` is the implementation; the same test file is green afterward with no further test edits.

Per the epic's standing instruction ("a test that asserts nothing is worse than no test"), I broke two of these on purpose to confirm they fail for the right reason before trusting them:
- `now_playing_resource_agrees_with_hifi_now_playing_tool_for_a_live_zone`: temporarily made `now_playing_payload` swap `artist`/`album` — the test failed with a value mismatch, not a panic or a vacuous pass.
- `hqplayer_resources_are_absent_when_adapter_disabled`: temporarily removed the `hqplayer_enabled` gate in `list_resources` — the test failed on the extra URIs.
Both reverted before the final commit.

## Explicitly deferred, and why

- **`subscribe`.** Would need a subscription registry the SDK doesn't provide, plus replay for a dropped stream, which `event_store: None` doesn't support. The issue explicitly excludes advertising it without implementing it.
- **Cover art / `BlobResourceContents` (#418).** Not started here; the URI scheme and content-enum choice don't foreclose it, per the issue's priority note.
- **Delivery proof for `listChanged`.** The notifier is exercised indirectly (bus events fire it, the handler doesn't panic, sessions stay usable afterward) but actual SSE delivery to an open GET stream isn't asserted — that would need a long-lived streaming test harness this suite doesn't have. Documented as best-effort in both `src/mcp/server.rs` and `src/mcp/resources.rs`; a client should treat it as a hint to re-list, not a guarantee.

## Verification (this checkout, in the order specified)

1. `make css` — clean, first thing in this fresh worktree.
2. `cargo fmt --check` — clean.
3. `cargo clippy -- -D warnings` — clean (not `--all-targets`; that target set is known-red crate-wide per #392's standing notes, unrelated to this change).
4. `cargo test --workspace` — 91 passed in `mcp_contract`, workspace-wide all green (including `tests/spawn_cancellation_lint.rs`, which the new background notifier task had to satisfy — see below).
5. `CARGO_BUILD_RUSTC_WRAPPER="" dx build --release --platform web --features web` — clean: client build completed (wasm-bindgen, assets copied) and server build completed. Needed rustup's toolchain ahead of Homebrew's on `PATH` (`~/.cargo/config.toml` pins `rustc-wrapper = sccache`, and Homebrew's `rustc` doesn't have `wasm32-unknown-unknown` installed under this account, so the first attempt failed with "Missing rust target wasm32-unknown-unknown" until `PATH` was corrected — a known local-environment quirk, not a code issue).

## CI (this PR targets `v3`, so this is a real gate — not just local-clean)

All checks green as of the latest push (`807d50c`): **Lint** pass (42s), **Test** pass (2m15s), **Build Linux x64** pass (4m8s), **Build WASM Assets** pass (4m25s), **Synology Package Contract** pass, **Smoke Test Binary** pass, **Build Summary** pass.

One thing not anticipated by the issue text: `tests/spawn_cancellation_lint.rs` is an AST-level lint asserting every `tokio::spawn` loop in `src/` selects on a cancellation token. `spawn_list_changed_notifier`'s bus-subscriber loop needed a `tokio::select!` arm on `AppState::shutdown` (the same `CancellationToken` every other background loop in this crate uses) to pass it — done in the implementation commit, not a separate fix.

## This PR does not

Merge, add labels, or force-push. Ready for the ship-gate review and dissent (posted as separate PR comments per the epic's process).
