### PR TITLE
ci: support beta LMS repository feeds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1679,8 +1679,9 @@ jobs:
 
       - name: Generate beta LMS repository feed
         if: needs.plan.outputs.is_beta == 'true'
+        env:
+          VERSION: ${{ needs.plan.outputs.version }}
         run: |
-          VERSION="${{ needs.plan.outputs.version }}"
           ZIP="release/lms-unified-hifi-control-${VERSION}.zip"
           SHA=$(sha1sum "$ZIP" | cut -d' ' -f1)
           REPO_URL="https://github.com/${{ github.repository }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1804,7 +1804,7 @@ jobs:
   publish-aur:
     name: Publish to AUR
     needs: [plan, upload-release]
-    if: needs.plan.outputs.is_release == 'true'
+    if: needs.plan.outputs.is_release == 'true' && needs.plan.outputs.is_beta != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       is_release: ${{ steps.decide.outputs.is_release }}
+      is_beta: ${{ steps.decide.outputs.is_beta }}
       build_linux_arm: ${{ steps.decide.outputs.build_linux_arm }}
       build_macos: ${{ steps.decide.outputs.build_macos }}
       build_windows: ${{ steps.decide.outputs.build_windows }}
@@ -171,6 +172,12 @@ jobs:
             IS_RELEASE="true"
           fi
           echo "is_release=$IS_RELEASE" >> $GITHUB_OUTPUT
+
+          IS_BETA="false"
+          if [[ "$IS_RELEASE" == "true" && "$GITHUB_REF_NAME" == *-* ]]; then
+            IS_BETA="true"
+          fi
+          echo "is_beta=$IS_BETA" >> $GITHUB_OUTPUT
 
           # Linux ARM: needed for ARM binaries, Synology ARM, QNAP ARM, linux packages
           BUILD_LINUX_ARM="false"
@@ -1670,17 +1677,48 @@ jobs:
           - `lms-unified-hifi-control-*.zip` - Install via LMS Settings > Plugins
           EOF
 
