### PR TITLE
fix(lms): remove zones after player disconnect

### DIFF
--- a/src/adapters/lms.rs
+++ b/src/adapters/lms.rs
@@ -2838,17 +2838,17 @@ async fn handle_cli_event(
                     }
                 }
                 "disconnect" => {
-                    // Client disconnected
-                    let mut s = state.write().await;
-                    if let Some(player) = s.players.get_mut(&player_id) {
-                        player.connected = false;
-                    }
-                    drop(s);
+                    // A CLI disconnect is authoritative membership evidence, not merely a state
+                    // delta. Retire immediately rather than republishing a cached stopped zone
+                    // and waiting for the deliberately slowed-down poller to catch up.
+                    state.write().await.players.remove(&player_id);
+                    let zone_id = PrefixedZoneId::lms(&player_id);
                     if let Some(bridge) = runtime_bridge {
-                        if let Err(error) = publish_cached_lms_zone(state, bridge, &player_id).await
-                        {
-                            warn!(%error, player = %player_id, "could not project LMS CLI disconnect readback");
+                        if let Err(error) = bridge.publish_removed(zone_id).await {
+                            warn!(%error, player = %player_id, "could not retire LMS CLI disconnect projection");
                         }
+                    } else {
+                        bus.publish(BusEvent::ZoneRemoved { zone_id });
                     }
                 }
                 _ => {}

--- a/src/adapters/lms.rs
+++ b/src/adapters/lms.rs
@@ -2170,8 +2170,14 @@ async fn update_players_internal(
     runtime_bridge: Option<&LmsRuntimeBridge>,
 ) -> Result<()> {
     let players = rpc.get_players().await?;
+    // LMS keeps disconnected Squeezelite clients in its `players` inventory.
+    // That inventory is useful for server diagnostics, but only a connected
+    // client is a controllable UHC zone. Treat the connected subset as this
+    // poll's authoritative projection membership so a disconnect retires the
+    // old `lms:` zone through the reliable removal path below.
     let observed_ids: std::collections::HashSet<String> = players
         .iter()
+        .filter(|player| player.connected)
         .map(|player| player.playerid.clone())
         .collect();
 
@@ -2276,10 +2282,11 @@ async fn update_players_internal(
         s.players.insert(player.playerid.clone(), player);
     }
 
-    // `players` is LMS's authoritative server inventory. Keep the last observation for a player
-    // whose follow-up status call failed, but retire ids the inventory itself no longer reports.
-    // Without this retain, `current_ids` was always a superset of `previous_ids`, making the
-    // ZoneRemoved path below unreachable and leaving disconnected players in the aggregator.
+    // LMS's connected subset is the authoritative controllable-zone membership. Keep the last
+    // observation when a connected player's follow-up status call fails, but retire both missing
+    // and disconnected ids. Without this retain, `current_ids` was always a superset of
+    // `previous_ids`, making the ZoneRemoved path below unreachable and leaving disconnected
+    // players in the aggregator.
     state
         .write()
         .await

--- a/tests/lifecycle_projection_lint.rs
+++ b/tests/lifecycle_projection_lint.rs
@@ -278,6 +278,27 @@ fn lms_reconnect_can_republish_unchanged_players_as_snapshots() {
     );
 }
 
+/// LMS has two observer paths.  A CLI `client disconnect` is authoritative
+/// membership evidence in its own right: waiting for the slowed-down poller
+/// leaves a dead zone controllable for up to one poll interval.
+#[test]
+fn lms_cli_disconnect_retires_its_projection_immediately() {
+    let cli = facts(named_body(
+        &parse(include_str!("../src/adapters/lms.rs")),
+        "handle_cli_event",
+    ));
+    assert!(
+        cli.method_calls
+            .iter()
+            .any(|call| call == "publish_removed"),
+        "the LMS CLI disconnect path must publish a reliable removal"
+    );
+    assert!(
+        cli.paths.iter().any(|path| path == "ZoneRemoved"),
+        "the LMS CLI disconnect path must preserve the legacy bus fallback"
+    );
+}
+
 #[test]
 fn roon_core_loss_retires_every_projected_zone() {
     let file = parse(include_str!("../src/adapters/roon.rs"));

--- a/tests/mcp_contract.rs
+++ b/tests/mcp_contract.rs
@@ -1886,6 +1886,53 @@ async fn lms_poll_removes_a_missing_player_from_the_canonical_projection() {
     panic!("removed LMS player remained in the aggregator: {last}");
 }
 
+/// LMS retains a disconnected Squeezelite client in its inventory. The poll's
+/// `connected` flag, not only disappearance from the inventory, is therefore
+/// authoritative for whether its zone is controllable.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn lms_poll_removes_a_disconnected_player_from_the_canonical_projection() {
+    let h = LmsHarness::start().await;
+    let zone_id = h.zone_id();
+    h.mock.set_connected(h.player_id, false).await;
+
+    let mut last = Value::Null;
+    for _ in 0..60 {
+        let text = result_text(&h.app.call_tool("hifi_zones", json!({})).await);
+        last = serde_json::from_str(&text).expect("hifi_zones JSON");
+        let still_present = last
+            .as_array()
+            .is_some_and(|zones| zones.iter().any(|zone| zone["zone_id"] == zone_id));
+        if !still_present {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    assert!(
+        !last
+            .as_array()
+            .is_some_and(|zones| zones.iter().any(|zone| zone["zone_id"] == zone_id)),
+        "disconnected LMS player remained in the aggregator: {last}"
+    );
+
+    h.mock.set_connected(h.player_id, true).await;
+    for _ in 0..60 {
+        let text = result_text(&h.app.call_tool("hifi_zones", json!({})).await);
+        last = serde_json::from_str(&text).expect("hifi_zones JSON");
+        if last
+            .as_array()
+            .is_some_and(|zones| zones.iter().any(|zone| zone["zone_id"] == zone_id))
+        {
+            h.stop().await;
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    panic!("reconnected LMS player did not return to the aggregator: {last}");
+}
+
 /// `hifi_control` returns the action name plus the zone's post-command state.
 /// The prose framing is what a model reads back to the user.
 #[tokio::test]

--- a/tests/mock_servers/lms.rs
+++ b/tests/mock_servers/lms.rs
@@ -153,6 +153,15 @@ impl MockLmsServer {
         self.state.write().await.players.remove(playerid);
     }
 
+    /// Keep a player in LMS's inventory while changing whether its client is
+    /// actually connected. Real LMS retains disconnected players this way.
+    pub async fn set_connected(&self, playerid: &str, connected: bool) {
+        let mut state = self.state.write().await;
+        if let Some(player) = state.players.get_mut(playerid) {
+            player.connected = connected;
+        }
+    }
+
     /// Set player state (play/pause/stop)
     pub async fn set_mode(&self, playerid: &str, mode: &str) {
         let mut state = self.state.write().await;


### PR DESCRIPTION
## Summary

LMS retains disconnected Squeezelite clients in its server inventory. The adapter previously treated that inventory as the authoritative zone set, so the aggregator was never told to remove a disconnected player.

This changes the authoritative projection membership to LMS players whose `connected` flag is true. The existing reliable `ZoneRemoved` path removes a disconnected `lms:` zone; reconnect publishes the same stable ID again.

Part of #459.

## Verification

- Added a deterministic regression test: disconnect removes the canonical projection; reconnect restores its exact `lms:` ID.
- `cargo test --all-features --quiet`
- `cargo test --test lifecycle_projection_lint --quiet`
- `cargo test --test adapter_boundary_lint --quiet`
- `cargo clippy --all-features -- -D warnings`

## Tester artifacts

Full LMS and QNAP x86 builds are being dispatched from this branch. This PR must remain unmerged until tester confirmation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disconnected players are now removed from active zone membership and canonical status views.
  * Zones can now be correctly marked as removed when their players disconnect.
  * Players remain available during temporary status-refresh failures, preventing premature removal.
  * Reconnected players automatically reappear in active zone and status views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->