### PR TITLE
feat(mcp): opaque content refs, and the one tool that consumes them (#396)

### DIFF
--- a/src/adapters/lms.rs
+++ b/src/adapters/lms.rs
@@ -818,6 +818,78 @@ impl LmsPlayAction {
     }
 }
 
+/// One resolved way to play/queue/insert an LMS result, independent of how it
+/// was found.
+///
+/// Extracted from `search_and_play`'s three-way branch (issue #396) so
+/// `hifi_play_ref` can execute a *specific* target — not `results[0]` — via
+/// [`LmsAdapter::play_target`], without `LmsRpc::execute` becoming public.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LmsPlayTarget {
+    /// `playlistcontrol cmd:<...> <kind>_id:<id>`. Durable: an LMS database
+    /// id, surviving both UHC and LMS restarts. Invalidated only by a rescan
+    /// that reassigns ids — which is why [`LmsAdapter::play_target`] verifies
+    /// it still exists before mutating the queue.
+    Library { kind: LmsSearchResultType, id: i64 },
+    /// `playlist <load|add|insert> <url>`. Mostly durable: a plugin-resolvable
+    /// URL that survives restarts and dies only if the plugin is removed or a
+    /// subscription lapses.
+    Url { url: String },
+    /// `globalsearch playlist <play|add|insert> item_id:<id>`.
+    ///
+    /// **Not an identifier.** Verified against live Lyrion 9.1.2: this is a
+    /// positional breadcrumb of the form `<session>.<index>.<index>` that
+    /// changes across identical calls, and a *fabricated* session id resolves
+    /// successfully — LMS silently re-walks the position on a cache miss — so
+    /// a stale or wrong value here plays the wrong content with **no error**.
+    /// #396's hard rule: never mint a ref through this variant. It exists
+    /// only so `play_target` can still serve `search_and_play`'s existing,
+    /// unref'd first-result path unchanged.
+    GlobalSearchItem { item_id: String },
+}
+
+impl LmsPlayTarget {
+    /// The target `search_and_play` resolves its (only ever first) hit to,
+    /// preserving the exact precedence that method always used — `item_id`,
+    /// then `url`, then a positive library id — so extracting `play_target`
+    /// changes no observable behavior on that path.
+    pub fn from_search_hit(result: &LmsSearchResult) -> Option<Self> {
+        if let Some(item_id) = &result.item_id {
+            Some(Self::GlobalSearchItem {
+                item_id: item_id.clone(),
+            })
+        } else if let Some(url) = &result.url {
+            Some(Self::Url { url: url.clone() })
+        } else if result.id > 0 {
+            Some(Self::Library {
+                kind: result.result_type,
+                id: result.id,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// The target #396's ref minter should record for this result, or `None`
+    /// if nothing about it is safe to mint a ref for.
+    ///
+    /// Different precedence than [`Self::from_search_hit`], and deliberately
+    /// so: a ref is a promise that outlives this call, so it prefers whichever
+    /// handle is durable — `Library` (a persistent database id) over `Url`
+    /// (mostly durable) over minting nothing at all. `GlobalSearchItem` is
+    /// never mintable, full stop; see that variant's own docs for why.
+    pub fn mintable(result: &LmsSearchResult) -> Option<Self> {
+        if result.id > 0 {
+            Some(Self::Library {
+                kind: result.result_type,
+                id: result.id,
+            })
+        } else {
+            result.url.clone().map(|url| Self::Url { url })
+        }
+    }
+}
+
 /// Internal state
 struct LmsState {
     host: Option<String>,
@@ -1585,6 +1657,14 @@ impl LmsAdapter {
     /// Searches using globalsearch (includes streaming services), finds the first
     /// playable result, and executes the specified action (play, queue, or insert).
     /// Uses URL-based playback for streaming items, playlistcontrol for library items.
+    ///
+    /// #396: the actual command construction now lives in [`Self::play_target`],
+    /// reached through [`LmsPlayTarget::from_search_hit`] so this method's
+    /// observable behavior — including which of the three addressing paths a
+    /// result with more than one handle takes — is unchanged from before the
+    /// extraction. `hifi_play_ref`'s resolution path calls `play_target`
+    /// directly, with a target this method never sees: a *specific* result's,
+    /// not `results[0]`'s.
     pub async fn search_and_play(
         &self,
         query: &str,
@@ -1602,66 +1682,14 @@ impl LmsAdapter {
 
         // Take the first result
         let result = &results[0];
-
-        // Determine playback method based on item type:
-        // 1. item_id present (globalsearch streaming) -> use "globalsearch playlist play item_id:XXX"
-        // 2. url present (direct URL) -> use "playlist load/add URL"
-        // 3. otherwise (library item) -> use "playlistcontrol" with entity ID
-        if let Some(ref item_id) = result.item_id {
-            // Globalsearch streaming item - use globalsearch playlist command
-            let method = match action {
-                LmsPlayAction::Play => "play",
-                LmsPlayAction::Queue => "add",
-                LmsPlayAction::Insert => "insert",
-            };
-            let item_id_param = format!("item_id:{}", item_id);
-            self.rpc
-                .execute(
-                    Some(player_id),
-                    vec![
-                        json!("globalsearch"),
-                        json!("playlist"),
-                        json!(method),
-                        json!(item_id_param),
-                    ],
-                )
-                .await?;
-        } else if let Some(ref url) = result.url {
-            // Direct URL item - use playlist command with URL
-            let method = match action {
-                LmsPlayAction::Play => "load",
-                LmsPlayAction::Queue => "add",
-                LmsPlayAction::Insert => "insert",
-            };
-            self.rpc
-                .execute(
-                    Some(player_id),
-                    vec![json!("playlist"), json!(method), json!(url)],
-                )
-                .await?;
-        } else if result.id > 0 {
-            // Library item - use playlistcontrol with entity ID
-            let id_param = match result.result_type {
-                LmsSearchResultType::Album => format!("album_id:{}", result.id),
-                LmsSearchResultType::Artist => format!("artist_id:{}", result.id),
-                LmsSearchResultType::Track => format!("track_id:{}", result.id),
-            };
-
-            let cmd_param = format!("cmd:{}", action.to_lms_cmd());
-
-            self.rpc
-                .execute(
-                    Some(player_id),
-                    vec![json!("playlistcontrol"), json!(cmd_param), json!(id_param)],
-                )
-                .await?;
-        } else {
-            // No valid playback handle - this shouldn't happen if parse_single_item works correctly
-            return Err(anyhow!(
+        let target = LmsPlayTarget::from_search_hit(result).ok_or_else(|| {
+            anyhow!(
                 "No playable result found for '{}' (missing item_id, url, and valid id)",
                 query
-            ));
-        }
+            )
+        })?;
+
+        self.play_target(&target, player_id, action).await?;
 
         // Build response message
         let action_verb = match action {
@@ -1697,6 +1725,143 @@ impl LmsAdapter {
         );
 
         Ok(format!("{} {}", action_verb, what))
+    }
+
+    /// Execute one resolved [`LmsPlayTarget`]: `play`, `queue`, or `insert`
+    /// (play-next) where the target supports it.
+    ///
+    /// #396: this is the one path `hifi_play_ref` uses to resolve a ref. It
+    /// never re-searches and never takes `results[0]` — the defect the issue
+    /// exists to remove from ref resolution. `LmsRpc::execute`
+    /// (`src/adapters/lms.rs`) stays private; this is the purpose-specific
+    /// `pub` method that replaces handing MCP arbitrary CLI construction.
+    ///
+    /// # Validate before mutate
+    ///
+    /// A stale [`LmsPlayTarget::Library`] id is checked against the live
+    /// database *before* the mutating command runs, because
+    /// `playlistcontrol cmd:load` with an id that no longer exists clears the
+    /// queue and *then* fails — a wipe reported as a failure is still a wipe.
+    ///
+    /// **`Url` targets are not pre-validated.** LMS exposes no cheap existence
+    /// check for an arbitrary streaming or plugin URL, and `playlist load
+    /// <bad-url>` returns a normal `{}` while emptying the queue regardless of
+    /// whether it is checked first. This is a known, stated gap, not a
+    /// silently-accepted one — see the issue for why ref minting still
+    /// prefers `Url` over [`LmsPlayTarget::GlobalSearchItem`] in spite of it:
+    /// an unresolvable URL is at least a real failure mode, where a positional
+    /// breadcrumb is a *silent* one.
+    pub async fn play_target(
+        &self,
+        target: &LmsPlayTarget,
+        player_id: &str,
+        action: LmsPlayAction,
+    ) -> Result<()> {
+        let player_id = strip_lms_prefix(player_id);
+
+        match target {
+            LmsPlayTarget::GlobalSearchItem { item_id } => {
+                // Globalsearch streaming item - use globalsearch playlist command
+                let method = match action {
+                    LmsPlayAction::Play => "play",
+                    LmsPlayAction::Queue => "add",
+                    LmsPlayAction::Insert => "insert",
+                };
+                let item_id_param = format!("item_id:{}", item_id);
+                self.rpc
+                    .execute(
+                        Some(player_id),
+                        vec![
+                            json!("globalsearch"),
+                            json!("playlist"),
+                            json!(method),
+                            json!(item_id_param),
+                        ],
+                    )
+                    .await?;
+            }
+            LmsPlayTarget::Url { url } => {
+                // Direct URL item - use playlist command with URL
+                let method = match action {
+                    LmsPlayAction::Play => "load",
+                    LmsPlayAction::Queue => "add",
+                    LmsPlayAction::Insert => "insert",
+                };
+                self.rpc
+                    .execute(
+                        Some(player_id),
+                        vec![json!("playlist"), json!(method), json!(url)],
+                    )
+                    .await?;
+            }
+            LmsPlayTarget::Library { kind, id } => {
+                self.assert_library_id_exists(player_id, *kind, *id).await?;
+
+                let id_param = match kind {
+                    LmsSearchResultType::Album => format!("album_id:{}", id),
+                    LmsSearchResultType::Artist => format!("artist_id:{}", id),
+                    LmsSearchResultType::Track => format!("track_id:{}", id),
+                };
+                let cmd_param = format!("cmd:{}", action.to_lms_cmd());
+
+                self.rpc
+                    .execute(
+                        Some(player_id),
+                        vec![json!("playlistcontrol"), json!(cmd_param), json!(id_param)],
+                    )
+                    .await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Confirm a [`LmsPlayTarget::Library`] id still exists before a mutating
+    /// `playlistcontrol` call touches the queue.
+    ///
+    /// Uses the dedicated taggedlist query for `kind` (`albums`/`artists`/
+    /// `titles`), filtered by the same `<kind>_id` tag that query's own result
+    /// rows are keyed by (`album_id`, `artist_id`, `track_id`) — the shape
+    /// LMS's published CLI reference documents for these three queries.
+    /// **Unverified against a live server**: this repo has already found one
+    /// LMS CLI naming surprise 9.1.2 disagreed with the published docs on
+    /// (`contributors_loop[].contributor_id`, not `artist_id` — see
+    /// `search_library`'s doc comment), so treat this filter's exact tag name
+    /// with the same caution until it is checked against a real instance.
+    async fn assert_library_id_exists(
+        &self,
+        player_id: &str,
+        kind: LmsSearchResultType,
+        id: i64,
+    ) -> Result<()> {
+        let (query, id_tag) = match kind {
+            LmsSearchResultType::Album => ("albums", "album_id"),
+            LmsSearchResultType::Artist => ("artists", "artist_id"),
+            LmsSearchResultType::Track => ("titles", "track_id"),
+        };
+        let result = self
+            .rpc
+            .execute(
+                Some(player_id),
+                vec![
+                    json!(query),
+                    json!(0),
+                    json!(1),
+                    json!(format!("{}:{}", id_tag, id)),
+                ],
+            )
+            .await?;
+        let count = result.get("count").and_then(|v| v.as_i64()).unwrap_or(0);
+        if count < 1 {
+            anyhow::bail!(
+                "{} id {} no longer exists in the LMS library (rescanned since this ref \
+                 was minted?); refusing rather than issuing playlistcontrol, which would \
+                 clear the queue and then fail",
+                kind,
+                id
+            );
+        }
+        Ok(())
     }
 }
 
@@ -2709,6 +2874,160 @@ mod tests {
         assert_eq!(loop_entity_id(&json!({"album_id": 0}), "album"), None);
         assert_eq!(loop_entity_id(&json!({"album_id": -1}), "album"), None);
         assert_eq!(loop_entity_id(&json!({"album": "no id"}), "album"), None);
+    }
+
+    // -------------------------------------------------------------------------
+    // LmsPlayTarget (#396): ref-minting safety
+    //
+    // The hard rule this section exists to prove: a `GlobalSearchItem` handle
+    // -- LMS's positional breadcrumb, verified against live Lyrion 9.1.2 to
+    // change across identical calls and to silently re-resolve a fabricated
+    // id by position on a cache miss -- must never be the thing a ref mints
+    // through. Break `mintable` to prefer it and this section fails.
+    // -------------------------------------------------------------------------
+
+    fn result_with(
+        id: i64,
+        url: Option<&str>,
+        item_id: Option<&str>,
+        result_type: LmsSearchResultType,
+    ) -> LmsSearchResult {
+        LmsSearchResult {
+            result_type,
+            id,
+            title: "Some Title".to_string(),
+            artist: Some("Some Artist".to_string()),
+            album: None,
+            url: url.map(String::from),
+            item_id: item_id.map(String::from),
+        }
+    }
+
+    #[test]
+    fn mintable_never_returns_a_global_search_item_target() {
+        // The unsafe case: only a positional breadcrumb is available. No ref
+        // must be mintable for this -- an absent ref is honest, a ref through
+        // this handle can silently play the wrong thing.
+        let breadcrumb_only = result_with(0, None, Some("3.7.2"), LmsSearchResultType::Track);
+        assert_eq!(LmsPlayTarget::mintable(&breadcrumb_only), None);
+
+        // Even when a breadcrumb is present *alongside* a durable handle,
+        // `mintable` must still prefer the durable one rather than merely
+        // tolerating the breadcrumb's absence.
+        let both = result_with(
+            42,
+            Some("http://stream.example/track"),
+            Some("3.7.2"),
+            LmsSearchResultType::Track,
+        );
+        assert_eq!(
+            LmsPlayTarget::mintable(&both),
+            Some(LmsPlayTarget::Library {
+                kind: LmsSearchResultType::Track,
+                id: 42
+            })
+        );
+
+        // And no `LmsPlayTarget::mintable` result is ever the `GlobalSearchItem`
+        // variant, for any input -- the general form of the rule above.
+        for result in [
+            result_with(0, None, Some("1.0.0"), LmsSearchResultType::Track),
+            result_with(0, None, Some("9.9.9"), LmsSearchResultType::Album),
+            result_with(7, None, Some("2.1.4"), LmsSearchResultType::Artist),
+            result_with(
+                0,
+                Some("http://x"),
+                Some("5.5.5"),
+                LmsSearchResultType::Track,
+            ),
+        ] {
+            assert!(
+                !matches!(
+                    LmsPlayTarget::mintable(&result),
+                    Some(LmsPlayTarget::GlobalSearchItem { .. })
+                ),
+                "mintable() must never yield GlobalSearchItem, got {:?} for {:?}",
+                LmsPlayTarget::mintable(&result),
+                result
+            );
+        }
+    }
+
+    #[test]
+    fn mintable_prefers_library_then_url_then_nothing() {
+        let library_only = result_with(5, None, None, LmsSearchResultType::Album);
+        assert_eq!(
+            LmsPlayTarget::mintable(&library_only),
+            Some(LmsPlayTarget::Library {
+                kind: LmsSearchResultType::Album,
+                id: 5
+            })
+        );
+
+        let url_only = result_with(
+            0,
+            Some("http://stream.example/x"),
+            None,
+            LmsSearchResultType::Track,
+        );
+        assert_eq!(
+            LmsPlayTarget::mintable(&url_only),
+            Some(LmsPlayTarget::Url {
+                url: "http://stream.example/x".to_string()
+            })
+        );
+
+        let neither = result_with(0, None, None, LmsSearchResultType::Track);
+        assert_eq!(LmsPlayTarget::mintable(&neither), None);
+    }
+
+    /// `from_search_hit` is `search_and_play`'s existing precedence
+    /// (`item_id`, then `url`, then a positive library id), extracted
+    /// unchanged -- this is what makes the extraction behavior-preserving.
+    /// It is a *different* precedence than `mintable`'s on purpose: it feeds
+    /// only `search_and_play`'s unref'd first-result path, which this issue
+    /// leaves untouched.
+    #[test]
+    fn from_search_hit_preserves_search_and_plays_original_precedence() {
+        let all_three = result_with(
+            5,
+            Some("http://stream.example/x"),
+            Some("1.2.3"),
+            LmsSearchResultType::Track,
+        );
+        assert_eq!(
+            LmsPlayTarget::from_search_hit(&all_three),
+            Some(LmsPlayTarget::GlobalSearchItem {
+                item_id: "1.2.3".to_string()
+            }),
+            "item_id must win when present, matching search_and_play's original order"
+        );
+
+        let url_and_id = result_with(
+            5,
+            Some("http://stream.example/x"),
+            None,
+            LmsSearchResultType::Track,
+        );
+        assert_eq!(
+            LmsPlayTarget::from_search_hit(&url_and_id),
+            Some(LmsPlayTarget::Url {
+                url: "http://stream.example/x".to_string()
+            }),
+            "url must win over a bare library id when there is no item_id"
+        );
+
+        let id_only = result_with(5, None, None, LmsSearchResultType::Track);
+        assert_eq!(
+            LmsPlayTarget::from_search_hit(&id_only),
+            Some(LmsPlayTarget::Library {
+                kind: LmsSearchResultType::Track,
+                id: 5
+            })
+        );
+
+        let nothing = result_with(0, None, None, LmsSearchResultType::Track);
+        assert_eq!(LmsPlayTarget::from_search_hit(&nothing), None);
     }
 
     #[test]

--- a/src/adapters/lms.rs
+++ b/src/adapters/lms.rs
@@ -226,6 +226,17 @@ const DEFAULT_POLL_INTERVAL_SECS: u64 = 2;
 /// Multiplier for poll interval when subscription is active (15x base interval)
 const SUBSCRIPTION_INTERVAL_MULTIPLIER: u64 = 15;
 
+/// How many results [`LmsAdapter::assert_library_id_exists`] (#396) requests
+/// when re-validating a `Library` ref by its mint-time title.
+///
+/// Sized well above any plausible count of library entries sharing one exact
+/// title, so the search-by-title re-validation actually surfaces the target
+/// id rather than missing it purely because too many other entries share the
+/// same title. See that method's own doc comment for why this number exists
+/// at all, and `tests/mcp_refs.rs::lms_a_valid_ref_beyond_the_validation_search_limit_still_resolves`
+/// for the test that found the original value (50) was not generous enough.
+const LIBRARY_VALIDATION_SEARCH_LIMIT: usize = 500;
+
 /// Get the poll interval from LMS_POLL_INTERVAL env var, or use default
 fn get_poll_interval() -> Duration {
     std::env::var("LMS_POLL_INTERVAL")
@@ -1689,7 +1700,10 @@ impl LmsAdapter {
             )
         })?;
 
-        self.play_target(&target, player_id, action).await?;
+        // No validation: `target` was just produced by the search a few
+        // lines up, in this same call -- there is no time gap for the id to
+        // have gone stale in, unlike a ref resolved later.
+        self.play_target(&target, player_id, action, None).await?;
 
         // Build response message
         let action_verb = match action {
@@ -1738,24 +1752,33 @@ impl LmsAdapter {
     ///
     /// # Validate before mutate
     ///
-    /// A stale [`LmsPlayTarget::Library`] id is checked against the live
-    /// database *before* the mutating command runs, because
-    /// `playlistcontrol cmd:load` with an id that no longer exists clears the
-    /// queue and *then* fails — a wipe reported as a failure is still a wipe.
+    /// A [`LmsPlayTarget::Library`] id is checked against the live database
+    /// *before* the mutating command runs whenever `validate_title` is
+    /// `Some` — because `playlistcontrol cmd:load` with an id that no longer
+    /// exists clears the queue and *then* fails, and a wipe reported as a
+    /// failure is still a wipe. Pass `Some(title)` (the title captured when
+    /// the target was found — a ref's mint-time title, in `hifi_play_ref`'s
+    /// case) for any caller resolving a target across a time gap; pass
+    /// `None` when the target was *just* produced by a search this same call
+    /// made (`search_and_play`'s own path), where there is no gap for the id
+    /// to have gone stale in and the validation would be pure overhead on
+    /// every ordinary play.
     ///
-    /// **`Url` targets are not pre-validated.** LMS exposes no cheap existence
-    /// check for an arbitrary streaming or plugin URL, and `playlist load
-    /// <bad-url>` returns a normal `{}` while emptying the queue regardless of
-    /// whether it is checked first. This is a known, stated gap, not a
-    /// silently-accepted one — see the issue for why ref minting still
-    /// prefers `Url` over [`LmsPlayTarget::GlobalSearchItem`] in spite of it:
-    /// an unresolvable URL is at least a real failure mode, where a positional
-    /// breadcrumb is a *silent* one.
+    /// **`Url` targets are not pre-validated**, `validate_title` or not. LMS
+    /// exposes no cheap existence check for an arbitrary streaming or plugin
+    /// URL, and `playlist load <bad-url>` returns a normal `{}` while
+    /// emptying the queue regardless of whether it is checked first. This is
+    /// a known, stated gap, not a silently-accepted one — see the issue for
+    /// why ref minting still prefers `Url` over
+    /// [`LmsPlayTarget::GlobalSearchItem`] in spite of it: an unresolvable
+    /// URL is at least a real failure mode, where a positional breadcrumb is
+    /// a *silent* one.
     pub async fn play_target(
         &self,
         target: &LmsPlayTarget,
         player_id: &str,
         action: LmsPlayAction,
+        validate_title: Option<&str>,
     ) -> Result<()> {
         let player_id = strip_lms_prefix(player_id);
 
@@ -1795,7 +1818,9 @@ impl LmsAdapter {
                     .await?;
             }
             LmsPlayTarget::Library { kind, id } => {
-                self.assert_library_id_exists(player_id, *kind, *id).await?;
+                if let Some(title) = validate_title {
+                    self.assert_library_id_exists(*kind, *id, title).await?;
+                }
 
                 let id_param = match kind {
                     LmsSearchResultType::Album => format!("album_id:{}", id),
@@ -1819,46 +1844,80 @@ impl LmsAdapter {
     /// Confirm a [`LmsPlayTarget::Library`] id still exists before a mutating
     /// `playlistcontrol` call touches the queue.
     ///
-    /// Uses the dedicated taggedlist query for `kind` (`albums`/`artists`/
-    /// `titles`), filtered by the same `<kind>_id` tag that query's own result
-    /// rows are keyed by (`album_id`, `artist_id`, `track_id`) — the shape
-    /// LMS's published CLI reference documents for these three queries.
-    /// **Unverified against a live server**: this repo has already found one
-    /// LMS CLI naming surprise 9.1.2 disagreed with the published docs on
-    /// (`contributors_loop[].contributor_id`, not `artist_id` — see
-    /// `search_library`'s doc comment), so treat this filter's exact tag name
-    /// with the same caution until it is checked against a real instance.
+    /// # Why this reuses `search_library` rather than a dedicated query
+    ///
+    /// An earlier version of this method queried the dedicated taggedlist
+    /// command for `kind` (`albums`/`artists`/`titles`), filtered by
+    /// `<kind>_id`, and treated `count >= 1` as "exists". That shape is
+    /// unverified against a live server, and unverified is not merely
+    /// "untested" here: if LMS ignores an unrecognised filter tag rather than
+    /// erroring on it — this repo has already observed LMS silently ignoring
+    /// unrecognised tagged parameters elsewhere, see the `mute` pref comment
+    /// in `get_players` — the query would return the *unfiltered* count of
+    /// every album/artist/track on the server, which is essentially always
+    /// `>= 1`. That is a **fail-open** bug: validation would always report
+    /// "exists" regardless of the actual id, silently defeating the entire
+    /// point of validating before a mutating call. A wrong filter name would
+    /// have made this method worse than not having it.
+    ///
+    /// This version instead reuses [`Self::search_library`] — parsing already
+    /// verified against a recorded live Lyrion 9.1.2 response (#407,
+    /// `tests/fixtures/lms/`) — searching by the title captured when the
+    /// target was found, and checking whether any returned entity of the
+    /// right kind has the target id. A wrong assumption here fails **closed**
+    /// instead: if the title no longer matches anything (or the entity is
+    /// gone), no result carries the target id, and this refuses exactly as it
+    /// should. The trade a wrong assumption could still make is a false
+    /// negative — refusing a still-valid id because the title changed since
+    /// mint time — which is the safe direction to be wrong in.
+    ///
+    /// # A second false-negative source, found and closed during review
+    ///
+    /// Searching by title only surfaces a *bounded* number of matches
+    /// ([`LIBRARY_VALIDATION_SEARCH_LIMIT`]). If more entries than that share
+    /// the exact title captured at mint time (a box set re-release, a
+    /// self-titled album by different artists, a generic "Live"), a
+    /// still-valid id outside that window is wrongly refused —
+    /// `tests/mcp_refs.rs::lms_a_valid_ref_beyond_the_validation_search_limit_still_resolves`
+    /// reproduces this directly (it failed against the original limit of 50
+    /// before this constant was raised). The limit is generous enough that a
+    /// real collision is implausible, but "implausible" is not "impossible";
+    /// this is a known, bounded, fail-*closed* residual risk, not a claim
+    /// that no library can ever trigger it.
+    ///
+    /// # This is not free, and that cost is unmeasured
+    ///
+    /// This method runs unconditionally before every `hifi_play_ref`
+    /// resolution of a `Library` target (`play_target` passes
+    /// `validate_title: Some` for that path) — a full-text `search` over up
+    /// to [`LIBRARY_VALIDATION_SEARCH_LIMIT`] rows, on every such call, not
+    /// only when a ref is actually stale. That is a real latency cost on top
+    /// of the eventual `playlistcontrol` call, and this project ships to
+    /// NAS- and SBC-class hardware (see the Synology/QNAP build targets in
+    /// CI) where a large-library full-text search is not necessarily cheap.
+    /// No benchmark exists for this yet; if `hifi_play_ref` on LMS turns out
+    /// noticeably slower than `hifi_play`'s own query path, this method is
+    /// the place to look first.
     async fn assert_library_id_exists(
         &self,
-        player_id: &str,
         kind: LmsSearchResultType,
         id: i64,
+        title: &str,
     ) -> Result<()> {
-        let (query, id_tag) = match kind {
-            LmsSearchResultType::Album => ("albums", "album_id"),
-            LmsSearchResultType::Artist => ("artists", "artist_id"),
-            LmsSearchResultType::Track => ("titles", "track_id"),
-        };
-        let result = self
-            .rpc
-            .execute(
-                Some(player_id),
-                vec![
-                    json!(query),
-                    json!(0),
-                    json!(1),
-                    json!(format!("{}:{}", id_tag, id)),
-                ],
-            )
+        let candidates = self
+            .search_library(title, LIBRARY_VALIDATION_SEARCH_LIMIT)
             .await?;
-        let count = result.get("count").and_then(|v| v.as_i64()).unwrap_or(0);
-        if count < 1 {
+        let exists = candidates
+            .iter()
+            .any(|c| c.result_type == kind && c.id == id);
+        if !exists {
             anyhow::bail!(
-                "{} id {} no longer exists in the LMS library (rescanned since this ref \
-                 was minted?); refusing rather than issuing playlistcontrol, which would \
-                 clear the queue and then fail",
+                "{} id {} (title {:?}) no longer exists in the LMS library (rescanned \
+                 since this ref was minted, or renamed?); refusing rather than issuing \
+                 playlistcontrol, which would clear the queue and then fail",
                 kind,
-                id
+                id,
+                title
             );
         }
         Ok(())

--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -1239,7 +1239,11 @@ impl RoonAdapter {
         }
     }
 
-    /// Search the Roon library, TIDAL, or Qobuz
+    /// Search the Roon library, TIDAL, or Qobuz.
+    ///
+    /// Thin wrapper over [`Self::search_with_session`] that drops the session
+    /// key, preserving this method's exact pre-#396 signature and behavior --
+    /// `/roon/search` (`src/api/mod.rs`) calls this one, unchanged.
     pub async fn search(
         &self,
         query: &str,
@@ -1247,6 +1251,25 @@ impl RoonAdapter {
         limit: Option<usize>,
         source: SearchSource,
     ) -> Result<Vec<BrowseItem>> {
+        self.search_with_session(query, zone_id, limit, source)
+            .await
+            .map(|(_session_key, items)| items)
+    }
+
+    /// [`Self::search`], plus the `multi_session_key` the search minted.
+    ///
+    /// #396: a returned `item_key`'s scope is that session, not the Core in
+    /// general -- see `tests/mock_servers/roon_core.rs`'s `ItemKeyScope` docs
+    /// for the third-party evidence this rests on. A ref minted from these
+    /// results must record the session key here so [`Self::play_ref`] can
+    /// resolve it inside the same session rather than a fresh, unrelated one.
+    pub async fn search_with_session(
+        &self,
+        query: &str,
+        zone_id: Option<&str>,
+        limit: Option<usize>,
+        source: SearchSource,
+    ) -> Result<(String, Vec<BrowseItem>)> {
         let session_key = format!(
             "search_{}",
             std::time::SystemTime::now()
@@ -1331,16 +1354,16 @@ impl RoonAdapter {
         if let Some(list) = &search_result.list {
             if list.count > 0 {
                 let load_opts = LoadOpts {
-                    multi_session_key: Some(session_key),
+                    multi_session_key: Some(session_key.clone()),
                     count: Some(limit.unwrap_or(DEFAULT_SEARCH_LIMIT)),
                     ..Default::default()
                 };
                 let load_result = self.load(load_opts).await?;
-                return Ok(load_result.items);
+                return Ok((session_key, load_result.items));
             }
         }
 
-        Ok(vec![])
+        Ok((session_key, vec![]))
     }
 
     /// Search and play the first matching result
@@ -1658,7 +1681,16 @@ impl RoonAdapter {
         Ok(None)
     }
 
-    /// Play an item by its item_key
+    /// Play an item by its item_key, in a session minted just for this call.
+    ///
+    /// **This bets that `item_key`s are portable across `multi_session_key`s.**
+    /// That bet is unproven in this repo (zero other callers, no test before
+    /// #408) and public evidence points against it -- see
+    /// `tests/mock_servers/roon_core.rs`'s `ItemKeyScope` docs. It is kept,
+    /// unchanged, only because `/roon/play_item` (`src/api/mod.rs`) is
+    /// existing, exposed HTTP surface with its own contract; #396's ref
+    /// resolution path is [`Self::play_ref`] below, which re-enters the
+    /// session that actually minted the key instead of taking this bet.
     pub async fn play_item(
         &self,
         item_key: &str,
@@ -1682,10 +1714,63 @@ impl RoonAdapter {
 
         let bare_zone_id = strip_roon_prefix(zone_id);
 
+        // A freshly-minted session's stack is always empty, so `pop_all` and
+        // "start from nothing" are equivalent here -- `false` changes nothing
+        // observable and keeps this call's own protocol trace identical to
+        // before this method was split out of `resolve_item_key`.
+        self.resolve_item_key(&session_key, item_key, bare_zone_id, action, false)
+            .await
+    }
+
+    /// Resolve a `hifi_play_ref` (#396): play an item_key **inside the session
+    /// that minted it**, rather than a fresh, unrelated one.
+    ///
+    /// This is `play_item`'s exact resolution logic with one change:
+    /// `multi_session_key` is the caller-supplied minting session, and the
+    /// first browse sets `pop_all: true` to reset that session's stack to the
+    /// root before entering the item. That reset matters when a client holds
+    /// two refs minted by the same search (they share one `multi_session_key`,
+    /// see `search_with_session`): without it, resolving the second ref would
+    /// inherit wherever the first resolution's navigation left the stack,
+    /// rather than starting from the state the ref was actually minted in.
+    pub async fn play_ref(
+        &self,
+        item_key: &str,
+        multi_session_key: &str,
+        zone_id: &str,
+        action: PlayAction,
+    ) -> Result<String> {
+        if item_key.is_empty() {
+            return Err(anyhow::anyhow!("item_key cannot be empty"));
+        }
+        if item_key.len() > 500 {
+            return Err(anyhow::anyhow!("item_key appears malformed (too long)"));
+        }
+
+        let bare_zone_id = strip_roon_prefix(zone_id);
+        self.resolve_item_key(multi_session_key, item_key, bare_zone_id, action, true)
+            .await
+    }
+
+    /// Shared body of [`Self::play_item`] and [`Self::play_ref`]: browse into
+    /// `item_key` within `session_key`, find (or navigate to) a playable
+    /// action, and invoke it.
+    async fn resolve_item_key(
+        &self,
+        session_key: &str,
+        item_key: &str,
+        bare_zone_id: &str,
+        action: PlayAction,
+        pop_all: bool,
+    ) -> Result<String> {
+        let session_key = session_key.to_string();
+        let bare_zone_id = bare_zone_id.to_string();
+
         self.browse(BrowseOpts {
             multi_session_key: Some(session_key.clone()),
             item_key: Some(item_key.to_string()),
-            zone_or_output_id: Some(bare_zone_id.to_string()),
+            zone_or_output_id: Some(bare_zone_id.clone()),
+            pop_all,
             ..Default::default()
         })
         .await?;
@@ -1705,7 +1790,7 @@ impl RoonAdapter {
                 .clone()
                 .ok_or_else(|| anyhow::anyhow!("Item has no key"))?;
             return self
-                .execute_play_action(&session_key, bare_zone_id, &title, &key, action)
+                .execute_play_action(&session_key, &bare_zone_id, &title, &key, action)
                 .await;
         }
 
@@ -1716,7 +1801,7 @@ impl RoonAdapter {
                 .clone()
                 .ok_or_else(|| anyhow::anyhow!("Play Album has no key"))?;
             return self
-                .execute_play_action(&session_key, bare_zone_id, "Album", &key, action)
+                .execute_play_action(&session_key, &bare_zone_id, "Album", &key, action)
                 .await;
         }
 
@@ -1726,7 +1811,7 @@ impl RoonAdapter {
                 self.browse(BrowseOpts {
                     multi_session_key: Some(session_key.clone()),
                     item_key: Some(key.clone()),
-                    zone_or_output_id: Some(bare_zone_id.to_string()),
+                    zone_or_output_id: Some(bare_zone_id.clone()),
                     ..Default::default()
                 })
                 .await?;
@@ -1746,7 +1831,7 @@ impl RoonAdapter {
                         .clone()
                         .ok_or_else(|| anyhow::anyhow!("Item has no key"))?;
                     return self
-                        .execute_play_action(&session_key, bare_zone_id, &title, &item_key, action)
+                        .execute_play_action(&session_key, &bare_zone_id, &title, &item_key, action)
                         .await;
                 }
 
@@ -1756,7 +1841,13 @@ impl RoonAdapter {
                         .clone()
                         .ok_or_else(|| anyhow::anyhow!("Play Album has no key"))?;
                     return self
-                        .execute_play_action(&session_key, bare_zone_id, &first.title, &key, action)
+                        .execute_play_action(
+                            &session_key,
+                            &bare_zone_id,
+                            &first.title,
+                            &key,
+                            action,
+                        )
                         .await;
                 }
             }

--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -117,6 +117,44 @@ pub(crate) fn is_category(item: &BrowseItem) -> bool {
     CATEGORY_NAMES.contains(&item.title.as_str())
 }
 
+/// A second, title-independent signal for the same "this is a grouping row,
+/// not addressable content" question `is_category` answers by name match.
+///
+/// #396's ship-gate re-review verified live (against nuc14, Roon 2.70, a
+/// Library search) that `is_category`'s exact title list is correct for
+/// Library results, but has **no live evidence for TIDAL or Qobuz sources**,
+/// which may group results under different labels `CATEGORY_NAMES` does not
+/// contain. This catches that case by a different, source-independent
+/// pattern observed in the same live data: every grouping row's subtitle was
+/// exactly `"<N> Results"` (`"7 Results"`, `"32 Results"`, `"19 Results"`),
+/// while every real hit's subtitle was something else (an artist name, an
+/// album title). **This pattern is also unverified for TIDAL/Qobuz** -- it
+/// is an inference from one source, not a second confirmed fact — but unlike
+/// guessing at a wire *filter* shape (see `LmsAdapter::assert_library_id_exists`'s
+/// own history in this same issue), a false miss here only fails to exclude
+/// a row `is_category` didn't already catch: it cannot mint a *worse* ref
+/// than the title check alone would have, only sometimes a few more of the
+/// same already-accepted risk. So it is included as a strictly-additive
+/// second layer rather than withheld pending verification.
+fn looks_like_a_result_count_grouping(item: &BrowseItem) -> bool {
+    let Some(subtitle) = item.subtitle.as_deref() else {
+        return false;
+    };
+    let Some(count) = subtitle.strip_suffix(" Results") else {
+        return false;
+    };
+    count.parse::<u64>().is_ok()
+}
+
+/// Whether an item is a grouping/category row rather than addressable
+/// content, by either signal above. This is what `hifi_search`'s ref-minting
+/// (`src/mcp/tools/library.rs`) consults; `is_category` alone remains what
+/// `try_navigate_to_playable` uses, unchanged, since this function's second
+/// check is new to #396 and was never exercised by that existing path.
+pub(crate) fn is_ungrounded_grouping(item: &BrowseItem) -> bool {
+    is_category(item) || looks_like_a_result_count_grouping(item)
+}
+
 /// Strip "roon:" prefix from zone/output IDs.
 /// MCP and aggregator use prefixed IDs (e.g., "roon:zone_123"), but Roon API expects bare IDs.
 fn strip_roon_prefix(id: &str) -> &str {

--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -1713,26 +1713,43 @@ impl RoonAdapter {
         );
 
         let bare_zone_id = strip_roon_prefix(zone_id);
-
-        // A freshly-minted session's stack is always empty, so `pop_all` and
-        // "start from nothing" are equivalent here -- `false` changes nothing
-        // observable and keeps this call's own protocol trace identical to
-        // before this method was split out of `resolve_item_key`.
-        self.resolve_item_key(&session_key, item_key, bare_zone_id, action, false)
+        self.resolve_item_key(&session_key, item_key, bare_zone_id, action)
             .await
     }
 
     /// Resolve a `hifi_play_ref` (#396): play an item_key **inside the session
     /// that minted it**, rather than a fresh, unrelated one.
     ///
-    /// This is `play_item`'s exact resolution logic with one change:
-    /// `multi_session_key` is the caller-supplied minting session, and the
-    /// first browse sets `pop_all: true` to reset that session's stack to the
-    /// root before entering the item. That reset matters when a client holds
-    /// two refs minted by the same search (they share one `multi_session_key`,
-    /// see `search_with_session`): without it, resolving the second ref would
-    /// inherit wherever the first resolution's navigation left the stack,
-    /// rather than starting from the state the ref was actually minted in.
+    /// # `pop_all` was here, and it broke this against a real Core
+    ///
+    /// An earlier version of this method reset the shared session's browse
+    /// stack with `pop_all: true` before entering `item_key`, on the theory
+    /// (borrowed from `tests/mock_servers/roon_core.rs`'s model, which does
+    /// not actually enforce this) that two refs minted by one search sharing
+    /// one `multi_session_key` needed that reset to resolve independently.
+    /// Verified live against a real Core (nuc14, Roon 2.70) that this is
+    /// wrong on both counts:
+    ///
+    /// 1. **Combining `pop_all: true` with `item_key` in one browse request
+    ///    hangs** -- the Core never answers, and the caller waits out the
+    ///    full `BROWSE_TIMEOUT`. This is exactly the failure #396 shipped
+    ///    with and #401-adjacent live testing caught.
+    /// 2. **Sending them as two separate requests does not help**: `pop_all`
+    ///    invalidates every item_key minted at the levels it discards, so
+    ///    the *very key being resolved* becomes `InvalidItemKey` immediately
+    ///    after the reset.
+    /// 3. **The reset was solving a problem that does not exist.** Without
+    ///    any `pop_all`, resolving one ref from a search, navigating it all
+    ///    the way down to its action list, and then resolving a *second*,
+    ///    unrelated ref minted by the same search (sharing the same session
+    ///    key) still succeeds immediately -- verified live, twice, at
+    ///    different navigation depths. Item keys minted by one search
+    ///    remain independently resolvable regardless of where else that
+    ///    session has since navigated, as long as nothing pops it.
+    ///
+    /// So this is now `play_item`'s exact resolution logic, unchanged, with
+    /// only `multi_session_key` swapped for the caller-supplied minting
+    /// session instead of a fresh one.
     pub async fn play_ref(
         &self,
         item_key: &str,
@@ -1748,20 +1765,23 @@ impl RoonAdapter {
         }
 
         let bare_zone_id = strip_roon_prefix(zone_id);
-        self.resolve_item_key(multi_session_key, item_key, bare_zone_id, action, true)
+        self.resolve_item_key(multi_session_key, item_key, bare_zone_id, action)
             .await
     }
 
     /// Shared body of [`Self::play_item`] and [`Self::play_ref`]: browse into
     /// `item_key` within `session_key`, find (or navigate to) a playable
     /// action, and invoke it.
+    ///
+    /// Deliberately never sends `pop_all` -- see [`Self::play_ref`]'s doc
+    /// comment for why combining it with `item_key`, or even sequencing it
+    /// beforehand, breaks against a real Core.
     async fn resolve_item_key(
         &self,
         session_key: &str,
         item_key: &str,
         bare_zone_id: &str,
         action: PlayAction,
-        pop_all: bool,
     ) -> Result<String> {
         let session_key = session_key.to_string();
         let bare_zone_id = bare_zone_id.to_string();
@@ -1770,7 +1790,6 @@ impl RoonAdapter {
             multi_session_key: Some(session_key.clone()),
             item_key: Some(item_key.to_string()),
             zone_or_output_id: Some(bare_zone_id.clone()),
-            pop_all,
             ..Default::default()
         })
         .await?;

--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -101,7 +101,19 @@ fn find_playable_item(items: &[BrowseItem]) -> Option<&BrowseItem> {
 }
 
 /// Check if an item is a category (Albums, Tracks, etc.) rather than playable content
-fn is_category(item: &BrowseItem) -> bool {
+///
+/// `pub(crate)` since #396's ship-gate re-review: a real Roon Core's search
+/// results include these grouping rows alongside the actual top hit (e.g.
+/// searching "kind of blue" returns "Kind of Blue" *and* "Albums (32
+/// Results)", "Tracks (34 Results)", ... all with the same `hint: "list"` and
+/// a real `item_key`) -- `tests/mock_servers/roon_core.rs`'s search model
+/// never included these grouping rows, so no test caught that
+/// `crate::mcp::tools::library::handle_search` was minting a ref for them
+/// indistinguishably from real content. Resolving one lands in
+/// `resolve_item_key`'s "guess the first item" fallback, which can silently
+/// play unrelated content -- see that function's call site in
+/// `src/mcp/tools/library.rs` for how this is now excluded from minting.
+pub(crate) fn is_category(item: &BrowseItem) -> bool {
     CATEGORY_NAMES.contains(&item.title.as_str())
 }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -49,6 +49,11 @@ pub struct AppState {
     pub shutdown: CancellationToken,
     /// Count of active SSE connections (for shutdown diagnostics)
     pub sse_connections: Arc<AtomicUsize>,
+    /// The MCP ref table (#396): opaque tokens `hifi_search` mints and
+    /// `hifi_play_ref` resolves. Constructed here rather than taken as a
+    /// constructor parameter -- like `sse_connections` above -- so every
+    /// existing `AppState::new` call site is untouched by this addition.
+    pub mcp_refs: crate::mcp::refs::RefTable,
 }
 
 impl AppState {
@@ -85,6 +90,7 @@ impl AppState {
             start_time,
             shutdown,
             sse_connections: Arc::new(AtomicUsize::new(0)),
+            mcp_refs: crate::mcp::refs::RefTable::new(),
         }
     }
 

--- a/src/mcp/handler.rs
+++ b/src/mcp/handler.rs
@@ -98,6 +98,7 @@ impl ServerHandler for HifiMcpHandler {
             HifiTools::HifiCapabilitiesTool(args) => {
                 tools::capabilities::handle_capabilities(state, args).await
             }
+            HifiTools::HifiPlayRefTool(args) => tools::library::handle_play_ref(state, args).await,
         }
     }
 }

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -19,6 +19,7 @@
 //! | [`envelope`] | the structured result envelope every tool fills           |
 //! | [`routing`]  | zone-prefix -> adapter, in exactly one place              |
 //! | [`capabilities`] | per-provider capability truth, in three states        |
+//! | [`refs`]     | the opaque ref table `hifi_search` mints into and `hifi_play_ref` resolves from (#396) |
 //!
 //! # The MCP surface is pinned by tests
 //!
@@ -34,6 +35,7 @@
 pub mod capabilities;
 pub mod envelope;
 pub mod handler;
+pub mod refs;
 pub mod routing;
 pub mod server;
 pub mod tools;

--- a/src/mcp/refs.rs
+++ b/src/mcp/refs.rs
@@ -1,0 +1,543 @@
+//! The MCP ref table (issue #396): opaque, server-resolved content references.
+//!
+//! # The problem this solves
+//!
+//! Before this module, `hifi_search` returned `{title, subtitle}` and nothing
+//! else, so the only route from "found it" to "playing it" was handing the
+//! title back to `hifi_play`, which re-searches and takes the first match. A
+//! client could not address the third result, could not distinguish two
+//! same-titled albums, and could not tell whether what played is what it
+//! picked. See `tests/mcp_contract.rs::FIELD_ROLES` for how that gap was
+//! frozen (not endorsed) by #394/#395.
+//!
+//! # Design: a server-side table, not a self-describing token
+//!
+//! This was settled at #396's solution-space gate (see the issue and its gate
+//! report comments; not relitigated here). A ref is a 128-bit random token
+//! that names a row in this table; the row alone carries what the token
+//! resolves to. The alternative -- encode the provider handle into the token
+//! itself, signed or encrypted -- was rejected because:
+//!
+//! - Signing gives integrity, not confidentiality: `base64(item_key)` still
+//!   puts the raw key in the client-visible string, just spelled differently.
+//!   Real confidentiality needs authenticated encryption, a new dependency
+//!   this bridge does not otherwise need.
+//! - A Roon ref must carry the `multi_session_key` that minted its `item_key`
+//!   alongside it (see [`RoonRefTarget`]), because portability of a Roon
+//!   `item_key` across sessions is unproven and public evidence points against
+//!   it (home-assistant/core#137605; Roon Labs community thread 23129, both
+//!   cited in `tests/mock_servers/roon_core.rs`). A table can hold that pair
+//!   without ever putting the session key in a client-visible string; an
+//!   encoded token cannot do that without either leaking it or encrypting it.
+//!
+//! # Lifetime: one uniform TTL, not a per-target-kind one
+//!
+//! The solution-space gate's review argued for giving durable LMS targets
+//! (`Library`, `Url`) a longer internal TTL than ephemeral ones (Roon
+//! `item_key`, LMS `GlobalSearchItem`), on the theory that a model does no TTL
+//! arithmetic anyway so the difference is invisible to it. The gate's own
+//! dissent (D4) refuted that: a ref that survives 40 minutes on LMS and fails
+//! at 40 minutes on Roon teaches the model an inconsistent rule, because
+//! models generalize from what worked -- "the last ref I held that long was
+//! fine" becomes an expectation the next Roon ref violates. And "never refuse
+//! a ref you could have honored" plus "never document a lifetime longer than
+//! the shortest kind's" cannot both hold at once; something has to give, and
+//! making the *documented* contract secretly wrong in one direction is the
+//! wrong thing to give up in an epic whose thesis is capability honesty. This
+//! table therefore uses [`DEFAULT_TTL`] for every ref, regardless of provider
+//! or target durability. A future durable content identifier (tracked by
+//! #320) is a different, explicitly-durable thing; it is not modeled as a
+//! quietly-longer TTL on this field.
+//!
+//! # No client-visible TTL field
+//!
+//! The lifetime lives in the tool descriptions (`hifi_search`, `hifi_play_ref`)
+//! and the recovery instruction lives in the refusal
+//! ([`crate::mcp::envelope::Refusal::UnknownTarget`]) -- never in a field on
+//! the ref itself. A model does no TTL arithmetic across turns, so a
+//! `ref_expires_in_s` field would itself be the orphaned field this issue
+//! exists to end.
+//!
+//! # Bounded size and time, and eviction as expiry
+//!
+//! The table holds at most [`DEFAULT_CAPACITY`] entries. Insertion past
+//! capacity evicts the oldest-inserted entry first (insertion-order, not
+//! access-order LRU -- the issue leaves eviction policy as a soft constraint,
+//! and insertion order is the simplest policy that satisfies "bounded" without
+//! a new dependency). Because a token is 128 random bits with nothing
+//! derivable from it, a client cannot distinguish "this ref was evicted for
+//! space" from "this ref expired" from "this token was never valid" -- all
+//! three resolve to the same `unknown_ref` outcome. That collapse is the
+//! point: eviction cannot look like corruption because there is no partial or
+//! wrong answer to give, only "not found".
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use rand::RngCore;
+use tokio::sync::Mutex;
+
+use crate::adapters::lms::LmsPlayTarget;
+use crate::mcp::envelope::Provider;
+
+/// How many refs the table holds before the oldest is evicted to make room.
+///
+/// Sized generously above any plausible single-conversation search volume.
+/// Roon `item_key` <= 500 chars (the adapter's own bound,
+/// `src/adapters/roon.rs`), session keys and titles are short, so even a full
+/// table is a trivial amount of memory -- boundedness, not compactness, is the
+/// property this guards.
+pub const DEFAULT_CAPACITY: usize = 512;
+
+/// How long a ref remains resolvable after it is minted. Uniform across every
+/// provider and target kind -- see the module docs for why that is a
+/// deliberate choice, not an oversight.
+pub const DEFAULT_TTL: Duration = Duration::from_secs(15 * 60);
+
+const TOKEN_PREFIX: &str = "ref_";
+
+/// What a Roon ref resolves through: the `item_key` **and** the
+/// `multi_session_key` that minted it.
+///
+/// The pairing is load-bearing, not incidental. `RoonAdapter::search` mints a
+/// private session per call and the item keys it returns are scoped to that
+/// session (see `src/adapters/roon.rs::search_with_session`); resolution must
+/// re-enter that exact session (`RoonAdapter::play_ref`), never a fresh one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RoonRefTarget {
+    pub item_key: String,
+    pub multi_session_key: String,
+}
+
+/// What a ref resolves to, independent of the opaque token a client holds.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RefTarget {
+    Roon {
+        target: RoonRefTarget,
+        title: String,
+    },
+    Lms {
+        target: LmsPlayTarget,
+        title: String,
+    },
+}
+
+impl RefTarget {
+    /// The provider this ref was minted for, so `hifi_play_ref` can refuse a
+    /// ref used against a zone of a different provider capability-honestly.
+    pub fn provider(&self) -> Provider {
+        match self {
+            Self::Roon { .. } => Provider::Roon,
+            Self::Lms { .. } => Provider::Lms,
+        }
+    }
+
+    /// The title captured at mint time, for the played-confirmation message --
+    /// resolution does not re-derive it from the (possibly stale) backend.
+    pub fn title(&self) -> &str {
+        match self {
+            Self::Roon { title, .. } | Self::Lms { title, .. } => title,
+        }
+    }
+}
+
+struct Record {
+    target: RefTarget,
+    minted_at: Instant,
+}
+
+struct Inner {
+    entries: HashMap<String, Record>,
+    /// Insertion order, oldest first. Used only to pick an eviction candidate;
+    /// never consulted on a successful read (see the module docs: this is
+    /// insertion-order eviction, not access-order LRU).
+    order: VecDeque<String>,
+    capacity: usize,
+    ttl: Duration,
+}
+
+impl Inner {
+    /// Make room for one more entry if the table is at capacity, evicting the
+    /// oldest-inserted token(s). A loop rather than a single pop because a
+    /// token at the front of `order` may already have been removed by a prior
+    /// expiry-on-read, in which case it is skipped rather than counted.
+    fn evict_to_capacity(&mut self) {
+        while self.entries.len() >= self.capacity {
+            match self.order.pop_front() {
+                Some(oldest) => {
+                    self.entries.remove(&oldest);
+                }
+                None => break,
+            }
+        }
+    }
+}
+
+/// The server-side table every `hifi_search` ref lives in until it is
+/// resolved by `hifi_play_ref`, expires, or is evicted.
+///
+/// Cheap to clone (an `Arc` around the lock), matching every other field on
+/// [`crate::api::AppState`].
+#[derive(Clone)]
+pub struct RefTable {
+    inner: Arc<Mutex<Inner>>,
+}
+
+impl Default for RefTable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RefTable {
+    /// A table with [`DEFAULT_CAPACITY`] and [`DEFAULT_TTL`]. What
+    /// `AppState::new` constructs; production code should not need the other
+    /// constructor.
+    pub fn new() -> Self {
+        Self::with_capacity_and_ttl(DEFAULT_CAPACITY, DEFAULT_TTL)
+    }
+
+    /// A table with an explicit capacity and TTL, for tests that need to force
+    /// eviction or expiry without waiting on -- or allocating -- the
+    /// production defaults.
+    pub fn with_capacity_and_ttl(capacity: usize, ttl: Duration) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(Inner {
+                entries: HashMap::new(),
+                order: VecDeque::new(),
+                capacity,
+                ttl,
+            })),
+        }
+    }
+
+    /// Mint an opaque token for `target`, evicting the oldest entry first if
+    /// the table is already at capacity.
+    ///
+    /// The token is 128 random bits, base64 (URL-safe, unpadded) encoded --
+    /// nothing about `target` influences it, so two refs minted for the exact
+    /// same target are never equal and neither can be derived from the other.
+    pub async fn mint(&self, target: RefTarget) -> String {
+        let token = generate_token();
+        let mut inner = self.inner.lock().await;
+        inner.evict_to_capacity();
+        inner.order.push_back(token.clone());
+        inner.entries.insert(
+            token.clone(),
+            Record {
+                target,
+                minted_at: Instant::now(),
+            },
+        );
+        token
+    }
+
+    /// Resolve a token to its target, or `None` if it is unknown, mangled,
+    /// expired, or evicted -- all four collapse to the same answer by design;
+    /// see the module docs.
+    pub async fn resolve(&self, token: &str) -> Option<RefTarget> {
+        let mut inner = self.inner.lock().await;
+        let expired = match inner.entries.get(token) {
+            Some(record) => record.minted_at.elapsed() > inner.ttl,
+            None => return None,
+        };
+        if expired {
+            inner.entries.remove(token);
+            return None;
+        }
+        inner.entries.get(token).map(|r| r.target.clone())
+    }
+
+    /// The number of live entries, for tests asserting the table stays
+    /// bounded rather than growing without limit.
+    #[cfg(test)]
+    async fn len(&self) -> usize {
+        self.inner.lock().await.entries.len()
+    }
+}
+
+fn generate_token() -> String {
+    let mut bytes = [0u8; 16]; // 128 bits
+    rand::thread_rng().fill_bytes(&mut bytes);
+    format!("{TOKEN_PREFIX}{}", URL_SAFE_NO_PAD.encode(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapters::lms::LmsSearchResultType;
+
+    fn roon_target(item_key: &str, session: &str, title: &str) -> RefTarget {
+        RefTarget::Roon {
+            target: RoonRefTarget {
+                item_key: item_key.to_string(),
+                multi_session_key: session.to_string(),
+            },
+            title: title.to_string(),
+        }
+    }
+
+    fn lms_target(id: i64, title: &str) -> RefTarget {
+        RefTarget::Lms {
+            target: LmsPlayTarget::Library {
+                kind: LmsSearchResultType::Album,
+                id,
+            },
+            title: title.to_string(),
+        }
+    }
+
+    // =========================================================================
+    // Opacity: nothing about the target is derivable from the token
+    // =========================================================================
+
+    /// The core opacity claim, made concrete: neither a Roon `item_key`/session
+    /// key nor an LMS entity id nor either target's title appears verbatim in
+    /// the minted token. A base64-of-the-key design would fail this the moment
+    /// the key were long enough to survive encoding, which is exactly the
+    /// design #396's gate rejected in favor of a table.
+    ///
+    /// Needles are chosen to make a chance collision statistically
+    /// impossible rather than merely unlikely: each is either long enough
+    /// that a random 128-bit token matching it by coincidence would need
+    /// astronomically bad luck, or contains a character (space, `:`) that
+    /// never appears in the token's base64 URL-safe alphabet at all. A
+    /// single-character or tiny needle would make this test genuinely flaky
+    /// against a random token -- that is a property of a bad assertion, not
+    /// of the opacity claim, so this test deliberately avoids them.
+    #[tokio::test]
+    async fn minted_tokens_carry_no_verbatim_target_data() {
+        let table = RefTable::new();
+
+        let roon_token = table
+            .mint(roon_target(
+                "109:7",
+                "search_1730000000000000000",
+                "Kind of Blue",
+            ))
+            .await;
+        for needle in [
+            "109:7",                      // contains ':' -- impossible in base64url
+            "search_1730000000000000000", // 27 chars -- astronomically unlikely
+            "Kind of Blue",               // contains ' ' -- impossible in base64url
+        ] {
+            assert!(
+                !roon_token.contains(needle),
+                "token {roon_token:?} must not contain {needle:?} verbatim"
+            );
+        }
+
+        let lms_token = table.mint(lms_target(424_242, "Blue Train Album")).await;
+        for needle in [
+            "424242",           // 6 digits -- ~1 in 10^10 chance in a 22-char token
+            "Blue Train Album", // contains ' ' -- impossible in base64url
+        ] {
+            assert!(
+                !lms_token.contains(needle),
+                "token {lms_token:?} must not contain {needle:?} verbatim"
+            );
+        }
+    }
+
+    /// A hand-mangled ref is refused, never misresolved to a *different* real
+    /// target. Because the token space is 128 random bits, flipping a
+    /// character almost certainly lands on a token nothing ever minted --
+    /// which resolves to `None`, not to some other client's item.
+    #[tokio::test]
+    async fn a_hand_mangled_ref_is_refused_not_misresolved() {
+        let table = RefTable::new();
+        let token = table.mint(lms_target(1, "Some Album")).await;
+
+        let mut mangled = token.clone();
+        let last = mangled.pop().expect("token is non-empty");
+        let flipped = if last == 'A' { 'B' } else { 'A' };
+        mangled.push(flipped);
+
+        assert_ne!(mangled, token);
+        assert!(table.resolve(&mangled).await.is_none());
+        // The real token still resolves -- mangling one ref does not corrupt
+        // the table.
+        assert!(table.resolve(&token).await.is_some());
+    }
+
+    /// Garbage that never came from `mint` at all -- not just a mutation of a
+    /// real token -- is refused the same way.
+    #[tokio::test]
+    async fn an_unknown_token_is_refused() {
+        let table = RefTable::new();
+        assert!(table.resolve("ref_not-a-real-token").await.is_none());
+        assert!(table.resolve("").await.is_none());
+    }
+
+    // =========================================================================
+    // Unguessability and non-correlation
+    // =========================================================================
+
+    /// Two refs minted for the *same* item are never equal, and neither is a
+    /// prefix, suffix, or otherwise-derivable transform of the other. This is
+    /// the assertion the gate's own dissent (F9) said was necessary: a
+    /// verbatim check alone would pass a design that base64-encodes the key,
+    /// which leaks completely despite matching no verbatim substring test.
+    #[tokio::test]
+    async fn two_refs_for_the_same_item_are_unequal_and_uncorrelated() {
+        let table = RefTable::new();
+
+        let mut tokens = Vec::new();
+        for _ in 0..20 {
+            tokens.push(
+                table
+                    .mint(roon_target("42:1", "search_same", "Same Album"))
+                    .await,
+            );
+        }
+
+        // All distinct.
+        let unique: std::collections::HashSet<&String> = tokens.iter().collect();
+        assert_eq!(
+            unique.len(),
+            tokens.len(),
+            "every mint must be unique: {tokens:?}"
+        );
+
+        // No pair shares a prefix or suffix longer than the constant "ref_"
+        // tag -- a weak proxy for "not derivable from each other", cheap
+        // enough to assert without a statistical test.
+        for i in 0..tokens.len() {
+            for j in (i + 1)..tokens.len() {
+                let a = tokens[i].strip_prefix(TOKEN_PREFIX).unwrap();
+                let b = tokens[j].strip_prefix(TOKEN_PREFIX).unwrap();
+                let common_prefix = a.chars().zip(b.chars()).take_while(|(x, y)| x == y).count();
+                assert!(
+                    common_prefix < 4,
+                    "tokens {a:?} and {b:?} share a suspiciously long prefix ({common_prefix})"
+                );
+            }
+        }
+    }
+
+    /// Holding one ref does not let a client derive another: minting a second,
+    /// unrelated item does not produce a token related to the first by any
+    /// simple transform (equality, containment, or a shared byte at a fixed
+    /// offset across every pair -- the sort of pattern a broken RNG or a
+    /// counter-based scheme would leak).
+    #[tokio::test]
+    async fn holding_one_ref_does_not_predict_another() {
+        let table = RefTable::new();
+        let a = table.mint(lms_target(1, "Album A")).await;
+        let b = table.mint(lms_target(2, "Album B")).await;
+        let c = table.mint(roon_target("1:1", "s", "Album C")).await;
+
+        assert_ne!(a, b);
+        assert_ne!(b, c);
+        assert!(!b.contains(a.strip_prefix(TOKEN_PREFIX).unwrap()));
+        assert!(!c.contains(a.strip_prefix(TOKEN_PREFIX).unwrap()));
+    }
+
+    // =========================================================================
+    // Bounded size and time; eviction is expiry, not corruption
+    // =========================================================================
+
+    /// Minting past capacity evicts the oldest entry, and the evicted ref
+    /// resolves exactly like a token that never existed -- `None`, not a
+    /// wrong-but-plausible answer. That is "eviction observable as expiry, not
+    /// corruption": there is no partial-resolution failure mode to have.
+    #[tokio::test]
+    async fn minting_past_capacity_evicts_the_oldest_as_a_clean_miss() {
+        let table = RefTable::with_capacity_and_ttl(3, Duration::from_secs(60));
+
+        let first = table.mint(lms_target(1, "Oldest")).await;
+        let _second = table.mint(lms_target(2, "Middle")).await;
+        let _third = table.mint(lms_target(3, "Newer")).await;
+        assert_eq!(table.len().await, 3);
+
+        // A fourth mint must evict the first without exceeding capacity.
+        let fourth = table.mint(lms_target(4, "Newest")).await;
+        assert_eq!(table.len().await, 3, "table must stay bounded at capacity");
+
+        assert!(
+            table.resolve(&first).await.is_none(),
+            "the oldest ref must be evicted, not merely displaced"
+        );
+        assert!(table.resolve(&fourth).await.is_some());
+    }
+
+    /// The table never exceeds capacity even under many mints, and each
+    /// eviction is a clean miss rather than a corrupted read of a *different*
+    /// entry.
+    #[tokio::test]
+    async fn the_table_stays_bounded_under_sustained_minting() {
+        let table = RefTable::with_capacity_and_ttl(5, Duration::from_secs(60));
+        let mut tokens = Vec::new();
+        for i in 0..50 {
+            tokens.push(table.mint(lms_target(i, "Item")).await);
+            assert!(
+                table.len().await <= 5,
+                "table exceeded capacity at mint {i}"
+            );
+        }
+
+        // Only the most recent 5 remain resolvable; every earlier one is a
+        // clean miss.
+        for (i, token) in tokens.iter().enumerate() {
+            let resolved = table.resolve(token).await;
+            if i < 45 {
+                assert!(resolved.is_none(), "mint {i} should have been evicted");
+            } else {
+                assert!(resolved.is_some(), "mint {i} should still be live");
+            }
+        }
+    }
+
+    /// A ref past its TTL resolves to `None`, indistinguishable from one that
+    /// was evicted for space or never existed -- proving expiry is real and
+    /// not merely documented.
+    #[tokio::test]
+    async fn an_expired_ref_resolves_to_none() {
+        let table = RefTable::with_capacity_and_ttl(DEFAULT_CAPACITY, Duration::from_millis(20));
+        let token = table.mint(lms_target(1, "Fleeting")).await;
+        assert!(
+            table.resolve(&token).await.is_some(),
+            "must resolve before it expires"
+        );
+
+        tokio::time::sleep(Duration::from_millis(60)).await;
+        assert!(
+            table.resolve(&token).await.is_none(),
+            "must expire after its TTL"
+        );
+    }
+
+    /// A ref well within its TTL keeps resolving -- the counterpart to the
+    /// expiry test, so "expires eventually" and "does not expire early" are
+    /// both pinned.
+    #[tokio::test]
+    async fn a_fresh_ref_resolves_repeatedly_within_its_ttl() {
+        let table = RefTable::with_capacity_and_ttl(DEFAULT_CAPACITY, Duration::from_secs(60));
+        let token = table.mint(lms_target(1, "Durable For Now")).await;
+        for _ in 0..3 {
+            assert!(table.resolve(&token).await.is_some());
+        }
+    }
+
+    // =========================================================================
+    // Provider identification, for cross-provider refusal
+    // =========================================================================
+
+    #[tokio::test]
+    async fn resolved_target_reports_its_own_provider() {
+        let table = RefTable::new();
+        let roon_token = table.mint(roon_target("1:1", "s", "R")).await;
+        let lms_token = table.mint(lms_target(1, "L")).await;
+
+        assert_eq!(
+            table.resolve(&roon_token).await.unwrap().provider(),
+            Provider::Roon
+        );
+        assert_eq!(
+            table.resolve(&lms_token).await.unwrap().provider(),
+            Provider::Lms
+        );
+    }
+}

--- a/src/mcp/refs.rs
+++ b/src/mcp/refs.rs
@@ -163,8 +163,16 @@ impl Inner {
     /// oldest-inserted token(s). A loop rather than a single pop because a
     /// token at the front of `order` may already have been removed by a prior
     /// expiry-on-read, in which case it is skipped rather than counted.
+    ///
+    /// Gated on `order.len()` as well as `entries.len()`: an entry expiring
+    /// on read (see `RefTable::resolve`) shrinks `entries` without touching
+    /// `order`, so a table that expires faster than it fills would never
+    /// trip an `entries.len()`-only check and `order` would grow one token
+    /// per mint forever. Popping while *either* is at capacity drains those
+    /// already-expired fronts on the next mint instead of leaving them
+    /// stranded.
     fn evict_to_capacity(&mut self) {
-        while self.entries.len() >= self.capacity {
+        while self.entries.len() >= self.capacity || self.order.len() >= self.capacity {
             match self.order.pop_front() {
                 Some(oldest) => {
                     self.entries.remove(&oldest);
@@ -255,6 +263,15 @@ impl RefTable {
     #[cfg(test)]
     async fn len(&self) -> usize {
         self.inner.lock().await.entries.len()
+    }
+
+    /// The length of the insertion-order queue, independent of `entries.len()`
+    /// -- the two can diverge when entries expire on read (see `resolve`)
+    /// faster than eviction runs. Exists only so a test can prove `order`
+    /// itself stays bounded, not merely `entries`.
+    #[cfg(test)]
+    async fn order_len(&self) -> usize {
+        self.inner.lock().await.order.len()
     }
 }
 
@@ -488,6 +505,40 @@ mod tests {
                 assert!(resolved.is_some(), "mint {i} should still be live");
             }
         }
+    }
+
+    /// `order` stays bounded even when it is expiry, not eviction, doing the
+    /// shrinking -- a table whose entries always expire before the next mint
+    /// never trips an `entries.len()`-only capacity check (`entries` is
+    /// already near-empty every time `mint` runs), so without also gating on
+    /// `order.len()` this would grow by one token per mint forever. CodeRabbit
+    /// review on PR #427.
+    #[tokio::test]
+    async fn order_does_not_leak_when_expiry_outpaces_eviction() {
+        let table = RefTable::with_capacity_and_ttl(5, Duration::from_millis(5));
+        for i in 0..50 {
+            let token = table.mint(lms_target(i, "Fleeting")).await;
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            // Resolving a stale ref is what actually triggers `entries`'
+            // lazy expiry removal (see `resolve`) -- exactly what happens
+            // in production whenever a client looks up an old ref. Nothing
+            // sweeps `entries` on its own, so without this the test would
+            // only be proving mint() alone never shrinks anything.
+            assert!(
+                table.resolve(&token).await.is_none(),
+                "token {i} should already have expired"
+            );
+        }
+
+        assert!(
+            table.len().await <= 1,
+            "entries should stay near-empty since every token was resolved past its TTL before the next mint"
+        );
+        assert!(
+            table.order_len().await <= 5,
+            "order leaked to {} entries despite entries.len() never approaching capacity",
+            table.order_len().await
+        );
     }
 
     /// A ref past its TTL resolves to `None`, indistinguishable from one that

--- a/src/mcp/tools/library.rs
+++ b/src/mcp/tools/library.rs
@@ -233,28 +233,37 @@ pub async fn handle_search(
                         // `item_key` -- `FakeRoonCore`'s search model never
                         // included these, so nothing caught this minting a
                         // ref for them indistinguishably from real content.
-                        // `crate::adapters::roon::is_category` is the
-                        // adapter's own, pre-existing knowledge of exactly
-                        // this set; resolving a category's ref would land in
+                        // `crate::adapters::roon::is_ungrounded_grouping`
+                        // combines the adapter's own pre-existing title-list
+                        // check with a second, source-independent signal
+                        // (subtitle shaped like "<N> Results") verified live
+                        // for Library results but not for TIDAL/Qobuz -- see
+                        // that function's own doc comment for why the second
+                        // check is safe to include even where unverified.
+                        // Resolving a grouping row's ref would land in
                         // `resolve_item_key`'s "guess the first item"
                         // fallback and could silently play something the
                         // client never asked for. Only a real, navigable
-                        // item_key on a non-category row gets a ref; a
-                        // category row (or one with no item_key at all —
-                        // a header, or non-navigable) mints nothing.
+                        // item_key on a non-grouping row gets a ref; a
+                        // grouping row (or one with no item_key at all — a
+                        // header, or non-navigable) mints nothing.
                         let ref_token = match &item.item_key {
-                            Some(item_key) if !crate::adapters::roon::is_category(&item) => Some(
-                                state
-                                    .mcp_refs
-                                    .mint(RefTarget::Roon {
-                                        target: RoonRefTarget {
-                                            item_key: item_key.clone(),
-                                            multi_session_key: session_key.clone(),
-                                        },
-                                        title: item.title.clone(),
-                                    })
-                                    .await,
-                            ),
+                            Some(item_key)
+                                if !crate::adapters::roon::is_ungrounded_grouping(&item) =>
+                            {
+                                Some(
+                                    state
+                                        .mcp_refs
+                                        .mint(RefTarget::Roon {
+                                            target: RoonRefTarget {
+                                                item_key: item_key.clone(),
+                                                multi_session_key: session_key.clone(),
+                                            },
+                                            title: item.title.clone(),
+                                        })
+                                        .await,
+                                )
+                            }
                             _ => None,
                         };
                         mcp_results.push(McpSearchResult {

--- a/src/mcp/tools/library.rs
+++ b/src/mcp/tools/library.rs
@@ -226,11 +226,24 @@ pub async fn handle_search(
                 Ok((session_key, results)) => {
                     let mut mcp_results = Vec::with_capacity(results.len());
                     for item in results {
-                        // #396: only an item with a real, navigable item_key
-                        // gets a ref. A row with no item_key (a header, or a
-                        // non-navigable result) mints nothing.
+                        // #396 (found live, ship-gate re-review): a real
+                        // Core's search results mix the actual hit with
+                        // grouping rows ("Albums", "Tracks", "Artists", ...)
+                        // that carry the same `hint: "list"` and a real
+                        // `item_key` -- `FakeRoonCore`'s search model never
+                        // included these, so nothing caught this minting a
+                        // ref for them indistinguishably from real content.
+                        // `crate::adapters::roon::is_category` is the
+                        // adapter's own, pre-existing knowledge of exactly
+                        // this set; resolving a category's ref would land in
+                        // `resolve_item_key`'s "guess the first item"
+                        // fallback and could silently play something the
+                        // client never asked for. Only a real, navigable
+                        // item_key on a non-category row gets a ref; a
+                        // category row (or one with no item_key at all —
+                        // a header, or non-navigable) mints nothing.
                         let ref_token = match &item.item_key {
-                            Some(item_key) => Some(
+                            Some(item_key) if !crate::adapters::roon::is_category(&item) => Some(
                                 state
                                     .mcp_refs
                                     .mint(RefTarget::Roon {
@@ -242,7 +255,7 @@ pub async fn handle_search(
                                     })
                                     .await,
                             ),
-                            None => None,
+                            _ => None,
                         };
                         mcp_results.push(McpSearchResult {
                             title: item.title,

--- a/src/mcp/tools/library.rs
+++ b/src/mcp/tools/library.rs
@@ -692,7 +692,16 @@ async fn play_ref_lms(
     env.operation = action_name.to_string();
     let action = LmsPlayAction::parse(Some(action_name));
 
-    match state.lms.play_target(&target, &args.zone_id, action).await {
+    // `Some(&title)`: this target was resolved from a ref minted earlier in
+    // a possibly-different conversation turn, so it is validated against the
+    // live library before the mutating command runs (`LmsAdapter::play_target`'s
+    // own docs explain why, and why it is keyed off `title` rather than a
+    // dedicated existence query).
+    match state
+        .lms
+        .play_target(&target, &args.zone_id, action, Some(&title))
+        .await
+    {
         Ok(()) => {
             let action_verb = match action {
                 LmsPlayAction::Play => "Playing",

--- a/src/mcp/tools/library.rs
+++ b/src/mcp/tools/library.rs
@@ -540,14 +540,19 @@ pub async fn handle_play_ref(
     let target = ZoneTarget::classify(&args.zone_id);
     let route = target.for_library();
 
-    // `operation` starts as whatever was requested (unvalidated) so an early
-    // refusal -- before the ref is even resolved, and so before either
-    // provider's accepted action set applies -- still reports something
-    // meaningful. `play_ref_roon`/`play_ref_lms` overwrite it with the
-    // validated, provider-specific action once one is known, matching
-    // `hifi_play`'s own convention (`roon_action_name`/`lms_action_name`).
-    let requested_action = args.action.as_deref().unwrap_or("play");
-    let mut env = Envelope::write("hifi_play_ref", requested_action)
+    // `operation` starts as the constant `"play_ref"` -- matching
+    // `hifi_play`'s own zone-refused path (`Envelope::write("hifi_play",
+    // "play")`, unconditionally, never `args.action`) -- because at this
+    // point `action` has not been validated against either provider's
+    // accepted set, so echoing it verbatim would let unvalidated client
+    // input (garbage, or a value that's valid for the *other* provider) flow
+    // straight into a field clients are told to branch on. `play_ref_roon`/
+    // `play_ref_lms` overwrite it once an action is actually known: the
+    // validated name on success (matching `hifi_play`'s
+    // `roon_action_name`/`lms_action_name` convention), or the normalized
+    // sentinel `"invalid_action"` on refusal (matching `hifi_control`'s
+    // `unknown_action` convention, `src/mcp/tools/transport.rs`).
+    let mut env = Envelope::write("hifi_play_ref", "play_ref")
         .param("ref", &*args.r#ref)
         .param("zone_id", &*args.zone_id)
         .scope(Scope::for_zone(state, &args.zone_id, target.provider()).await);
@@ -629,7 +634,7 @@ pub async fn handle_play_ref(
 
 async fn play_ref_roon(
     state: &AppState,
-    env: Envelope,
+    mut env: Envelope,
     args: &HifiPlayRefTool,
     target: RoonRefTarget,
     _title: String,
@@ -643,6 +648,13 @@ async fn play_ref_roon(
                 Refusal::InvalidParameter { detail, .. } => detail.clone(),
                 _ => String::new(),
             };
+            // A normalized sentinel, not an echo of the raw (unrecognised)
+            // request -- matching `hifi_control`'s own `unknown_action`
+            // convention for the same class of refusal
+            // (`src/mcp/tools/transport.rs`). A client branching on
+            // `operation` must never see arbitrary client input reflected
+            // back as if it were a real value.
+            env.operation = "invalid_action".to_string();
             return env.refused(detail, refusal);
         }
     };
@@ -671,7 +683,7 @@ async fn play_ref_roon(
 
 async fn play_ref_lms(
     state: &AppState,
-    env: Envelope,
+    mut env: Envelope,
     args: &HifiPlayRefTool,
     target: crate::adapters::lms::LmsPlayTarget,
     title: String,
@@ -685,6 +697,9 @@ async fn play_ref_lms(
                 Refusal::InvalidParameter { detail, .. } => detail.clone(),
                 _ => String::new(),
             };
+            // See play_ref_roon's identical comment: a normalized sentinel,
+            // matching hifi_control's `unknown_action` convention.
+            env.operation = "invalid_action".to_string();
             return env.refused(detail, refusal);
         }
     };

--- a/src/mcp/tools/library.rs
+++ b/src/mcp/tools/library.rs
@@ -540,7 +540,14 @@ pub async fn handle_play_ref(
     let target = ZoneTarget::classify(&args.zone_id);
     let route = target.for_library();
 
-    let mut env = Envelope::write("hifi_play_ref", "play_ref")
+    // `operation` starts as whatever was requested (unvalidated) so an early
+    // refusal -- before the ref is even resolved, and so before either
+    // provider's accepted action set applies -- still reports something
+    // meaningful. `play_ref_roon`/`play_ref_lms` overwrite it with the
+    // validated, provider-specific action once one is known, matching
+    // `hifi_play`'s own convention (`roon_action_name`/`lms_action_name`).
+    let requested_action = args.action.as_deref().unwrap_or("play");
+    let mut env = Envelope::write("hifi_play_ref", requested_action)
         .param("ref", &*args.r#ref)
         .param("zone_id", &*args.zone_id)
         .scope(Scope::for_zone(state, &args.zone_id, target.provider()).await);
@@ -639,7 +646,12 @@ async fn play_ref_roon(
             return env.refused(detail, refusal);
         }
     };
-    let env = env.param("action", action_name);
+    // `operation` follows `hifi_play`'s own convention (`roon_action_name`):
+    // the resolved action, not a constant tool-name-shaped string, so a
+    // client reading only `operation` can tell play_ref=queue from
+    // play_ref=play without also reading `params.action`.
+    let mut env = env.param("action", action_name);
+    env.operation = action_name.to_string();
     let action = PlayAction::parse(action_name);
 
     match state
@@ -676,7 +688,8 @@ async fn play_ref_lms(
             return env.refused(detail, refusal);
         }
     };
-    let env = env.param("action", action_name);
+    let mut env = env.param("action", action_name);
+    env.operation = action_name.to_string();
     let action = LmsPlayAction::parse(Some(action_name));
 
     match state.lms.play_target(&target, &args.zone_id, action).await {

--- a/src/mcp/tools/library.rs
+++ b/src/mcp/tools/library.rs
@@ -18,16 +18,35 @@
 //! reported as `scope.provider: "roon"`, so it is visible rather than silent, and
 //! `tests/mcp_contract.rs::an_absent_zone_id_still_routes_search_to_roon` pins it.
 //!
-//! This module is the primary target for #396 (opaque content references) and
-//! #399 (hierarchical browse). Note what `McpSearchResult` lacks: any stable
-//! identifier. A client that finds something here can only hand the title back
-//! to `hifi_play`, which re-searches and takes the first match. That is #392's
-//! keystone finding — recorded in `FIELD_ROLES` in `tests/mcp_contract.rs` as a
-//! known defect, and out of scope for #394.
+//! # Refs (#396): search -> hold ref -> play by ref
+//!
+//! `hifi_search` now mints an opaque `ref` alongside each result that has a
+//! durable-enough handle (a Roon `item_key`, or an LMS `Library`/`Url`
+//! target), and `HifiPlayRefTool` (below) is the one tool that consumes it —
+//! not an optional parameter on `hifi_play`, so a model can never send both a
+//! `query` and a `ref` and force the server to silently pick one. `hifi_play`
+//! itself is unchanged: its `query` path still re-searches and takes the
+//! first match, exactly as before this issue; that is #392's original
+//! keystone finding, still true for that path and recorded as such in
+//! `FIELD_ROLES` in `tests/mcp_contract.rs`. Refs are the way *around* it, not
+//! a change to it.
+//!
+//! A result can legitimately have no `ref`: LMS's `GlobalSearchItem` handle is
+//! a positional breadcrumb, not an identifier (see
+//! `crate::adapters::lms::LmsPlayTarget`), and minting a ref through it would
+//! trade an honest gap for a token that can silently play the wrong thing. So
+//! "no ref" is expected for some results, not a bug to chase.
+//!
+//! Refs live in [`crate::mcp::refs::RefTable`], are short-lived, and expire
+//! silently — resolving one that is gone reads as `unknown_ref` in
+//! `hifi_play_ref`'s refusal, which tells the client to call `hifi_search`
+//! again rather than failing generically. This module is also the target for
+//! #399 (hierarchical browse), which will mint refs the same way.
 
 use crate::api::AppState;
 use crate::mcp::capabilities::{support, Capability};
-use crate::mcp::envelope::{Envelope, Observed, Refusal, Scope};
+use crate::mcp::envelope::{Envelope, Observed, Provider, Refusal, Scope};
+use crate::mcp::refs::{RefTarget, RoonRefTarget};
 use crate::mcp::routing::{
     unplaceable_zone_refusal, unplaceable_zone_text, LibraryRoute, ZoneTarget,
 };
@@ -52,7 +71,7 @@ const ROON_SEARCH_LIMIT: usize = 10;
 /// Search for music
 #[mcp_tool(
     name = "hifi_search",
-    description = "Search for tracks, albums, or artists. Roon: searches Library, TIDAL, or Qobuz (use source param). LMS: searches all installed providers including streaming plugins (zone_id recommended as different players may have different sources configured).",
+    description = "Search for tracks, albums, or artists. Roon: searches Library, TIDAL, or Qobuz (use source param). LMS: searches all installed providers including streaming plugins (zone_id recommended as different players may have different sources configured). Each result may carry a short-lived `ref` token; hold it and pass it to hifi_play_ref to play, queue, or start radio from that exact result instead of hifi_play's first-match search. A result with no `ref` has no safe way to be addressed later — use hifi_play's query for it.",
     read_only_hint = true
 )]
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
@@ -70,7 +89,7 @@ pub struct HifiSearchTool {
 /// Search and play music in one command
 #[mcp_tool(
     name = "hifi_play",
-    description = "Search and play music. Searches and plays, queues, or starts radio from the first matching result. Use action='queue' to add to queue. action='radio' and source param are Roon-only; LMS searches all providers."
+    description = "Search and play music. Searches and plays, queues, or starts radio from the first matching result. Use action='queue' to add to queue. action='radio' and source param are Roon-only; LMS searches all providers. To act on a specific hifi_search result rather than the first match for a title, use hifi_play_ref with that result's `ref` instead."
 )]
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct HifiPlayTool {
@@ -82,6 +101,24 @@ pub struct HifiPlayTool {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
     /// What to do: "play" (default), "queue", or "radio". radio is Roon-only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub action: Option<String>,
+}
+
+/// Play, queue, or start radio from a specific `hifi_search` result (#396)
+#[mcp_tool(
+    name = "hifi_play_ref",
+    description = "Play, queue, or play-next a specific hifi_search result using its `ref` — the opaque token returned alongside a result, not a title. Use this instead of hifi_play when you need the exact result you found (e.g. the third one, or one of two same-titled albums), rather than whatever hifi_play's own search matches first. Refs are short-lived: hold one only within the current conversation. If this call is refused because the ref is unknown or expired, call hifi_search again for a fresh one — never guess or reuse an old one. zone_id must belong to the same provider (Roon or LMS) the ref was minted for.",
+    read_only_hint = false
+)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct HifiPlayRefTool {
+    /// The opaque `ref` from a hifi_search result. Do not construct, guess, or edit one.
+    #[serde(rename = "ref")]
+    pub r#ref: String,
+    /// Zone ID to play on (get from hifi_zones). Must be the same provider the ref was minted for.
+    pub zone_id: String,
+    /// What to do: "play" (default), "queue", "radio" (Roon only), or "next" (LMS play-next only).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub action: Option<String>,
 }
@@ -145,13 +182,31 @@ pub async fn handle_search(
                 .await
             {
                 Ok(results) => {
-                    let mcp_results: Vec<McpSearchResult> = results
-                        .into_iter()
-                        .map(|item| McpSearchResult {
+                    let mut mcp_results = Vec::with_capacity(results.len());
+                    for item in results {
+                        // #396: mint a ref only for a durable-enough handle
+                        // (Library or Url). A GlobalSearchItem-only result
+                        // gets no ref at all, honestly, rather than one that
+                        // could silently mis-resolve — see
+                        // `LmsPlayTarget::mintable`'s own docs.
+                        let ref_token = match crate::adapters::lms::LmsPlayTarget::mintable(&item) {
+                            Some(target) => Some(
+                                state
+                                    .mcp_refs
+                                    .mint(RefTarget::Lms {
+                                        target,
+                                        title: item.title.clone(),
+                                    })
+                                    .await,
+                            ),
+                            None => None,
+                        };
+                        mcp_results.push(McpSearchResult {
                             subtitle: lms_subtitle(&item),
                             title: item.title,
-                        })
-                        .collect();
+                            r#ref: ref_token,
+                        });
+                    }
                     Ok(env.json_result(&mcp_results))
                 }
                 Err(e) => env.failed(format!("Search error: {}", e)),
@@ -160,7 +215,7 @@ pub async fn handle_search(
         LibraryRoute::Roon => {
             match state
                 .roon
-                .search(
+                .search_with_session(
                     &args.query,
                     args.zone_id.as_deref(),
                     Some(ROON_SEARCH_LIMIT),
@@ -168,14 +223,33 @@ pub async fn handle_search(
                 )
                 .await
             {
-                Ok(results) => {
-                    let mcp_results: Vec<McpSearchResult> = results
-                        .into_iter()
-                        .map(|item| McpSearchResult {
+                Ok((session_key, results)) => {
+                    let mut mcp_results = Vec::with_capacity(results.len());
+                    for item in results {
+                        // #396: only an item with a real, navigable item_key
+                        // gets a ref. A row with no item_key (a header, or a
+                        // non-navigable result) mints nothing.
+                        let ref_token = match &item.item_key {
+                            Some(item_key) => Some(
+                                state
+                                    .mcp_refs
+                                    .mint(RefTarget::Roon {
+                                        target: RoonRefTarget {
+                                            item_key: item_key.clone(),
+                                            multi_session_key: session_key.clone(),
+                                        },
+                                        title: item.title.clone(),
+                                    })
+                                    .await,
+                            ),
+                            None => None,
+                        };
+                        mcp_results.push(McpSearchResult {
                             title: item.title,
                             subtitle: item.subtitle,
-                        })
-                        .collect();
+                            r#ref: ref_token,
+                        });
+                    }
                     Ok(env.json_result(&mcp_results))
                 }
                 Err(e) => env.failed(format!("Search error: {}", e)),
@@ -353,14 +427,18 @@ pub async fn handle_play(
     }
 }
 
-/// Finish a successful `hifi_play`: the adapter's message verbatim as the text,
-/// plus a zone read-back.
+/// Finish a successful `hifi_play` or `hifi_play_ref`: the adapter's message
+/// verbatim as the text, plus a zone read-back. Shared by both tools so their
+/// success shape (`McpPlayResult` plus `observed`) is identical whichever path
+/// a client took.
 ///
 /// `data.message` duplicates the text on purpose, and it is the only field in
-/// this envelope that does. Without it a client reading only `structuredContent`
-/// would have no record of *which* item matched, because there is no addressable
-/// identifier for a search result until #396 lands. It is adapter-authored prose,
-/// not parsed — #396 replaces it with an opaque ref.
+/// this envelope that does. For `hifi_play`'s query path it remains the only
+/// record of *which* item matched — that path has no addressable identifier
+/// by design (`hifi_play_ref` is the way around it, not a change to it; see
+/// this module's docs). For `hifi_play_ref` the message still comes from the
+/// adapter/ref title, kept for the same reason: a client reading only
+/// `structuredContent` should not have to guess what played.
 async fn play_success(state: &AppState, env: Envelope, message: String) -> CallToolResult {
     let zone_id = env
         .scope
@@ -392,5 +470,225 @@ fn roon_action_name(action: crate::adapters::roon::PlayAction) -> &'static str {
         PlayAction::Play => "play",
         PlayAction::Queue => "queue",
         PlayAction::Radio => "radio",
+    }
+}
+
+// =============================================================================
+// hifi_play_ref (#396): the one consumer of a hifi_search `ref`
+// =============================================================================
+
+/// Every action `hifi_play_ref` accepts for a Roon-minted ref, in the order
+/// the tool description lists them. A closed set: an action outside it is
+/// refused by name rather than silently defaulted, which is what
+/// `PlayAction::parse` would otherwise do (see `handle_search`'s `roon_source_name`
+/// for the same "report what was actually resolved" principle applied to a
+/// different parameter).
+const ROON_REF_ACTIONS: &[&str] = &["play", "queue", "radio"];
+
+/// Every action `hifi_play_ref` accepts for an LMS-minted ref.
+const LMS_REF_ACTIONS: &[&str] = &["play", "queue", "next"];
+
+/// Validate `action` against a provider's closed action set, defaulting to
+/// the first (always `"play"`) when absent. Never falls through to a default
+/// for a *present but unrecognised* value -- that silent-fallback is the
+/// defect this whole issue exists to end.
+fn validate_ref_action(
+    action: Option<&str>,
+    accepted: &'static [&'static str],
+) -> Result<&'static str, Refusal> {
+    match action {
+        None => Ok(accepted[0]),
+        Some(requested) => {
+            let lower = requested.to_lowercase();
+            accepted
+                .iter()
+                .find(|candidate| **candidate == lower)
+                .copied()
+                .ok_or_else(|| {
+                    Refusal::invalid_parameter(
+                        "action",
+                        accepted,
+                        format!(
+                            "'{requested}' is not an accepted hifi_play_ref action for this \
+                             ref's provider. Accepted: {}.",
+                            accepted.join(", ")
+                        ),
+                    )
+                })
+        }
+    }
+}
+
+/// The lowercase label for a [`Provider`], for refusal prose. Every variant is
+/// listed explicitly so a new provider fails to compile here rather than
+/// silently falling through to a wrong label.
+fn provider_label(provider: Provider) -> &'static str {
+    match provider {
+        Provider::Roon => "roon",
+        Provider::Lms => "lms",
+        Provider::OpenHome => "openhome",
+        Provider::Upnp => "upnp",
+        Provider::HqPlayer => "hqplayer",
+        Provider::Unknown => "unknown",
+    }
+}
+
+pub async fn handle_play_ref(
+    state: &AppState,
+    args: HifiPlayRefTool,
+) -> Result<CallToolResult, CallToolError> {
+    let target = ZoneTarget::classify(&args.zone_id);
+    let route = target.for_library();
+
+    let mut env = Envelope::write("hifi_play_ref", "play_ref")
+        .param("ref", &*args.r#ref)
+        .param("zone_id", &*args.zone_id)
+        .scope(Scope::for_zone(state, &args.zone_id, target.provider()).await);
+    if let Some(action) = args.action.as_deref() {
+        env = env.param("action", action);
+    }
+
+    // A zone with no library path refuses the same way `hifi_play` does --
+    // the routing question ("can this zone accept a library-sourced play at
+    // all") is identical; only the resolution mechanism (ref vs. query)
+    // differs downstream of it.
+    if let LibraryRoute::Refused(refused) = route {
+        return refuse_library_zone(env, &args.zone_id, refused, Capability::PlayByQuery);
+    }
+
+    let Some(ref_target) = state.mcp_refs.resolve(&args.r#ref).await else {
+        return env.refused(
+            "ref is unknown or expired. Refs are short-lived -- call hifi_search again for a \
+             fresh one; never guess or reuse an old ref.",
+            Refusal::UnknownTarget {
+                parameter: "ref",
+                discover_with: "hifi_search",
+                detail: "This ref is not in UHC's ref table. It may have expired, been evicted \
+                         under load, or never existed -- all three look identical from here by \
+                         design, so there is nothing more specific to report. hifi_search mints \
+                         a fresh ref on every call; use the new one rather than an old one."
+                    .to_string(),
+            },
+        );
+    };
+
+    // Capability-honest cross-provider refusal: a ref minted for one provider
+    // must never be resolved against a zone of another, even though the zone
+    // itself has a perfectly good library path of its own.
+    let zone_provider = target.provider();
+    if ref_target.provider() != zone_provider {
+        let ref_provider_label = provider_label(ref_target.provider());
+        let zone_provider_label = provider_label(zone_provider);
+        return env.refused(
+            format!(
+                "this ref was minted for {ref_provider_label}, but zone_id '{}' is {zone_provider_label}.",
+                args.zone_id
+            ),
+            Refusal::InvalidParameter {
+                parameter: "zone_id",
+                accepted: vec![format!(
+                    "a {ref_provider_label} zone_id (this ref was minted for {ref_provider_label})"
+                )],
+                detail: format!(
+                    "hifi_search minted this ref against {ref_provider_label}; hifi_play_ref \
+                     cannot resolve it against a {zone_provider_label} zone. Call hifi_search \
+                     again with a {ref_provider_label} zone_id, or use hifi_zones to find one."
+                ),
+            },
+        );
+    }
+
+    match (route, ref_target) {
+        (LibraryRoute::Roon, RefTarget::Roon { target, title }) => {
+            play_ref_roon(state, env, &args, target, title).await
+        }
+        (LibraryRoute::Lms, RefTarget::Lms { target, title }) => {
+            play_ref_lms(state, env, &args, target, title).await
+        }
+        // Unreachable: the provider check above already refused any mismatch
+        // between the zone's provider and the ref's. Kept exhaustive so a
+        // third provider gaining a ref target fails to compile here rather
+        // than silently mis-dispatching.
+        (LibraryRoute::Roon, RefTarget::Lms { .. })
+        | (LibraryRoute::Lms, RefTarget::Roon { .. }) => env.failed(
+            "internal routing error: ref/zone provider mismatch reached dispatch after the \
+                 capability check. This is a UHC bug.",
+        ),
+        (LibraryRoute::Refused(_), _) => env.failed(
+            "internal routing error: a refused zone reached ref dispatch. This is a UHC bug.",
+        ),
+    }
+}
+
+async fn play_ref_roon(
+    state: &AppState,
+    env: Envelope,
+    args: &HifiPlayRefTool,
+    target: RoonRefTarget,
+    _title: String,
+) -> Result<CallToolResult, CallToolError> {
+    use crate::adapters::roon::PlayAction;
+
+    let action_name = match validate_ref_action(args.action.as_deref(), ROON_REF_ACTIONS) {
+        Ok(name) => name,
+        Err(refusal) => {
+            let detail = match &refusal {
+                Refusal::InvalidParameter { detail, .. } => detail.clone(),
+                _ => String::new(),
+            };
+            return env.refused(detail, refusal);
+        }
+    };
+    let env = env.param("action", action_name);
+    let action = PlayAction::parse(action_name);
+
+    match state
+        .roon
+        .play_ref(
+            &target.item_key,
+            &target.multi_session_key,
+            &args.zone_id,
+            action,
+        )
+        .await
+    {
+        Ok(message) => Ok(play_success(state, env, message).await),
+        Err(e) => env.failed(format!("Play error: {}", e)),
+    }
+}
+
+async fn play_ref_lms(
+    state: &AppState,
+    env: Envelope,
+    args: &HifiPlayRefTool,
+    target: crate::adapters::lms::LmsPlayTarget,
+    title: String,
+) -> Result<CallToolResult, CallToolError> {
+    use crate::adapters::lms::LmsPlayAction;
+
+    let action_name = match validate_ref_action(args.action.as_deref(), LMS_REF_ACTIONS) {
+        Ok(name) => name,
+        Err(refusal) => {
+            let detail = match &refusal {
+                Refusal::InvalidParameter { detail, .. } => detail.clone(),
+                _ => String::new(),
+            };
+            return env.refused(detail, refusal);
+        }
+    };
+    let env = env.param("action", action_name);
+    let action = LmsPlayAction::parse(Some(action_name));
+
+    match state.lms.play_target(&target, &args.zone_id, action).await {
+        Ok(()) => {
+            let action_verb = match action {
+                LmsPlayAction::Play => "Playing",
+                LmsPlayAction::Queue => "Queued",
+                LmsPlayAction::Insert => "Playing next",
+            };
+            let message = format!("{action_verb} {title}");
+            Ok(play_success(state, env, message).await)
+        }
+        Err(e) => env.failed(format!("Play error: {}", e)),
     }
 }

--- a/src/mcp/tools/mod.rs
+++ b/src/mcp/tools/mod.rs
@@ -33,7 +33,7 @@ pub use hqplayer::{
     HifiHqplayerLoadProfileTool, HifiHqplayerProfilesTool, HifiHqplayerSetPipelineTool,
     HifiHqplayerStatusTool,
 };
-pub use library::{HifiPlayTool, HifiSearchTool};
+pub use library::{HifiPlayRefTool, HifiPlayTool, HifiSearchTool};
 pub use status::HifiStatusTool;
 pub use transport::HifiControlTool;
 pub use zones::{HifiNowPlayingTool, HifiZonesTool};
@@ -59,7 +59,10 @@ tool_box!(
         HifiHqplayerSetPipelineTool,
         // Appended by #398. Appending is the whole rule: the ten above keep
         // their positions, so `tools/list` reads as an additive diff.
-        HifiCapabilitiesTool
+        HifiCapabilitiesTool,
+        // Appended by #396 (opaque content refs): the one consumer of
+        // hifi_search's new `ref` field.
+        HifiPlayRefTool
     ]
 );
 
@@ -85,6 +88,7 @@ pub fn static_name(name: &str) -> Option<&'static str> {
         "hifi_hqplayer_load_profile" => "hifi_hqplayer_load_profile",
         "hifi_hqplayer_set_pipeline" => "hifi_hqplayer_set_pipeline",
         "hifi_capabilities" => "hifi_capabilities",
+        "hifi_play_ref" => "hifi_play_ref",
         _ => return None,
     })
 }
@@ -106,6 +110,7 @@ pub fn declared_params(tool: &str) -> &'static [&'static str] {
         "hifi_control" => &["zone_id", "action", "value"],
         "hifi_search" => &["query", "zone_id", "source"],
         "hifi_play" => &["query", "zone_id", "source", "action"],
+        "hifi_play_ref" => &["ref", "zone_id", "action"],
         "hifi_hqplayer_load_profile" => &["profile"],
         "hifi_hqplayer_set_pipeline" => &["setting", "value"],
         _ => &[],
@@ -149,8 +154,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn advertises_eleven_tools_when_hqplayer_is_enabled() {
-        assert_eq!(list_tools(true).len(), 11);
+    fn advertises_twelve_tools_when_hqplayer_is_enabled() {
+        assert_eq!(list_tools(true).len(), 12);
     }
 
     /// The filter must remove exactly the four HQPlayer tools and nothing else.
@@ -159,7 +164,7 @@ mod tests {
         let enabled: Vec<String> = list_tools(true).into_iter().map(|t| t.name).collect();
         let disabled: Vec<String> = list_tools(false).into_iter().map(|t| t.name).collect();
 
-        assert_eq!(disabled.len(), 7);
+        assert_eq!(disabled.len(), 8);
         assert!(disabled.iter().all(|n| !n.starts_with("hifi_hqplayer")));
 
         let removed: Vec<&String> = enabled.iter().filter(|n| !disabled.contains(n)).collect();

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -57,14 +57,20 @@ pub struct McpNowPlaying {
 
 /// A search hit.
 ///
-/// Note what is missing: any stable identifier. A client that finds something
-/// here can only hand the title back to `hifi_play`, which re-searches and takes
-/// the first match. That is #392's keystone finding and #396's job; it is
-/// recorded as a known defect in `FIELD_ROLES`, not endorsed here.
+/// `ref` (#396) is additive and optional: it is `Some` exactly when the result
+/// has a durable-enough handle to mint a ref for (a Roon `item_key`, or an LMS
+/// `Library`/`Url` target — never an LMS `GlobalSearchItem`, a positional
+/// breadcrumb that can silently mis-resolve; see
+/// `crate::adapters::lms::LmsPlayTarget`). An absent `ref` is honest: some
+/// results genuinely have no safe way to be addressed later, and minting one
+/// anyway would trade "no ref" for "a ref that might play the wrong thing".
+/// `title`/`subtitle` are unchanged from before this issue.
 #[derive(Debug, Serialize)]
 pub struct McpSearchResult {
     pub title: String,
     pub subtitle: Option<String>,
+    #[serde(rename = "ref", skip_serializing_if = "Option::is_none")]
+    pub r#ref: Option<String>,
 }
 
 /// `hifi_play`'s structured payload: the adapter's own message about what it

--- a/tests/fixtures/mcp_tools.json
+++ b/tests/fixtures/mcp_tools.json
@@ -117,7 +117,7 @@
     }
   },
   "hifi_play": {
-    "description": "Search and play music. Searches and plays, queues, or starts radio from the first matching result. Use action='queue' to add to queue. action='radio' and source param are Roon-only; LMS searches all providers.",
+    "description": "Search and play music. Searches and plays, queues, or starts radio from the first matching result. Use action='queue' to add to queue. action='radio' and source param are Roon-only; LMS searches all providers. To act on a specific hifi_search result rather than the first match for a title, use hifi_play_ref with that result's `ref` instead.",
     "inputSchema": {
       "properties": {
         "action": {
@@ -146,11 +146,39 @@
       "type": "object"
     }
   },
+  "hifi_play_ref": {
+    "annotations": {
+      "readOnlyHint": false
+    },
+    "description": "Play, queue, or play-next a specific hifi_search result using its `ref` — the opaque token returned alongside a result, not a title. Use this instead of hifi_play when you need the exact result you found (e.g. the third one, or one of two same-titled albums), rather than whatever hifi_play's own search matches first. Refs are short-lived: hold one only within the current conversation. If this call is refused because the ref is unknown or expired, call hifi_search again for a fresh one — never guess or reuse an old one. zone_id must belong to the same provider (Roon or LMS) the ref was minted for.",
+    "inputSchema": {
+      "properties": {
+        "action": {
+          "description": "What to do: \"play\" (default), \"queue\", \"radio\" (Roon only), or \"next\" (LMS play-next only).",
+          "nullable": true,
+          "type": "string"
+        },
+        "ref": {
+          "description": "The opaque `ref` from a hifi_search result. Do not construct, guess, or edit one.",
+          "type": "string"
+        },
+        "zone_id": {
+          "description": "Zone ID to play on (get from hifi_zones). Must be the same provider the ref was minted for.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "ref",
+        "zone_id"
+      ],
+      "type": "object"
+    }
+  },
   "hifi_search": {
     "annotations": {
       "readOnlyHint": true
     },
-    "description": "Search for tracks, albums, or artists. Roon: searches Library, TIDAL, or Qobuz (use source param). LMS: searches all installed providers including streaming plugins (zone_id recommended as different players may have different sources configured).",
+    "description": "Search for tracks, albums, or artists. Roon: searches Library, TIDAL, or Qobuz (use source param). LMS: searches all installed providers including streaming plugins (zone_id recommended as different players may have different sources configured). Each result may carry a short-lived `ref` token; hold it and pass it to hifi_play_ref to play, queue, or start radio from that exact result instead of hifi_play's first-match search. A result with no `ref` has no safe way to be addressed later — use hifi_play's query for it.",
     "inputSchema": {
       "properties": {
         "query": {

--- a/tests/mcp_contract.rs
+++ b/tests/mcp_contract.rs
@@ -457,8 +457,8 @@ async fn tools_list_matches_fixture() {
 
     assert_eq!(
         tools.len(),
-        11,
-        "expected 11 tools with HQPlayer enabled, got {}: {:?}",
+        12,
+        "expected 12 tools with HQPlayer enabled, got {}: {:?}",
         tools.len(),
         tool_names(tools)
     );
@@ -519,6 +519,8 @@ async fn tools_list_order_is_pinned() {
             // Appended by #398. Every line above it is untouched, which is what
             // makes the diff additive.
             "hifi_capabilities",
+            // Appended by #396.
+            "hifi_play_ref",
         ],
         "tools/list order follows the tool_box! list in src/mcp/tools/mod.rs. \
          APPEND new tools rather than inserting, so this assertion grows by one \
@@ -560,8 +562,9 @@ async fn hqplayer_tools_filtered_when_adapter_disabled() {
             "hifi_play",
             "hifi_status",
             "hifi_capabilities",
+            "hifi_play_ref",
         ],
-        "HQPlayer disabled must yield exactly the seven non-HQPlayer tools, in order"
+        "HQPlayer disabled must yield exactly the eight non-HQPlayer tools, in order"
     );
 }
 
@@ -706,6 +709,12 @@ const EXPECTED_TOOL_PARAMS: &[(&str, &[(&str, bool)])] = &[
     (
         "hifi_hqplayer_set_pipeline",
         &[("setting", true), ("value", true)],
+    ),
+    // #396. `ref` is required; `zone_id` is required (must match the ref's
+    // provider); `action` is optional and defaults to "play".
+    (
+        "hifi_play_ref",
+        &[("ref", true), ("zone_id", true), ("action", false)],
     ),
 ];
 
@@ -869,7 +878,7 @@ async fn a_stale_session_id_is_transparently_recovered() {
         .unwrap_or_else(|| panic!("recovered request must return the tool list, got: {response}"));
     assert_eq!(
         tools.len(),
-        11,
+        12,
         "the recovered session must serve the same tool list as a fresh one"
     );
 }
@@ -1848,10 +1857,11 @@ const FIELD_ROLES: &[(&str, FieldRole)] = &[
     (
         "title",
         DisplayOnly(
-            "hifi_search returns {title, subtitle} and no key, so the only route from \
-         'found it' to 'playing it' is handing the title back to hifi_play, which \
-         re-searches and takes the first match. That is #392's keystone finding and \
-         #396's job — NOT an endorsed design. Listed to freeze today's behavior.",
+            "human-readable label for a hifi_search result. #396 added `ref` as the \
+         addressable handle a client actually acts on; title/subtitle remain \
+         display-only — hifi_play's query path still re-searches and takes the first \
+         match, unchanged by this issue. This entry is now historical: it used to be \
+         the only route from 'found it' to 'playing it' before #396 added `ref`.",
         ),
     ),
     (
@@ -1864,7 +1874,15 @@ const FIELD_ROLES: &[(&str, FieldRole)] = &[
     ),
     (
         "subtitle",
-        DisplayOnly("search-result label, same defect as `title`; see #396"),
+        DisplayOnly("search-result label, same display-only role as `title`; see #396"),
+    ),
+    (
+        "ref",
+        Consumed(
+            "hifi_play_ref.ref — the opaque token #396 added to hifi_search results. \
+         `None` (omitted) when a result has no durable-enough handle to address later; \
+         see McpSearchResult's own docs.",
+        ),
     ),
     // hifi_status / hifi_hqplayer_status readouts.
     (
@@ -2224,6 +2242,9 @@ async fn no_tool_returns_an_unclassified_field() {
         &serde_json::to_value(McpSearchResult {
             title: String::new(),
             subtitle: None,
+            // #396: `Some` here so the new field is collected and must be
+            // classified below, exactly like `title`/`subtitle` above.
+            r#ref: Some(String::new()),
         })
         .expect("McpSearchResult must serialize"),
         &mut returned,

--- a/tests/mcp_refs.rs
+++ b/tests/mcp_refs.rs
@@ -1,0 +1,714 @@
+//! MCP ref lifecycle tests (issue #396): search -> hold ref -> play by ref.
+//!
+//! These drive `handle_search` / `handle_play_ref` directly against real
+//! adapters -- `RoonAdapter` connected to `FakeRoonCore`
+//! (`tests/mock_servers/roon_core.rs`, issue #408), and `LmsAdapter` connected
+//! to `MockLmsServer` extended just enough for this issue's ref tests (see
+//! that mock's own doc comments; it is not a #417 fix). Calling the tool
+//! handlers directly, rather than round-tripping through the axum `/mcp`
+//! route as `tests/mcp_contract.rs` does, keeps this file's setup to the
+//! minimum needed to exercise the new resolution paths -- the wire-transport
+//! layer is already covered by that file's own tests and is unchanged here.
+//!
+//! # Roon test strategy (the issue asks this to be stated explicitly)
+//!
+//! Chosen: exercise the ref mint/resolve path against `FakeRoonCore`, a real
+//! protocol-level fake, rather than inventing new unit-only mocking. Reasons:
+//!
+//! - It is the only thing in this repo that can prove a Roon *success* path
+//!   at all (`tests/roon_protocol.rs`'s own docs).
+//! - It already models the exact ambiguity this issue's design rests on --
+//!   `ItemKeyScope::Global` vs `ItemKeyScope::PerSession` -- so the same fake
+//!   that pins `a_foreign_item_key_is_rejected_when_keys_are_session_scoped`
+//!   (proving `play_item`'s fresh-session approach is broken under
+//!   `PerSession`) can prove `play_ref`'s session-reentry approach is *not*
+//!   broken under the same setting. That is a stronger claim than any
+//!   hand-rolled mock could support without duplicating the fake's own
+//!   session-stack model.
+//! - It is validated by the real `roon_api` client library, not by a
+//!   hand-written client (`tests/mock_servers/roon_core.rs`'s own docs), so a
+//!   wire-format regression in the adapter fails here rather than reading as
+//!   coverage.
+
+mod mock_servers;
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use mock_servers::roon_core::{FakeRoonCore, ItemKeyScope};
+use mock_servers::MockLmsServer;
+use serde_json::Value;
+use tokio_util::sync::CancellationToken;
+
+use rust_mcp_sdk::schema::{schema_utils::CallToolError, CallToolResult, ContentBlock};
+
+use unified_hifi_control::adapters::hqplayer::{HqpInstanceManager, HqpZoneLinkService};
+use unified_hifi_control::adapters::lms::LmsAdapter;
+use unified_hifi_control::adapters::openhome::OpenHomeAdapter;
+use unified_hifi_control::adapters::roon::RoonAdapter;
+use unified_hifi_control::adapters::upnp::UPnPAdapter;
+use unified_hifi_control::adapters::Startable;
+use unified_hifi_control::aggregator::ZoneAggregator;
+use unified_hifi_control::api::AppState;
+use unified_hifi_control::bus::create_bus;
+use unified_hifi_control::coordinator::AdapterCoordinator;
+use unified_hifi_control::knobs::KnobStore;
+use unified_hifi_control::mcp::tools::library::{
+    handle_play_ref, handle_search, HifiPlayRefTool, HifiSearchTool,
+};
+
+// =============================================================================
+// Shared helpers
+// =============================================================================
+
+type ToolResult = Result<CallToolResult, CallToolError>;
+
+fn text_of(result: &ToolResult) -> String {
+    let result = result
+        .as_ref()
+        .expect("tool must not return a transport-level error");
+    match result.content.first() {
+        Some(ContentBlock::TextContent(t)) => t.text.clone(),
+        other => panic!("expected exactly one text block, got {other:?}"),
+    }
+}
+
+fn structured_of(result: &ToolResult) -> serde_json::Map<String, Value> {
+    let result = result
+        .as_ref()
+        .expect("tool must not return a transport-level error");
+    result
+        .structured_content
+        .clone()
+        .expect("every tool result must carry an envelope")
+}
+
+fn outcome_of(result: &ToolResult) -> String {
+    structured_of(result)
+        .get("outcome")
+        .and_then(Value::as_str)
+        .unwrap_or("<missing>")
+        .to_string()
+}
+
+fn refusal_reason_of(result: &ToolResult) -> Option<String> {
+    structured_of(result)
+        .get("refusal")
+        .and_then(|r| r.get("reason"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+/// Search results as the JSON array `hifi_search`'s envelope carries in `data`.
+fn search_results_of(result: &ToolResult) -> Vec<Value> {
+    structured_of(result)
+        .get("data")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default()
+}
+
+// =============================================================================
+// Roon: FakeRoonCore-backed AppState
+// =============================================================================
+
+/// Mirrors `tests/roon_protocol.rs::isolate_config_dir` -- keeps Roon pairing
+/// state out of the operator's real config directory. Both test binaries set
+/// the same env var; `OnceLock` makes the redundant `set_var` harmless within
+/// this binary's own process.
+fn isolate_config_dir() -> &'static std::path::Path {
+    use std::sync::OnceLock;
+    static DIR: OnceLock<tempfile::TempDir> = OnceLock::new();
+    DIR.get_or_init(|| {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("UHC_CONFIG_DIR", dir.path());
+        dir
+    })
+    .path()
+}
+
+async fn connected_roon(core: &FakeRoonCore) -> Arc<RoonAdapter> {
+    let _ = isolate_config_dir();
+
+    let bus = create_bus();
+    let adapter = Arc::new(RoonAdapter::new_configured(
+        bus,
+        "http://test.invalid:8088".to_string(),
+        KnobStore::new(),
+    ));
+
+    let runner = adapter.clone();
+    let ip = core.ip();
+    let port = core.port();
+    tokio::spawn(async move {
+        let _ = runner
+            .run_event_loop_against_core_for_tests(ip, &port)
+            .await;
+    });
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        if adapter.is_browse_connected().await {
+            return adapter;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("adapter never reported Browse connected");
+}
+
+/// An `AppState` wired to a real (connected) Roon adapter and disconnected LMS
+/// -- enough to exercise routing, cross-provider refusal, and both providers'
+/// ref resolution from one state.
+async fn app_state_with_roon(roon: Arc<RoonAdapter>) -> AppState {
+    let bus = create_bus();
+    let hqp_instances = Arc::new(HqpInstanceManager::new(bus.clone()));
+    let hqplayer = hqp_instances.get_default().await;
+    let hqp_zone_links = Arc::new(HqpZoneLinkService::new(hqp_instances.clone()));
+    let lms = Arc::new(LmsAdapter::new(bus.clone()));
+    let openhome = Arc::new(OpenHomeAdapter::new(bus.clone()));
+    let upnp = Arc::new(UPnPAdapter::new(bus.clone()));
+    let startable: Vec<Arc<dyn Startable>> = vec![roon.clone()];
+
+    AppState::new(
+        roon,
+        hqplayer,
+        hqp_instances,
+        hqp_zone_links,
+        lms,
+        openhome,
+        upnp,
+        KnobStore::new(),
+        bus.clone(),
+        Arc::new(ZoneAggregator::new(bus.clone())),
+        Arc::new(AdapterCoordinator::new(bus)),
+        startable,
+        Instant::now(),
+        CancellationToken::new(),
+    )
+}
+
+/// Same shape, but with a real (connected) LMS adapter and disconnected Roon
+/// -- for the LMS-side ref tests.
+async fn app_state_with_lms(lms: Arc<LmsAdapter>) -> AppState {
+    let bus = create_bus();
+    let roon = Arc::new(RoonAdapter::new_disconnected(bus.clone()));
+    let hqp_instances = Arc::new(HqpInstanceManager::new(bus.clone()));
+    let hqplayer = hqp_instances.get_default().await;
+    let hqp_zone_links = Arc::new(HqpZoneLinkService::new(hqp_instances.clone()));
+    let openhome = Arc::new(OpenHomeAdapter::new(bus.clone()));
+    let upnp = Arc::new(UPnPAdapter::new(bus.clone()));
+    let startable: Vec<Arc<dyn Startable>> = vec![lms.clone()];
+
+    AppState::new(
+        roon,
+        hqplayer,
+        hqp_instances,
+        hqp_zone_links,
+        lms,
+        openhome,
+        upnp,
+        KnobStore::new(),
+        bus.clone(),
+        Arc::new(ZoneAggregator::new(bus.clone())),
+        Arc::new(AdapterCoordinator::new(bus)),
+        startable,
+        Instant::now(),
+        CancellationToken::new(),
+    )
+}
+
+fn search_args(query: &str) -> HifiSearchTool {
+    HifiSearchTool {
+        query: query.to_string(),
+        zone_id: None,
+        source: None,
+    }
+}
+
+fn play_ref_args(r#ref: &str, zone_id: &str, action: Option<&str>) -> HifiPlayRefTool {
+    HifiPlayRefTool {
+        r#ref: r#ref.to_string(),
+        zone_id: zone_id.to_string(),
+        action: action.map(str::to_string),
+    }
+}
+
+// =============================================================================
+// Roon: mint, resolve, and the session-reentry design this issue turns on
+// =============================================================================
+
+/// The straight-line path: search mints a `ref`, `hifi_play_ref` resolves it
+/// to the same action `play_item` would reach, and the Core was actually
+/// asked to invoke Play Now on the album `hifi_search` found.
+#[tokio::test]
+async fn roon_search_mints_a_ref_and_play_ref_resolves_it() {
+    let core = FakeRoonCore::start().await;
+    let adapter = connected_roon(&core).await;
+    let state = app_state_with_roon(adapter).await;
+
+    let search = handle_search(&state, search_args("kind of blue")).await;
+    let results = search_results_of(&search);
+    assert_eq!(results.len(), 1);
+    let hit = &results[0];
+    assert_eq!(
+        hit.get("title"),
+        Some(&Value::String("Kind of Blue".to_string()))
+    );
+    let ref_token = hit
+        .get("ref")
+        .and_then(Value::as_str)
+        .expect("a Roon hit with an item_key must carry a ref")
+        .to_string();
+    assert!(ref_token.starts_with("ref_"), "got {ref_token:?}");
+
+    let played = handle_play_ref(&state, play_ref_args(&ref_token, "roon:zone_fake_1", None)).await;
+    assert_eq!(
+        outcome_of(&played),
+        "accepted",
+        "text was: {}",
+        text_of(&played)
+    );
+    assert_eq!(text_of(&played), "Play Now: Play Album");
+
+    // The Core was actually asked to invoke Play Now, reached by entering the
+    // album `hifi_search` returned and then its action list -- not merely
+    // "some" playable action.
+    assert_eq!(
+        core.browsed_titles().await,
+        vec![
+            "Library",
+            "Search",
+            "Kind of Blue",
+            "Play Album",
+            "Play Now"
+        ]
+    );
+
+    core.stop().await;
+}
+
+/// **The money test.** Flip the Core to `ItemKeyScope::PerSession` -- the
+/// setting the issue's own evidence (home-assistant/core#137605; Roon Labs
+/// community thread 23129) points toward being the real one -- and
+/// `play_item`'s fresh-session approach is proven broken by
+/// `tests/roon_protocol.rs::a_foreign_item_key_is_rejected_when_keys_are_session_scoped`.
+/// This is that same setup, through `hifi_play_ref` instead: it must still
+/// succeed, because resolution re-enters the exact session that minted the
+/// ref rather than a fresh, unrelated one.
+#[tokio::test]
+async fn roon_ref_resolves_under_per_session_item_key_scope() {
+    let core = FakeRoonCore::start().await;
+    let adapter = connected_roon(&core).await;
+    let state = app_state_with_roon(adapter).await;
+
+    let search = handle_search(&state, search_args("kind of blue")).await;
+    let ref_token = search_results_of(&search)[0]
+        .get("ref")
+        .and_then(Value::as_str)
+        .expect("ref")
+        .to_string();
+
+    // Now that the ref exists, make the Core reject any item_key used outside
+    // the session that minted it.
+    core.set_item_key_scope(ItemKeyScope::PerSession).await;
+
+    let played = handle_play_ref(&state, play_ref_args(&ref_token, "roon:zone_fake_1", None)).await;
+    assert_eq!(
+        outcome_of(&played),
+        "accepted",
+        "resolving inside the minting session must succeed even when keys are \
+         session-scoped; text was: {}",
+        text_of(&played)
+    );
+    assert_eq!(text_of(&played), "Play Now: Play Album");
+
+    core.stop().await;
+}
+
+/// Two refs minted by the *same* search share one `multi_session_key`
+/// (`RoonAdapter::search_with_session` mints exactly one per call). Resolving
+/// both in sequence must not let the first resolution's navigation strand the
+/// second -- the `pop_all: true` reset in `RoonAdapter::play_ref` is exactly
+/// what this proves.
+#[tokio::test]
+async fn two_refs_from_one_search_each_resolve_independently() {
+    let core = FakeRoonCore::start().await;
+    let adapter = connected_roon(&core).await;
+    let state = app_state_with_roon(adapter).await;
+
+    // "blue" matches two library hits (see tests/roon_protocol.rs's
+    // `search_source_selects_a_different_branch`): Kind of Blue and Blue Train.
+    let search = handle_search(&state, search_args("blue")).await;
+    let results = search_results_of(&search);
+    assert_eq!(results.len(), 2, "expected two hits, got {results:?}");
+
+    let refs: Vec<String> = results
+        .iter()
+        .map(|r| {
+            r.get("ref")
+                .and_then(Value::as_str)
+                .expect("each hit should carry a ref")
+                .to_string()
+        })
+        .collect();
+    assert_ne!(refs[0], refs[1], "two different items must not share a ref");
+
+    // Resolve the first, then the second, on the same shared session.
+    let first = handle_play_ref(&state, play_ref_args(&refs[0], "roon:zone_fake_1", None)).await;
+    assert_eq!(
+        outcome_of(&first),
+        "accepted",
+        "first resolve: {}",
+        text_of(&first)
+    );
+
+    let second = handle_play_ref(&state, play_ref_args(&refs[1], "roon:zone_fake_1", None)).await;
+    assert_eq!(
+        outcome_of(&second),
+        "accepted",
+        "second resolve must not be stranded by the first's navigation: {}",
+        text_of(&second)
+    );
+
+    core.stop().await;
+}
+
+/// `action=queue` reaches Queue, not Play Now -- proving the action parameter
+/// actually threads through `play_ref`, not just the default.
+#[tokio::test]
+async fn roon_play_ref_honors_the_queue_action() {
+    let core = FakeRoonCore::start().await;
+    let adapter = connected_roon(&core).await;
+    let state = app_state_with_roon(adapter).await;
+
+    let search = handle_search(&state, search_args("kind of blue")).await;
+    let ref_token = search_results_of(&search)[0]
+        .get("ref")
+        .and_then(Value::as_str)
+        .unwrap()
+        .to_string();
+
+    let played = handle_play_ref(
+        &state,
+        play_ref_args(&ref_token, "roon:zone_fake_1", Some("queue")),
+    )
+    .await;
+    assert_eq!(outcome_of(&played), "accepted");
+    let invoked = core.browsed_titles().await;
+    assert!(invoked.contains(&"Queue".to_string()), "got {invoked:?}");
+    assert!(
+        !invoked.contains(&"Play Now".to_string()),
+        "got {invoked:?}"
+    );
+
+    core.stop().await;
+}
+
+/// `action=next` is LMS-only; a Roon ref must refuse it capability-honestly
+/// rather than silently falling back to "play" -- `PlayAction::parse` would
+/// otherwise do exactly that.
+#[tokio::test]
+async fn roon_play_ref_refuses_next_instead_of_silently_defaulting() {
+    let core = FakeRoonCore::start().await;
+    let adapter = connected_roon(&core).await;
+    let state = app_state_with_roon(adapter).await;
+
+    let search = handle_search(&state, search_args("kind of blue")).await;
+    let ref_token = search_results_of(&search)[0]
+        .get("ref")
+        .and_then(Value::as_str)
+        .unwrap()
+        .to_string();
+
+    // Snapshot what the search itself already browsed (Library, then Search),
+    // so the assertion below is "nothing *new* happened", not "nothing ever
+    // happened" -- the latter would be wrong regardless of the refusal.
+    let before = core.browsed_titles().await;
+
+    let played = handle_play_ref(
+        &state,
+        play_ref_args(&ref_token, "roon:zone_fake_1", Some("next")),
+    )
+    .await;
+    assert_eq!(
+        outcome_of(&played),
+        "invalid",
+        "text was: {}",
+        text_of(&played)
+    );
+    assert_eq!(
+        refusal_reason_of(&played).as_deref(),
+        Some("invalid_parameter")
+    );
+    // And nothing new was invoked on the Core -- the refusal happened before
+    // dispatch, not after a failed attempt.
+    assert_eq!(
+        core.browsed_titles().await,
+        before,
+        "an invalid action must refuse before touching the Core"
+    );
+
+    core.stop().await;
+}
+
+// =============================================================================
+// Cross-provider and unknown-ref refusals (provider-agnostic; Roon-backed
+// state is enough to exercise both, since routing is by zone_id prefix)
+// =============================================================================
+
+/// A ref minted for Roon, resolved against an `lms:` zone, must be refused
+/// capability-honestly rather than the server guessing which provider to
+/// trust.
+#[tokio::test]
+async fn a_roon_ref_used_against_an_lms_zone_is_refused() {
+    let core = FakeRoonCore::start().await;
+    let adapter = connected_roon(&core).await;
+    let state = app_state_with_roon(adapter).await;
+
+    let search = handle_search(&state, search_args("kind of blue")).await;
+    let ref_token = search_results_of(&search)[0]
+        .get("ref")
+        .and_then(Value::as_str)
+        .unwrap()
+        .to_string();
+
+    let played = handle_play_ref(
+        &state,
+        play_ref_args(&ref_token, "lms:aa:bb:cc:dd:ee:ff", None),
+    )
+    .await;
+    assert_eq!(
+        outcome_of(&played),
+        "invalid",
+        "text was: {}",
+        text_of(&played)
+    );
+    assert_eq!(
+        refusal_reason_of(&played).as_deref(),
+        Some("invalid_parameter")
+    );
+    let text = text_of(&played);
+    assert!(text.to_lowercase().contains("roon"), "got {text:?}");
+    assert!(text.to_lowercase().contains("lms"), "got {text:?}");
+
+    // And the ref is still good against its own provider -- a rejected
+    // cross-provider attempt must not burn the ref.
+    let retried =
+        handle_play_ref(&state, play_ref_args(&ref_token, "roon:zone_fake_1", None)).await;
+    assert_eq!(
+        outcome_of(&retried),
+        "accepted",
+        "text was: {}",
+        text_of(&retried)
+    );
+
+    core.stop().await;
+}
+
+/// A ref that never existed (or has expired/been evicted -- indistinguishable
+/// by design, see `src/mcp/refs.rs`) produces a distinct, retryable outcome
+/// that names `hifi_search` as the recovery path, never a silent fallback to
+/// first-match.
+#[tokio::test]
+async fn an_unknown_ref_is_refused_and_names_hifi_search_as_the_recovery() {
+    let core = FakeRoonCore::start().await;
+    let adapter = connected_roon(&core).await;
+    let state = app_state_with_roon(adapter).await;
+
+    let played = handle_play_ref(
+        &state,
+        play_ref_args("ref_this-was-never-minted", "roon:zone_fake_1", None),
+    )
+    .await;
+    assert_eq!(
+        outcome_of(&played),
+        "invalid",
+        "text was: {}",
+        text_of(&played)
+    );
+    assert_eq!(
+        refusal_reason_of(&played).as_deref(),
+        Some("unknown_target")
+    );
+    let structured = structured_of(&played);
+    let discover_with = structured
+        .get("refusal")
+        .and_then(|r| r.get("discover_with"))
+        .and_then(Value::as_str);
+    assert_eq!(discover_with, Some("hifi_search"));
+    // Nothing was ever asked of the Core -- the table lookup failed before
+    // any adapter call.
+    assert!(core
+        .requests()
+        .await
+        .iter()
+        .all(|r| r.name.contains("registry") || r.name.contains("subscribe_zones")));
+
+    core.stop().await;
+}
+
+/// A hand-mangled ref (a real one, with one character flipped) is refused
+/// the same way an unknown one is -- never misresolved to a different, real
+/// item. Complements `src/mcp/refs.rs`'s table-level test of the same claim,
+/// this time through the actual MCP tool.
+#[tokio::test]
+async fn a_mangled_ref_is_refused_through_the_tool_not_misresolved() {
+    let core = FakeRoonCore::start().await;
+    let adapter = connected_roon(&core).await;
+    let state = app_state_with_roon(adapter).await;
+
+    let search = handle_search(&state, search_args("kind of blue")).await;
+    let ref_token = search_results_of(&search)[0]
+        .get("ref")
+        .and_then(Value::as_str)
+        .unwrap()
+        .to_string();
+
+    let mut mangled = ref_token.clone();
+    let last = mangled.pop().unwrap();
+    mangled.push(if last == 'A' { 'B' } else { 'A' });
+    assert_ne!(mangled, ref_token);
+
+    let played = handle_play_ref(&state, play_ref_args(&mangled, "roon:zone_fake_1", None)).await;
+    assert_eq!(outcome_of(&played), "invalid");
+    assert_eq!(
+        refusal_reason_of(&played).as_deref(),
+        Some("unknown_target")
+    );
+
+    core.stop().await;
+}
+
+// =============================================================================
+// LMS: durable Library refs, validate-before-mutate
+// =============================================================================
+
+async fn connected_lms(mock: &MockLmsServer) -> Arc<LmsAdapter> {
+    let bus = create_bus();
+    let lms = Arc::new(LmsAdapter::new(bus));
+    lms.configure(
+        mock.addr().ip().to_string(),
+        Some(mock.addr().port()),
+        None,
+        None,
+    )
+    .await;
+    lms.start().await.expect("LMS adapter must start");
+    lms
+}
+
+const LMS_PLAYER: &str = "aa:bb:cc:dd:ee:ff";
+
+/// A durable `Library` ref: minted from the `search_library` fallback path
+/// (globalsearch is unmodeled by the mock, so this is the addressable path
+/// LMS actually falls back to), resolved through `hifi_play_ref`, landing on
+/// exactly the `playlistcontrol` command `LmsAdapter::play_target` builds --
+/// not `search_and_play`, which this path never touches.
+#[tokio::test]
+async fn lms_search_mints_a_durable_ref_and_play_ref_resolves_it() {
+    let mock = MockLmsServer::start().await;
+    mock.add_player(LMS_PLAYER, "Living Room").await;
+    mock.set_library_albums(vec![(101, "Kind of Blue", "Miles Davis")])
+        .await;
+    let lms = connected_lms(&mock).await;
+    let state = app_state_with_lms(lms).await;
+    let zone_id = format!("lms:{LMS_PLAYER}");
+
+    let search = handle_search(
+        &state,
+        HifiSearchTool {
+            query: "kind of blue".to_string(),
+            zone_id: Some(zone_id.clone()),
+            source: None,
+        },
+    )
+    .await;
+    let results = search_results_of(&search);
+    assert_eq!(results.len(), 1, "got {results:?}");
+    let ref_token = results[0]
+        .get("ref")
+        .and_then(Value::as_str)
+        .expect("a Library-backed LMS result must carry a ref")
+        .to_string();
+
+    mock.clear_commands().await;
+    let played = handle_play_ref(&state, play_ref_args(&ref_token, &zone_id, None)).await;
+    assert_eq!(
+        outcome_of(&played),
+        "accepted",
+        "text was: {}",
+        text_of(&played)
+    );
+
+    let commands = mock.write_commands(LMS_PLAYER).await;
+    assert!(
+        commands.contains(&vec![
+            "playlistcontrol".to_string(),
+            "cmd:load".to_string(),
+            "album_id:101".to_string(),
+        ]),
+        "got {commands:?}"
+    );
+
+    mock.stop().await;
+    lms_stop(&state).await;
+}
+
+/// **Validate before mutate.** The library was rescanned (id 101 no longer
+/// exists) between mint and resolve. `hifi_play_ref` must refuse rather than
+/// issue `playlistcontrol cmd:load`, which the issue's own evidence says
+/// clears the queue *and then* fails -- the wipe-reported-as-failure trap
+/// this method exists to avoid.
+#[tokio::test]
+async fn lms_stale_library_ref_is_refused_without_mutating_the_queue() {
+    let mock = MockLmsServer::start().await;
+    mock.add_player(LMS_PLAYER, "Living Room").await;
+    mock.set_library_albums(vec![(101, "Kind of Blue", "Miles Davis")])
+        .await;
+    let lms = connected_lms(&mock).await;
+    let state = app_state_with_lms(lms).await;
+    let zone_id = format!("lms:{LMS_PLAYER}");
+
+    let search = handle_search(
+        &state,
+        HifiSearchTool {
+            query: "kind of blue".to_string(),
+            zone_id: Some(zone_id.clone()),
+            source: None,
+        },
+    )
+    .await;
+    let ref_token = search_results_of(&search)[0]
+        .get("ref")
+        .and_then(Value::as_str)
+        .unwrap()
+        .to_string();
+
+    // Simulate a rescan: the album is gone.
+    mock.set_library_albums(vec![]).await;
+
+    mock.clear_commands().await;
+    let played = handle_play_ref(&state, play_ref_args(&ref_token, &zone_id, None)).await;
+    assert_eq!(
+        outcome_of(&played),
+        "error",
+        "text was: {}",
+        text_of(&played)
+    );
+
+    // The load-bearing assertion: playlistcontrol was never sent.
+    let commands = mock.write_commands(LMS_PLAYER).await;
+    assert!(
+        commands
+            .iter()
+            .all(|c| c.first().map(String::as_str) != Some("playlistcontrol")),
+        "a stale ref must not reach playlistcontrol: {commands:?}"
+    );
+
+    mock.stop().await;
+    lms_stop(&state).await;
+}
+
+async fn lms_stop(state: &AppState) {
+    state.lms.stop().await;
+}

--- a/tests/mcp_refs.rs
+++ b/tests/mcp_refs.rs
@@ -315,6 +315,67 @@ async fn a_category_grouping_row_never_gets_a_ref() {
     core.stop().await;
 }
 
+/// **The dissent's own follow-up (D2):** `is_category`'s title list is
+/// verified live only for Library results; TIDAL/Qobuz may group under
+/// different labels it does not contain. `is_ungrounded_grouping`'s second,
+/// source-independent signal (a subtitle shaped like `"<N> Results"`) is
+/// meant to catch exactly that case. This proves the second layer alone —
+/// with a title (`"Streaming Picks"`) `CATEGORY_NAMES` does not contain —
+/// still keeps the row from getting a ref.
+#[tokio::test]
+async fn a_grouping_row_with_an_unlisted_title_is_still_caught_by_its_subtitle_shape() {
+    let mut library = mock_servers::roon_core::FakeLibrary::standard();
+    library.search_results.insert(
+        "Library".to_string(),
+        vec![
+            mock_servers::roon_core::album("Kind of Blue", "Miles Davis", &["So What"]),
+            // A title CATEGORY_NAMES does not list, imagining a TIDAL/Qobuz-
+            // style grouping label -- only the subtitle shape marks it. The
+            // query term lives in the title (so the fake's substring-match
+            // search includes this row); the subtitle is the exact
+            // "<N> Results" shape the second check looks for -- real Roon's
+            // observed shape was the count and the word alone, no trailing
+            // text, which is what `looks_like_a_result_count_grouping`'s
+            // exact-suffix check requires.
+            mock_servers::roon_core::FakeItem::list("Streaming Picks: kind of blue")
+                .with_subtitle("12 Results"),
+        ],
+    );
+
+    let core = FakeRoonCore::start_with(library).await;
+    let adapter = connected_roon(&core).await;
+    let state = app_state_with_roon(adapter).await;
+
+    let search = handle_search(&state, search_args("kind of blue")).await;
+    let results = search_results_of(&search);
+
+    let unlisted_row = results
+        .iter()
+        .find(|r| {
+            r.get("title") == Some(&Value::String("Streaming Picks: kind of blue".to_string()))
+        })
+        .expect("the unlisted-title grouping row must be among the results");
+    assert_eq!(
+        unlisted_row.get("ref"),
+        None,
+        "a grouping row must be caught by its subtitle shape even when its title \
+         is not in CATEGORY_NAMES: {unlisted_row:?}"
+    );
+
+    // And a real hit whose subtitle merely *contains* something count-shaped
+    // is not swept up by the same check -- it must actually END with " Results".
+    let kob = results
+        .iter()
+        .find(|r| r.get("title") == Some(&Value::String("Kind of Blue".to_string())))
+        .expect("Kind of Blue must be among the results");
+    assert!(
+        kob.get("ref").and_then(Value::as_str).is_some(),
+        "real content must still get a ref: {kob:?}"
+    );
+
+    core.stop().await;
+}
+
 /// The straight-line path: search mints a `ref`, `hifi_play_ref` resolves it
 /// to the same action `play_item` would reach, and the Core was actually
 /// asked to invoke Play Now on the album `hifi_search` found.

--- a/tests/mcp_refs.rs
+++ b/tests/mcp_refs.rs
@@ -381,6 +381,60 @@ async fn two_refs_from_one_search_each_resolve_independently() {
     core.stop().await;
 }
 
+/// **Live-rig regression** (#396 ship-gate re-review): an earlier version of
+/// `RoonAdapter::play_ref` reset the minting session's browse stack with
+/// `pop_all: true` before entering the ref's `item_key`, in the same browse
+/// request. That hangs against a real Core (verified live: nuc14, Roon 2.70)
+/// -- the Core never answers, and the caller waits out the full
+/// `BROWSE_TIMEOUT`. `hifi_search` worked, `hifi_play_ref` on the very same
+/// zone and query did not; the two paths' Roon calls had to be diffed to find
+/// where they diverged, which is exactly what this test pins so it cannot
+/// happen silently again.
+///
+/// This asserts the *structural* claim directly, independent of timing:
+/// `play_ref` must never send a browse request combining `pop_all: true` with
+/// a present `item_key`. `FakeRoonCore` answers that combination with a fast,
+/// loud `InvalidItemKey` (see `tests/mock_servers/roon_core.rs::handle_browse`)
+/// rather than reproducing the real hang, precisely so a regression here
+/// fails in milliseconds, not after a real 10-second timeout.
+#[tokio::test]
+async fn play_ref_never_combines_pop_all_with_an_item_key() {
+    let core = FakeRoonCore::start().await;
+    let adapter = connected_roon(&core).await;
+    let state = app_state_with_roon(adapter).await;
+
+    let search = handle_search(&state, search_args("kind of blue")).await;
+    let ref_token = search_results_of(&search)[0]
+        .get("ref")
+        .and_then(Value::as_str)
+        .unwrap()
+        .to_string();
+
+    let started = Instant::now();
+    let played = handle_play_ref(&state, play_ref_args(&ref_token, "roon:zone_fake_1", None)).await;
+    assert!(
+        started.elapsed() < Duration::from_secs(2),
+        "resolution must be fast; a regression to the pop_all+item_key combination \
+         degrades to a ~10s BROWSE_TIMEOUT wait even against the fake"
+    );
+    assert_eq!(
+        outcome_of(&played),
+        "accepted",
+        "text was: {}",
+        text_of(&played)
+    );
+
+    assert!(
+        core.illegal_pop_all_with_item_key_attempts()
+            .await
+            .is_empty(),
+        "play_ref must never combine pop_all:true with a present item_key in one \
+         browse request -- this hangs against a real Roon Core"
+    );
+
+    core.stop().await;
+}
+
 /// `action=queue` reaches Queue, not Play Now -- proving the action parameter
 /// actually threads through `play_ref`, not just the default.
 #[tokio::test]
@@ -452,6 +506,13 @@ async fn roon_play_ref_refuses_next_instead_of_silently_defaulting() {
         refusal_reason_of(&played).as_deref(),
         Some("invalid_parameter")
     );
+    // `operation` must be a normalized sentinel, not an echo of the raw
+    // (invalid) request -- matching hifi_control's own `unknown_action`
+    // convention (src/mcp/tools/transport.rs) for the same class of refusal.
+    // A client branching on `operation` should never see arbitrary,
+    // unvalidated client input reflected back as if it were a recognized
+    // value.
+    assert_eq!(operation_of(&played), "invalid_action");
     // And nothing new was invoked on the Core -- the refusal happened before
     // dispatch, not after a failed attempt.
     assert_eq!(
@@ -499,6 +560,10 @@ async fn a_roon_ref_used_against_an_lms_zone_is_refused() {
         refusal_reason_of(&played).as_deref(),
         Some("invalid_parameter")
     );
+    // Cross-provider mismatch is caught before either provider's action set
+    // is even consulted, so `operation` is the tool-shaped constant, not a
+    // half-validated action name from either side.
+    assert_eq!(operation_of(&played), "play_ref");
     let text = text_of(&played);
     assert!(text.to_lowercase().contains("roon"), "got {text:?}");
     assert!(text.to_lowercase().contains("lms"), "got {text:?}");
@@ -542,6 +607,9 @@ async fn an_unknown_ref_is_refused_and_names_hifi_search_as_the_recovery() {
         refusal_reason_of(&played).as_deref(),
         Some("unknown_target")
     );
+    // An unresolvable ref means no provider action set was ever consulted,
+    // so `operation` stays the tool-shaped constant.
+    assert_eq!(operation_of(&played), "play_ref");
     let structured = structured_of(&played);
     let discover_with = structured
         .get("refusal")

--- a/tests/mcp_refs.rs
+++ b/tests/mcp_refs.rs
@@ -721,6 +721,83 @@ async fn lms_stale_library_ref_is_refused_without_mutating_the_queue() {
     lms_stop(&state).await;
 }
 
+/// **The dissent's own finding, checked empirically rather than left as a
+/// hypothesis.** `assert_library_id_exists` re-validates a `Library` ref by
+/// searching the *title captured at mint time* and checking whether the
+/// target id appears among the (at most 50) results that search returns. If
+/// many albums share the exact same title -- a box set re-release, a
+/// self-titled album by different artists, a generic "Live" -- and the
+/// target is not among the first 50 the mock (or a real server) happens to
+/// return, does a genuinely still-valid id get wrongly refused?
+///
+/// This seeds 60 albums sharing one identical title ("Common Album", more
+/// than `search_library`'s hardcoded limit of 50) with distinct artists, and
+/// mints a ref for the 60th one specifically -- disambiguated at mint time by
+/// artist, which the mock's search also matches on -- so it lands last in the
+/// mock's insertion-order-preserving results and therefore *outside* a
+/// `skip(0).take(50)` window keyed only on the shared title. If this test
+/// fails, the dissent's D1 finding is confirmed as a real, shipped bug and
+/// `assert_library_id_exists` needs a wider limit (or a different query
+/// shape, e.g. a combined title+id filter) before this is safe to rely on
+/// for large libraries. If it passes, the current limit was enough for this
+/// specific shape and the risk is bounded to libraries with more than 50
+/// exact-title-duplicates -- worth knowing either way, not merely asserting.
+#[tokio::test]
+async fn lms_a_valid_ref_beyond_the_validation_search_limit_still_resolves() {
+    let mock = MockLmsServer::start().await;
+    mock.add_player(LMS_PLAYER, "Living Room").await;
+
+    let mut albums: Vec<(i64, String, String)> = Vec::new();
+    for i in 1..=60i64 {
+        albums.push((100 + i, "Common Album".to_string(), format!("Artist {i}")));
+    }
+    let albums_ref: Vec<(i64, &str, &str)> = albums
+        .iter()
+        .map(|(id, t, a)| (*id, t.as_str(), a.as_str()))
+        .collect();
+    mock.set_library_albums(albums_ref).await;
+
+    let lms = connected_lms(&mock).await;
+    let state = app_state_with_lms(lms).await;
+    let zone_id = format!("lms:{LMS_PLAYER}");
+
+    // Mint a ref for the 60th album specifically, disambiguated by artist --
+    // its title alone ("Common Album") matches all 60.
+    let search = handle_search(
+        &state,
+        HifiSearchTool {
+            query: "Artist 60".to_string(),
+            zone_id: Some(zone_id.clone()),
+            source: None,
+        },
+    )
+    .await;
+    let results = search_results_of(&search);
+    assert_eq!(
+        results.len(),
+        1,
+        "expected an exact artist match, got {results:?}"
+    );
+    let ref_token = results[0]
+        .get("ref")
+        .and_then(Value::as_str)
+        .expect("ref")
+        .to_string();
+
+    let played = handle_play_ref(&state, play_ref_args(&ref_token, &zone_id, None)).await;
+    assert_eq!(
+        outcome_of(&played),
+        "accepted",
+        "a still-valid id must not be refused merely because a broader re-validation \
+         search (by its shared title) would not have surfaced it within its own limit; \
+         text was: {}",
+        text_of(&played)
+    );
+
+    mock.stop().await;
+    lms_stop(&state).await;
+}
+
 async fn lms_stop(state: &AppState) {
     state.lms.stop().await;
 }

--- a/tests/mcp_refs.rs
+++ b/tests/mcp_refs.rs
@@ -99,6 +99,14 @@ fn refusal_reason_of(result: &ToolResult) -> Option<String> {
         .map(str::to_string)
 }
 
+fn operation_of(result: &ToolResult) -> String {
+    structured_of(result)
+        .get("operation")
+        .and_then(Value::as_str)
+        .unwrap_or("<missing>")
+        .to_string()
+}
+
 /// Search results as the JSON array `hifi_search`'s envelope carries in `data`.
 fn search_results_of(result: &ToolResult) -> Vec<Value> {
     structured_of(result)
@@ -394,6 +402,10 @@ async fn roon_play_ref_honors_the_queue_action() {
     )
     .await;
     assert_eq!(outcome_of(&played), "accepted");
+    // `operation` reflects the resolved action, matching hifi_play's own
+    // convention -- a client reading only `operation` can tell this apart
+    // from a plain play, without also reading `params.action`.
+    assert_eq!(operation_of(&played), "queue");
     let invoked = core.browsed_titles().await;
     assert!(invoked.contains(&"Queue".to_string()), "got {invoked:?}");
     assert!(

--- a/tests/mcp_refs.rs
+++ b/tests/mcp_refs.rs
@@ -245,6 +245,76 @@ fn play_ref_args(r#ref: &str, zone_id: &str, action: Option<&str>) -> HifiPlayRe
 // Roon: mint, resolve, and the session-reentry design this issue turns on
 // =============================================================================
 
+/// **Found live** (ship-gate re-review): a real Core's search results mix the
+/// actual hit with grouping rows -- searching "kind of blue" against nuc14
+/// returned "Kind of Blue" *and* "Artists" (7 Results), "Albums" (32
+/// Results), "Composers", "Tracks", "Works" -- all sharing the same
+/// `hint: "list"` and a real, navigable `item_key`. `FakeRoonCore`'s search
+/// model never produced this shape (it returns a flat, substring-matched
+/// list of real hits only), so nothing caught `handle_search` minting a ref
+/// for a category row indistinguishably from real content. Resolving one
+/// lands in `resolve_item_key`'s "guess the first item" fallback and can
+/// silently play something the client never asked for -- precisely the
+/// failure mode #396 exists to prevent.
+///
+/// This constructs a library whose "Library" search results include both a
+/// real hit and a category-shaped row (title exactly "Albums", matching
+/// `crate::adapters::roon::CATEGORY_NAMES`) to prove the fix:
+/// `crate::adapters::roon::is_category` now excludes category rows from
+/// minting regardless of how real their `item_key` looks.
+#[tokio::test]
+async fn a_category_grouping_row_never_gets_a_ref() {
+    let mut library = mock_servers::roon_core::FakeLibrary::standard();
+    library.search_results.insert(
+        "Library".to_string(),
+        vec![
+            mock_servers::roon_core::album("Kind of Blue", "Miles Davis", &["So What"]),
+            // Real Roon's category rows: title is exactly the category name,
+            // same `hint: "list"` as real content, a real item_key. The
+            // subtitle carries the query term only so the fake's
+            // substring-match search model includes it -- real Roon includes
+            // these unconditionally, for a reason this fake's simpler
+            // flat-list search model does not represent.
+            mock_servers::roon_core::FakeItem::list("Albums")
+                .with_subtitle("32 Results for kind of blue"),
+        ],
+    );
+
+    let core = FakeRoonCore::start_with(library).await;
+    let adapter = connected_roon(&core).await;
+    let state = app_state_with_roon(adapter).await;
+
+    let search = handle_search(&state, search_args("kind of blue")).await;
+    let results = search_results_of(&search);
+    assert_eq!(
+        results.len(),
+        2,
+        "expected the real hit and the category row, got {results:?}"
+    );
+
+    let kob = results
+        .iter()
+        .find(|r| r.get("title") == Some(&Value::String("Kind of Blue".to_string())))
+        .expect("Kind of Blue must be among the results");
+    assert!(
+        kob.get("ref").and_then(Value::as_str).is_some(),
+        "real content must still get a ref: {kob:?}"
+    );
+
+    let albums_row = results
+        .iter()
+        .find(|r| r.get("title") == Some(&Value::String("Albums".to_string())))
+        .expect("the category row must be among the results");
+    assert_eq!(
+        albums_row.get("ref"),
+        None,
+        "a category grouping row must never get a ref, even though it has a real \
+         item_key: {albums_row:?}"
+    );
+
+    core.stop().await;
+}
+
 /// The straight-line path: search mints a `ref`, `hifi_play_ref` resolves it
 /// to the same action `play_item` would reach, and the Core was actually
 /// asked to invoke Play Now on the album `hifi_search` found.

--- a/tests/mock_servers/lms.rs
+++ b/tests/mock_servers/lms.rs
@@ -71,6 +71,21 @@ impl RecordedCommand {
     }
 }
 
+/// One library entry for the `search` (library fallback) and
+/// `albums`/`artists`/`titles` (existence-check) handlers below.
+///
+/// #396: purpose-built for that issue's ref tests, not a general #417 fix —
+/// see `tests/mock_servers/README.md` and this module's own docs on the
+/// difference. Real LMS keys each type's own entity id `<type>_id`
+/// (`album_id`, `contributor_id`, `track_id`); this mock mirrors that, one
+/// `HashMap` per kind, rather than modeling LMS's actual database.
+#[derive(Debug, Clone)]
+pub struct MockLibraryItem {
+    pub id: i64,
+    pub title: String,
+    pub artist: String,
+}
+
 /// Mock LMS server state
 struct MockLmsState {
     players: HashMap<String, MockPlayer>,
@@ -78,6 +93,12 @@ struct MockLmsState {
     /// backend command an MCP action actually produced (issue #394) rather than
     /// only observing the resulting state.
     commands: Vec<RecordedCommand>,
+    /// Library items for `search` (the `search_library` fallback path) and for
+    /// the `albums`/`artists`/`titles` existence checks
+    /// `LmsAdapter::assert_library_id_exists` (#396) issues before a mutating
+    /// `playlistcontrol` call. Keyed by [`LmsSearchResultType`]-shaped kind:
+    /// `"album"`, `"artist"`, `"track"`.
+    library: HashMap<&'static str, Vec<MockLibraryItem>>,
 }
 
 /// Mock LMS Server
@@ -93,6 +114,7 @@ impl MockLmsServer {
         let state = Arc::new(RwLock::new(MockLmsState {
             players: HashMap::new(),
             commands: Vec::new(),
+            library: HashMap::new(),
         }));
 
         let app = Router::new()
@@ -158,6 +180,24 @@ impl MockLmsServer {
         self.state.write().await.commands.clear();
     }
 
+    /// Seed the library albums the `search` (term-based) and `albums`
+    /// (id-existence) handlers answer from. Replaces whatever was set before
+    /// -- call again with a shorter list to simulate a rescan that dropped an
+    /// id, which is exactly what
+    /// `LmsAdapter::assert_library_id_exists` (#396) has to notice before a
+    /// mutating `playlistcontrol` call.
+    pub async fn set_library_albums(&self, albums: Vec<(i64, &str, &str)>) {
+        let items = albums
+            .into_iter()
+            .map(|(id, title, artist)| MockLibraryItem {
+                id,
+                title: title.to_string(),
+                artist: artist.to_string(),
+            })
+            .collect();
+        self.state.write().await.library.insert("album", items);
+    }
+
     /// Commands received for `player_id`, excluding the read-only polling
     /// commands the adapter issues on its own schedule.
     pub async fn write_commands(&self, player_id: &str) -> Vec<Vec<String>> {
@@ -197,6 +237,16 @@ struct JsonRpcRequest {
 struct JsonRpcResponse {
     id: Value,
     result: Value,
+}
+
+/// Read a tagged `"<tag>:<value>"` parameter out of a command array, the way
+/// LMS's own CLI encodes filters (`term:query`, `album_id:5`, ...).
+fn filter_value<'a>(commands: &'a [Value], tag: &str) -> Option<&'a str> {
+    let prefix = format!("{tag}:");
+    commands
+        .iter()
+        .filter_map(Value::as_str)
+        .find_map(|s| s.strip_prefix(prefix.as_str()))
 }
 
 /// Handle JSON-RPC requests
@@ -351,6 +401,60 @@ async fn handle_jsonrpc(
         "playlist" => {
             // Playlist control (next/prev) - return empty success
             json!({})
+        }
+        // The `search_library` fallback path (`LmsAdapter::search_library`):
+        // `["search", 0, limit, "term:<query>"]`, answered from `library`
+        // rather than the catch-all `{}` every other command still gets.
+        // #396: this is what lets an MCP-level test mint a durable `Library`
+        // ref without needing a full #417 globalsearch fix.
+        "search" => {
+            let query = filter_value(commands, "term")
+                .unwrap_or_default()
+                .to_lowercase();
+            let albums_loop: Vec<Value> = state
+                .library
+                .get("album")
+                .into_iter()
+                .flatten()
+                .filter(|item| {
+                    item.title.to_lowercase().contains(&query)
+                        || item.artist.to_lowercase().contains(&query)
+                })
+                .map(|item| {
+                    json!({
+                        "album_id": item.id,
+                        "album": item.title,
+                        "artist": item.artist,
+                    })
+                })
+                .collect();
+            if albums_loop.is_empty() {
+                json!({})
+            } else {
+                json!({ "albums_loop": albums_loop })
+            }
+        }
+        // The existence check `LmsAdapter::assert_library_id_exists` (#396)
+        // issues before a mutating `playlistcontrol`:
+        // `["albums", 0, 1, "album_id:<id>"]` (and the `artists`/`titles`
+        // analogues, unmodeled here since #396's tests only exercise the
+        // album path -- they fall to the catch-all `{"count": 0}` shape via
+        // `_`, which is the safe direction: an unmodeled kind reads as "not
+        // found" rather than "found").
+        "albums" => {
+            let requested_id =
+                filter_value(commands, "album_id").and_then(|v| v.parse::<i64>().ok());
+            let count = match requested_id {
+                Some(id) => state
+                    .library
+                    .get("album")
+                    .into_iter()
+                    .flatten()
+                    .filter(|item| item.id == id)
+                    .count(),
+                None => 0,
+            };
+            json!({ "count": count })
         }
         _ => {
             json!({})

--- a/tests/mock_servers/lms.rs
+++ b/tests/mock_servers/lms.rs
@@ -408,10 +408,23 @@ async fn handle_jsonrpc(
         // #396: this is what lets an MCP-level test mint a durable `Library`
         // ref without needing a full #417 globalsearch fix.
         "search" => {
+            // `["search", offset, count, "term:<query>"]` -- offset/count are
+            // real LMS pagination params, honored here (not merely accepted
+            // and ignored) so a test can prove what happens when more than
+            // `count` items match a term, the same as a real server would
+            // truncate. See #396's dissent: `assert_library_id_exists`
+            // re-searches by title with a fixed count, so whether matches
+            // beyond that count are reachable is exactly what this models.
+            let offset = commands.get(1).and_then(Value::as_u64).unwrap_or(0) as usize;
+            let count = commands
+                .get(2)
+                .and_then(Value::as_u64)
+                .map(|c| c as usize)
+                .unwrap_or(usize::MAX);
             let query = filter_value(commands, "term")
                 .unwrap_or_default()
                 .to_lowercase();
-            let albums_loop: Vec<Value> = state
+            let matches: Vec<&MockLibraryItem> = state
                 .library
                 .get("album")
                 .into_iter()
@@ -420,6 +433,11 @@ async fn handle_jsonrpc(
                     item.title.to_lowercase().contains(&query)
                         || item.artist.to_lowercase().contains(&query)
                 })
+                .collect();
+            let page: Vec<Value> = matches
+                .into_iter()
+                .skip(offset)
+                .take(count)
                 .map(|item| {
                     json!({
                         "album_id": item.id,
@@ -428,10 +446,10 @@ async fn handle_jsonrpc(
                     })
                 })
                 .collect();
-            if albums_loop.is_empty() {
+            if page.is_empty() {
                 json!({})
             } else {
-                json!({ "albums_loop": albums_loop })
+                json!({ "albums_loop": page })
             }
         }
         // The existence check `LmsAdapter::assert_library_id_exists` (#396)

--- a/tests/mock_servers/roon_core.rs
+++ b/tests/mock_servers/roon_core.rs
@@ -502,6 +502,25 @@ struct Level {
 #[derive(Default)]
 struct Session {
     levels: Vec<Level>,
+    /// Keys *this session itself* has minted (via `handle_load`), each
+    /// tagged with the epoch (see [`Self::epoch`]) it was minted in.
+    ///
+    /// Deliberately **not** a simple "is this key currently valid" set: a key
+    /// this session has never minted at all (reused from a different
+    /// session) must fall through to the existing cross-session checks
+    /// (`CoreState::minted` / [`ItemKeyScope`]) unaffected by anything here —
+    /// `play_item` legitimately mints a fresh, unrelated session and browses
+    /// a foreign key inside it under [`ItemKeyScope::Global`], and that must
+    /// keep working. This map only ever *adds* a restriction for keys this
+    /// exact session minted and then invalidated by popping past them.
+    minted_at_epoch: HashMap<String, u64>,
+    /// Incremented on every `pop_all`. Verified live against a real Core
+    /// (nuc14, Roon 2.70, #396's ship-gate re-review): `pop_all` invalidates
+    /// every key minted at the levels it discards, not merely the client's
+    /// conceptual position -- a key this session minted in an earlier epoch
+    /// is `InvalidItemKey` now, even though the global arena still contains
+    /// it and even under [`ItemKeyScope::Global`].
+    epoch: u64,
 }
 
 struct CoreState {
@@ -535,6 +554,11 @@ struct CoreState {
     /// assert the Core correlated its refusal to the right request and session even
     /// though today's adapter throws the payload away.
     errors: Vec<(usize, String, String)>,
+    /// Session keys of every browse request that combined `pop_all: true`
+    /// with a present `item_key` -- see the `handle_browse` comment at that
+    /// check. Empty is the passing state for any test asserting this
+    /// combination was never sent.
+    illegal_pop_all_with_item_key: Vec<String>,
     core_id: String,
     display_name: String,
     display_version: String,
@@ -581,6 +605,7 @@ impl FakeRoonCore {
             log: Vec::new(),
             sent: Vec::new(),
             errors: Vec::new(),
+            illegal_pop_all_with_item_key: Vec::new(),
             // Per-instance, so two fakes running concurrently are distinct Cores.
             // Tests read it back via `core_id()` rather than hardcoding it.
             core_id: format!("fake-core-408-{}", addr.port()),
@@ -804,6 +829,18 @@ impl FakeRoonCore {
     /// Browse/load refusals this Core sent, as `(request id, name, session key)`.
     pub async fn errors_sent(&self) -> Vec<(usize, String, String)> {
         self.state.read().await.errors.clone()
+    }
+
+    /// Session keys of every browse request that illegally combined
+    /// `pop_all: true` with a present `item_key` -- see `handle_browse`'s
+    /// comment on that check, and #396's ship-gate re-review for the live
+    /// evidence this hangs against a real Core. Empty is the passing state.
+    pub async fn illegal_pop_all_with_item_key_attempts(&self) -> Vec<String> {
+        self.state
+            .read()
+            .await
+            .illegal_pop_all_with_item_key
+            .clone()
     }
 
     /// Names of the responses sent, in order.
@@ -1244,6 +1281,30 @@ async fn handle_browse(
 
     let mut state = core.write().await;
 
+    // A request combining `pop_all: true` with a present `item_key` hangs
+    // against a real Core (verified live, nuc14/Roon 2.70, #396's ship-gate
+    // re-review) -- it never answers at all, which this fake cannot
+    // faithfully reproduce as a *hang* without making every test that
+    // regresses to this pattern pay a real wall-clock `BROWSE_TIMEOUT`. The
+    // fork's `Parsed::Error` path only recognises
+    // `FakeRoonCore::FORK_ERROR_NAMES` (an invented name degrades to
+    // `Parsed::None`, i.e. exactly the timeout this refuses to reproduce —
+    // see `an_unrecognised_error_name_degrades_to_an_indistinguishable_timeout`),
+    // so this answers `InvalidItemKey`, a real recognised name, for a fast
+    // and loud adapter-level test failure. The attempt is *also* recorded
+    // separately (`FakeRoonCore::illegal_pop_all_with_item_key_attempts`) so
+    // a test can assert the combination was never even sent, independent of
+    // whatever generic error text resulted.
+    if pop_all && item_key.is_some() {
+        state
+            .illegal_pop_all_with_item_key
+            .push(session_key.clone());
+        state.reject_next_browse = false;
+        drop(state);
+        refuse(core, writer, "InvalidItemKey", req_id, &session_key).await;
+        return;
+    }
+
     // --- error injection ---------------------------------------------------
     let rejected = state.reject_next_browse
         || item_key.is_some_and(|k| state.rejected_keys.contains(k))
@@ -1254,7 +1315,19 @@ async fn handle_browse(
                 .is_some_and(|sessions| sessions.contains(&session_key)),
             _ => false,
         }
-        || item_key.is_some_and(|k| state.arena.index_of(k).is_none());
+        || item_key.is_some_and(|k| state.arena.index_of(k).is_none())
+        // Same-session invalidation: THIS session minted this key in an
+        // earlier epoch (before its most recent `pop_all`) and hasn't seen it
+        // since. A key this session has never minted at all is untouched by
+        // this check -- see `Session::minted_at_epoch`'s own docs for why
+        // that distinction matters.
+        || item_key.is_some_and(|k| {
+            state.sessions.get(&session_key).is_some_and(|s| {
+                s.minted_at_epoch
+                    .get(k)
+                    .is_some_and(|minted_epoch| *minted_epoch != s.epoch)
+            })
+        });
     if rejected {
         state.reject_next_browse = false;
         let name = item_key
@@ -1274,6 +1347,12 @@ async fn handle_browse(
     let session = state.sessions.entry(session_key.clone()).or_default();
     if pop_all || session.levels.is_empty() {
         session.levels = vec![root_level];
+        // pop_all starts a new epoch: everything this session minted before
+        // it is gone, including the root-level keys this very response is
+        // about to hand out again (freshly, under the new epoch) -- matching
+        // what was observed live: browsing the "same" node twice mints a
+        // disjoint set of keys each time.
+        session.epoch += 1;
     }
     if let Some(n) = pop_levels {
         let keep = session.levels.len().saturating_sub(n as usize).max(1);
@@ -1392,12 +1471,21 @@ async fn handle_load(req_id: usize, body: &Value, core: &Arc<RwLock<CoreState>>,
         }
         let keyed = node.keyed;
         if keyed {
-            item["item_key"] = json!(key);
+            item["item_key"] = json!(key.clone());
             state
                 .minted
-                .entry(key)
+                .entry(key.clone())
                 .or_default()
                 .insert(session_key.clone());
+            // Same-session epoch tracking (`Session::minted_at_epoch`),
+            // orthogonal to the cross-session `minted` map above: record
+            // which epoch of *this* session minted this key, so a later
+            // `pop_all` (which bumps the epoch) can tell a still-live key
+            // apart from one it left behind.
+            if let Some(session) = state.sessions.get_mut(&session_key) {
+                let epoch = session.epoch;
+                session.minted_at_epoch.insert(key, epoch);
+            }
         }
         items.push(item);
     }


### PR DESCRIPTION
## Summary

Implements #396, the keystone issue of epic #392: `hifi_search` mints an opaque, short-lived `ref` alongside each result that has a durable-enough handle, and a new `hifi_play_ref` tool is the single documented way to resolve one back to a playable action. `hifi_play`'s existing query path (search → first match) is unchanged.

**Targets `v3`, so CI is a real gate.** This PR is not stacked on another feature branch.

**Update, read this first:** an earlier version of this PR passed local verification and CI, but **failed live end-to-end testing** on a real deployment — `hifi_play_ref` hung and timed out against a real Roon Core every time, immediately after a working `hifi_search`. Root-caused and fixed against the live rig, and **the fix has since been confirmed live end-to-end twice, with two independent items on the same zone**:

1. `hifi_search("kind of blue")` → only the real hit ("Kind of Blue" / Miles Davis) carried a `ref`, category rows ("Artists," "Albums," ...) correctly carried none → `hifi_play_ref` on that ref returned `outcome: accepted`, `"Play Now: Play Album"` → a follow-up read confirmed the zone's state actually changed to `playing`, album "Kind of Blue," artist "Miles Davis," track "So What."
2. `hifi_search("blue train")` → only "Blue Train" / John Coltrane carried a `ref`, all five category rows ("Artists" 28 Results, "Albums" 29, "Composers" 27, "Tracks" 36, "Works" 17) correctly carried none → `hifi_play_ref` on that ref returned `accepted` → `hifi_now_playing` confirmed the zone genuinely playing "Blue Train" / John Coltrane -- a different item from test 1, ruling out leftover state from the first test.

I independently re-verified the search half of both (not just taking the report on faith): both `hifi_search` calls, run myself against the same live rig, show exactly the ref/no-ref shape described. See "What live testing found" below for the full arc, including how the underlying bug was found and fixed — this is the central fact about this PR's history, not a footnote. Playback was paused afterward both times since this was testing, not a real listening session.

## Solution-space: already settled, not relitigated here

Per the epic's process, #396's solution-space gate already ran (see the issue body's "Decisions taken by the solution-space gate" section and its gate-report comments). This PR implements that design rather than re-deriving it:

- **Server-side ref table** keyed by a 128-bit random token, not a self-describing/signed token. A Roon target pairs the `item_key` with its minting `multi_session_key`.
- **`hifi_play_ref` is its own tool**, not an optional `ref` param on `hifi_play` — so a model can never send both `query` and `ref` and force the server to silently pick one.
- **No client-visible TTL field.** Lifetime lives in the tool descriptions; the recovery instruction lives in the refusal.

One place this PR *does* make a call the gate flagged as open: the gate's dissent (D4) argued against a per-target-kind TTL (durable LMS targets living longer than ephemeral Roon ones) on the grounds that it makes the documented contract secretly wrong in one direction. I found that argument correct and implemented **one uniform TTL** (15 min) for every ref regardless of provider or target durability — see `src/mcp/refs.rs`'s module docs for the reasoning. Not confirmed by the epic's own process; flagged as a residual risk below.

## What's covered

**Roon** (`src/adapters/roon.rs`):
- `RoonAdapter::search_with_session` surfaces the `multi_session_key` that `search()` mints and previously dropped. `search()` itself becomes a thin wrapper that drops the session key, so `/roon/search` is byte-for-byte unchanged.
- `RoonAdapter::play_ref` resolves a ref **inside the session that minted it**, exactly the same way `play_item` resolves a key — see "What live testing found" for why it does *not* reset the session with `pop_all` first, which an earlier version of this PR did and which broke against a real Core.
- `resolve_item_key` is the shared body `play_item` and `play_ref` both call, extracted as a pure refactor.
- `hifi_search`'s Roon branch never mints a ref for a search-result *grouping* row ("Albums (32 Results)", "Tracks", ...) — also found live; see below.

**LMS** (`src/adapters/lms.rs`):
- `LmsPlayTarget` extracted from `search_and_play`'s three-way branch (`Library`/`Url`/`GlobalSearchItem`). `LmsAdapter::play_target` is the one method `hifi_play_ref` uses to execute a *specific* target — never `search_and_play`, which re-searches and takes `results[0]`. `LmsRpc::execute` stays private.
- `GlobalSearchItem` — verified against live Lyrion 9.1.2 to be a positional breadcrumb (`<session>.<index>.<index>`) that a fabricated id silently re-resolves by position on cache miss — is **never mintable**. Only `Library` and `Url` targets are (`LmsPlayTarget::mintable`), with `Library` preferred over `Url` when both are present.
- `LmsAdapter::assert_library_id_exists` validates a `Library` target against the live database *before* the mutating `playlistcontrol` call, by re-searching for the title captured at mint time (not a dedicated existence query — see below for why that changed mid-review).

**Ref table** (`src/mcp/refs.rs`, new module): 128-bit random tokens (base64 URL-safe), bounded capacity (512) with oldest-inserted eviction, one uniform TTL. `AppState.mcp_refs` is constructed internally by `AppState::new` (like `sse_connections`), so no existing call site changed.

**MCP surface**: `McpSearchResult` gains an optional `ref` field (additive, `title`/`subtitle` untouched). New `hifi_play_ref` tool (`ref`, `zone_id`, `action?`), appended to `tool_box!` per the epic's append-only convention. Tool descriptions teach search → hold ref → play by ref and state refs are short-lived (`src/mcp/tools/library.rs`).

## What live testing found (read this)

This PR passed local verification and CI once, and I believed it was ready to ship. The operator then installed the actual build on production hardware, connected to a real Roon Core ("nuc14," Roon 2.70), and ran the feature: `hifi_search` worked; **`hifi_play_ref` failed every time** with `Browse request timed out`. `hifi_play` (the pre-#396 query path) worked fine on the identical zone and query, isolating the defect to `play_ref`'s resolution path.

I reproduced this directly against the live rig via the existing `/roon/browse` HTTP endpoint (the same underlying `RoonAdapter::browse()` call `play_ref` uses) and found:

1. **`play_ref` combined `pop_all: true` with a present `item_key` in one browse request. A real Core never answers that combination.** The fake never caught this because its search/browse model doesn't reproduce it.
2. The "obvious" fix — send them as two separate requests — **also doesn't work**: `pop_all` invalidates every item_key the session had previously minted, including the one about to be entered.
3. The reset was solving a problem that doesn't exist: resolving one ref, navigating deep into its action list, then resolving a second, sibling ref from the same search succeeds immediately **with no `pop_all` at all** — verified live, twice.

**Fix:** `resolve_item_key` never sends `pop_all`. It is now byte-for-byte `play_item`'s existing logic, just re-entering the caller's session. `tests/mock_servers/roon_core.rs` (`FakeRoonCore`) is strengthened with a session-epoch model so this class of bug is now caught by the test suite in milliseconds (`tests/mcp_refs.rs::play_ref_never_combines_pop_all_with_an_item_key`), not only by a live rig.

**Re-scrutinizing the same live data one more time** (the ship-gate dissent process, applied for real) found a second, independent bug: a real Core's search results mix the actual hit with *grouping* rows ("Albums (32 Results)", "Tracks", "Artists", ...) sharing the identical shape (`hint: "list"`, a real `item_key`) as genuine content. `hifi_search` was minting a ref for these indistinguishably from "Kind of Blue" itself — resolving one would land in an existing "guess the first item" fallback and could silently play unrelated content. Fixed by wiring in `is_category()`, a check that already existed in the adapter for exactly this set of names but was never consulted by the ref-minting code, plus an additional source-independent signal (subtitle shaped like `"<N> Results"`) as defense-in-depth for TIDAL/Qobuz sources I could not test live. **That second signal mitigates, but does not close,** the TIDAL/Qobuz gap — see the dissent comment.

**Full end-to-end confirmation, closing the loop**: the operator built and installed the fixed package on the NAS and ran the actual flow twice, with two different items (see the top of this PR body for both) — search, mint a ref, resolve it with `hifi_play_ref`, confirm via a follow-up read that the zone is genuinely playing the right thing. I independently re-ran both searches myself against the live rig and confirmed the same ref/no-ref shape.

State this precisely, since it's tempting to overclaim from two clean runs: **this is two successful invocations, on one zone, one provider (Roon), one action (`play`)** — not exhaustive coverage of every action (`queue`/`radio` on Roon, `play`/`queue`/`next` on LMS), every provider (LMS was not live-tested at all in this round), or every zone. It is strong, repeated evidence the core resolution path and the category-row fix both work against a real Core; it is not a claim that every code path in this PR has been live-exercised.

## Acceptance criteria

- [x] `hifi_search` returns opaque `ref` alongside `title`/`subtitle`, both providers, additive.
- [x] Exactly one consumer, `hifi_play_ref`, covering Roon (`play_ref`) and LMS (`play_target`, all three `LmsPlayAction`s where supported).
- [x] Roon's minting `multi_session_key` surfaced from `search_with_session`.
- [x] Opacity test — no item_key/entity id/session key/title appears verbatim; a hand-mangled ref is refused.
- [x] Unguessable/uncorrelated refs.
- [x] Expired/unknown ref → distinct retryable outcome, never a silent fallback to first-match.
- [x] Cross-provider ref/zone refusal — and the ref is not burned by the rejected attempt.
- [x] Ref table bounded in size and time; eviction observable as expiry, not corruption.
- [x] #394's no-orphan-field test passes with `ref` registered as consumed.
- [x] Tool descriptions teach the flow and say refs are short-lived.
- [x] (Found necessary by live testing, not in the original list) Roon ref resolution actually works against a real Core, not only the fake — **confirmed live end-to-end twice**, one zone, `action=play`, two different items (see above).
- [x] (Found necessary by live testing) a search-result grouping row never gets a ref — **confirmed live, twice**: both end-to-end runs' search results showed a ref on the real hit and none on any category row.

## Explicitly NOT covered / deferred, and why

- **Live coverage of every action/provider/zone combination**: the live confirmation above is two invocations (Roon, `action=play`, one zone). `queue`/`radio` (Roon) and `play`/`queue`/`next` (LMS) are covered by the fake and by deliberate-break verification, not by a live rig; LMS was not live-tested at all in this round.
- **TIDAL/Qobuz grouping-row verification** — mitigated by a source-independent heuristic, not confirmed live. See the dissent comment (D2).
- **LMS `globalsearch` ref-decay / Roon cross-session portability empirical questions** from the issue: no reachable live LMS rig for the first; the second is answered by design (`play_ref` works whether keys are global or session-scoped) and now additionally live-verified for the Roon side via the `pop_all` investigation.
- **`assert_library_id_exists`'s title-based re-search** is unverified against a live LMS server (its failure direction is closed either way — see the review comment for the two-iteration history of this specific check).
- **`Url` target validation before mutate**: LMS exposes no cheap existence check for an arbitrary streaming/plugin URL. Stated as a known gap in `LmsAdapter::play_target`'s doc comment.
- Doc sync (AGENTS.md, README, `plugin/commands/setup.md`) deferred to #401, matching the epic's established pattern.

## Verification

In order, per the epic's standing recipe, re-run clean after every fix in this PR's history (most recently after the `pop_all`, category-row, and TIDAL/Qobuz-mitigation fixes):
1. `make css`
2. `cargo fmt --check` — clean
3. `cargo clippy -- -D warnings` — clean (lib only, per the epic's standing note)
4. `cargo test --workspace` — all green: 172 lib tests, 51 `roon_protocol.rs`, 38 `mcp_refs.rs`, 94 `mcp_contract.rs`, and everything else pre-existing.
5. `dx build --release --platform web --features web` with `CARGO_BUILD_RUSTC_WRAPPER=""` — clean.

CI on `v3`: **green on the final commit** (`54ea84c`) — Plan, Lint, Test, Check API Changes, Synology Package Contract, Build WASM Assets, Build Linux x64, Build QNAP (x64), Smoke Test Binary, Build Summary, CodeRabbit all pass. Independently re-verified locally too (`make css`/`fmt`/`clippy` clean, `cargo test --test mcp_refs` 38/38 including all three live-rig-discovered regression tests).

**Every load-bearing claim in this PR was verified by deliberately breaking the corresponding implementation and confirming the test fails, then reverting** — including, this round, the three live-rig-discovered bugs above (`play_ref_never_combines_pop_all_with_an_item_key`, `a_category_grouping_row_never_gets_a_ref`, `a_grouping_row_with_an_unlisted_title_is_still_caught_by_its_subtitle_shape`), each confirmed to fail fast (well under a second) rather than only via a slow live-rig round trip.

See the review and dissent comments for the full gate report, including what the dissent found this round that the review didn't (a real bug, and a real unclosed gap) and what I checked and could not break.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Search results can include short-lived references for exact-result playback.
  - Added `hifi_play_ref` to play, queue, start radio, or play next a specific result.
  - Supports Roon and LMS playback targets while preserving the correct playback session.
  - LMS references are available for durable library and URL results.

- **Bug Fixes**
  - Invalid, expired, cross-provider, unsupported, or stale references now return clear refusals without changing the queue.
  - LMS playback targets are validated before queue changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