+      - name: Generate beta LMS repository feed
+        if: needs.plan.outputs.is_beta == 'true'
+        run: |
+          VERSION="${{ needs.plan.outputs.version }}"
+          ZIP="release/lms-unified-hifi-control-${VERSION}.zip"
+          SHA=$(sha1sum "$ZIP" | cut -d' ' -f1)
+          REPO_URL="https://github.com/${{ github.repository }}"
+
+          cat > release/lms-beta.xml << REPOXML
+          <?xml version="1.0" encoding="UTF-8"?>
+          <extensions>
+            <plugins>
+              <plugin name="UnifiedHiFi"
+                      version="${VERSION}"
+                      minTarget="8.0"
+                      maxTarget="*">
+                <title lang="EN">Unified Hi-Fi Control (Beta)</title>
+                <desc lang="EN">Beta builds of Unified Hi-Fi Control for testing.</desc>
+                <url>${REPO_URL}/releases/download/v${VERSION}/lms-unified-hifi-control-${VERSION}.zip</url>
+                <sha>${SHA}</sha>
+                <creator>Muness Castle</creator>
+                <link>https://github.com/${{ github.repository }}/releases/tag/v${VERSION}</link>
+              </plugin>
+            </plugins>
+          </extensions>
+          REPOXML
+
+          echo "Generated beta feed:"
+          cat release/lms-beta.xml
+
       - name: Upload to release
         uses: softprops/action-gh-release@v2
         with:
           files: release/*
           append_body: true
           body_path: release-assets.md
+          prerelease: ${{ needs.plan.outputs.is_beta == 'true' }}
 
   update-repo-xml:
     name: Update LMS repo.xml
     needs: [plan, upload-release]
-    if: needs.plan.outputs.is_release == 'true'
+    if: needs.plan.outputs.is_release == 'true' && needs.plan.outputs.is_beta != 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/build/synology/build-spk.sh
+++ b/build/synology/build-spk.sh
@@ -12,6 +12,13 @@ normalize_version() {
 
     if [[ "$version" =~ ^([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
         printf '%s-10000\n' "${BASH_REMATCH[1]}"
+    elif [[ "$version" =~ ^([0-9]+\.[0-9]+\.[0-9]+)-beta(\.([0-9]+))?$ ]]; then
+        local beta_number=${BASH_REMATCH[3]:-0}
+        if ((beta_number > 999)); then
+            echo "Beta number is too large for Synology version encoding: $version" >&2
+            return 1
+        fi
+        printf '%s-%04d\n' "${BASH_REMATCH[1]}" "$((8000 + beta_number))"
     elif [[ "$version" =~ ^([0-9]+\.[0-9]+\.[0-9]+)-rc\.([0-9]+)$ ]]; then
         local rc_number=${BASH_REMATCH[2]}
         if ((rc_number > 999)); then

--- a/build/synology/build-spk.sh
+++ b/build/synology/build-spk.sh
@@ -14,6 +14,7 @@ normalize_version() {
         printf '%s-10000\n' "${BASH_REMATCH[1]}"
     elif [[ "$version" =~ ^([0-9]+\.[0-9]+\.[0-9]+)-beta(\.([0-9]+))?$ ]]; then
         local beta_number=${BASH_REMATCH[3]:-0}
+        beta_number=$((10#$beta_number))
         if ((beta_number > 999)); then
             echo "Beta number is too large for Synology version encoding: $version" >&2
             return 1

--- a/tests/synology_package_contract.sh
+++ b/tests/synology_package_contract.sh
@@ -59,7 +59,7 @@ else
     printf '#!/bin/sh\nexit 0\n' > "$test_binary"
     chmod +x "$test_binary"
 
-    for version_case in '3.4.1:3.4.1-10000' '3.5.1-beta:3.5.1-8000' '3.5.0-rc.2:3.5.0-9002' '0.0.0-pr171:0.0.0-0171' '0.0.0-dev:0.0.0-0001'; do
+    for version_case in '3.4.1:3.4.1-10000' '3.5.1-beta:3.5.1-8000' '3.5.1-beta.08:3.5.1-8008' '3.5.0-rc.2:3.5.0-9002' '0.0.0-pr171:0.0.0-0171' '0.0.0-dev:0.0.0-0001'; do
         input_version=${version_case%%:*}
         expected_version=${version_case#*:}
         output_spk="${test_tmp}/${input_version}.spk"

--- a/tests/synology_package_contract.sh
+++ b/tests/synology_package_contract.sh
@@ -59,7 +59,7 @@ else
     printf '#!/bin/sh\nexit 0\n' > "$test_binary"
     chmod +x "$test_binary"
 
-    for version_case in '3.4.1:3.4.1-10000' '3.5.0-rc.2:3.5.0-9002' '0.0.0-pr171:0.0.0-0171' '0.0.0-dev:0.0.0-0001'; do
+    for version_case in '3.4.1:3.4.1-10000' '3.5.1-beta:3.5.1-8000' '3.5.0-rc.2:3.5.0-9002' '0.0.0-pr171:0.0.0-0171' '0.0.0-dev:0.0.0-0001'; do
         input_version=${version_case%%:*}
         expected_version=${version_case#*:}
         output_spk="${test_tmp}/${input_version}.spk"
@@ -94,7 +94,7 @@ else
     arm_arch=$(tar -xOf "$arm_spk" INFO | sed -n 's/^arch="\([^"]*\)"$/\1/p')
     [[ "$arm_arch" == 'armv8' ]] || fail "ARM SPK arch is ${arm_arch}, expected armv8"
 
-    if "${SYNOLOGY_DIR}/build-spk.sh" 3.5.0-beta.1 x86_64 "$test_binary" "${test_tmp}/invalid.spk" 2>/dev/null; then
+    if "${SYNOLOGY_DIR}/build-spk.sh" 3.5.0-alpha.1 x86_64 "$test_binary" "${test_tmp}/invalid.spk" 2>/dev/null; then
         fail "build-spk.sh must reject prerelease formats without an explicit DSM ordering rule"
     fi
 fi


### PR DESCRIPTION
Adds durable prerelease delivery support to the v3 release workflow.

- Generates and publishes lms-beta.xml alongside each prerelease LMS ZIP
- Encodes beta versions for Synology SPK metadata
- Skips AUR publication for hyphenated prerelease versions
- Keeps stable repo.xml and Docker latest unchanged for beta releases

Tested: tests/synology_package_contract.sh; workflow YAML parse.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for beta release publishing with prerelease labeling and a dedicated beta feed containing download and verification details.
  * Beta Synology packages now support versions with optional numeric beta suffixes.

* **Bug Fixes**
  * Beta releases are excluded from stable repository and AUR publishing.
  * Invalid or excessively large beta version numbers are rejected.

* **Tests**
  * Added coverage for Synology beta version normalization and prerelease validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->