### PR TITLE
test(architecture): enforce provider recovery projections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,7 +156,7 @@ syn = { version = "2", features = ["full", "parsing", "visit"] }
 # Token-level inspection for tests/adaptive_publication_lint.rs. Already in the lock
 # graph as a transitive dependency of syn; declared so the lint can walk TokenTree
 # without stringifying a macro body, which made string literals fabricate matches.
-proc-macro2 = "1"
+proc-macro2 = { version = "1", features = ["span-locations"] }
 walkdir = "2"
 tempfile = "3"
 # WebSocket *server* for tests/mock_servers/roon_core.rs (the Roon Core protocol fake).

--- a/src/adapters/lms.rs
+++ b/src/adapters/lms.rs
@@ -1043,6 +1043,9 @@ pub struct LmsAdapter {
     runtime_bridge: Option<Arc<LmsRuntimeBridge>>,
     /// Wrapped in RwLock to allow creating fresh token on restart
     shutdown: Arc<RwLock<CancellationToken>>,
+    /// The polling supervisor.  Stop waits for this task so a readback from an
+    /// old LMS server cannot cross a reconfiguration projection retirement.
+    task: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
 }
 
 impl LmsAdapter {
@@ -1064,6 +1067,7 @@ impl LmsAdapter {
             bus,
             runtime_bridge,
             shutdown: Arc::new(RwLock::new(CancellationToken::new())),
+            task: Arc::new(Mutex::new(None)),
         };
         // Load saved config synchronously at startup
         adapter.load_config_sync();
@@ -1264,7 +1268,10 @@ impl LmsAdapter {
         let bus = self.bus.clone();
         let handle = AdapterHandle::new(adapter, bus, shutdown);
 
-        tokio::spawn(async move { handle.run_with_retry(RetryConfig::default()).await });
+        let task = tokio::spawn(async move {
+            let _ = handle.run_with_retry(RetryConfig::default()).await;
+        });
+        *self.task.lock().await = Some(task);
 
         Ok(())
     }
@@ -1284,6 +1291,15 @@ impl LmsAdapter {
     async fn stop_internal(&self) {
         // Cancel background tasks first
         self.shutdown.read().await.cancel();
+
+        // Do not let a request already in flight publish a snapshot from the
+        // old server after the paired LMS projection has been retired.
+        let task = self.task.lock().await.take();
+        if let Some(task) = task {
+            if let Err(error) = task.await {
+                warn!(%error, "LMS polling supervisor did not stop cleanly");
+            }
+        }
 
         let host = {
             let mut state = self.state.write().await;
@@ -3139,6 +3155,8 @@ pub struct LmsCliAdapter {
     shutdown: Arc<RwLock<CancellationToken>>,
     /// Guard against duplicate start() calls
     running: Arc<RwLock<bool>>,
+    /// CLI supervisor, joined on stop to fence in-flight CLI readbacks.
+    task: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
 }
 
 impl LmsCliAdapter {
@@ -3157,6 +3175,7 @@ impl LmsCliAdapter {
             runtime_bridge,
             shutdown: Arc::new(RwLock::new(CancellationToken::new())),
             running: Arc::new(RwLock::new(false)),
+            task: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -3251,17 +3270,24 @@ impl Startable for LmsCliAdapter {
         let running_flag = self.running.clone();
         let handle = AdapterHandle::new(adapter, bus, shutdown);
 
-        tokio::spawn(async move {
+        let task = tokio::spawn(async move {
             let _ = handle.run_with_retry(RetryConfig::default()).await;
             // Reset running flag when task completes
             *running_flag.write().await = false;
         });
+        *self.task.lock().await = Some(task);
 
         Ok(())
     }
 
     async fn stop(&self) {
         self.shutdown.read().await.cancel();
+        let task = self.task.lock().await.take();
+        if let Some(task) = task {
+            if let Err(error) = task.await {
+                warn!(%error, "LMS CLI supervisor did not stop cleanly");
+            }
+        }
     }
 
     async fn can_start(&self) -> bool {

--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -2890,7 +2890,28 @@ async fn run_roon_loop(
                             .await;
                     }
 
+                    // Losing the Core invalidates every zone it supplied. Capture their
+                    // prefixed identities before clearing the operational cache, then retire
+                    // the canonical projection. A later reconnect commonly reuses the same
+                    // zone IDs, so merely clearing local state leaves controllers displaying
+                    // controllable ghosts until some unrelated update happens.
+                    let removed_zone_ids: Vec<PrefixedZoneId> = state_for_events
+                        .read()
+                        .await
+                        .zones
+                        .keys()
+                        .map(PrefixedZoneId::roon)
+                        .collect();
                     clear_roon_runtime_state(&state_for_events).await;
+                    for zone_id in removed_zone_ids {
+                        if let Some(bridge) = runtime_bridge_for_events.as_ref() {
+                            if let Err(error) = bridge.publish_removed(zone_id).await {
+                                tracing::warn!(%error, "Roon Core-loss projection removal failed");
+                            }
+                        } else {
+                            bus_for_events.publish(BusEvent::ZoneRemoved { zone_id });
+                        }
+                    }
 
                     // Publish disconnected event
                     bus_for_events.publish(BusEvent::RoonDisconnected);

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1864,10 +1864,12 @@ pub async fn lms_configure_handler(
     State(state): State<AppState>,
     Json(req): Json<LmsConfigRequest>,
 ) -> impl IntoResponse {
-    // Stop existing connection if any
+    // LMS has two concurrent observers of the same `lms:` projection.  Stop
+    // both before retirement/reconfiguration so an old CLI callback cannot
+    // republish zones from the former server after the projection is flushed.
     state
         .coordinator
-        .stop_adapter_and_flush(state.lms.as_ref(), "LMS reconfiguration")
+        .stop_adapter_and_companions_then_flush(state.lms.as_ref(), "lms", "LMS reconfiguration")
         .await;
 
     // Configure new connection
@@ -1876,8 +1878,13 @@ pub async fn lms_configure_handler(
         .configure(req.host.clone(), req.port, req.username, req.password)
         .await;
 
-    // Start the adapter
-    match state.lms.start().await {
+    // Start both observers together; the CLI companion is not an optional
+    // feature of a manually configured LMS connection.
+    match state
+        .coordinator
+        .start_adapter_and_companions(state.lms.as_ref())
+        .await
+    {
         Ok(()) => (
             StatusCode::OK,
             Json(serde_json::json!({
@@ -2681,18 +2688,30 @@ pub async fn api_settings_post_handler(
         if let Some(adapter) = adapters_list.iter().find(|a| a.name() == name) {
             if now_enabled {
                 tracing::info!("Dynamically enabling adapter: {}", name);
-                if adapter.can_start().await {
-                    if let Err(e) = adapter.start().await {
+                if name == "lms" {
+                    if let Err(e) = coord.start_adapter_and_companions(adapter.as_ref()).await {
+                        tracing::warn!("Failed to start LMS observers: {}", e);
+                    }
+                } else if adapter.can_start().await {
+                    if let Err(e) = coord.start_adapter_and_track(adapter.as_ref()).await {
                         tracing::warn!("Failed to start adapter {}: {}", name, e);
-                    } else {
-                        coord.set_running(name, true).await;
                     }
                 }
             } else {
                 tracing::info!("Dynamically disabling adapter: {}", name);
-                coord
-                    .stop_adapter_and_flush(adapter.as_ref(), "disabled via settings")
-                    .await;
+                if name == "lms" {
+                    coord
+                        .stop_adapter_and_companions_then_flush(
+                            adapter.as_ref(),
+                            "lms",
+                            "disabled via settings",
+                        )
+                        .await;
+                } else {
+                    coord
+                        .stop_adapter_and_flush(adapter.as_ref(), "disabled via settings")
+                        .await;
+                }
             }
         }
     }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1865,7 +1865,7 @@ pub async fn lms_configure_handler(
     Json(req): Json<LmsConfigRequest>,
 ) -> impl IntoResponse {
     // Stop existing connection if any
-    state.lms.stop().await;
+    stop_adapter_and_flush_zones(state.lms.as_ref(), &state.bus).await;
 
     // Configure new connection
     state
@@ -2634,7 +2634,7 @@ pub async fn api_settings_get_handler() -> impl IntoResponse {
 /// but until this fix nothing ever published that event, so a disabled
 /// adapter's zones stayed listed in `/zones`, `hifi_zones`, and (since #397)
 /// MCP resources, forever (issue #429).
-async fn stop_adapter_and_flush_zones(adapter: &Arc<dyn Startable>, bus: &SharedBus) {
+async fn stop_adapter_and_flush_zones(adapter: &dyn Startable, bus: &SharedBus) {
     bus.publish(BusEvent::AdapterStopping {
         adapter: adapter.name().to_string(),
         reason: Some("disabled via settings".to_string()),
@@ -2703,7 +2703,7 @@ pub async fn api_settings_post_handler(
                 }
             } else {
                 tracing::info!("Dynamically disabling adapter: {}", name);
-                stop_adapter_and_flush_zones(adapter, &state.bus).await;
+                stop_adapter_and_flush_zones(adapter.as_ref(), &state.bus).await;
             }
         }
     }
@@ -2780,7 +2780,7 @@ mod tests {
         );
 
         let adapter: Arc<dyn Startable> = Arc::new(FakeAdapter("lms"));
-        stop_adapter_and_flush_zones(&adapter, &bus).await;
+        stop_adapter_and_flush_zones(adapter.as_ref(), &bus).await;
         tokio::time::sleep(Duration::from_millis(20)).await;
 
         let remaining = aggregator.get_zones().await;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -13,7 +13,7 @@ use crate::bus::runtime::{
     CommandDeadlines, CommandGateway, CommandLane, CommandRequest, CommandStatus,
     HqpRuntimeCommand, RuntimeCommand,
 };
-use crate::bus::{BusEvent, Command, PrefixedZoneId, SharedBus};
+use crate::bus::{Command, PrefixedZoneId, SharedBus};
 use crate::coordinator::AdapterCoordinator;
 use crate::knobs::KnobStore;
 use axum::{
@@ -1865,7 +1865,10 @@ pub async fn lms_configure_handler(
     Json(req): Json<LmsConfigRequest>,
 ) -> impl IntoResponse {
     // Stop existing connection if any
-    stop_adapter_and_flush_zones(state.lms.as_ref(), &state.bus).await;
+    state
+        .coordinator
+        .stop_adapter_and_flush(state.lms.as_ref(), "LMS reconfiguration")
+        .await;
 
     // Configure new connection
     state
@@ -2626,22 +2629,6 @@ pub async fn api_settings_get_handler() -> impl IntoResponse {
     Json(load_app_settings())
 }
 
-/// Stop an adapter and tell the aggregator to flush its zones.
-///
-/// `Startable::stop` alone leaves `ZoneAggregator`'s zone map untouched.
-/// The aggregator already handles `BusEvent::AdapterStopping` correctly --
-/// removes every zone prefixed `"{adapter}:"`, publishes `ZonesFlushed` --
-/// but until this fix nothing ever published that event, so a disabled
-/// adapter's zones stayed listed in `/zones`, `hifi_zones`, and (since #397)
-/// MCP resources, forever (issue #429).
-async fn stop_adapter_and_flush_zones(adapter: &dyn Startable, bus: &SharedBus) {
-    bus.publish(BusEvent::AdapterStopping {
-        adapter: adapter.name().to_string(),
-        reason: Some("disabled via settings".to_string()),
-    });
-    adapter.stop().await;
-}
-
 /// POST /api/settings - Update app settings with dynamic adapter enable/disable
 pub async fn api_settings_post_handler(
     State(state): State<AppState>,
@@ -2703,7 +2690,9 @@ pub async fn api_settings_post_handler(
                 }
             } else {
                 tracing::info!("Dynamically disabling adapter: {}", name);
-                stop_adapter_and_flush_zones(adapter.as_ref(), &state.bus).await;
+                coord
+                    .stop_adapter_and_flush(adapter.as_ref(), "disabled via settings")
+                    .await;
             }
         }
     }
@@ -2714,7 +2703,7 @@ pub async fn api_settings_post_handler(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::bus::{create_bus, PlaybackState, Zone};
+    use crate::bus::{create_bus, BusEvent, PlaybackState, Zone};
     use serial_test::serial;
     use std::env;
     use std::time::Duration;
@@ -2780,7 +2769,11 @@ mod tests {
         );
 
         let adapter: Arc<dyn Startable> = Arc::new(FakeAdapter("lms"));
-        stop_adapter_and_flush_zones(adapter.as_ref(), &bus).await;
+        let coordinator = AdapterCoordinator::new(bus.clone());
+        coordinator.register("lms", true).await;
+        coordinator
+            .stop_adapter_and_flush(adapter.as_ref(), "test shutdown")
+            .await;
         tokio::time::sleep(Duration::from_millis(20)).await;
 
         let remaining = aggregator.get_zones().await;
@@ -2825,7 +2818,7 @@ mod tests {
     /// Issue #429, proving the wiring itself: calling the real
     /// `POST /api/settings` handler to disable an adapter must remove its
     /// zones. Unlike `stopping_an_adapter_flushes_its_zones_from_the_aggregator`
-    /// above (which calls `stop_adapter_and_flush_zones` directly and would
+    /// above (which calls the coordinator lifecycle operation directly and would
     /// stay green even if the handler stopped calling it), this goes through
     /// `api_settings_post_handler` itself.
     #[tokio::test]
@@ -2841,6 +2834,8 @@ mod tests {
 
         let adapter: Arc<dyn Startable> = Arc::new(FakeAdapter("lms"));
         let state = app_state_with_startable(adapter).await;
+        state.coordinator.register("lms", true).await;
+        state.coordinator.set_running("lms", true).await;
         let agg_for_task = state.aggregator.clone();
         tokio::spawn(async move { agg_for_task.run().await });
         tokio::time::sleep(Duration::from_millis(10)).await;
@@ -2866,6 +2861,10 @@ mod tests {
             remaining.len(),
             0,
             "disabling lms via the real endpoint should flush its zone, got {remaining:?}"
+        );
+        assert!(
+            !state.coordinator.is_running("lms").await,
+            "disabling an adapter must also retire its coordinator running state"
         );
 
         env::remove_var("UHC_CONFIG_DIR");

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -121,6 +121,13 @@ impl AdapterCoordinator {
     /// Stop all adapters from the provided list.
     pub async fn stop_all(&self, adapters: &[Arc<dyn Startable>]) {
         for adapter in adapters {
+            // The aggregator owns client-visible zones. Stopping the worker alone
+            // leaves that projection live until a future discovery happens; flush
+            // before cancellation on every coordinator-owned shutdown route.
+            self.bus.publish(BusEvent::AdapterStopping {
+                adapter: adapter.name().to_string(),
+                reason: Some("coordinator shutdown".to_string()),
+            });
             adapter.stop().await;
             if let Some(registered) = self.adapters.write().await.get_mut(adapter.name()) {
                 registered.direct_running = false;

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -121,19 +121,25 @@ impl AdapterCoordinator {
     /// Stop all adapters from the provided list.
     pub async fn stop_all(&self, adapters: &[Arc<dyn Startable>]) {
         for adapter in adapters {
-            // The aggregator owns client-visible zones. Stopping the worker alone
-            // leaves that projection live until a future discovery happens; flush
-            // before cancellation on every coordinator-owned shutdown route.
-            self.bus.publish(BusEvent::AdapterStopping {
-                adapter: adapter.name().to_string(),
-                reason: Some("coordinator shutdown".to_string()),
-            });
-            adapter.stop().await;
-            if let Some(registered) = self.adapters.write().await.get_mut(adapter.name()) {
-                registered.direct_running = false;
-            }
-            debug!("Stopped adapter: {}", adapter.name());
+            self.stop_adapter_and_flush(adapter.as_ref(), "coordinator shutdown")
+                .await;
         }
+    }
+
+    /// Retire an adapter's client-visible projection before stopping its worker.
+    ///
+    /// `ZoneAggregator` owns zones, so this is the one lifecycle operation for
+    /// every stop path: publish `AdapterStopping`, stop the adapter, then update
+    /// the coordinator's running state. The caller supplies a precise reason so
+    /// observability distinguishes shutdown, reconfiguration, and settings disable.
+    pub async fn stop_adapter_and_flush(&self, adapter: &dyn Startable, reason: &str) {
+        self.bus.publish(BusEvent::AdapterStopping {
+            adapter: adapter.name().to_string(),
+            reason: Some(reason.to_string()),
+        });
+        adapter.stop().await;
+        self.set_running(adapter.name(), false).await;
+        debug!("Stopped adapter: {}", adapter.name());
     }
 
     /// Register an adapter without starting it

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -43,6 +43,10 @@ struct RegisteredAdapter {
 /// - Coordinate graceful shutdown
 pub struct AdapterCoordinator {
     adapters: RwLock<HashMap<String, RegisteredAdapter>>,
+    /// Companion workers grouped under their provider's one client-visible
+    /// projection. The coordinator owns this topology so every lifecycle path
+    /// applies the same cancellation fence.
+    companions: RwLock<HashMap<String, Vec<Arc<dyn Startable>>>>,
     bus: SharedBus,
     /// Global shutdown token (parent of all adapter tokens)
     shutdown: CancellationToken,
@@ -54,6 +58,7 @@ impl AdapterCoordinator {
     pub fn new(bus: SharedBus) -> Self {
         Self {
             adapters: RwLock::new(HashMap::new()),
+            companions: RwLock::new(HashMap::new()),
             bus,
             shutdown: CancellationToken::new(),
             shutdown_timeout: Duration::from_secs(5),
@@ -64,6 +69,7 @@ impl AdapterCoordinator {
     pub fn with_shutdown_timeout(bus: SharedBus, timeout: Duration) -> Self {
         Self {
             adapters: RwLock::new(HashMap::new()),
+            companions: RwLock::new(HashMap::new()),
             bus,
             shutdown: CancellationToken::new(),
             shutdown_timeout: timeout,
@@ -96,8 +102,12 @@ impl AdapterCoordinator {
     /// Start all enabled adapters from the provided list.
     /// This is the single codepath for starting adapters.
     pub async fn start_all_enabled(&self, adapters: &[Arc<dyn Startable>]) {
+        let companion_names = self.companion_names().await;
         for adapter in adapters {
             let name = adapter.name();
+            if companion_names.iter().any(|companion| companion == name) {
+                continue;
+            }
             if !self.is_enabled(name).await {
                 debug!("Adapter {} is disabled, skipping", name);
                 continue;
@@ -106,23 +116,41 @@ impl AdapterCoordinator {
                 debug!("Adapter {} cannot start (not configured?), skipping", name);
                 continue;
             }
-            match adapter.start().await {
-                Ok(()) => {
-                    if let Some(registered) = self.adapters.write().await.get_mut(name) {
-                        registered.direct_running = true;
-                    }
-                    info!("Started adapter: {}", name);
-                }
+            match self.start_adapter_and_companions(adapter.as_ref()).await {
+                Ok(()) => info!("Started adapter: {}", name),
                 Err(e) => warn!("Failed to start adapter {}: {}", name, e),
             }
         }
     }
 
+    /// Start one direct [`Startable`] and update the coordinator's lifecycle
+    /// record.  HTTP configuration paths use this rather than owning a shadow
+    /// "running" state beside the coordinator.
+    pub async fn start_adapter_and_track(&self, adapter: &dyn Startable) -> Result<()> {
+        if !adapter.can_start().await {
+            return Err(anyhow::anyhow!("adapter cannot start"));
+        }
+        adapter.start().await?;
+        self.set_running(adapter.name(), true).await;
+        Ok(())
+    }
+
     /// Stop all adapters from the provided list.
     pub async fn stop_all(&self, adapters: &[Arc<dyn Startable>]) {
+        let companion_names = self.companion_names().await;
         for adapter in adapters {
-            self.stop_adapter_and_flush(adapter.as_ref(), "coordinator shutdown")
-                .await;
+            if companion_names
+                .iter()
+                .any(|companion| companion == adapter.name())
+            {
+                continue;
+            }
+            self.stop_adapter_and_companions_then_flush(
+                adapter.as_ref(),
+                adapter.name(),
+                "coordinator shutdown",
+            )
+            .await;
         }
     }
 
@@ -140,6 +168,107 @@ impl AdapterCoordinator {
         adapter.stop().await;
         self.set_running(adapter.name(), false).await;
         debug!("Stopped adapter: {}", adapter.name());
+    }
+
+    /// Cancel a group of workers which jointly observe one provider, then retire that
+    /// provider's projection exactly once.
+    ///
+    /// LMS is the current user: its HTTP poller and CLI subscription share an
+    /// `lms:` projection.  Retiring the projection after only one observer has
+    /// stopped lets the other observer re-publish a fact from the old server.
+    /// Cancellation is therefore issued to *every* observer before the
+    /// aggregator is told the provider has stopped.  The explicit projection
+    /// owner is separate from worker names because companion workers need not
+    /// have their own zone-ID prefix.
+    pub async fn stop_adapters_then_flush(
+        &self,
+        adapters: &[&dyn Startable],
+        projection_adapter: &str,
+        reason: &str,
+    ) {
+        for adapter in adapters {
+            adapter.stop().await;
+        }
+        self.bus.publish(BusEvent::AdapterStopping {
+            adapter: projection_adapter.to_string(),
+            reason: Some(reason.to_string()),
+        });
+        for adapter in adapters {
+            self.set_running(adapter.name(), false).await;
+            debug!("Stopped adapter: {}", adapter.name());
+        }
+    }
+
+    /// Register a worker that observes the same provider projection as
+    /// `provider`. Composition does this once; handlers never need to know a
+    /// provider's internal worker topology.
+    pub async fn register_companion(&self, provider: &str, companion: Arc<dyn Startable>) {
+        self.companions
+            .write()
+            .await
+            .entry(provider.to_string())
+            .or_default()
+            .push(companion);
+    }
+
+    /// Start a provider's primary adapter and every registered companion,
+    /// tracking their lifecycle centrally.
+    pub async fn start_adapter_and_companions(&self, adapter: &dyn Startable) -> Result<()> {
+        self.start_adapter_and_track(adapter).await?;
+        let companions = self
+            .companions
+            .read()
+            .await
+            .get(adapter.name())
+            .cloned()
+            .unwrap_or_default();
+        for companion in companions {
+            if let Err(error) = self.start_adapter_and_track(companion.as_ref()).await {
+                self.stop_adapters_then_flush(
+                    &[adapter],
+                    adapter.name(),
+                    "companion start failure",
+                )
+                .await;
+                return Err(error);
+            }
+        }
+        Ok(())
+    }
+
+    /// Cancel a provider's primary worker and its registered companions, then
+    /// retire their shared projection once.
+    pub async fn stop_adapter_and_companions_then_flush(
+        &self,
+        adapter: &dyn Startable,
+        projection_adapter: &str,
+        reason: &str,
+    ) {
+        let companions = self
+            .companions
+            .read()
+            .await
+            .get(projection_adapter)
+            .cloned()
+            .unwrap_or_default();
+        let mut observers: Vec<&dyn Startable> = vec![adapter];
+        observers.extend(
+            companions
+                .iter()
+                .map(|companion| companion.as_ref() as &dyn Startable),
+        );
+        self.stop_adapters_then_flush(&observers, projection_adapter, reason)
+            .await;
+    }
+
+    async fn companion_names(&self) -> Vec<String> {
+        self.companions
+            .read()
+            .await
+            .values()
+            .flatten()
+            .map(|companion| companion.name().to_string())
+            .collect()
     }
 
     /// Register an adapter without starting it
@@ -412,6 +541,26 @@ mod tests {
         started: AtomicBool,
     }
 
+    struct RecordingStartable {
+        name: &'static str,
+        stopped: Arc<AtomicBool>,
+    }
+
+    #[async_trait::async_trait]
+    impl Startable for RecordingStartable {
+        fn name(&self) -> &'static str {
+            self.name
+        }
+
+        async fn start(&self) -> Result<()> {
+            Ok(())
+        }
+
+        async fn stop(&self) {
+            self.stopped.store(true, Ordering::SeqCst);
+        }
+    }
+
     #[async_trait::async_trait]
     impl Startable for DirectStartable {
         fn name(&self) -> &'static str {
@@ -487,6 +636,46 @@ mod tests {
         assert!(!adapter.started.load(Ordering::SeqCst));
         assert!(!coord.is_running("direct").await);
         assert!(!coord.adapter_status().await["direct"].running);
+    }
+
+    #[tokio::test]
+    async fn grouped_lifecycle_cancels_every_lms_observer_and_retires_one_projection() {
+        let bus = create_bus();
+        let mut events = bus.subscribe();
+        let coord = AdapterCoordinator::new(bus);
+        coord.register("lms", true).await;
+        coord.register("lms-cli", true).await;
+        coord.set_running("lms", true).await;
+        coord.set_running("lms-cli", true).await;
+
+        let polling_stopped = Arc::new(AtomicBool::new(false));
+        let cli_stopped = Arc::new(AtomicBool::new(false));
+        let polling = Arc::new(RecordingStartable {
+            name: "lms",
+            stopped: polling_stopped.clone(),
+        });
+        let cli = Arc::new(RecordingStartable {
+            name: "lms-cli",
+            stopped: cli_stopped.clone(),
+        });
+        coord.register_companion("lms", cli.clone()).await;
+
+        coord
+            .stop_adapter_and_companions_then_flush(
+                polling.as_ref(),
+                "lms",
+                "test LMS reconfiguration",
+            )
+            .await;
+
+        assert!(polling_stopped.load(Ordering::SeqCst));
+        assert!(cli_stopped.load(Ordering::SeqCst));
+        assert!(!coord.is_running("lms").await);
+        assert!(!coord.is_running("lms-cli").await);
+        assert!(matches!(
+            events.recv().await,
+            Ok(BusEvent::AdapterStopping { adapter, .. }) if adapter == "lms"
+        ));
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -267,6 +267,7 @@ mod server {
         ));
         let (lms, lms_cli) =
             adapters::lms::create_lms_adapters_with_runtime(bus.clone(), Some(lms_runtime_bridge));
+        coord.register_companion("lms", lms_cli.clone()).await;
         if let Some(ref lms_config) = config.lms {
             lms.configure(
                 lms_config.host.clone(),

--- a/tests/fixtures/adapter_boundary_debt.txt
+++ b/tests/fixtures/adapter_boundary_debt.txt
@@ -62,7 +62,6 @@ src/api/mod.rs|status_handler|direct-field-access|lms
 src/api/mod.rs|status_handler|direct-field-access|openhome
 src/api/mod.rs|status_handler|direct-field-access|roon
 src/api/mod.rs|status_handler|direct-field-access|upnp
-src/api/mod.rs|stop_adapter_and_flush_zones|concrete-adapter-type|Startable
 src/api/mod.rs|upnp_now_playing_handler|direct-field-access|upnp
 src/api/mod.rs|upnp_status_handler|direct-field-access|upnp
 src/api/mod.rs|upnp_zones_handler|direct-field-access|upnp

--- a/tests/lifecycle_projection_lint.rs
+++ b/tests/lifecycle_projection_lint.rs
@@ -6,6 +6,7 @@
 //! must remove its projection, and every coordinator/API stop route must flush
 //! before cancellation.
 
+use syn::spanned::Spanned;
 use syn::visit::{self, Visit};
 use syn::{Expr, ExprMatch, ImplItem, Item, Pat};
 
@@ -87,9 +88,9 @@ fn facts(block: &syn::Block) -> SyntaxFacts {
     facts
 }
 
-fn expression_facts(expression: &Expr) -> SyntaxFacts {
+fn statement_facts(statement: &syn::Stmt) -> SyntaxFacts {
     let mut facts = SyntaxFacts::default();
-    facts.visit_expr(expression);
+    facts.visit_stmt(statement);
     facts
 }
 
@@ -105,7 +106,7 @@ impl<'ast> Visit<'ast> for StopFacts {
                 .path
                 .segments
                 .last()
-                .is_some_and(|segment| segment.ident == "stop_adapter_and_flush_zones")
+                .is_some_and(|segment| segment.ident == "stop_adapter_and_flush")
             {
                 self.events.push("flush");
                 self.events.push("stop");
@@ -115,6 +116,10 @@ impl<'ast> Visit<'ast> for StopFacts {
     }
 
     fn visit_expr_method_call(&mut self, call: &'ast syn::ExprMethodCall) {
+        if call.method == "stop_adapter_and_flush" {
+            self.events.push("flush");
+            self.events.push("stop");
+        }
         if call.method == "publish" {
             let mut arguments = SyntaxFacts::default();
             for argument in &call.args {
@@ -168,19 +173,82 @@ fn pat_has_core_lost(pat: &Pat) -> bool {
 
 #[derive(Default)]
 struct CoreLossFacts {
-    removes_projection: bool,
+    saw_lost: bool,
+    collects_all_zone_ids: bool,
+    clears_cache: bool,
+    retires_each_zone: bool,
+    bridge_removal: bool,
+    bus_fallback: bool,
+    restart_after_retirement: bool,
 }
 
 impl<'ast> Visit<'ast> for CoreLossFacts {
     fn visit_expr_match(&mut self, expression: &'ast ExprMatch) {
         for arm in &expression.arms {
-            if pat_has_core_lost(&arm.pat) {
-                let arm_facts = expression_facts(&arm.body);
-                self.removes_projection |= arm_facts
+            if !pat_has_core_lost(&arm.pat) {
+                continue;
+            }
+            self.saw_lost = true;
+            let mut arm_facts = SyntaxFacts::default();
+            arm_facts.visit_expr(&arm.body);
+            self.collects_all_zone_ids = arm_facts.method_calls.iter().any(|call| call == "keys")
+                && arm_facts.method_calls.iter().any(|call| call == "map")
+                && arm_facts.method_calls.iter().any(|call| call == "collect")
+                && arm_facts.paths.iter().any(|path| path == "PrefixedZoneId")
+                && arm_facts.paths.iter().any(|path| path == "roon");
+            self.clears_cache = arm_facts
+                .paths
+                .iter()
+                .any(|path| path == "clear_roon_runtime_state");
+            self.retires_each_zone = arm_facts
+                .paths
+                .iter()
+                .any(|path| path == "removed_zone_ids")
+                && arm_facts
                     .method_calls
                     .iter()
                     .any(|call| call == "publish_removed");
-            }
+            self.bridge_removal = arm_facts
+                .method_calls
+                .iter()
+                .any(|call| call == "publish_removed");
+            self.bus_fallback = arm_facts.paths.iter().any(|path| path == "ZoneRemoved");
+            let Expr::Block(block) = arm.body.as_ref() else {
+                continue;
+            };
+            let clear_line = block.block.stmts.iter().find_map(|statement| {
+                let facts = statement_facts(statement);
+                facts
+                    .paths
+                    .iter()
+                    .any(|path| path == "clear_roon_runtime_state")
+                    .then(|| statement.span().start().line)
+            });
+            let retirement_line = block.block.stmts.iter().find_map(|statement| {
+                let facts = statement_facts(statement);
+                (facts.paths.iter().any(|path| path == "removed_zone_ids")
+                    && facts
+                        .method_calls
+                        .iter()
+                        .any(|call| call == "publish_removed")
+                    && facts.paths.iter().any(|path| path == "ZoneRemoved"))
+                .then(|| statement.span().start().line)
+            });
+            let restart_line = block.block.stmts.iter().find_map(|statement| {
+                let facts = statement_facts(statement);
+                facts
+                    .method_calls
+                    .iter()
+                    .any(|call| call == "store")
+                    .then(|| statement.span().start().line)
+            });
+            self.restart_after_retirement = self.collects_all_zone_ids
+                && self.clears_cache
+                && self.retires_each_zone
+                && self.bridge_removal
+                && self.bus_fallback
+                && matches!((clear_line, retirement_line, restart_line),
+                    (Some(clear), Some(retirement), Some(restart)) if clear < retirement && retirement < restart);
         }
         visit::visit_expr_match(self, expression);
     }
@@ -200,10 +268,31 @@ fn lms_reconnect_can_republish_unchanged_players_as_snapshots() {
 fn roon_core_loss_retires_every_projected_zone() {
     let file = parse(include_str!("../src/adapters/roon.rs"));
     let mut facts = CoreLossFacts::default();
-    facts.visit_file(&file);
+    facts.visit_block(named_body(&file, "run_roon_loop"));
+    assert!(facts.saw_lost, "run_roon_loop must handle CoreEvent::Lost");
     assert!(
-        facts.removes_projection,
-        "CoreEvent::Lost must publish ZoneRemoved projections before reconnecting"
+        facts.collects_all_zone_ids,
+        "CoreEvent::Lost must collect every cached Roon zone ID"
+    );
+    assert!(
+        facts.clears_cache,
+        "CoreEvent::Lost must clear its operational cache"
+    );
+    assert!(
+        facts.retires_each_zone,
+        "CoreEvent::Lost must retire each collected zone"
+    );
+    assert!(
+        facts.bridge_removal,
+        "CoreEvent::Lost must use the reliable removal bridge"
+    );
+    assert!(
+        facts.bus_fallback,
+        "CoreEvent::Lost must fall back to BusEvent::ZoneRemoved"
+    );
+    assert!(
+        facts.restart_after_retirement,
+        "CoreEvent::Lost must retire projections before restart"
     );
 }
 
@@ -227,9 +316,9 @@ fn openhome_and_upnp_pollers_republish_cached_devices_as_snapshots() {
 fn every_production_stop_route_flushes_before_stopping() {
     for (name, source, function) in [
         (
-            "settings disable",
-            include_str!("../src/api/mod.rs"),
-            "stop_adapter_and_flush_zones",
+            "shared stop and flush",
+            include_str!("../src/coordinator.rs"),
+            "stop_adapter_and_flush",
         ),
         (
             "LMS reconfiguration",

--- a/tests/lifecycle_projection_lint.rs
+++ b/tests/lifecycle_projection_lint.rs
@@ -3,8 +3,8 @@
 //! The adapter-boundary lint prevents new surface-to-adapter bypasses. This
 //! suite protects the recovery half of that contract using parsed Rust syntax:
 //! every composed observer must be able to re-admit a full snapshot, Core loss
-//! must remove its projection, and every coordinator/API stop route must flush
-//! before cancellation.
+//! must remove its projection, and every coordinator/API stop route must cover
+//! every observer before it retires a shared projection.
 
 use syn::spanned::Spanned;
 use syn::visit::{self, Visit};
@@ -50,6 +50,20 @@ fn named_body<'a>(file: &'a syn::File, name: &str) -> &'a syn::Block {
 struct SyntaxFacts {
     method_calls: Vec<String>,
     paths: Vec<String>,
+}
+
+#[derive(Default)]
+struct AwaitFacts {
+    awaits_task: bool,
+}
+
+impl<'ast> Visit<'ast> for AwaitFacts {
+    fn visit_expr_await(&mut self, expression: &'ast syn::ExprAwait) {
+        let mut base = SyntaxFacts::default();
+        base.visit_expr(&expression.base);
+        self.awaits_task |= base.paths.iter().any(|path| path == "task");
+        visit::visit_expr_await(self, expression);
+    }
 }
 
 #[derive(Default)]
@@ -314,23 +328,11 @@ fn openhome_and_upnp_pollers_republish_cached_devices_as_snapshots() {
 
 #[test]
 fn every_production_stop_route_flushes_before_stopping() {
-    for (name, source, function) in [
-        (
-            "shared stop and flush",
-            include_str!("../src/coordinator.rs"),
-            "stop_adapter_and_flush",
-        ),
-        (
-            "LMS reconfiguration",
-            include_str!("../src/api/mod.rs"),
-            "lms_configure_handler",
-        ),
-        (
-            "coordinator shutdown",
-            include_str!("../src/coordinator.rs"),
-            "stop_all",
-        ),
-    ] {
+    for (name, source, function) in [(
+        "shared stop and flush",
+        include_str!("../src/coordinator.rs"),
+        "stop_adapter_and_flush",
+    )] {
         let events = stop_events(named_body(&parse(source), function));
         let flush = events
             .iter()
@@ -341,6 +343,103 @@ fn every_production_stop_route_flushes_before_stopping() {
             .position(|event| *event == "stop")
             .unwrap_or_else(|| panic!("{name} must stop adapters"));
         assert!(flush < stop, "{name} must flush the projection before stop");
+    }
+}
+
+#[test]
+fn lms_reconfiguration_cancels_both_observers_before_retiring_lms_projection() {
+    let coordinator = parse(include_str!("../src/coordinator.rs"));
+    let group_stop = named_body(&coordinator, "stop_adapters_then_flush");
+    let events = stop_events(group_stop);
+    let first_flush = events
+        .iter()
+        .position(|event| *event == "flush")
+        .expect("group lifecycle must retire the shared projection");
+    assert!(
+        events[..first_flush]
+            .iter()
+            .filter(|event| **event == "stop")
+            .count()
+            >= 1,
+        "group lifecycle must cancel its observers before retirement"
+    );
+
+    let api = parse(include_str!("../src/api/mod.rs"));
+    let configure = facts(named_body(&api, "lms_configure_handler"));
+    assert!(
+        configure
+            .method_calls
+            .iter()
+            .any(|call| call == "stop_adapter_and_companions_then_flush"),
+        "LMS reconfiguration must use the paired-observer stop path"
+    );
+    assert!(
+        configure
+            .method_calls
+            .iter()
+            .any(|call| call == "start_adapter_and_companions"),
+        "LMS reconfiguration must restart the CLI companion with the poller"
+    );
+    let settings = facts(named_body(&api, "api_settings_post_handler"));
+    assert!(
+        settings
+            .method_calls
+            .iter()
+            .any(|call| call == "stop_adapter_and_companions_then_flush"),
+        "settings disable must stop LMS's complete observer group"
+    );
+    assert!(
+        settings
+            .method_calls
+            .iter()
+            .any(|call| call == "start_adapter_and_companions"),
+        "settings enable must start LMS's complete observer group"
+    );
+
+    let paired_stop = facts(named_body(
+        &coordinator,
+        "stop_adapter_and_companions_then_flush",
+    ));
+    assert!(
+        paired_stop.paths.iter().any(|path| path == "companions"),
+        "the LMS lifecycle must include the CLI observer"
+    );
+    assert!(
+        paired_stop
+            .method_calls
+            .iter()
+            .any(|call| call == "stop_adapters_then_flush"),
+        "the LMS pair must be retired through the coordinator"
+    );
+    let shutdown = facts(named_body(&coordinator, "stop_all"));
+    assert!(
+        shutdown
+            .method_calls
+            .iter()
+            .any(|call| call == "stop_adapter_and_companions_then_flush"),
+        "coordinator shutdown must use the paired-observer stop path"
+    );
+
+    for (name, body) in [
+        (
+            "LMS poller",
+            named_body(
+                &parse(include_str!("../src/adapters/lms.rs")),
+                "stop_internal",
+            ),
+        ),
+        (
+            "LMS CLI",
+            named_body(&parse(include_str!("../src/adapters/lms.rs")), "stop"),
+        ),
+    ] {
+        let stop = facts(body);
+        let mut awaits = AwaitFacts::default();
+        awaits.visit_block(body);
+        assert!(
+            stop.method_calls.iter().any(|call| call == "take") && awaits.awaits_task,
+            "{name} stop must join its supervisor, not merely signal cancellation"
+        );
     }
 }
 

--- a/tests/lifecycle_projection_lint.rs
+++ b/tests/lifecycle_projection_lint.rs
@@ -99,6 +99,21 @@ struct StopFacts {
 }
 
 impl<'ast> Visit<'ast> for StopFacts {
+    fn visit_expr_call(&mut self, call: &'ast syn::ExprCall) {
+        if let Expr::Path(path) = call.func.as_ref() {
+            if path
+                .path
+                .segments
+                .last()
+                .is_some_and(|segment| segment.ident == "stop_adapter_and_flush_zones")
+            {
+                self.events.push("flush");
+                self.events.push("stop");
+            }
+        }
+        visit::visit_expr_call(self, call);
+    }
+
     fn visit_expr_method_call(&mut self, call: &'ast syn::ExprMethodCall) {
         if call.method == "publish" {
             let mut arguments = SyntaxFacts::default();
@@ -215,6 +230,11 @@ fn every_production_stop_route_flushes_before_stopping() {
             "settings disable",
             include_str!("../src/api/mod.rs"),
             "stop_adapter_and_flush_zones",
+        ),
+        (
+            "LMS reconfiguration",
+            include_str!("../src/api/mod.rs"),
+            "lms_configure_handler",
         ),
         (
             "coordinator shutdown",

--- a/tests/lifecycle_projection_lint.rs
+++ b/tests/lifecycle_projection_lint.rs
@@ -1,0 +1,215 @@
+//! Deterministic lifecycle/projection architecture checks.
+//!
+//! The adapter-boundary lint prevents new surface-to-adapter bypasses. This suite
+//! protects the complementary invariant: producers may only publish after the
+//! ZoneAggregator is receiving events, and lifecycle helpers must retire a
+//! provider's projection before stopping it.
+
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprMethodCall, ExprPath, File, ItemFn, Lit};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StartupEvent {
+    AggregatorReady,
+    HqplayerConnect,
+    StartAdapters,
+}
+
+struct StartupVisitor {
+    events: Vec<StartupEvent>,
+}
+
+impl<'ast> Visit<'ast> for StartupVisitor {
+    fn visit_expr_method_call(&mut self, call: &'ast ExprMethodCall) {
+        let receiver = expression_root_ident(call.receiver.as_ref());
+        match (receiver.as_deref(), call.method.to_string().as_str()) {
+            (Some("zone_aggregator"), "start") => self.events.push(StartupEvent::AggregatorReady),
+            (Some("hqplayer"), "get_pipeline_status") => {
+                self.events.push(StartupEvent::HqplayerConnect)
+            }
+            (_, "start_all_enabled") => self.events.push(StartupEvent::StartAdapters),
+            _ => {}
+        }
+        visit::visit_expr_method_call(self, call);
+    }
+}
+
+fn expression_root_ident(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Path(ExprPath { path, .. }) if path.segments.len() == 1 => path
+            .segments
+            .first()
+            .map(|segment| segment.ident.to_string()),
+        Expr::MethodCall(call) => expression_root_ident(call.receiver.as_ref()),
+        Expr::Paren(paren) => expression_root_ident(paren.expr.as_ref()),
+        Expr::Reference(reference) => expression_root_ident(reference.expr.as_ref()),
+        _ => None,
+    }
+}
+
+fn startup_events(source: &str) -> Vec<StartupEvent> {
+    let syntax: File = syn::parse_file(source).expect("main.rs must parse");
+    let run = syntax
+        .items
+        .iter()
+        .find_map(|item| match item {
+            syn::Item::Mod(module) => module.content.as_ref().and_then(|(_, items)| {
+                items.iter().find_map(|item| match item {
+                    syn::Item::Fn(function) if function.sig.ident == "run" => Some(function),
+                    _ => None,
+                })
+            }),
+            _ => None,
+        })
+        .expect("server::run must exist");
+    let mut visitor = StartupVisitor { events: Vec::new() };
+    visitor.visit_block(&run.block);
+    visitor.events
+}
+
+fn assert_aggregator_precedes_producers(events: &[StartupEvent]) -> Result<(), String> {
+    let aggregator = events
+        .iter()
+        .position(|event| *event == StartupEvent::AggregatorReady)
+        .ok_or_else(|| "ZoneAggregator::start was not awaited".to_string())?;
+    for producer in [StartupEvent::HqplayerConnect, StartupEvent::StartAdapters] {
+        let index = events
+            .iter()
+            .position(|event| *event == producer)
+            .ok_or_else(|| format!("missing producer event {producer:?}"))?;
+        if index < aggregator {
+            return Err(format!("{producer:?} happens before ZoneAggregator::start"));
+        }
+    }
+    Ok(())
+}
+
+struct StartsWithVisitor {
+    prefixes: Vec<String>,
+}
+
+impl<'ast> Visit<'ast> for StartsWithVisitor {
+    fn visit_expr_method_call(&mut self, call: &'ast ExprMethodCall) {
+        if call.method == "starts_with" {
+            if let Some(syn::Expr::Lit(literal)) = call.args.first() {
+                if let Lit::Str(prefix) = &literal.lit {
+                    self.prefixes.push(prefix.value());
+                }
+            }
+        }
+        visit::visit_expr_method_call(self, call);
+    }
+}
+
+fn zone_prefixes(source: &str) -> Vec<String> {
+    let syntax: File = syn::parse_file(source).expect("routes.rs must parse");
+    let mut visitor = StartsWithVisitor {
+        prefixes: Vec::new(),
+    };
+    visitor.visit_file(&syntax);
+    visitor.prefixes
+}
+
+struct StopFlushVisitor {
+    events: Vec<&'static str>,
+}
+
+impl<'ast> Visit<'ast> for StopFlushVisitor {
+    fn visit_expr_method_call(&mut self, call: &'ast ExprMethodCall) {
+        if call.method == "publish" && contains_adapter_stopping(call) {
+            self.events.push("flush");
+        }
+        if call.method == "stop" {
+            self.events.push("stop");
+        }
+        visit::visit_expr_method_call(self, call);
+    }
+}
+
+fn contains_adapter_stopping(call: &ExprMethodCall) -> bool {
+    struct EventVisitor {
+        found: bool,
+    }
+    impl<'ast> Visit<'ast> for EventVisitor {
+        fn visit_path_segment(&mut self, segment: &'ast syn::PathSegment) {
+            if segment.ident == "AdapterStopping" {
+                self.found = true;
+            }
+            visit::visit_path_segment(self, segment);
+        }
+    }
+    let mut visitor = EventVisitor { found: false };
+    for argument in &call.args {
+        visitor.visit_expr(argument);
+    }
+    visitor.found
+}
+
+fn stop_flush_events(source: &str) -> Vec<&'static str> {
+    let syntax: File = syn::parse_file(source).expect("api/mod.rs must parse");
+    let helper = syntax
+        .items
+        .iter()
+        .find_map(|item| match item {
+            syn::Item::Fn(ItemFn { sig, block, .. })
+                if sig.ident == "stop_adapter_and_flush_zones" =>
+            {
+                Some(block)
+            }
+            _ => None,
+        })
+        .expect("stop_adapter_and_flush_zones must exist");
+    let mut visitor = StopFlushVisitor { events: Vec::new() };
+    visitor.visit_block(helper);
+    visitor.events
+}
+
+#[test]
+fn aggregator_subscription_precedes_every_startup_producer() {
+    let source = include_str!("../src/main.rs");
+    assert_aggregator_precedes_producers(&startup_events(source)).unwrap();
+}
+
+#[test]
+fn controller_filters_the_full_prefixed_zone_vocabulary() {
+    let prefixes = zone_prefixes(include_str!("../src/knobs/routes.rs"));
+    for expected in ["roon:", "lms:", "openhome:", "upnp:", "hqplayer:"] {
+        assert!(
+            prefixes.contains(&expected.to_string()),
+            "missing {expected}"
+        );
+    }
+    assert!(
+        !prefixes.contains(&"hqp:".to_string()),
+        "hqp: is not a valid PrefixedZoneId provider"
+    );
+}
+
+#[test]
+fn adapter_stop_flushes_its_projection_before_cancellation() {
+    assert_eq!(
+        stop_flush_events(include_str!("../src/api/mod.rs")),
+        ["flush", "stop"],
+        "stopping a provider must first publish AdapterStopping for the aggregator"
+    );
+}
+
+#[test]
+fn startup_lint_rejects_a_producer_before_the_aggregator() {
+    let events = [
+        StartupEvent::HqplayerConnect,
+        StartupEvent::AggregatorReady,
+        StartupEvent::StartAdapters,
+    ];
+    assert!(assert_aggregator_precedes_producers(&events).is_err());
+}
+
+#[test]
+fn startup_lint_accepts_an_aggregator_before_every_producer() {
+    let events = [
+        StartupEvent::AggregatorReady,
+        StartupEvent::HqplayerConnect,
+        StartupEvent::StartAdapters,
+    ];
+    assert_aggregator_precedes_producers(&events).unwrap();
+}

--- a/tests/lifecycle_projection_lint.rs
+++ b/tests/lifecycle_projection_lint.rs
@@ -1,98 +1,66 @@
 //! Deterministic lifecycle/projection architecture checks.
 //!
-//! The adapter-boundary lint prevents new surface-to-adapter bypasses. This suite
-//! protects the complementary invariant: producers may only publish after the
-//! ZoneAggregator is receiving events, and lifecycle helpers must retire a
-//! provider's projection before stopping it.
+//! The adapter-boundary lint prevents new surface-to-adapter bypasses. This
+//! suite protects the recovery half of that contract using parsed Rust syntax:
+//! every composed observer must be able to re-admit a full snapshot, Core loss
+//! must remove its projection, and every coordinator/API stop route must flush
+//! before cancellation.
 
 use syn::visit::{self, Visit};
-use syn::{Expr, ExprMethodCall, ExprPath, File, ItemFn, Lit};
+use syn::{Expr, ExprMatch, ImplItem, Item, Pat};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum StartupEvent {
-    AggregatorReady,
-    HqplayerConnect,
-    StartAdapters,
+fn parse(source: &str) -> syn::File {
+    syn::parse_file(source).expect("production Rust must parse")
 }
 
-struct StartupVisitor {
-    events: Vec<StartupEvent>,
-}
-
-impl<'ast> Visit<'ast> for StartupVisitor {
-    fn visit_expr_method_call(&mut self, call: &'ast ExprMethodCall) {
-        let receiver = expression_root_ident(call.receiver.as_ref());
-        match (receiver.as_deref(), call.method.to_string().as_str()) {
-            (Some("zone_aggregator"), "start") => self.events.push(StartupEvent::AggregatorReady),
-            (Some("hqplayer"), "get_pipeline_status") => {
-                self.events.push(StartupEvent::HqplayerConnect)
+fn named_body<'a>(file: &'a syn::File, name: &str) -> &'a syn::Block {
+    fn find<'a>(items: &'a [Item], name: &str) -> Option<&'a syn::Block> {
+        for item in items {
+            match item {
+                Item::Fn(function) if function.sig.ident == name => return Some(&function.block),
+                Item::Mod(module) => {
+                    if let Some((_, children)) = &module.content {
+                        if let Some(block) = find(children, name) {
+                            return Some(block);
+                        }
+                    }
+                }
+                Item::Impl(implementation) => {
+                    for member in &implementation.items {
+                        if let ImplItem::Fn(function) = member {
+                            if function.sig.ident == name {
+                                return Some(&function.block);
+                            }
+                        }
+                    }
+                }
+                _ => {}
             }
-            (_, "start_all_enabled") => self.events.push(StartupEvent::StartAdapters),
-            _ => {}
         }
-        visit::visit_expr_method_call(self, call);
+        None
     }
-}
-
-fn expression_root_ident(expr: &Expr) -> Option<String> {
-    match expr {
-        Expr::Path(ExprPath { path, .. }) if path.segments.len() == 1 => path
-            .segments
-            .first()
-            .map(|segment| segment.ident.to_string()),
-        Expr::MethodCall(call) => expression_root_ident(call.receiver.as_ref()),
-        Expr::Paren(paren) => expression_root_ident(paren.expr.as_ref()),
-        Expr::Reference(reference) => expression_root_ident(reference.expr.as_ref()),
-        _ => None,
+    if let Some(block) = find(&file.items, name) {
+        return block;
     }
+    panic!("missing function `{name}`")
 }
 
-fn startup_events(source: &str) -> Vec<StartupEvent> {
-    let syntax: File = syn::parse_file(source).expect("main.rs must parse");
-    let run = syntax
-        .items
-        .iter()
-        .find_map(|item| match item {
-            syn::Item::Mod(module) => module.content.as_ref().and_then(|(_, items)| {
-                items.iter().find_map(|item| match item {
-                    syn::Item::Fn(function) if function.sig.ident == "run" => Some(function),
-                    _ => None,
-                })
-            }),
-            _ => None,
-        })
-        .expect("server::run must exist");
-    let mut visitor = StartupVisitor { events: Vec::new() };
-    visitor.visit_block(&run.block);
-    visitor.events
+#[derive(Default)]
+struct SyntaxFacts {
+    method_calls: Vec<String>,
+    paths: Vec<String>,
 }
 
-fn assert_aggregator_precedes_producers(events: &[StartupEvent]) -> Result<(), String> {
-    let aggregator = events
-        .iter()
-        .position(|event| *event == StartupEvent::AggregatorReady)
-        .ok_or_else(|| "ZoneAggregator::start was not awaited".to_string())?;
-    for producer in [StartupEvent::HqplayerConnect, StartupEvent::StartAdapters] {
-        let index = events
-            .iter()
-            .position(|event| *event == producer)
-            .ok_or_else(|| format!("missing producer event {producer:?}"))?;
-        if index < aggregator {
-            return Err(format!("{producer:?} happens before ZoneAggregator::start"));
-        }
-    }
-    Ok(())
-}
-
-struct StartsWithVisitor {
+#[derive(Default)]
+struct PrefixFacts {
     prefixes: Vec<String>,
 }
 
-impl<'ast> Visit<'ast> for StartsWithVisitor {
-    fn visit_expr_method_call(&mut self, call: &'ast ExprMethodCall) {
+impl<'ast> Visit<'ast> for PrefixFacts {
+    fn visit_expr_method_call(&mut self, call: &'ast syn::ExprMethodCall) {
         if call.method == "starts_with" {
-            if let Some(syn::Expr::Lit(literal)) = call.args.first() {
-                if let Lit::Str(prefix) = &literal.lit {
+            if let Some(Expr::Lit(literal)) = call.args.first() {
+                if let syn::Lit::Str(prefix) = &literal.lit {
                     self.prefixes.push(prefix.value());
                 }
             }
@@ -101,23 +69,45 @@ impl<'ast> Visit<'ast> for StartsWithVisitor {
     }
 }
 
-fn zone_prefixes(source: &str) -> Vec<String> {
-    let syntax: File = syn::parse_file(source).expect("routes.rs must parse");
-    let mut visitor = StartsWithVisitor {
-        prefixes: Vec::new(),
-    };
-    visitor.visit_file(&syntax);
-    visitor.prefixes
+impl<'ast> Visit<'ast> for SyntaxFacts {
+    fn visit_expr_method_call(&mut self, call: &'ast syn::ExprMethodCall) {
+        self.method_calls.push(call.method.to_string());
+        visit::visit_expr_method_call(self, call);
+    }
+
+    fn visit_path_segment(&mut self, segment: &'ast syn::PathSegment) {
+        self.paths.push(segment.ident.to_string());
+        visit::visit_path_segment(self, segment);
+    }
 }
 
-struct StopFlushVisitor {
+fn facts(block: &syn::Block) -> SyntaxFacts {
+    let mut facts = SyntaxFacts::default();
+    facts.visit_block(block);
+    facts
+}
+
+fn expression_facts(expression: &Expr) -> SyntaxFacts {
+    let mut facts = SyntaxFacts::default();
+    facts.visit_expr(expression);
+    facts
+}
+
+#[derive(Default)]
+struct StopFacts {
     events: Vec<&'static str>,
 }
 
-impl<'ast> Visit<'ast> for StopFlushVisitor {
-    fn visit_expr_method_call(&mut self, call: &'ast ExprMethodCall) {
-        if call.method == "publish" && contains_adapter_stopping(call) {
-            self.events.push("flush");
+impl<'ast> Visit<'ast> for StopFacts {
+    fn visit_expr_method_call(&mut self, call: &'ast syn::ExprMethodCall) {
+        if call.method == "publish" {
+            let mut arguments = SyntaxFacts::default();
+            for argument in &call.args {
+                arguments.visit_expr(argument);
+            }
+            if arguments.paths.iter().any(|path| path == "AdapterStopping") {
+                self.events.push("flush");
+            }
         }
         if call.method == "stop" {
             self.events.push("stop");
@@ -126,90 +116,157 @@ impl<'ast> Visit<'ast> for StopFlushVisitor {
     }
 }
 
-fn contains_adapter_stopping(call: &ExprMethodCall) -> bool {
-    struct EventVisitor {
-        found: bool,
-    }
-    impl<'ast> Visit<'ast> for EventVisitor {
-        fn visit_path_segment(&mut self, segment: &'ast syn::PathSegment) {
-            if segment.ident == "AdapterStopping" {
-                self.found = true;
+fn stop_events(block: &syn::Block) -> Vec<&'static str> {
+    let mut facts = StopFacts::default();
+    facts.visit_block(block);
+    facts.events
+}
+
+fn requires_snapshot_bridge(
+    source: &str,
+    bridge_method: &str,
+    observer_publish: &str,
+    observer_name: &str,
+) {
+    let file = parse(source);
+    let bridge = facts(named_body(&file, bridge_method));
+    assert!(
+        bridge.paths.iter().any(|path| path == "Snapshot"),
+        "the reliable bridge must publish ProjectionKind::Snapshot, not a lossy delta"
+    );
+    let observer = facts(named_body(&file, observer_name));
+    assert!(
+        observer
+            .method_calls
+            .iter()
+            .any(|call| call == observer_publish),
+        "{observer_name} must re-publish an authoritative zone through `{observer_publish}`"
+    );
+}
+
+fn pat_has_core_lost(pat: &Pat) -> bool {
+    let mut facts = SyntaxFacts::default();
+    facts.visit_pat(pat);
+    facts.paths.iter().any(|path| path == "CoreEvent")
+        && facts.paths.iter().any(|path| path == "Lost")
+}
+
+#[derive(Default)]
+struct CoreLossFacts {
+    removes_projection: bool,
+}
+
+impl<'ast> Visit<'ast> for CoreLossFacts {
+    fn visit_expr_match(&mut self, expression: &'ast ExprMatch) {
+        for arm in &expression.arms {
+            if pat_has_core_lost(&arm.pat) {
+                let arm_facts = expression_facts(&arm.body);
+                self.removes_projection |= arm_facts
+                    .method_calls
+                    .iter()
+                    .any(|call| call == "publish_removed");
             }
-            visit::visit_path_segment(self, segment);
         }
+        visit::visit_expr_match(self, expression);
     }
-    let mut visitor = EventVisitor { found: false };
-    for argument in &call.args {
-        visitor.visit_expr(argument);
-    }
-    visitor.found
 }
 
-fn stop_flush_events(source: &str) -> Vec<&'static str> {
-    let syntax: File = syn::parse_file(source).expect("api/mod.rs must parse");
-    let helper = syntax
-        .items
+#[test]
+fn lms_reconnect_can_republish_unchanged_players_as_snapshots() {
+    requires_snapshot_bridge(
+        include_str!("../src/adapters/lms.rs"),
+        "publish",
+        "publish_zone",
+        "update_players_internal",
+    );
+}
+
+#[test]
+fn roon_core_loss_retires_every_projected_zone() {
+    let file = parse(include_str!("../src/adapters/roon.rs"));
+    let mut facts = CoreLossFacts::default();
+    facts.visit_file(&file);
+    assert!(
+        facts.removes_projection,
+        "CoreEvent::Lost must publish ZoneRemoved projections before reconnecting"
+    );
+}
+
+#[test]
+fn openhome_and_upnp_pollers_republish_cached_devices_as_snapshots() {
+    requires_snapshot_bridge(
+        include_str!("../src/adapters/openhome.rs"),
+        "publish_zone",
+        "publish_zone",
+        "poll_device",
+    );
+    requires_snapshot_bridge(
+        include_str!("../src/adapters/upnp.rs"),
+        "publish_zone",
+        "publish_zone",
+        "poll_renderer",
+    );
+}
+
+#[test]
+fn every_production_stop_route_flushes_before_stopping() {
+    for (name, source, function) in [
+        (
+            "settings disable",
+            include_str!("../src/api/mod.rs"),
+            "stop_adapter_and_flush_zones",
+        ),
+        (
+            "coordinator shutdown",
+            include_str!("../src/coordinator.rs"),
+            "stop_all",
+        ),
+    ] {
+        let events = stop_events(named_body(&parse(source), function));
+        let flush = events
+            .iter()
+            .position(|event| *event == "flush")
+            .unwrap_or_else(|| panic!("{name} must publish AdapterStopping"));
+        let stop = events
+            .iter()
+            .position(|event| *event == "stop")
+            .unwrap_or_else(|| panic!("{name} must stop adapters"));
+        assert!(flush < stop, "{name} must flush the projection before stop");
+    }
+}
+
+#[test]
+fn aggregator_subscribes_before_starting_any_adapter() {
+    let facts = facts(named_body(&parse(include_str!("../src/main.rs")), "run"));
+    let subscription = facts
+        .method_calls
         .iter()
-        .find_map(|item| match item {
-            syn::Item::Fn(ItemFn { sig, block, .. })
-                if sig.ident == "stop_adapter_and_flush_zones" =>
-            {
-                Some(block)
-            }
-            _ => None,
-        })
-        .expect("stop_adapter_and_flush_zones must exist");
-    let mut visitor = StopFlushVisitor { events: Vec::new() };
-    visitor.visit_block(helper);
-    visitor.events
+        .position(|call| call == "run_with_ready")
+        .expect("startup must use the aggregator readiness barrier");
+    let starts = facts
+        .method_calls
+        .iter()
+        .position(|call| call == "start_all_enabled")
+        .expect("startup must use AdapterCoordinator::start_all_enabled");
+    assert!(
+        subscription < starts,
+        "adapter startup must not precede the aggregator subscription barrier"
+    );
 }
 
 #[test]
-fn aggregator_subscription_precedes_every_startup_producer() {
-    let source = include_str!("../src/main.rs");
-    assert_aggregator_precedes_producers(&startup_events(source)).unwrap();
-}
-
-#[test]
-fn controller_filters_the_full_prefixed_zone_vocabulary() {
-    let prefixes = zone_prefixes(include_str!("../src/knobs/routes.rs"));
-    for expected in ["roon:", "lms:", "openhome:", "upnp:", "hqplayer:"] {
+fn controller_recognizes_every_prefixed_provider() {
+    let file = parse(include_str!("../src/knobs/routes.rs"));
+    let mut facts = PrefixFacts::default();
+    facts.visit_file(&file);
+    for prefix in ["roon:", "lms:", "openhome:", "upnp:", "hqplayer:"] {
         assert!(
-            prefixes.contains(&expected.to_string()),
-            "missing {expected}"
+            facts.prefixes.iter().any(|actual| actual == prefix),
+            "controller does not recognize `{prefix}`"
         );
     }
     assert!(
-        !prefixes.contains(&"hqp:".to_string()),
-        "hqp: is not a valid PrefixedZoneId provider"
+        !facts.prefixes.iter().any(|prefix| prefix == "hqp:"),
+        "hqp: is not a valid provider prefix"
     );
-}
-
-#[test]
-fn adapter_stop_flushes_its_projection_before_cancellation() {
-    assert_eq!(
-        stop_flush_events(include_str!("../src/api/mod.rs")),
-        ["flush", "stop"],
-        "stopping a provider must first publish AdapterStopping for the aggregator"
-    );
-}
-
-#[test]
-fn startup_lint_rejects_a_producer_before_the_aggregator() {
-    let events = [
-        StartupEvent::HqplayerConnect,
-        StartupEvent::AggregatorReady,
-        StartupEvent::StartAdapters,
-    ];
-    assert!(assert_aggregator_precedes_producers(&events).is_err());
-}
-
-#[test]
-fn startup_lint_accepts_an_aggregator_before_every_producer() {
-    let events = [
-        StartupEvent::AggregatorReady,
-        StartupEvent::HqplayerConnect,
-        StartupEvent::StartAdapters,
-    ];
-    assert_aggregator_precedes_producers(&events).unwrap();
 }


### PR DESCRIPTION
Addresses #436 and the cross-provider projection-recovery failure reported in #459.

## What changed

- add deterministic `syn` AST lifecycle/projection checks for LMS snapshot readmission, Roon Core loss, OpenHome/UPnP cached-device republishing, startup readiness, and all known stop/recovery entrypoints;
- retire every Roon projection when its Core is lost, before reconnect;
- flush LMS projections before reconfiguration and on coordinator shutdown.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-features -- -D warnings`
- `cargo test --all-features --quiet`

#459 remains open as the generic user-facing state-degradation report; its LMS restart failure is one critical example. This PR provides the deterministic guardrails and one identified runtime correction, while user-visible recovery still needs manual verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed stale zones when the Roon Core connection is lost.
  * Improved cleanup during adapter shutdown so unavailable zones are removed consistently.
  * Ensured adapter state updates are published before services stop, preventing outdated information from remaining visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->