### PR TITLE
fix(hqplayer): align live DSP state across surfaces

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1282,7 +1282,7 @@ jobs:
             -v "$(pwd)/qnap-build:/src" \
             -w /src \
             owncloudci/qnap-qpkg-builder@sha256:e342184e415b1df87ef00b8c1df47988ffd6a9d232a21331556067d400f06189 \
-            sh -c '/usr/share/qdk2/QDK/bin/qbuild --build-dir /src/build && cp /src/build/*.qpkg /src/ && chmod 666 /src/*.qpkg'
+            sh -c '/usr/share/qdk2/QDK/bin/qbuild --build-dir /src/build --build-arch x86_64 && cp /src/build/*.qpkg /src/ && chmod 666 /src/*.qpkg'
 
       - name: Move QPKG to dist
         run: |
@@ -1334,7 +1334,7 @@ jobs:
             -v "$(pwd)/qnap-build:/src" \
             -w /src \
             owncloudci/qnap-qpkg-builder@sha256:e342184e415b1df87ef00b8c1df47988ffd6a9d232a21331556067d400f06189 \
-            sh -c '/usr/share/qdk2/QDK/bin/qbuild --build-dir /src/build && cp /src/build/*.qpkg /src/ && chmod 666 /src/*.qpkg'
+            sh -c '/usr/share/qdk2/QDK/bin/qbuild --build-dir /src/build --build-arch arm_64 && cp /src/build/*.qpkg /src/ && chmod 666 /src/*.qpkg'
 
       - name: Move QPKG to dist
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1278,11 +1278,15 @@ jobs:
 
       - name: Build QPKG with Docker
         run: |
+          docker build \
+            --file build/qnap/Dockerfile \
+            --tag qnap-qdk:2.5.3 \
+            build/qnap
           docker run --rm --platform linux/amd64 \
             -v "$(pwd)/qnap-build:/src" \
             -w /src \
-            owncloudci/qnap-qpkg-builder@sha256:e342184e415b1df87ef00b8c1df47988ffd6a9d232a21331556067d400f06189 \
-            sh -c '/usr/share/qdk2/QDK/bin/qbuild --build-dir /src/build --build-arch x86_64 && cp /src/build/*.qpkg /src/ && chmod 666 /src/*.qpkg'
+            qnap-qdk:2.5.3 \
+            sh -c '/usr/share/QDK/bin/qbuild --build-dir /src/build --build-arch x86_64 && cp /src/build/*.qpkg /src/ && chmod 666 /src/*.qpkg'
 
       - name: Move QPKG to dist
         run: |
@@ -1330,11 +1334,15 @@ jobs:
 
       - name: Build QPKG with Docker
         run: |
+          docker build \
+            --file build/qnap/Dockerfile \
+            --tag qnap-qdk:2.5.3 \
+            build/qnap
           docker run --rm --platform linux/amd64 \
             -v "$(pwd)/qnap-build:/src" \
             -w /src \
-            owncloudci/qnap-qpkg-builder@sha256:e342184e415b1df87ef00b8c1df47988ffd6a9d232a21331556067d400f06189 \
-            sh -c '/usr/share/qdk2/QDK/bin/qbuild --build-dir /src/build --build-arch arm_64 && cp /src/build/*.qpkg /src/ && chmod 666 /src/*.qpkg'
+            qnap-qdk:2.5.3 \
+            sh -c '/usr/share/QDK/bin/qbuild --build-dir /src/build --build-arch arm_64 && cp /src/build/*.qpkg /src/ && chmod 666 /src/*.qpkg'
 
       - name: Move QPKG to dist
         run: |

--- a/.oh/hqplayer-capability-audit-2026-08-15.md
+++ b/.oh/hqplayer-capability-audit-2026-08-15.md
@@ -1,0 +1,243 @@
+# HQPlayer live-control audit — 2026-08-15
+
+## Scope
+
+This audit covers the user-approved surface only:
+
+1. native configuration-profile inventory, optional active getter, and verified changer;
+2. all immediate DSP getters and selectors;
+3. PCM/SDM re-enumeration and readback;
+4. adapter → aggregator → web UI/MCP consistency;
+5. existing matrix-profile list and switch.
+
+Restart-backed configuration editing, user-owned presets, system/hardware tuning, and matrix CRUD or
+pipeline editing are explicitly excluded.
+
+The reference is HQPTuner 1.7.0 at commit `f996561`. Live comparisons used installed UHC 3.5.1 at
+`192.168.1.2:8088`, HQPTuner at `217.myqnapcloud.com:8090`, and HQPlayer Embedded 6.0.4 at
+`192.168.1.61:4321`.
+
+## Verdict
+
+The installed 3.5.1 build is wrong and must not be promoted as the fix. The worktree now fixes the
+identified code paths, but it has not been deployed to the live host yet.
+
+| Capability | Installed 3.5.1 | Current worktree | Evidence |
+|---|---|---|---|
+| Named native profile list | Correct | Correct | Same four names; unnamed base omitted |
+| Optional active native profile | Missing from aggregator/UI/MCP | Implemented | Native `ConfigurationGet`; empty becomes `None` / `(no preset)` |
+| Verified native profile changer | Implemented | Implemented, canonical result required | Live `Zen` load followed by direct native `ConfigurationGet value="Zen"`; hermetic restart/readback tests cover failure paths |
+| Immediate selectors | Present | Present | Mode, rate, 1x/Nx filter, dither/modulator, junk, matrix, convolution, adaptive, repeat, random, volume |
+| PCM/SDM re-enumeration | Correct inventories | Correct inventories | Exact live comparison in both chains |
+| Live mode/rate display | Wrong | Fixed | Installed says PCM while configured SDM; stopped worktree suppresses stale mode/rate |
+| Mutation projection | Can return bare `{"ok":true}` | Fixed | Canonical aggregator payload or explicit failure |
+| Matrix unnamed default | Blank | `[Default]` | Empty native name remains distinct from saved `Default` |
+| Selector UX | Opaque raw names/Hz | Improved | Friendly rates/mode, native filter guidance, search, rate-gated modulators |
+
+## Live HQPTuner cross-check
+
+### Exact inventory and selected-value parity
+
+The comparison used both applications' live APIs while pointed at the same daemon. Values below are
+semantic names or exact Hz, never native list indexes.
+
+| Chain | Modes | Filters | Dither/modulators | Rates | Selected values |
+|---|---:|---:|---:|---:|---|
+| SDM | exact order match | 77, exact order match | 36, exact order match | 6, exact order match | mode, 1x, Nx, modulator, and rate all matched |
+| PCM | exact order match | 67, exact order match | 10, exact order match | 13, exact order match | mode, 1x, Nx, dither, and rate all matched |
+
+The initial and restored SDM/DSD256 selections were:
+
+```text
+mode      SDM (DSD)
+filter1x  poly-sinc-gauss-long
+filterNx  poly-sinc-gauss-hires-lp
+modulator ASDM7EC-fast
+rate      11289600
+```
+
+The targeted PCM pass changed every dependent selector. Both applications independently reported:
+
+```text
+mode      PCM
+filter1x  poly-sinc-gauss-short
+filterNx  poly-sinc-gauss-hires-mp
+dither    TPDF
+rate      705600
+```
+
+The targeted SDM pass then exercised DSD128 with `poly-sinc-gauss-medium`,
+`poly-sinc-gauss-hires-ip`, and `ASDM7EC-fast`, followed by DSD256 with
+`poly-sinc-gauss-long`, `poly-sinc-gauss-hires-lp`, and both `DSD7 256+fs` and
+`ASDM7EC-fast`. No rate above DSD256 was selected. The audit restored the exact original Zen
+SDM/DSD256 mode, rate, filters, modulator, volume, matrix, and advanced-control state.
+
+The eight junk-filter names and ordering also matched exactly.
+
+### Matrix identity
+
+The daemon reports an empty current matrix name. HQPTuner renders that as `[Default]`, followed by
+saved profiles `Default` and `Mch-to-Stereo mixdown`. Installed UHC renders no selection.
+
+The worktree now applies the same user-facing rule:
+
+- `[Default]` serializes to the daemon's empty `MatrixSetProfile.value`;
+- saved `Default` remains the literal non-empty name `Default`;
+- an unknown non-empty current name is retained instead of being mislabeled as `[Default]`.
+
+### Native configuration profiles
+
+The daemon's named inventory is `Cen.Grand`, `GaN`, `Zen`, and `Zen1`. The audit loaded `Zen`
+through UHC and then queried the daemon's TCP control protocol independently; it returned
+`ConfigurationGet result="OK" value="Zen"`. An empty value is HQPlayer's unnamed base
+configuration, not a profile choice.
+
+The worktree therefore:
+
+- never puts the unnamed base in the profile list;
+- preserves a genuinely saved native profile named `Default`; only the exact `[default]` base
+  sentinel (or an empty value) is omitted;
+- exposes the active name as `Option<String>` in the Rust client and aggregator;
+- renders no active name as `(no preset)`;
+- adds the optional active name to MCP status;
+- marks exactly the matching named profile active after a list or load refresh.
+
+HQPTuner's header presets are its own snapshot store in 1.7.0, not a trustworthy implementation
+source for native profile loading. Its `/api/config.active` deliberately reports that store rather
+than native `ConfigurationGet`; the source says its restore-only workflow leaves the daemon on
+`[default]`. Its neutral `(no preset)` presentation is still the correct UX reference for an absent
+named native selection, but direct protocol readback is the authority for UHC's getter/changer.
+
+### Live immediate controls
+
+The audit also exercised and independently read back the non-selector controls:
+
+- junk filter `20k` and restore to `none`;
+- random and adaptive volume on/off, restored off;
+- convolution-on rejection when the daemon did not apply it, with convolution left off;
+- repeat-one refusal/readback on an empty playlist, with repeat left off;
+- HQPlayer digital volume from -3 dB to -4 dB and back to -3 dB.
+
+The Zen's external endpoint may be fixed-volume, but this daemon advertises an enabled -60..0 dB
+digital range and both UHC and HQPTuner observed the -4 dB write. UHC must follow the native
+`VolumeRange`, not infer fixed volume from the downstream endpoint.
+
+## Defects found and fixed
+
+### 1. Wrong live PCM/SDM authority
+
+Installed UHC derives the displayed active mode from `State.active_mode`. On this live 6.0.4 daemon,
+configured SDM reported a stale PCM state index while `Status.active_mode` correctly reported
+`SDM (DSD)`.
+
+The worktree now uses:
+
+- `State.mode` for the configured selector;
+- `Status.active_mode` for an explicit running chain;
+- `Status.active_rate` to derive the loaded family under source-following mode;
+- `Status.active_filter`, `active_shaper`, and `active_rate` for live readouts;
+- no live mode/output claim while stopped or paused.
+
+MCP now carries live `pipeline.mode` separately from configured `options.mode.current`.
+
+### 2. Active profile was verification-only state
+
+The adapter already queried `ConfigurationGet` to verify a profile load but discarded it everywhere
+else. It is now a public optional Rust getter and part of the coherent native observation retained
+by the aggregator and projected to UI/MCP.
+
+The first implementation placed this reconnect-capable query after the setting-list coherence
+boundary. The full suite caught that it could mix a new session's profile identity with an old
+session's lists. It now runs before the boundary; a reconnect invalidates and refills the complete
+chain-relative set.
+
+### 3. Filter metadata was discarded
+
+HQPlayer's live `FiltersItem.description` contains compact selector guidance such as quality, focus,
+and rate-ratio suitability. HQPTuner preserves it; UHC parsed only index/name/value/arg.
+
+The Rust client now retains the optional daemon-authored description. UI filter labels and search
+use it while the raw semantic filter name remains the wire value. Unknown future filters still
+render and remain selectable.
+
+### 4. Rate and modulator UX was needlessly opaque
+
+The worktree presents exact values with familiar tiers, for example:
+
+```text
+352800   → 8× · 352.8 kHz
+5644800  → DSD128 · 5.6448 MHz
+11289600 → DSD256 · 11.2896 MHz
+```
+
+`[source]` is labeled `Auto (follow source)`, PCM calls the shaper `Dither`, and SDM calls it
+`Modulator`. Filter and shaper controls are searchable. Rate-specific `256+fs`, `512+fs`, and AHM
+modulators remain visible but are disabled below their HQPTuner-validated minimum rate with an
+explanation.
+
+### 5. Verified writes could still lie to callers
+
+The reliable dispatch path already performed the native write, same-session verification, and
+canonical publication. The HTTP handler then performed a redundant second full native refresh. If
+that extra read failed, it returned legacy `{"ok":true}` instead of the state the reliable path had
+already published.
+
+The live exhaustive run made the bug concrete:
+
+```text
+391 selector/control rows exercised across PCM and SDM
+103 returned canonical projected state
+288 filter rows returned HTTP 200 without projected settings
+exact original configuration restored
+```
+
+Those 288 rows are exactly the two 1x/Nx filter passes across the 67-option PCM and 77-option SDM
+inventories. The worktree removes the redundant refresh and returns the already-published aggregator
+snapshot. HTTP and MCP now fail explicitly if canonical readback is unavailable; neither can claim a
+successful mutation without data.
+
+### 6. Matrix default identity was collapsed
+
+The UI now always offers `[Default]` after a successful matrix inventory read, even when there are
+no saved named profiles. The same empty-name normalization is used by the modern HTTP control path,
+Rust client, and MCP.
+
+## Immediate-control inventory
+
+| Setting | Read authority | Semantic write | Web | MCP | Verification |
+|---|---|---|---|---|---|
+| Mode | State + modes | `SetMode` | Yes | Yes | Re-enumerate + readback |
+| Active mode | Status/rate | N/A | Yes | Yes | Running-only projection |
+| Rate | State + rates | `SetRate` | Yes | Yes | Fresh list + readback |
+| Filter 1x/Nx | State + filters | paired `SetFilter` | Yes | Yes | Sibling preserved + readback |
+| Dither/modulator | State + shapers | `SetShaping` | Yes | Yes | Fresh list + readback |
+| Junk filter | State + list | `SetJunkFilter` | Yes | Yes | Readback |
+| Matrix profile | State + list | `MatrixSetProfile` | Yes | Yes | Empty/named semantic readback |
+| Convolution | State | `SetConvolution` | Yes | Yes | Readback |
+| Adaptive volume | State | `SetAdaptiveVolume` | Yes | Yes | Readback |
+| Repeat | State | `SetRepeat` | Yes | Yes | Readback |
+| Random | State | `SetRandom` | Yes | Yes | Readback |
+| Volume | State + range | absolute/relative | Yes | General MCP | Exact dB readback |
+
+`State.invert` is readable but no supported immediate native setter was established in either UHC
+or HQPTuner's live lane, so it is not counted as a missing selector.
+
+## Qualification boundary
+
+Hermetic tests cover active profile identity, profile-load verification, all immediate setter
+readbacks, source/PCM/SDM chain changes, stale-index rejection, matrix empty-name semantics,
+stopped-state projection, canonical mutation responses, UI filtering/rate guidance, and MCP shape.
+
+The live daemon audit now covers named profile load and direct native readback, semantic PCM and SDM
+selector changes, exact inventories, representative advanced controls, volume, and restoration. The
+patched worktree is not installed on `192.168.1.2`, so its corrected rendered UI and MCP projection
+still require one packaged-beta pass; this is a deployment qualification boundary, not an untested
+native-client path.
+
+Playback did not sustain during this pass: native `Play` initially reported an empty transport, and
+the Roon `HQPlayer dsp` source later supplied an HTTP URL that returned 404. DSP writes and readbacks
+were therefore qualified while stopped; transport/source failure was kept separate and is not
+misreported as a successful playback test.
+
+Separate dormant PCM/SDM user intent and user-owned live presets are HQPTuner product features. They
+are not native daemon state and remain outside this explicitly narrowed effort.

--- a/.oh/hqplayer-control-salvage-2026-08-15.md
+++ b/.oh/hqplayer-control-salvage-2026-08-15.md
@@ -1,0 +1,155 @@
+## Salvage
+
+### Salvage Report
+
+**Salvaged:** 2026-08-15 — HQPlayer direct-control audit/restart
+
+**Reason:** The work expanded from one live-mode display defect into a full HQPTuner parity audit across the native Rust client, adapter, aggregator, UI, and MCP. A live setter matrix also restarted HQPlayer into a source URL that returned 404, making the stopping point ambiguous.
+
+**Original Aim:** Make UHC a trustworthy HQPlayer control surface: every displayed live value should describe the running engine, every control should change the native engine and verify readback, and the Rust client should be a strong reusable HQPlayer library.
+
+### Learnings
+
+1. HQPlayer has two distinct domains: configured settings (`State.mode`, filter indexes, rate index) and running-engine facts (`Status.active_mode`, `active_filter`, `active_shaper`, `active_rate`). They cannot be projected interchangeably.
+2. On the live HQPlayer 6.0.4 engine, explicit SDM playback reported `State.mode=2` and `State.active_mode=1` while `Status.active_mode="SDM (DSD)"`. The existing UHC projection therefore showed PCM for an SDM engine.
+3. The native `Status.active_filter` is the loaded filter, while configured `filter1x` and `filterNx` are separate chain settings. A UI must label these as active filter versus 1x/Nx configuration, never collapse them.
+4. The aggregator already has the correct architectural role as the canonical retained snapshot. Fixes should improve the native observation/projection entering it, not create surface-specific reads.
+5. MCP currently projected state/filter/shaper/rate from the canonical snapshot but had no active-mode field. Configured `options.mode.current` is not a substitute for live mode.
+6. The current live instance accepted several setter requests and returned verified pipeline payloads, but a mode/control restart caused the source URL to return HTTP 404 and left HQPlayer stopped. A control test is not complete until transport state and source availability are recorded separately from DSP readback.
+7. HQPTuner’s useful reference boundary is its live-chain model: active chain, configured chain, output-aware choices, settle/reconcile behavior, and explicit status/control separation. Its UI vocabulary should inform UHC, but its implementation should not be copied wholesale into the adapter.
+
+### Frame Shifts
+
+- “The UI has a bad mode label” → “The native client needs a typed distinction between configured pipeline and running engine state.”
+- “Test each UI control independently” → “Test a control transaction: precondition snapshot, semantic write, native readback, aggregator publication, UI/MCP projection, and restoration.”
+- “The filter is wrong” → “There are multiple filter facts: active loaded filter, 1x filter, Nx filter, and output-aware chain choices.”
+- “HQPlayer is a set of setters” → “HQPlayer is a stateful session protocol with chain transitions, stale enumerations, ambiguous acknowledgements, restart recovery, and source lifecycle.”
+
+### New Guardrails
+
+1. Never use `State.active_mode` as the live display authority on the verified 6.0.4 engine; prefer native `Status.active_mode`, with a documented fallback only when the attribute is absent.
+2. Keep configured selections and active output facts in separate types/fields all the way through the aggregator, UI, and MCP.
+3. Every live setter test must snapshot state, mutate one semantic setting, verify native readback, verify aggregator/UI/MCP values, and restore the snapshot.
+4. Do not treat an HTTP success or `result="OK"` as applied without readback; do not retry an ambiguous write blindly.
+5. A stopped engine’s last active filter/rate is not fresh playback evidence. Surfaces must show lifecycle freshness explicitly or suppress stale active-chain claims.
+6. Do not qualify the full matrix while the configured source is unavailable; separate source/transport failure from DSP-control failure.
+7. Keep native indexes private to the Rust client/adapter boundary. HQPTuner parity should expose semantic names and typed values to all higher layers.
+8. Additive MCP fields require contract tests and deliberate compatibility review; tool/resource payloads must remain generated from the same canonical snapshot.
+
+### Missing Context
+
+- A stable, controllable HQPlayer source was needed before running mutating PCM/SDM qualification.
+- The full HQPTuner live-chain/control schema should have been inventoried before selecting individual UHC fields.
+- Explicit live captures for PCM, SDM, and `[source]` were needed to settle active-mode and active-filter semantics by mode, not by one snapshot.
+- The desired behavior for stale active values while stopped needs an explicit product decision.
+
+### Ownership / Coordination Breakdowns
+
+- The adapter, aggregator, and UI each had a plausible value, but no single typed contract named configured versus active DSP state.
+- Live qualification authority was blurred: UHC controlled HQPlayer while Roon supplied the stream, so a source 404 looked like a DSP-control failure.
+- The MCP schema gap was discovered after the UI issue because display and assistant projections were audited separately.
+
+### Reusable Fragments
+
+- `HqpAdapter::active_mode_name` now prefers the native live `Status.active_mode` and has regression coverage for a stale `State.active_mode` index.
+- `PipelineStatus` remains the shared projection feeding HTTP, aggregator, UI, and MCP.
+- MCP `McpPipelineStatus.mode` now carries active mode separately from configured options.
+- Existing coherent snapshot fencing, semantic name-to-index resolution, verified setter receipts, and aggregator publication are the foundation for the restart.
+- HQPTuner’s live-chain/status/control separation and output-aware filter narrowing are the reference behaviors to port as Rust concepts.
+
+### Fresh Start Recommendation
+
+Restart as one scoped HQPlayer client-library effort:
+
+1. Define typed native observations for configured pipeline, active engine chain, transport lifecycle, capabilities, and setter outcomes.
+2. Build a parity matrix from HQPTuner and native wire behavior for PCM, SDM, and source-following modes.
+3. Add hermetic failing tests for each projection and transaction before implementation.
+4. Route one coherent observation through the adapter and aggregator, then derive HTTP/UI/MCP from it.
+5. Run the complete live matrix against a stable source, including restoration and stopped/reconnect cases.
+6. Review the diff and package a beta only after the live matrix and source lifecycle both pass.
+
+## Dissent
+
+### Dissent Report
+
+**Decision under review:** Treat the existing coherent pipeline snapshot plus active-mode correction as the foundation of a complete HQPlayer surface.
+
+**Stakes:** This sets the public Rust library, aggregator state, UI vocabulary, and MCP contract. Calling the current slice complete would freeze a live-control subset while omitting the persistent settings and preset lifecycle the user explicitly expects.
+
+**Confidence before dissent:** MEDIUM
+
+### Steel-Man Position
+
+The existing adapter already has a strong native protocol implementation, coherent generation-fenced snapshots, semantic name-to-index conversion, verified immediate setters, native profile listing/loading, matrix profile switching, aggregator ownership, UI selectors, and MCP tools. Extending that path avoids duplicating HQPTuner and preserves UHC's architecture.
+
+### Contrary Evidence
+
+1. UHC exposes only immediate mode, rate, active-chain 1x/Nx filters, shaper/modulator, junk filter, matrix profile, convolution, adaptive volume, repeat, random, and volume. HQPTuner exposes persistent Output, DSP, Volume, Matrix, and System settings in addition to its LIVE lane.
+2. UHC can list and load daemon profiles, but the active configuration name is private to profile-load verification. The aggregator, UI, and MCP cannot report which profile is active. There is no profile preview, save, delete, rename, autosave, or description lifecycle.
+3. HQPTuner found the daemon's native profile subsystem unreliable and owns full-config presets itself. UHC currently assumes daemon profile list/load is the desired product model.
+4. UHC models one currently enumerated filter/shaper/rate set. HQPTuner preserves separate dormant PCM and SDM chain selections, re-enumerates after mode changes, reapplies held chain/rate values, and sequences mode before dependent settings.
+5. UHC exposes opaque filter names. HQPTuner joins live enumerations with filter/modulator metadata, device capability and rate constraints, favorites, and narrowing facets.
+6. UHC has no persistent-config transaction: no staged changes, restart-impact preview, backup, surgical XML edit, restore, reconnect/settle, or readback of the resulting active configuration.
+7. UHC lacks persistent selectors for backend, output devices, PCM/SDM rate ceilings, DAC bits, DoP/DSD transport, buffers, high-frequency filter, DAC correction, Direct SDM, integrator, SDM conversion, fixed/startup/min/max volume, gain compensation, CUDA/multicore/E-core/blocks-per-cycle, pre-metering, and logging.
+8. UHC lacks full matrix pipeline editing, filter import, speaker/crossfeed/EQ operations, and live response models.
+9. UHC also has capabilities HQPTuner intentionally omits: transport, queue-related flags, repeat/random, and convolution. The target is the union of useful capabilities, not a clone.
+
+### Pre-Mortem Scenarios
+
+1. **Functional failure:** A mode switch succeeds but dependent filter/rate values resolve against old enumerations or reset, so the UI reports a coherent-looking chain the engine did not keep.
+2. **Adoption failure:** Users still open HQPTuner for profiles, hardware/output settings, filter guidance, or matrix work; UHC remains a secondary remote rather than the trusted control surface.
+3. **Opportunity cost:** Surface-specific endpoints accumulate around the legacy `PipelineStatus`, making a later complete Rust client harder because configured, active, persistent, and staged state have already leaked into incompatible payloads.
+
+### Hidden Assumptions
+
+| Assumption | Evidence | Risk if Wrong | Test |
+|---|---|---|---|
+| Daemon native profiles are sufficient | UHC list/load works and verifies `ConfigurationGet` | Cannot save/preview/delete reliably; profile identity remains hidden | Compare native profile round trips with HQPTuner-owned snapshot behavior on 6.0.4 |
+| One active enumeration set is enough | Native API only serves the loaded chain | Dormant PCM/SDM choices disappear or reset across mode changes | Set distinct chains, switch twice, verify held values and rate pins |
+| Immediate controls constitute “all settings” | Existing UI/MCP expose twelve names | Most output/DSP/volume/system configuration remains unreachable | Derive a generated capability matrix from HQPTuner settings metadata and UHC typed operations |
+| `PipelineStatus` can remain the primary model | It feeds all existing surfaces | Persistent/staged/profile state gets bolted on or duplicated | Define a typed client snapshot first and prove every surface is a projection |
+| HQPTuner parity means copying its surface | It is the strongest live reference | UHC loses transport/convolution or imports HQPTuner-specific storage assumptions | Build a union matrix with provenance and explicit exclusions |
+
+### Reconstructed Story
+
+- **Still true:** The coherent native adapter and aggregator ownership are the correct foundation.
+- **Weakest assumption:** Existing profile list/load and twelve immediate selectors are close to a complete HQPlayer client.
+- **Changed situation model:** HQPlayer needs four distinct lanes: observed runtime, immediate live control, persistent restart-backed configuration, and user-owned presets/profiles.
+- **Changed beliefs:** Confidence in the current architecture remains high; confidence in the current model and scope drops to low.
+- **Next action:** Define a complete, generated capability/settings inventory and typed Rust contracts for the four lanes before adding more public fields.
+
+### Decision
+
+**Recommendation:** RECONSIDER
+
+**Reasoning:** Keep the adapter/aggregator architecture, but reject the narrow feature boundary and the legacy pipeline payload as the model of completeness. The public design must include active profile identity, profile/preset CRUD, both PCM and SDM chains, all native live selectors, persistent configuration selectors, matrix capabilities, and consistent UI/MCP projections.
+
+**Confidence after dissent:** HIGH
+
+**Follow-up artifact:** This report; a formal ADR should follow once the four-lane Rust contract and API compatibility strategy are concrete.
+
+### User Scope Correction — 2026-08-15
+
+The user explicitly rejected the persistent-configuration, custom preset, hardware/system tuning,
+and matrix-editing scope introduced by the dissent. Those are not requirements for this effort.
+
+The approved target is:
+
+1. Native HQPlayer profile inventory, current/active profile identity, and verified profile loading in
+   the Rust client, aggregator, UI, and MCP. Native profile save/delete/rename is not requested.
+2. Complete immediate/live DSP selectors and readback: configured mode, active mode, rate, separate
+   1x/Nx filters, shaper/modulator, junk filter, matrix profile selection, convolution, adaptive
+   volume, repeat, random, volume, and any additional setting the native control protocol exposes as
+   an immediate verified setter.
+3. Correct PCM/SDM behavior: re-enumerate after mode changes, preserve/restore dependent selections
+   where the native protocol permits it, and never resolve a setting against the previous chain's
+   indexes.
+4. One coherent native observation retained by the aggregator and projected consistently to the web
+   UI and MCP.
+
+Explicitly out of scope:
+
+- restart-backed persistent configuration editing;
+- user-owned live or full-configuration presets;
+- CUDA, multicore DSP, E-core, blocks/cycle, logging, license, and device-capability configuration;
+- matrix profile CRUD and full matrix pipeline editing.

--- a/build/qnap/Dockerfile
+++ b/build/qnap/Dockerfile
@@ -7,7 +7,7 @@ ARG QDK_DEB_SHA256=17b3841b7d4590a4ee025844ba583304b5e3c497d9fa8934d5175131d3908
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes \
-        bsdextrautils ca-certificates curl fakeroot gnupg2 pv rsync xz-utils \
+        ca-certificates curl fakeroot gnupg2 pv rsync xz-utils \
     && curl --fail --silent --show-error --location \
         "https://github.com/qnap-dev/QDK/releases/download/v${QDK_VERSION}/qdk_${QDK_VERSION}_amd64.deb" \
         --output /tmp/qdk.deb \

--- a/build/qnap/Dockerfile
+++ b/build/qnap/Dockerfile
@@ -1,0 +1,19 @@
+# QNAP's official QDK release, wrapped in a repository-owned builder image.
+# The base image and downloaded tool are both immutable to keep CI auditable.
+FROM ubuntu:20.04@sha256:8feb4d8ca5354def3d8fce243717141ce31e2c428701f6682bd2fafe15388214
+
+ARG QDK_VERSION=2.5.3
+ARG QDK_DEB_SHA256=17b3841b7d4590a4ee025844ba583304b5e3c497d9fa8934d5175131d3908022
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes \
+        bsdextrautils ca-certificates curl fakeroot gnupg2 pv rsync xz-utils \
+    && curl --fail --silent --show-error --location \
+        "https://github.com/qnap-dev/QDK/releases/download/v${QDK_VERSION}/qdk_${QDK_VERSION}_amd64.deb" \
+        --output /tmp/qdk.deb \
+    && echo "${QDK_DEB_SHA256}  /tmp/qdk.deb" | sha256sum --check --strict \
+    && apt-get install --no-install-recommends --yes /tmp/qdk.deb \
+    && rm -f /tmp/qdk.deb \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src

--- a/build/qnap/qpkg.cfg
+++ b/build/qnap/qpkg.cfg
@@ -15,6 +15,9 @@ QPKG_SERVICE_PORT="8088"
 QPKG_WEB_PORT="8088"
 QPKG_WEBUI="/"
 
+# Let App Center choose the install volume and migrate the app later if needed.
+QPKG_VOLUME_SELECT=3
+
 # QDK2 directory structure - shared only (static binary)
 QDK_DATA_DIR_SHARED="shared"
 

--- a/docs/gh-release.md
+++ b/docs/gh-release.md
@@ -236,7 +236,23 @@ and an unprivileged start/status/stop lifecycle. See the
 [Synology Developer Guide](https://help.synology.com/developer-guide/synology_package/introduction.html)
 for SPK structure.
 
-**QNAP QPKG:** Uses `qbuild` via Docker.
+**QNAP QPKG:** Uses a repository-owned Docker image containing QNAP's official
+QDK 2.5.3 release. The image is based on digest-pinned Ubuntu 20.04 and
+checksum-pins the official `qdk_2.5.3_amd64.deb` artifact. Both jobs run the
+AMD64 builder on the AMD64 GitHub runner; QDK's `qbuild --build-arch` selects
+the normal `.qpkg` output architecture (`x86_64` or `arm_64`), so this is not a
+package-format migration. The official release also ships an ARM64 QDK
+package, but it is not needed for the cross-target build and is not used
+speculatively.
+
+To upgrade the builder, choose a published release from
+[qnap-dev/QDK](https://github.com/qnap-dev/QDK/releases), verify the release
+asset SHA-256 in the Dockerfile, update `QDK_VERSION`, the checksum, and the
+base-image digest together, then run the QNAP contract tests and both CI jobs.
+The QDK 2.5.3 release assets used here are:
+
+- `qdk_2.5.3_amd64.deb`: `17b3841b7d4590a4ee025844ba583304b5e3c497d9fa8934d5175131d3908022`
+- `qdk_2.5.3_arm64.deb`: `4b00c009cb48c0ffa7e4b7b00c5a6a1982a0955d663c0c6ec57020353e68eeb9` (available from the release, not used by CI)
 
 ## Build Matrix
 

--- a/src/adapters/hqplayer.rs
+++ b/src/adapters/hqplayer.rs
@@ -9671,6 +9671,17 @@ impl HqpInstanceManager {
     }
 }
 
+#[async_trait::async_trait]
+impl crate::bus::HqpImageSource for HqpInstanceManager {
+    async fn get_current_cover(&self, instance: &str) -> Result<crate::bus::ImageData> {
+        let adapter = self
+            .get(instance)
+            .await
+            .ok_or_else(|| anyhow!("Unknown HQPlayer instance: {instance}"))?;
+        adapter.get_current_cover().await
+    }
+}
+
 /// Consume one exact-instance reliable endpoint.  The native write is not a success response:
 /// only the coherent readback's correlated projection commit resolves the caller's ticket.
 async fn run_hqplayer_command_endpoint(

--- a/src/adapters/hqplayer.rs
+++ b/src/adapters/hqplayer.rs
@@ -1376,6 +1376,9 @@ pub struct HqpInfo {
 pub struct HqpStatus {
     pub state: u8,
     pub track: u32,
+    /// Native HQPlayer playlist size. Zero means the daemon did not provide a total.
+    #[serde(skip)]
+    pub tracks_total: u32,
     pub track_id: String,
     pub position: u32,
     pub length: u32,
@@ -5067,6 +5070,7 @@ impl HqpAdapter {
         HqpStatus {
             state: Self::parse_attr_u32(response, "state") as u8,
             track: Self::parse_attr_u32(response, "track"),
+            tracks_total: Self::parse_attr_u32(response, "tracks_total"),
             track_id: Self::parse_attr(response, "track_id").unwrap_or_default(),
             position: Self::parse_attr_u32(response, "position"),
             length: Self::parse_attr_u32(response, "length"),
@@ -9057,10 +9061,13 @@ impl HqpAdapter {
             // `track` is HQPlayer's native playlist cursor. A source-fed stream can have metadata,
             // a duration, and even a track ID while still having no HQPlayer queue; that is the
             // state in which native Next/Previous returns `result="Error"`. Only advertise queue
-            // skips when HQPlayer reports a native cursor. Linked source zones retain their own
-            // transport flags and remain controllable from the HQPlayer page.
-            is_next_allowed: status.track > 0,
-            is_previous_allowed: status.track > 0,
+            // skips when HQPlayer reports a native cursor. When the daemon supplies the queue
+            // size, also enforce its bounds: a one-item source-backed playlist reports track=1,
+            // but Next still fails and may clear the track. Older daemon/status variants omit the
+            // total, so retain the cursor-only fallback for those observations.
+            is_next_allowed: status.track > 0
+                && (status.tracks_total == 0 || status.track < status.tracks_total),
+            is_previous_allowed: status.track > 1,
         }
     }
 }
@@ -9759,6 +9766,21 @@ async fn run_hqplayer_command_endpoint(
         let projection = match result {
             Ok(projection) => projection,
             Err(error) => {
+                // HQPlayer's negative transport response is not state-neutral: with a source-fed
+                // track, `<Next result="Error"/>` / `<Previous result="Error"/>` can still leave
+                // the daemon stopped with an empty Status document. Refresh before completing the
+                // ticket so the aggregator, MCP, and UI converge on that native outcome while the
+                // caller still receives the original backend error.
+                if let Err(refresh_error) = adapter
+                    .observe_and_publish_managed(native_worker.as_ref())
+                    .await
+                {
+                    tracing::warn!(
+                        %refresh_error,
+                        command_id = command_id.get(),
+                        "HQPlayer command failed and its state refresh also failed"
+                    );
+                }
                 permit.complete_native(NativeResult::Failed(error.to_string()));
                 continue;
             }

--- a/src/adapters/hqplayer.rs
+++ b/src/adapters/hqplayer.rs
@@ -9054,14 +9054,13 @@ impl HqpAdapter {
             // a legitimate action rather than avoid an impossible one.
             is_play_allowed: state != PlaybackState::Playing,
             is_pause_allowed: state == PlaybackState::Playing,
-            // HQPlayer is the DSP endpoint, not UHC's playback-queue owner. A loaded track and
-            // metadata therefore do not make HQPlayer's native Next/Previous commands a valid
-            // capability: Roon/JPLAY (or another source) owns the queue and must receive skips.
-            // Keeping these false prevents a direct HQPlayer zone from drawing buttons that the
-            // daemon will reject with `result="Error"`. Linked source zones retain their own
+            // `track` is HQPlayer's native playlist cursor. A source-fed stream can have metadata,
+            // a duration, and even a track ID while still having no HQPlayer queue; that is the
+            // state in which native Next/Previous returns `result="Error"`. Only advertise queue
+            // skips when HQPlayer reports a native cursor. Linked source zones retain their own
             // transport flags and remain controllable from the HQPlayer page.
-            is_next_allowed: false,
-            is_previous_allowed: false,
+            is_next_allowed: status.track > 0,
+            is_previous_allowed: status.track > 0,
         }
     }
 }

--- a/src/adapters/hqplayer.rs
+++ b/src/adapters/hqplayer.rs
@@ -9054,10 +9054,14 @@ impl HqpAdapter {
             // a legitimate action rather than avoid an impossible one.
             is_play_allowed: state != PlaybackState::Playing,
             is_pause_allowed: state == PlaybackState::Playing,
-            // Skip needs something to skip from. With nothing loaded these are the flags that had a
-            // knob drawing enabled buttons for a daemon that would answer `result="Error"`.
-            is_next_allowed: track_loaded,
-            is_previous_allowed: track_loaded,
+            // HQPlayer is the DSP endpoint, not UHC's playback-queue owner. A loaded track and
+            // metadata therefore do not make HQPlayer's native Next/Previous commands a valid
+            // capability: Roon/JPLAY (or another source) owns the queue and must receive skips.
+            // Keeping these false prevents a direct HQPlayer zone from drawing buttons that the
+            // daemon will reject with `result="Error"`. Linked source zones retain their own
+            // transport flags and remain controllable from the HQPlayer page.
+            is_next_allowed: false,
+            is_previous_allowed: false,
         }
     }
 }

--- a/src/adapters/hqplayer.rs
+++ b/src/adapters/hqplayer.rs
@@ -7465,14 +7465,31 @@ impl HqpAdapter {
     }
 
     async fn remember_rate_from_snapshot(&self, snapshot: &CoherentPipelineSnapshot) {
-        let Some(rate) = snapshot
+        let configured_rate = snapshot
             .chain
             .rates
             .iter()
             .find(|rate| rate.index == snapshot.state.rate)
             .map(|rate| rate.rate)
-            .filter(|rate| *rate != 0)
-        else {
+            .filter(|rate| *rate != 0);
+        // Auto is a real daemon selection, but not a safe return target for every NAA. Once the
+        // running engine has resolved it to an exact output rate, retain that observable value as
+        // the family's safe return pin. This extends HQPTuner's explicit per-family memory to the
+        // one trustworthy value Auto reveals. Require it to belong to the current chain's fresh
+        // enumeration: Status can otherwise carry stale or source-relative numbers that the entered
+        // family cannot pin.
+        let live_auto_rate = (snapshot.state.rate == 0
+            && snapshot.playback_status.state != 0
+            && snapshot.playback_status.active_rate != 0)
+            .then_some(snapshot.playback_status.active_rate)
+            .filter(|active| {
+                snapshot
+                    .chain
+                    .rates
+                    .iter()
+                    .any(|candidate| candidate.rate == *active)
+            });
+        let Some(rate) = configured_rate.or(live_auto_rate) else {
             return;
         };
         let family = snapshot

--- a/src/adapters/hqplayer.rs
+++ b/src/adapters/hqplayer.rs
@@ -1497,6 +1497,9 @@ pub struct FilterItem {
     pub name: String,
     pub value: i32, // Filter values can be negative
     pub arg: u32,
+    /// Compact, daemon-authored selector metadata (quality/focus/rate suitability).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
 }
 
 /// Pipeline settings for a single setting type
@@ -1548,6 +1551,7 @@ pub struct HqpAdvancedOptionsSnapshot {
 #[derive(Debug, Clone)]
 struct CoherentPipelineSnapshot {
     legacy: PipelineStatus,
+    active_profile: Option<String>,
     state: HqpState,
     playback_status: HqpStatus,
     chain: ChainSnapshot,
@@ -1596,6 +1600,8 @@ pub struct HqpNativeObservation {
     /// consumers can project their unchanged contract from the aggregator without re-querying the
     /// adapter and accidentally joining two daemon moments.
     pub pipeline: PipelineStatus,
+    /// Active named persistent configuration. `None` is HQPlayer's unnamed base configuration.
+    pub active_profile: Option<String>,
     pub transport: HqpNativeTransportState,
     pub metadata: HqpNativeMetadata,
     pub volume: HqpNativeVolume,
@@ -2070,6 +2076,10 @@ impl Drop for InFlightConnection {
 pub struct HqpProfile {
     pub value: String,
     pub title: String,
+    /// Whether the native daemon currently reports this named configuration as active.
+    /// HQPlayer's unnamed base configuration is intentionally represented by no active item.
+    #[serde(default)]
+    pub active: bool,
 }
 
 /// Matrix profile info
@@ -3313,7 +3323,8 @@ impl HqpAdapter {
                 .then_some(snapshot.playback_status.active_filter.clone()),
             shaper: (!snapshot.playback_status.active_shaper.is_empty())
                 .then_some(snapshot.playback_status.active_shaper.clone()),
-            rate: (snapshot.playback_status.active_rate != 0)
+            rate: (snapshot.playback_status.state != 0
+                && snapshot.playback_status.active_rate != 0)
                 .then_some(snapshot.playback_status.active_rate.to_string()),
         });
 
@@ -3376,7 +3387,8 @@ impl HqpAdapter {
             host,
             filter: (!status.active_filter.is_empty()).then_some(status.active_filter),
             shaper: (!status.active_shaper.is_empty()).then_some(status.active_shaper),
-            rate: (status.active_rate != 0).then_some(status.active_rate.to_string()),
+            rate: (status.state != 0 && status.active_rate != 0)
+                .then_some(status.active_rate.to_string()),
         });
         Ok(())
     }
@@ -3453,6 +3465,7 @@ impl HqpAdapter {
                 info: Some(snapshot.info.clone()),
             },
             pipeline: snapshot.legacy.clone(),
+            active_profile: snapshot.active_profile.clone(),
             transport: match snapshot.playback_status.state {
                 0 => HqpNativeTransportState::Stopped,
                 1 => HqpNativeTransportState::Paused,
@@ -3805,6 +3818,7 @@ impl HqpAdapter {
             name: Self::parse_attr(item, "name").unwrap_or_default(),
             value: Self::parse_attr_i32(item, "value"),
             arg: Self::parse_attr_u32(item, "arg"),
+            description: Self::parse_attr(item, "description"),
         });
         self.publish_fresh_family(FreshFamily::Filters(filters.clone()), since)
             .await?;
@@ -5323,6 +5337,7 @@ impl HqpAdapter {
             name: Self::parse_attr(item, "name").unwrap_or_default(),
             value: Self::parse_attr_i32(item, "value"),
             arg: Self::parse_attr_u32(item, "arg"),
+            description: Self::parse_attr(item, "description"),
         });
 
         // Log first 10 filters to help debug index vs value issues
@@ -5351,6 +5366,7 @@ impl HqpAdapter {
                 name: Self::parse_attr(item, "name").unwrap_or_default(),
                 value: Self::parse_attr_i32(item, "value"),
                 arg: Self::parse_attr_u32(item, "arg"),
+                description: Self::parse_attr(item, "description"),
             }),
             generation,
         ))
@@ -6157,6 +6173,113 @@ impl HqpAdapter {
             return Some(ModeFamily::Sdm);
         }
         None
+    }
+
+    /// Resolve the mode currently reported by the running engine.
+    ///
+    /// `State.active_mode` is not the live output mode on the HQPlayer 6.0.4 daemon we support:
+    /// while an explicitly configured SDM chain is loaded, `State` can still report the PCM index.
+    /// `Status.active_mode` is authoritative for an explicit PCM/SDM mode. Under `[source]` it can
+    /// echo `[source]` rather than name the loaded chain, so the unambiguous output-rate family is
+    /// the authority there. Keep the state-index fallback only for older/partial replies.
+    fn active_mode_name(
+        modes: &[ListItem],
+        state: &HqpState,
+        playback_status: &HqpStatus,
+    ) -> String {
+        const SDM_RATE_FLOOR_HZ: u32 = 2_822_400;
+
+        let configured_is_source = modes
+            .iter()
+            .find(|mode| mode.index == u32::from(state.mode))
+            .is_some_and(|mode| Self::mode_family(&mode.name) == Some(ModeFamily::Source));
+        let reported_family = Self::mode_family(&playback_status.active_mode);
+        if (reported_family == Some(ModeFamily::Source)
+            || (playback_status.active_mode.trim().is_empty() && configured_is_source))
+            && playback_status.active_rate > 0
+        {
+            let active_family = if playback_status.active_rate >= SDM_RATE_FLOOR_HZ {
+                ModeFamily::Sdm
+            } else {
+                ModeFamily::Pcm
+            };
+            return modes
+                .iter()
+                .find(|mode| Self::mode_family(&mode.name) == Some(active_family))
+                .map(|mode| mode.name.clone())
+                .unwrap_or_else(|| match active_family {
+                    ModeFamily::Pcm => "PCM".to_string(),
+                    ModeFamily::Sdm => "SDM (DSD)".to_string(),
+                    ModeFamily::Source => unreachable!("the output-rate family is never source"),
+                });
+        }
+        if !playback_status.active_mode.trim().is_empty() {
+            return playback_status.active_mode.clone();
+        }
+        modes
+            .iter()
+            .find(|mode| mode.index == u32::from(state.active_mode))
+            .map(|mode| mode.name.clone())
+            .unwrap_or_else(|| format!("Unknown({})", state.active_mode))
+    }
+
+    fn rate_label(rate: u32) -> String {
+        if rate == 0 {
+            return "Auto".to_string();
+        }
+
+        let frequency = Self::format_rate_frequency(rate);
+        const SDM_RATE_FLOOR_HZ: u32 = 2_822_400;
+        let tier = if rate >= SDM_RATE_FLOOR_HZ {
+            [44_100, 48_000].into_iter().find_map(|base| {
+                rate.is_multiple_of(base)
+                    .then_some(rate / base)
+                    .filter(|multiple| multiple.is_power_of_two() && *multiple >= 64)
+                    .map(|multiple| format!("DSD{multiple}"))
+            })
+        } else {
+            [44_100, 48_000].into_iter().find_map(|base| {
+                rate.is_multiple_of(base)
+                    .then_some(rate / base)
+                    .filter(|multiple| multiple.is_power_of_two())
+                    .map(|multiple| format!("{multiple}×"))
+            })
+        };
+
+        tier.map_or(frequency.clone(), |tier| format!("{tier} · {frequency}"))
+    }
+
+    fn mode_label(name: &str) -> String {
+        if Self::mode_family(name) == Some(ModeFamily::Source) {
+            "Auto (follow source)".to_string()
+        } else {
+            name.to_string()
+        }
+    }
+
+    fn filter_label(filter: &FilterItem) -> String {
+        filter.description.as_deref().map_or_else(
+            || filter.name.clone(),
+            |description| format!("{} · {description}", filter.name),
+        )
+    }
+
+    fn format_rate_frequency(rate: u32) -> String {
+        let (scaled, unit, precision) = if rate >= 1_000_000 {
+            (f64::from(rate) / 1_000_000.0, "MHz", 4)
+        } else if rate >= 1_000 {
+            (f64::from(rate) / 1_000.0, "kHz", 3)
+        } else {
+            return format!("{rate} Hz");
+        };
+        let mut number = format!("{scaled:.precision$}");
+        while number.contains('.') && number.ends_with('0') {
+            number.pop();
+        }
+        if number.ends_with('.') {
+            number.pop();
+        }
+        format!("{number} {unit}")
     }
 
     /// Resolve a mode name against the list the daemon is serving **now**.
@@ -7283,7 +7406,7 @@ impl HqpAdapter {
         // *now* as when the lists were published; a move out and back inside that window leaves it
         // agreeing. Only a daemon-side atomic snapshot could do better, and the protocol has none.
         let mut retried = false;
-        let (state, playback_status, snapshot, vol_range, session) = loop {
+        let (state, playback_status, active_profile, snapshot, vol_range, session) = loop {
             // Query recovery may replace only the TCP transport and deliberately leave managed
             // reachability false. Any first-attempt disturbance can discover that replacement —
             // an unsettled list fill, failed probe, replaced snapshot, or the closing fence — so
@@ -7298,7 +7421,7 @@ impl HqpAdapter {
 
             // (1) Reconnect-capable, so it goes ahead of everything the proof will cover. On the
             // first read of a connection this is always a real request.
-            let (vol_range, mut attempt_generation) = match self.ensure_volume_range().await? {
+            let (mut vol_range, volume_generation) = match self.ensure_volume_range().await? {
                 PipelineVolumeRange::Observed { range, generation } => (range, generation),
                 PipelineVolumeRange::FixedFallback(range) => {
                     // A timeout/lost reply discarded the old socket. Establish the replacement
@@ -7309,6 +7432,46 @@ impl HqpAdapter {
                     (range, self.transport_generation().await)
                 }
             };
+
+            // ConfigurationGet is also reconnect-capable. Read it before capturing any
+            // chain-scoped identity, and date the attempt from the session that answered it. A
+            // reconnect here invalidates the list cache; the fill below will then rebuild the
+            // complete set on the replacement session instead of joining an old set to a new
+            // profile identity.
+            let (active_configuration, mut attempt_generation) =
+                self.active_configuration_with_generation().await?;
+            let active_profile = Self::named_configuration(active_configuration);
+
+            // ConfigurationGet may have reconciled a cancelled or failed transport. In that case
+            // the range above belongs to the discarded session and must be read again. A second
+            // session change means the reconnect-capable preflight itself did not settle; restart
+            // the one bounded whole-read attempt instead of joining the two sessions.
+            if volume_generation != attempt_generation {
+                let (refreshed_range, refreshed_generation) =
+                    match self.ensure_volume_range().await? {
+                        PipelineVolumeRange::Observed { range, generation } => (range, generation),
+                        PipelineVolumeRange::FixedFallback(range) => {
+                            self.ensure_connected().await?;
+                            (range, self.transport_generation().await)
+                        }
+                    };
+                if refreshed_generation != attempt_generation {
+                    if !retried {
+                        tracing::info!(
+                            "HQPlayer's native session changed twice during the reconnect-capable \
+                             pipeline preflight; restarting the complete read"
+                        );
+                        retried = true;
+                        continue;
+                    }
+                    return Err(anyhow!(
+                        "HQPlayer's native session would not settle while its profile identity and \
+                         volume capability were being read; refusing to join preflight state from \
+                         different sessions"
+                    ));
+                }
+                vol_range = refreshed_range;
+            }
 
             // A query may establish a usable native transport without declaring the managed
             // session reachable. Complete that handshake on the same socket and carry the range
@@ -7372,7 +7535,6 @@ impl HqpAdapter {
             // `HqpStatus::default()`. A failed Status reply therefore invalidates this complete
             // coherent reading just as an unsettled chain does.
             let observed_status = self.get_playback_status().await?;
-
             // (4) A probe that could not run is not a probe that passed. "The cache was not
             // invalidated, so the lists are still the ones the state was read against" is true about
             // the *cache* and answers nothing about the *daemon*: whether it still has that chain
@@ -7432,7 +7594,14 @@ impl HqpAdapter {
                             ));
                         }
                     };
-                    break (observed, observed_status, snapshot, vol_range, session);
+                    break (
+                        observed,
+                        observed_status,
+                        active_profile,
+                        snapshot,
+                        vol_range,
+                        session,
+                    );
                 }
                 Err(reason) if !retried => {
                     tracing::info!(
@@ -7499,23 +7668,25 @@ impl HqpAdapter {
         let legacy = PipelineStatus {
             status: PipelineState {
                 state: state_str.to_string(),
-                // State.mode and State.active_mode are INDEX (0,1,2) - look up by ModesItem.index
+                // State.mode returns an INDEX (0,1,2) - look it up by ModesItem.index.
                 mode: get_mode_by_index(state.mode),
-                // `State.active_mode`, resolved through the modes list. This is a **reporting choice
-                // between two fields whose semantics are not both measured**, not a statement that one
-                // is right: `Status.active_mode` is measured to echo the configured mode under
-                // `[source]` (HQP-C-023), and what `State.active_mode` reports there has never been
-                // measured by anyone (HQP-C-024). An earlier comment here called the `Status` field
-                // "unreliable" and instructed always using this one, which asserted the unmeasured half
-                // as fact; #332 owns settling it.
-                //
-                // Nothing that has to be *correct* depends on this field. The loaded chain — which
-                // decides every enumeration below — is resolved from the enumerations the daemon
-                // serves, never from either `active_mode`.
-                active_mode: get_mode_by_index(state.active_mode),
+                // `Status.active_mode` is the live engine's semantic readout. The supported 6.0.4
+                // daemon can leave State.active_mode at the PCM index while an explicit SDM chain is
+                // loaded, so State is only a compatibility fallback when Status omits the field.
+                // Source-following mode derives the loaded PCM/SDM chain from Status.active_rate
+                // when Status echoes `[source]`; enumerations never depend on this display field.
+                active_mode: if state.state == 0 {
+                    String::new()
+                } else {
+                    Self::active_mode_name(&modes, &state, &playback_status)
+                },
                 active_filter: playback_status.active_filter.clone(),
                 active_shaper: playback_status.active_shaper.clone(),
-                active_rate: state.active_rate,
+                active_rate: if state.state == 0 {
+                    0
+                } else {
+                    playback_status.active_rate
+                },
                 convolution: state.convolution,
                 invert: state.invert,
             },
@@ -7530,13 +7701,13 @@ impl HqpAdapter {
                     selected: SelectedOption {
                         // Use name for the value - adapter handles name→value conversion
                         value: get_mode_by_index(state.mode),
-                        label: get_mode_by_index(state.mode),
+                        label: Self::mode_label(&get_mode_by_index(state.mode)),
                     },
                     options: modes
                         .iter()
                         .map(|m| SelectOption {
                             value: m.name.clone(), // Send NAME, not value
-                            label: m.name.clone(),
+                            label: Self::mode_label(&m.name),
                         })
                         .collect(),
                 },
@@ -7544,13 +7715,13 @@ impl HqpAdapter {
                     selected: SelectedOption {
                         // Use name - adapter handles name→index conversion
                         value: filter1x_obj.map(|f| f.name.clone()).unwrap_or_default(),
-                        label: filter1x_obj.map(|f| f.name.clone()).unwrap_or_default(),
+                        label: filter1x_obj.map(Self::filter_label).unwrap_or_default(),
                     },
                     options: filters
                         .iter()
                         .map(|f| SelectOption {
                             value: f.name.clone(), // Send NAME, not index
-                            label: f.name.clone(),
+                            label: Self::filter_label(f),
                         })
                         .collect(),
                 },
@@ -7558,13 +7729,13 @@ impl HqpAdapter {
                     selected: SelectedOption {
                         // Use name - adapter handles name→index conversion
                         value: filter_nx_obj.map(|f| f.name.clone()).unwrap_or_default(),
-                        label: filter_nx_obj.map(|f| f.name.clone()).unwrap_or_default(),
+                        label: filter_nx_obj.map(Self::filter_label).unwrap_or_default(),
                     },
                     options: filters
                         .iter()
                         .map(|f| SelectOption {
                             value: f.name.clone(), // Send NAME, not index
-                            label: f.name.clone(),
+                            label: Self::filter_label(f),
                         })
                         .collect(),
                 },
@@ -7582,17 +7753,16 @@ impl HqpAdapter {
                         })
                         .collect(),
                 },
-                // In PCM mode, it's called "Shaper"; in DSD/SDM mode, it's "Modulator"
+                // HQPTuner and HQPlayer's own terminology call the PCM family "Dither" and the
+                // SDM family "Modulator". The wire still calls both families shapers.
                 shaper_label: {
                     let mode_name = get_mode_by_index(state.mode);
-                    // PCM mode → "Shaper", DSD/SDM mode → "Modulator"
-                    // "[source]" mode depends on source material - default to "Shaper"
-                    if mode_name.to_uppercase().contains("SDM")
-                        || mode_name.to_uppercase().contains("DSD")
-                    {
+                    if Self::mode_family(&mode_name) == Some(ModeFamily::Sdm) {
                         "Modulator".to_string()
+                    } else if Self::mode_family(&mode_name) == Some(ModeFamily::Source) {
+                        "Dither / modulator".to_string()
                     } else {
-                        "Shaper".to_string()
+                        "Dither".to_string()
                     }
                 },
                 samplerate: PipelineSetting {
@@ -7607,25 +7777,15 @@ impl HqpAdapter {
                         label: rates
                             .iter()
                             .find(|r| r.index == state.rate)
-                            .map(|r| {
-                                if r.rate == 0 {
-                                    "Auto".to_string()
-                                } else {
-                                    r.rate.to_string()
-                                }
-                            })
-                            .unwrap_or_else(|| state.active_rate.to_string()),
+                            .map(|r| Self::rate_label(r.rate))
+                            .unwrap_or_else(|| Self::rate_label(state.active_rate)),
                     },
                     options: rates
                         .iter()
                         .map(|r| SelectOption {
                             // Use rate as value (what HQPlayer expects)
                             value: r.rate.to_string(),
-                            label: if r.rate == 0 {
-                                "Auto".to_string()
-                            } else {
-                                r.rate.to_string()
-                            },
+                            label: Self::rate_label(r.rate),
                         })
                         .collect(),
                 },
@@ -7634,6 +7794,7 @@ impl HqpAdapter {
 
         Ok(CoherentPipelineSnapshot {
             legacy,
+            active_profile,
             state,
             playback_status,
             chain: ChainSnapshot {
@@ -7998,10 +8159,34 @@ impl HqpAdapter {
     /// Ask the native protocol which named configuration is active.
     /// Empty means the base configuration; a named value is returned exactly.
     async fn active_configuration_under_operation(&self) -> Result<String> {
+        self.active_configuration_with_generation()
+            .await
+            .map(|(active, _)| active)
+    }
+
+    async fn active_configuration_with_generation(&self) -> Result<(String, u64)> {
         let xml = Self::build_request("ConfigurationGet", &[]);
-        let response = self.send_command(&xml).await?;
-        Self::parse_attr(&response, "value")
-            .ok_or_else(|| anyhow!("ConfigurationGet response omitted its active value"))
+        let (response, generation) = self.send_command_with_generation(&xml).await?;
+        let active = Self::parse_attr(&response, "value")
+            .ok_or_else(|| anyhow!("ConfigurationGet response omitted its active value"))?;
+        Ok((active, generation))
+    }
+
+    fn named_configuration(active: String) -> Option<String> {
+        let active = active.trim();
+        (!active.is_empty()).then(|| active.to_string())
+    }
+
+    /// Return the active named profile, hiding HQPlayer's unnamed base configuration.
+    ///
+    /// HQPlayer reports the base configuration as an empty `ConfigurationGet.value`. That value is
+    /// not a user-facing profile in UHC; callers receive `None`, while named profiles retain their
+    /// semantic identity.
+    pub async fn get_active_profile(&self) -> Result<Option<String>> {
+        let _operation_guard = self.operation_lock.lock().await;
+        Ok(Self::named_configuration(
+            self.active_configuration_under_operation().await?,
+        ))
     }
 
     /// Parse hidden form inputs from HTML
@@ -8057,20 +8242,21 @@ impl HqpAdapter {
                     .map(|c| c[1].to_string())
                     .unwrap_or_else(|| text.to_string());
 
-                // Skip default/empty profiles
-                let slug: String = value
-                    .to_lowercase()
-                    .chars()
-                    .filter(|c| c.is_alphanumeric())
-                    .collect();
-                if !value.is_empty() && !slug.is_empty() && slug != "default" {
+                // HQPlayer exposes its unnamed base configuration as `[default]`.
+                // That is not a user profile, but a saved profile literally named
+                // `Default` is valid and must remain selectable.
+                let trimmed_value = value.trim();
+                let is_unnamed_base =
+                    trimmed_value.is_empty() || trimmed_value.eq_ignore_ascii_case("[default]");
+                if !is_unnamed_base {
                     profiles.push(HqpProfile {
-                        value: value.trim().to_string(),
+                        value: trimmed_value.to_string(),
                         title: if text.is_empty() {
                             value.clone()
                         } else {
                             text.to_string()
                         },
+                        active: false,
                     });
                 }
             }
@@ -8126,7 +8312,14 @@ impl HqpAdapter {
         }
 
         let hidden_fields = Self::parse_hidden_inputs(html);
-        let profiles = Self::parse_profiles_from_html(html);
+        let mut profiles = Self::parse_profiles_from_html(html);
+        let active = self.active_configuration_under_operation().await?;
+        let active = active.trim();
+        if !active.is_empty() {
+            for profile in &mut profiles {
+                profile.active = profile.value == active;
+            }
+        }
 
         // Cache for later use
         {
@@ -8351,6 +8544,7 @@ impl HqpAdapter {
     /// of application (HQP-C-028) — so the write is confirmed by reading `State.matrix_profile` back.
     pub async fn set_matrix_profile_named(&self, name: &str) -> Result<SettingOutcome> {
         let _operation_guard = self.operation_lock.lock().await;
+        let name = Self::native_matrix_profile_name(name);
         let (state, generation) = self.get_state_with_generation().await?;
         if state.matrix_profile == name {
             return Ok(SettingOutcome::AlreadySet);
@@ -8364,6 +8558,7 @@ impl HqpAdapter {
         name: &str,
         generation: u64,
     ) -> Result<SettingOutcome> {
+        let name = Self::native_matrix_profile_name(name);
         if self
             .get_state_on_transport(generation)
             .await?
@@ -8374,6 +8569,14 @@ impl HqpAdapter {
         }
         self.write_matrix_profile_on_transport(name, generation)
             .await
+    }
+
+    fn native_matrix_profile_name(name: &str) -> &str {
+        if name.eq_ignore_ascii_case("[default]") {
+            ""
+        } else {
+            name
+        }
     }
 
     async fn write_matrix_profile_on_transport(
@@ -10145,6 +10348,97 @@ mod parse_attr_scope_tests {
 mod chain_identity_tests {
     use super::*;
 
+    #[test]
+    fn live_mode_uses_status_active_mode_when_state_reports_a_stale_index() {
+        let modes = vec![mode(1, "PCM"), mode(2, "SDM (DSD)")];
+        let state = HqpState {
+            mode: 2,
+            active_mode: 1,
+            ..HqpState::default()
+        };
+        let status = HqpStatus {
+            active_mode: "SDM (DSD)".to_string(),
+            ..HqpStatus::default()
+        };
+
+        assert_eq!(
+            HqpAdapter::active_mode_name(&modes, &state, &status),
+            "SDM (DSD)"
+        );
+    }
+
+    #[test]
+    fn live_mode_falls_back_to_state_only_when_status_omits_it() {
+        let modes = vec![mode(1, "PCM"), mode(2, "SDM (DSD)")];
+        let state = HqpState {
+            active_mode: 1,
+            ..HqpState::default()
+        };
+
+        assert_eq!(
+            HqpAdapter::active_mode_name(&modes, &state, &HqpStatus::default()),
+            "PCM"
+        );
+    }
+
+    #[test]
+    fn source_mode_uses_the_active_output_rate_to_name_the_loaded_chain() {
+        let modes = vec![mode(0, "[source]"), mode(1, "PCM"), mode(2, "SDM (DSD)")];
+        let state = HqpState {
+            mode: 0,
+            active_mode: 1,
+            ..HqpState::default()
+        };
+
+        let pcm = HqpStatus {
+            active_mode: "[source]".to_string(),
+            active_rate: 192_000,
+            ..HqpStatus::default()
+        };
+        assert_eq!(HqpAdapter::active_mode_name(&modes, &state, &pcm), "PCM");
+
+        let sdm = HqpStatus {
+            active_mode: "[source]".to_string(),
+            active_rate: 5_644_800,
+            ..HqpStatus::default()
+        };
+        assert_eq!(
+            HqpAdapter::active_mode_name(&modes, &state, &sdm),
+            "SDM (DSD)"
+        );
+    }
+
+    #[test]
+    fn rate_labels_match_hqptuners_user_facing_tiers_without_losing_frequency() {
+        assert_eq!(HqpAdapter::rate_label(0), "Auto");
+        assert_eq!(HqpAdapter::rate_label(352_800), "8× · 352.8 kHz");
+        assert_eq!(HqpAdapter::rate_label(384_000), "8× · 384 kHz");
+        assert_eq!(HqpAdapter::rate_label(5_644_800), "DSD128 · 5.6448 MHz");
+        assert_eq!(HqpAdapter::rate_label(6_144_000), "DSD128 · 6.144 MHz");
+        assert_eq!(HqpAdapter::rate_label(12_345), "12.345 kHz");
+    }
+
+    #[test]
+    fn source_following_mode_gets_a_human_label_without_changing_its_wire_value() {
+        assert_eq!(HqpAdapter::mode_label("[source]"), "Auto (follow source)");
+        assert_eq!(HqpAdapter::mode_label("PCM"), "PCM");
+        assert_eq!(HqpAdapter::mode_label("SDM (DSD)"), "SDM (DSD)");
+    }
+
+    #[test]
+    fn filter_labels_keep_the_native_name_and_its_daemon_authored_guidance() {
+        let mut described = filter(0, "poly-sinc-gauss-long");
+        described.description = Some("5/5 timbre, transients ⤣ Any".to_string());
+        assert_eq!(
+            HqpAdapter::filter_label(&described),
+            "poly-sinc-gauss-long · 5/5 timbre, transients ⤣ Any"
+        );
+        assert_eq!(
+            HqpAdapter::filter_label(&filter(1, "future-filter")),
+            "future-filter"
+        );
+    }
+
     fn mode(index: u32, name: &str) -> ListItem {
         ListItem {
             index,
@@ -10159,6 +10453,7 @@ mod chain_identity_tests {
             name: name.to_string(),
             value: 0,
             arg: 0,
+            description: None,
         }
     }
 

--- a/src/adapters/hqplayer.rs
+++ b/src/adapters/hqplayer.rs
@@ -2399,6 +2399,10 @@ struct HqpAdapterState {
     /// session or poll, and nothing in the contents distinguishes that from the cache never having
     /// been touched. Monotonic, bumped on every clear and every publication, and never reset.
     chain_generation: u64,
+    /// Last verified exact-rate pin for each forced output family. HQPlayer has only one live pin
+    /// and clears it on `SetMode`, so these restore the family being entered.
+    remembered_pcm_rate: Option<u32>,
+    remembered_sdm_rate: Option<u32>,
     volume_range: Option<VolumeRange>,
     /// The last volume capability this endpoint was ever *observed* to have (#328).
     ///
@@ -2463,6 +2467,8 @@ impl Default for HqpAdapterState {
             shapers_fingerprint: None,
             rates_fingerprint: None,
             chain_generation: 0,
+            remembered_pcm_rate: None,
+            remembered_sdm_rate: None,
             volume_range: None,
             last_observed_volume_range: None,
             profiles: Vec::new(),
@@ -2519,6 +2525,9 @@ pub struct HqpAdapter {
 }
 
 impl HqpAdapter {
+    const MAX_COVER_BYTES: usize = 16 * 1024 * 1024;
+    const MAX_COVER_REDIRECTS: usize = 4;
+
     fn store_captured_receipt(
         captured: &std::sync::Mutex<Option<NativeSettingReceipt>>,
         receipt: NativeSettingReceipt,
@@ -2754,6 +2763,8 @@ impl HqpAdapter {
                 // Clear every native-session cache when switching native endpoints.
                 state.info = None;
                 state.last_state = None;
+                state.remembered_pcm_rate = None;
+                state.remembered_sdm_rate = None;
                 // Through the common helper rather than by hand. The lists, the fingerprints that
                 // anchor them and the generation that dates them are one fact in three parts — a
                 // second spelling of the clearing is how one of the three gets left behind, and a
@@ -6175,6 +6186,43 @@ impl HqpAdapter {
         None
     }
 
+    fn receipt_verified(receipt: &NativeSettingReceipt) -> bool {
+        matches!(
+            receipt,
+            NativeSettingReceipt::DaemonAcknowledged {
+                readback: NativeSettingReadback::Verified
+            } | NativeSettingReceipt::NotAttempted {
+                readback: NativeSettingReadback::Noop,
+                ..
+            }
+        )
+    }
+
+    async fn remembered_rate(&self, family: ModeFamily) -> Option<u32> {
+        let state = self.state.read().await;
+        match family {
+            ModeFamily::Pcm => state.remembered_pcm_rate,
+            ModeFamily::Sdm => state.remembered_sdm_rate,
+            ModeFamily::Source => None,
+        }
+    }
+
+    async fn remember_rate_for_current_mode(&self, rate: u32, fence: Option<u64>) -> Result<()> {
+        let (modes, generation) = self.command_modes(fence).await?;
+        let current = self.get_state_on_transport(generation).await?;
+        let family = modes
+            .iter()
+            .find(|mode| mode.index == u32::from(current.mode))
+            .and_then(|mode| Self::mode_family(&mode.name));
+        let mut state = self.state.write().await;
+        match family {
+            Some(ModeFamily::Pcm) => state.remembered_pcm_rate = (rate != 0).then_some(rate),
+            Some(ModeFamily::Sdm) => state.remembered_sdm_rate = (rate != 0).then_some(rate),
+            _ => {}
+        }
+        Ok(())
+    }
+
     /// Resolve the mode currently reported by the running engine.
     ///
     /// `State.active_mode` is not the live output mode on the HQPlayer 6.0.4 daemon we support:
@@ -6334,7 +6382,7 @@ impl HqpAdapter {
     /// A mode the daemon is already in is **not written**. `SetMode` clears the exact-rate pin even
     /// when the mode does not change (HQP-C-017), so an unconditional write destroys a user's pinned
     /// rate for nothing. When a write is performed the chain reloads, so every chain-scoped list is
-    /// dropped and the pin the daemon just cleared is re-read rather than remembered.
+    /// dropped and re-read before a verified rate previously seen for the entered family is restored.
     /// The chain-transition hazard [`SemanticFamily`] describes cannot reach *this* family: `GetModes`
     /// is device-scoped, so the loaded chain moving does not renumber it. What can reshape it is a
     /// device or profile change — a PCM-only DAC's list has **no** SDM entry and the survivors keep
@@ -6348,7 +6396,7 @@ impl HqpAdapter {
     }
 
     async fn set_mode_under_operation(&self, mode_name: &str) -> Result<SettingOutcome> {
-        self.execute_mode_receipt_under_operation(mode_name, None)
+        self.execute_mode_with_rate_restore_under_operation(mode_name, None)
             .await?
             .into_setting_outcome("mode")
     }
@@ -6686,9 +6734,15 @@ impl HqpAdapter {
         // write; checking only once outside the bracket would let a transition to `[source]` during
         // the first attempt send a pin on the retry.
         let _operation_guard = self.operation_lock.lock().await;
-        self.execute_rate_receipt_under_operation(rate_value, None)
-            .await?
-            .into_setting_outcome("rate")
+        let receipt = self
+            .execute_rate_receipt_under_operation(rate_value, None)
+            .await?;
+        if Self::receipt_verified(&receipt) {
+            if let Err(error) = self.remember_rate_for_current_mode(rate_value, None).await {
+                tracing::warn!(%error, rate = rate_value, "could not retain verified HQPlayer rate pin");
+            }
+        }
+        receipt.into_setting_outcome("rate")
     }
 
     /// Execute one semantic pipeline command and retain typed native evidence for its caller.
@@ -6716,7 +6770,7 @@ impl HqpAdapter {
         let fence = Some(target.transport_generation);
         match setting {
             HqpNativeSetting::Mode(value) => {
-                self.execute_mode_receipt_under_operation(&value, fence)
+                self.execute_mode_with_rate_restore_under_operation(&value, fence)
                     .await
             }
             HqpNativeSetting::Filter1x(value) => {
@@ -6732,10 +6786,53 @@ impl HqpAdapter {
                     .await
             }
             HqpNativeSetting::Rate(value) => {
-                self.execute_rate_receipt_under_operation(value, fence)
-                    .await
+                let receipt = self
+                    .execute_rate_receipt_under_operation(value, fence)
+                    .await?;
+                if Self::receipt_verified(&receipt) {
+                    if let Err(error) = self.remember_rate_for_current_mode(value, fence).await {
+                        tracing::warn!(%error, rate = value, "could not retain verified HQPlayer rate pin");
+                    }
+                }
+                Ok(receipt)
             }
         }
+    }
+
+    async fn execute_mode_with_rate_restore_under_operation(
+        &self,
+        mode_name: &str,
+        fence: Option<u64>,
+    ) -> Result<NativeSettingReceipt> {
+        let receipt = self
+            .execute_mode_receipt_under_operation(mode_name, fence)
+            .await?;
+        let changed = matches!(
+            receipt,
+            NativeSettingReceipt::DaemonAcknowledged {
+                readback: NativeSettingReadback::Verified
+            }
+        );
+        if changed {
+            let remembered = match Self::mode_family(mode_name) {
+                Some(family) => self.remembered_rate(family).await,
+                None => None,
+            };
+            if let Some(rate) = remembered {
+                let rate_receipt = self
+                    .execute_rate_receipt_under_operation(rate, fence)
+                    .await?;
+                rate_receipt
+                    .into_setting_outcome("rate")?
+                    .into_applied_result()
+                    .with_context(|| {
+                        format!(
+                            "HQPlayer changed mode to {mode_name}, but could not restore its remembered {rate} Hz rate"
+                        )
+                    })?;
+            }
+        }
+        Ok(receipt)
     }
 
     async fn execute_mode_receipt_under_operation(
@@ -7792,6 +7889,24 @@ impl HqpAdapter {
             },
         };
 
+        // Seed the same per-family memory used by explicit SetRate calls from authoritative State.
+        // This lets an adapter that attached after another controller configured the engine preserve
+        // that family on later switches instead of learning only from its own writes.
+        if let Some(rate) = rates
+            .iter()
+            .find(|rate| rate.index == state.rate)
+            .map(|rate| rate.rate)
+            .filter(|rate| *rate != 0)
+        {
+            let family = Self::mode_family(&get_mode_by_index(state.mode));
+            let mut adapter_state = self.state.write().await;
+            match family {
+                Some(ModeFamily::Pcm) => adapter_state.remembered_pcm_rate = Some(rate),
+                Some(ModeFamily::Sdm) => adapter_state.remembered_sdm_rate = Some(rate),
+                _ => {}
+            }
+        }
+
         Ok(CoherentPipelineSnapshot {
             legacy,
             active_profile,
@@ -7833,6 +7948,18 @@ impl HqpAdapter {
     /// MD5 hash helper
     fn md5_hash(input: &str) -> String {
         format!("{:x}", md5::compute(input.as_bytes()))
+    }
+
+    fn cover_cache_key(status: &HqpStatus) -> String {
+        let identity = format!(
+            "{}\0{}\0{}\0{}\0{}",
+            status.track_id,
+            status.title.as_deref().unwrap_or_default(),
+            status.artist.as_deref().unwrap_or_default(),
+            status.album.as_deref().unwrap_or_default(),
+            status.length
+        );
+        format!("hqplayer:{}", Self::md5_hash(&identity))
     }
 
     /// Build digest auth header
@@ -8031,6 +8158,101 @@ impl HqpAdapter {
         }
 
         Ok(response.text().await?)
+    }
+
+    /// Fetch the artwork HQPlayer Embedded displays for its current track.
+    ///
+    /// The daemon serves bytes directly for local/library artwork and redirects streaming-service
+    /// artwork to a CDN. Redirects are followed explicitly because ordinary configuration reads
+    /// deliberately disable them to detect HQPlayer's operational-page redirects to `/about`.
+    pub async fn get_current_cover(&self) -> Result<crate::bus::ImageData> {
+        let path = "/cover/current";
+        let base_url = self.web_base_url().await?;
+        let url = format!("{base_url}{path}");
+
+        let send_origin = |authorization: Option<String>| {
+            let mut request = self.http_client.get(&url);
+            if let Some(value) = authorization {
+                request = request.header("Authorization", value);
+            }
+            request
+        };
+
+        let mut response = send_origin(self.build_digest_header("GET", path).await)
+            .send()
+            .await?;
+        if response.status() == reqwest::StatusCode::UNAUTHORIZED {
+            let challenge = response
+                .headers()
+                .get("www-authenticate")
+                .and_then(|value| value.to_str().ok())
+                .filter(|value| value.to_ascii_lowercase().starts_with("digest"))
+                .map(str::to_string)
+                .ok_or_else(|| anyhow!("HQPlayer cover authentication failed"))?;
+            self.parse_digest_challenge(&challenge).await;
+            response = send_origin(self.build_digest_header("GET", path).await)
+                .send()
+                .await?;
+        }
+
+        for redirect_count in 0..=Self::MAX_COVER_REDIRECTS {
+            if response.status().is_redirection() {
+                if redirect_count == Self::MAX_COVER_REDIRECTS {
+                    return Err(anyhow!("HQPlayer cover exceeded the redirect limit"));
+                }
+                let location = response
+                    .headers()
+                    .get("location")
+                    .and_then(|value| value.to_str().ok())
+                    .ok_or_else(|| anyhow!("HQPlayer cover redirect omitted Location"))?;
+                let next = response
+                    .url()
+                    .join(location)
+                    .context("HQPlayer cover redirect was not a valid URL")?;
+                if !matches!(next.scheme(), "http" | "https") {
+                    return Err(anyhow!(
+                        "HQPlayer cover redirect used unsupported scheme {}",
+                        next.scheme()
+                    ));
+                }
+                response = self.http_client.get(next).send().await?;
+                continue;
+            }
+
+            if !response.status().is_success() {
+                return Err(anyhow!(
+                    "HQPlayer cover request failed: {}",
+                    response.status()
+                ));
+            }
+            if response
+                .content_length()
+                .is_some_and(|length| length > Self::MAX_COVER_BYTES as u64)
+            {
+                return Err(anyhow!("HQPlayer cover exceeded the size limit"));
+            }
+
+            let content_type = response
+                .headers()
+                .get("content-type")
+                .and_then(|value| value.to_str().ok())
+                .map(|value| value.split(';').next().unwrap_or(value).trim().to_string())
+                .filter(|value| value.starts_with("image/"))
+                .ok_or_else(|| anyhow!("HQPlayer cover response was not an image"))?;
+            let mut data = Vec::new();
+            while let Some(chunk) = response.chunk().await? {
+                if data.len().saturating_add(chunk.len()) > Self::MAX_COVER_BYTES {
+                    return Err(anyhow!("HQPlayer cover exceeded the size limit"));
+                }
+                data.extend_from_slice(&chunk);
+            }
+            if data.is_empty() {
+                return Err(anyhow!("HQPlayer cover response was empty"));
+            }
+            return Ok(crate::bus::ImageData { content_type, data });
+        }
+
+        Err(anyhow!("HQPlayer cover redirect handling exhausted"))
     }
 
     /// Send one profile form request inside its dedicated whole-request budget.
@@ -8720,10 +8942,10 @@ impl HqpAdapter {
                 title: status.title.clone().unwrap_or_default(),
                 artist: status.artist.clone().unwrap_or_default(),
                 album: status.album.clone().unwrap_or_default(),
-                // Album art is explicitly unavailable rather than promised. Native `LibraryPicture`
-                // needs binary framing on a connection this client treats as XML-only, plus caps,
-                // authentication and cache policy — none of which #328 establishes.
-                image_key: None,
+                // HQPlayer Embedded exposes the current cover through its authenticated web lane.
+                // The key identifies the track rather than the URL: `/cover/current` is stable, so
+                // clients need this value to invalidate an earlier cover when playback advances.
+                image_key: Some(Self::cover_cache_key(status)),
                 seek_position: Some(status.position as f64),
                 duration: Some(status.length as f64),
                 metadata: Some(TrackMetadata {

--- a/src/adapters/hqplayer.rs
+++ b/src/adapters/hqplayer.rs
@@ -7459,7 +7459,34 @@ impl HqpAdapter {
     /// daemon moments even if the legacy response still looked plausible.
     async fn read_coherent_pipeline(&self) -> Result<CoherentPipelineSnapshot> {
         let _operation_guard = self.operation_lock.lock().await;
-        self.read_coherent_pipeline_under_operation().await
+        let snapshot = self.read_coherent_pipeline_under_operation().await?;
+        self.remember_rate_from_snapshot(&snapshot).await;
+        Ok(snapshot)
+    }
+
+    async fn remember_rate_from_snapshot(&self, snapshot: &CoherentPipelineSnapshot) {
+        let Some(rate) = snapshot
+            .chain
+            .rates
+            .iter()
+            .find(|rate| rate.index == snapshot.state.rate)
+            .map(|rate| rate.rate)
+            .filter(|rate| *rate != 0)
+        else {
+            return;
+        };
+        let family = snapshot
+            .chain
+            .modes
+            .iter()
+            .find(|mode| mode.index == u32::from(snapshot.state.mode))
+            .and_then(|mode| Self::mode_family(&mode.name));
+        let mut state = self.state.write().await;
+        match family {
+            Some(ModeFamily::Pcm) => state.remembered_pcm_rate = Some(rate),
+            Some(ModeFamily::Sdm) => state.remembered_sdm_rate = Some(rate),
+            _ => {}
+        }
     }
 
     async fn read_coherent_pipeline_under_operation(&self) -> Result<CoherentPipelineSnapshot> {
@@ -7888,24 +7915,6 @@ impl HqpAdapter {
                 },
             },
         };
-
-        // Seed the same per-family memory used by explicit SetRate calls from authoritative State.
-        // This lets an adapter that attached after another controller configured the engine preserve
-        // that family on later switches instead of learning only from its own writes.
-        if let Some(rate) = rates
-            .iter()
-            .find(|rate| rate.index == state.rate)
-            .map(|rate| rate.rate)
-            .filter(|rate| *rate != 0)
-        {
-            let family = Self::mode_family(&get_mode_by_index(state.mode));
-            let mut adapter_state = self.state.write().await;
-            match family {
-                Some(ModeFamily::Pcm) => adapter_state.remembered_pcm_rate = Some(rate),
-                Some(ModeFamily::Sdm) => adapter_state.remembered_sdm_rate = Some(rate),
-                _ => {}
-            }
-        }
 
         Ok(CoherentPipelineSnapshot {
             legacy,

--- a/src/aggregator.rs
+++ b/src/aggregator.rs
@@ -771,6 +771,7 @@ mod tests {
                 info: None,
             },
             pipeline: crate::adapters::hqplayer::PipelineStatus::default(),
+            active_profile: None,
             transport: HqpNativeTransportState::Stopped,
             metadata: HqpNativeMetadata {
                 track_id: None,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -116,7 +116,7 @@ impl AppState {
 
     /// Fetch image from the appropriate adapter based on zone_id prefix
     ///
-    /// Routes to the correct backend (Roon, LMS, OpenHome) based on the zone_id
+    /// Routes to the correct backend (Roon, LMS, OpenHome, HQPlayer) based on the zone_id
     /// prefix and fetches the image using that adapter's API.
     ///
     /// Note: UPnP zones don't support image retrieval as the protocol doesn't
@@ -148,6 +148,13 @@ impl AppState {
             anyhow::bail!(
                 "UPnP zones don't support image retrieval - the protocol doesn't expose album art URLs"
             )
+        } else if let Some(instance) = zone_id.strip_prefix("hqplayer:") {
+            let adapter = self
+                .hqp_instances
+                .get(instance)
+                .await
+                .ok_or_else(|| anyhow::anyhow!("Unknown HQPlayer instance: {instance}"))?;
+            adapter.get_current_cover().await?
         } else if zone_id.starts_with("roon:") || !zone_id.contains(':') {
             let img = self.roon.get_image(image_key, width, height).await?;
             ImageData {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1203,6 +1203,8 @@ async fn hqp_apply_named_setting(
         "mode" | "filter1x" | "filterNx" | "filternx" | "shaper" | "dither" | "junk_filter" => {
             value.to_string()
         }
+        "matrix_profile" if value.eq_ignore_ascii_case("[default]") => String::new(),
+        "matrix_profile" => value.to_string(),
         "convolution" | "adaptive_volume" | "random" => parse_hqp_bool(value)?.to_string(),
         "repeat" => parse_hqp_repeat(value)?.to_string(),
         "samplerate" | "rate" => {
@@ -1318,6 +1320,7 @@ pub async fn hqp_pipeline_update_handler(
         "adaptive_volume",
         "repeat",
         "random",
+        "matrix_profile",
     ];
     if !valid_settings.contains(&req.setting.as_str()) {
         return (
@@ -1358,19 +1361,16 @@ pub async fn hqp_pipeline_update_handler(
     };
 
     match result {
-        Ok(()) => {
-            // Publish verified readback first, then answer from the one shared state owner.
-            if refresh_hqp_advanced_aggregate(&state, "default")
-                .await
-                .is_ok()
-            {
-                if let Some(pipeline) = hqp_default_pipeline_from_aggregator(&state).await {
-                    return (StatusCode::OK, Json(pipeline)).into_response();
-                }
-            }
-            // Preserve the legacy success fallback when the post-write refresh cannot complete.
-            (StatusCode::OK, Json(serde_json::json!({"ok": true}))).into_response()
-        }
+        Ok(()) => match hqp_default_pipeline_from_aggregator(&state).await {
+            Some(pipeline) => (StatusCode::OK, Json(pipeline)).into_response(),
+            None => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(ErrorResponse {
+                    error: "HQPlayer accepted and verified the native setting, but its canonical pipeline readback is unavailable".to_string(),
+                }),
+            )
+                .into_response(),
+        },
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ErrorResponse {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1921,12 +1921,6 @@ pub async fn hqp_configure_handler(
     State(state): State<AppState>,
     Json(req): Json<HqpConfigRequest>,
 ) -> impl IntoResponse {
-    // Clear zone links for "default" instance - prevents stale data after host change
-    state
-        .hqp_zone_links
-        .remove_links_for_instance("default")
-        .await;
-
     // Configure the adapter
     state
         .hqplayer

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -13,7 +13,7 @@ use crate::bus::runtime::{
     CommandDeadlines, CommandGateway, CommandLane, CommandRequest, CommandStatus,
     HqpRuntimeCommand, RuntimeCommand,
 };
-use crate::bus::{Command, PrefixedZoneId, SharedBus};
+use crate::bus::{Command, HqpImageSource, PrefixedZoneId, SharedBus};
 use crate::coordinator::AdapterCoordinator;
 use crate::knobs::KnobStore;
 use axum::{
@@ -41,6 +41,7 @@ pub struct AppState {
     pub roon: Arc<RoonAdapter>,
     pub hqplayer: Arc<HqpAdapter>,
     pub hqp_instances: Arc<HqpInstanceManager>,
+    hqp_images: Arc<dyn HqpImageSource>,
     pub hqp_zone_links: Arc<HqpZoneLinkService>,
     pub lms: Arc<LmsAdapter>,
     pub openhome: Arc<OpenHomeAdapter>,
@@ -83,10 +84,12 @@ impl AppState {
         start_time: Instant,
         shutdown: CancellationToken,
     ) -> Self {
+        let hqp_images: Arc<dyn HqpImageSource> = hqp_instances.clone();
         Self {
             roon,
             hqplayer,
             hqp_instances,
+            hqp_images,
             hqp_zone_links,
             lms,
             openhome,
@@ -149,12 +152,7 @@ impl AppState {
                 "UPnP zones don't support image retrieval - the protocol doesn't expose album art URLs"
             )
         } else if let Some(instance) = zone_id.strip_prefix("hqplayer:") {
-            let adapter = self
-                .hqp_instances
-                .get(instance)
-                .await
-                .ok_or_else(|| anyhow::anyhow!("Unknown HQPlayer instance: {instance}"))?;
-            adapter.get_current_cover().await?
+            self.hqp_images.get_current_cover(instance).await?
         } else if zone_id.starts_with("roon:") || !zone_id.contains(':') {
             let img = self.roon.get_image(image_key, width, height).await?;
             ImageData {

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -201,6 +201,8 @@ pub struct HqpSettings {
     #[serde(rename = "filterNx")]
     pub filter_nx: Option<HqpSettingOptions>,
     pub shaper: Option<HqpSettingOptions>,
+    #[serde(rename = "shaperLabel")]
+    pub shaper_label: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
@@ -213,6 +215,10 @@ pub struct HqpSettingOptions {
 pub struct HqpOption {
     pub value: String,
     pub label: Option<String>,
+    #[serde(default)]
+    pub disabled: bool,
+    #[serde(default)]
+    pub reason: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
@@ -220,6 +226,8 @@ pub struct HqpProfile {
     pub name: Option<String>,
     pub title: Option<String>,
     pub value: Option<String>,
+    #[serde(default)]
+    pub active: bool,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]

--- a/src/app/components/hqp_controls.rs
+++ b/src/app/components/hqp_controls.rs
@@ -28,7 +28,11 @@ pub fn HqpProfileSelect(
                     on_select.call(value);
                 }
             },
-            option { value: "", "Profile..." }
+            option {
+                value: "",
+                selected: !profiles.iter().any(|profile| profile.active),
+                "(no preset)"
+            }
             for profile in profiles.iter() {
                 {
                     let value = profile
@@ -41,6 +45,7 @@ pub fn HqpProfileSelect(
                         option {
                             key: "{value}",
                             value: "{value}",
+                            selected: profile.active,
                             "{title}"
                         }
                     }
@@ -55,10 +60,10 @@ pub fn HqpProfileSelect(
 pub fn HqpMatrixSelect(
     /// Available matrix profiles to choose from
     profiles: Vec<HqpMatrixProfile>,
-    /// Currently active profile index (if any)
-    active: Option<u32>,
-    /// Called when a matrix profile is selected (passes the profile index)
-    on_select: EventHandler<u32>,
+    /// Currently active profile name. `None` is the unnamed `[Default]` matrix.
+    active: Option<String>,
+    /// Called with the native profile name; empty selects `[Default]`.
+    on_select: EventHandler<String>,
     /// Optional CSS class for the select element
     #[props(default = "input".to_string())]
     class: String,
@@ -71,16 +76,14 @@ pub fn HqpMatrixSelect(
             class: "{class}",
             disabled: disabled,
             onchange: move |evt| {
-                if let Ok(idx) = evt.value().parse::<u32>() {
-                    on_select.call(idx);
-                }
+                on_select.call(evt.value());
             },
-            option { value: "", "Matrix..." }
+            option { value: "", selected: active.is_none(), "[Default]" }
             for profile in profiles.iter() {
                 option {
                     key: "{profile.index}",
-                    value: "{profile.index}",
-                    selected: active == Some(profile.index),
+                    value: "{profile.name}",
+                    selected: active.as_deref() == Some(profile.name.as_str()),
                     "{profile.name}"
                 }
             }
@@ -95,12 +98,15 @@ pub fn HqpControlsCompact(
     profiles: Vec<HqpProfile>,
     /// Available matrix profiles
     matrix_profiles: Vec<HqpMatrixProfile>,
-    /// Currently active matrix profile index
-    active_matrix: Option<u32>,
+    /// Whether the matrix inventory was read successfully. The unnamed `[Default]` exists even
+    /// when there are no saved named profiles.
+    matrix_available: bool,
+    /// Currently active matrix profile name; `None` is the unnamed `[Default]` matrix.
+    active_matrix: Option<String>,
     /// Called when a profile is selected
     on_profile_select: EventHandler<String>,
     /// Called when a matrix profile is selected
-    on_matrix_select: EventHandler<u32>,
+    on_matrix_select: EventHandler<String>,
 ) -> Element {
     rsx! {
         div { class: "flex flex-wrap gap-2 mt-4",
@@ -111,7 +117,7 @@ pub fn HqpControlsCompact(
                     class: "input flex-1 min-w-0".to_string(),
                 }
             }
-            if !matrix_profiles.is_empty() {
+            if matrix_available {
                 HqpMatrixSelect {
                     profiles: matrix_profiles,
                     active: active_matrix,

--- a/src/app/pages/hqplayer.rs
+++ b/src/app/pages/hqplayer.rs
@@ -386,6 +386,7 @@ pub fn HqPlayer() -> Element {
                 hqp_error.set(Some(format!("Profile load failed: {e}")));
             } else {
                 pipeline.restart();
+                profiles.restart();
                 refresh_advanced_projection(matrix, matrix_refresh, false);
             }
             hqp_loading.set(false);
@@ -393,18 +394,20 @@ pub fn HqPlayer() -> Element {
     };
 
     // Set matrix profile handler
-    let set_matrix = move |profile_idx: u32| {
+    let set_matrix = move |profile_name: String| {
         hqp_error.set(None);
         hqp_loading.set(true);
         spawn(async move {
             #[derive(serde::Serialize)]
             struct MatrixRequest {
-                profile: u32,
+                setting: &'static str,
+                value: String,
             }
             let req = MatrixRequest {
-                profile: profile_idx,
+                setting: "matrix_profile",
+                value: profile_name,
             };
-            if let Err(e) = api::post_json_no_response("/hqplayer/matrix/profile", &req).await {
+            if let Err(e) = api::post_json_no_response("/hqp/pipeline", &req).await {
                 hqp_error.set(Some(format!("Matrix profile failed: {e}")));
             } else {
                 refresh_advanced_projection(matrix, matrix_refresh, false);
@@ -568,7 +571,11 @@ pub fn HqPlayer() -> Element {
 
 #[cfg(test)]
 mod tests {
-    use super::{hqplayer_mute_control, CoalescingRefresh};
+    use super::{
+        filter_hqp_options, format_hqp_rate, hqp_live_mode_readout, hqp_live_output_readout,
+        hqp_shaper_minimum_rate_hz, hqplayer_mute_control, CoalescingRefresh,
+    };
+    use crate::app::api::{HqpOption, HqpPipelineStatus, HqpSettingOptions};
 
     #[test]
     fn advanced_refreshes_never_overlap_and_coalesce_bursts() {
@@ -608,6 +615,120 @@ mod tests {
         let floored = hqplayer_mute_control(Some(-60.0), Some(-60.0));
         assert_eq!(floored.label, "At minimum volume");
         assert!(floored.disabled);
+    }
+
+    #[test]
+    fn active_rates_are_presented_as_human_frequencies() {
+        assert_eq!(format_hqp_rate(44_100), "44.1 kHz");
+        assert_eq!(format_hqp_rate(384_000), "384 kHz");
+        assert_eq!(format_hqp_rate(5_644_800), "5.6448 MHz");
+    }
+
+    #[test]
+    fn stopped_and_paused_engines_do_not_advertise_stale_mode_or_output() {
+        for state in ["Stopped", "Paused"] {
+            let status = HqpPipelineStatus {
+                state: Some(state.to_string()),
+                mode: Some("SDM (DSD)".to_string()),
+                active_mode: Some("PCM".to_string()),
+                active_rate: Some(5_644_800),
+                ..HqpPipelineStatus::default()
+            };
+
+            assert_eq!(hqp_live_mode_readout(&status), "—");
+            assert_eq!(hqp_live_output_readout(&status), "—");
+        }
+    }
+
+    #[test]
+    fn playing_engine_readouts_use_only_active_mode_and_rate() {
+        let status = HqpPipelineStatus {
+            state: Some("Playing".to_string()),
+            mode: Some("PCM".to_string()),
+            active_mode: Some("SDM (DSD)".to_string()),
+            active_rate: Some(5_644_800),
+            ..HqpPipelineStatus::default()
+        };
+
+        assert_eq!(hqp_live_mode_readout(&status), "SDM (DSD)");
+        assert_eq!(hqp_live_output_readout(&status), "5.6448 MHz");
+    }
+
+    #[test]
+    fn filter_search_keeps_the_current_choice_visible_without_lying_about_matches() {
+        let options = vec![
+            HqpOption {
+                value: "poly-sinc-gauss-long".to_string(),
+                label: None,
+                disabled: false,
+                reason: None,
+            },
+            HqpOption {
+                value: "poly-sinc-ext2-hires-lp".to_string(),
+                label: None,
+                disabled: false,
+                reason: None,
+            },
+            HqpOption {
+                value: "IIR".to_string(),
+                label: None,
+                disabled: false,
+                reason: None,
+            },
+        ];
+
+        let filtered = filter_hqp_options(&options, "hires", "poly-sinc-gauss-long");
+        assert_eq!(
+            filtered
+                .iter()
+                .map(|option| option.value.as_str())
+                .collect::<Vec<_>>(),
+            vec!["poly-sinc-gauss-long", "poly-sinc-ext2-hires-lp"]
+        );
+    }
+
+    #[test]
+    fn hqptuner_rate_gates_are_applied_to_rate_specific_modulators() {
+        assert_eq!(hqp_shaper_minimum_rate_hz("DSD7 256+fs"), Some(10_240_000));
+        assert_eq!(
+            hqp_shaper_minimum_rate_hz("ASDM7EC-fast 512+fs"),
+            Some(22_579_200)
+        );
+        assert_eq!(
+            hqp_shaper_minimum_rate_hz("AMSDM7EC 512+fs"),
+            Some(20_480_000)
+        );
+        assert_eq!(hqp_shaper_minimum_rate_hz("AHM7EC8B"), Some(40_960_000));
+        assert_eq!(hqp_shaper_minimum_rate_hz("ASDM7EC-fast"), None);
+    }
+
+    #[test]
+    fn rate_specific_modulators_stay_visible_but_explain_why_they_are_unavailable() {
+        let options = HqpSettingOptions {
+            options: vec![
+                HqpOption {
+                    value: "ASDM7EC-fast".to_string(),
+                    label: Some("ASDM7EC-fast".to_string()),
+                    disabled: false,
+                    reason: None,
+                },
+                HqpOption {
+                    value: "ASDM7EC-fast 512+fs".to_string(),
+                    label: Some("ASDM7EC-fast 512+fs".to_string()),
+                    disabled: false,
+                    reason: None,
+                },
+            ],
+            selected: None,
+        };
+
+        let guided = super::apply_hqp_shaper_rate_guidance(options, 11_289_600);
+        assert!(!guided.options[0].disabled);
+        assert!(guided.options[1].disabled);
+        assert_eq!(
+            guided.options[1].reason.as_deref(),
+            Some("needs at least 22.5792 MHz")
+        );
     }
 }
 
@@ -919,7 +1040,7 @@ fn DspSettings(
     loading: bool,
     on_set_pipeline: EventHandler<(String, String)>,
     on_load_profile: EventHandler<String>,
-    on_set_matrix: EventHandler<u32>,
+    on_set_matrix: EventHandler<String>,
 ) -> Element {
     let Some(ref pipe) = pipeline else {
         return rsx! {
@@ -937,19 +1058,23 @@ fn DspSettings(
     let samplerate_opts = settings.and_then(|s| s.samplerate.clone());
     let filter1x_opts = settings.and_then(|s| s.filter1x.clone());
     let filter_nx_opts = settings.and_then(|s| s.filter_nx.clone());
-    let shaper_opts = settings.and_then(|s| s.shaper.clone());
+    let shaper_opts = settings.and_then(|s| s.shaper.clone()).map(|options| {
+        let selected_rate = samplerate_opts
+            .as_ref()
+            .and_then(|rates| rates.selected.as_ref())
+            .and_then(|rate| rate.value.parse::<u32>().ok())
+            .unwrap_or_default();
+        apply_hqp_shaper_rate_guidance(options, selected_rate)
+    });
 
-    let has_matrix = matrix
-        .as_ref()
-        .map(|m| !m.profiles.is_empty())
-        .unwrap_or(false);
+    let has_matrix = matrix.is_some();
     let matrix_profiles = matrix
         .as_ref()
         .map(|m| m.profiles.clone())
         .unwrap_or_default();
     let matrix_current = matrix
         .as_ref()
-        .and_then(|m| m.current.as_ref().map(|profile| profile.index));
+        .and_then(|m| m.current.as_ref().map(|profile| profile.name.clone()));
     let junk_filter_opts = matrix.as_ref().and_then(|advanced| {
         if advanced.junk_filters.is_empty() {
             return None;
@@ -962,6 +1087,8 @@ fn DspSettings(
                 .map(|choice| crate::app::api::HqpOption {
                     value: choice.name.clone(),
                     label: Some(choice.name.clone()),
+                    disabled: false,
+                    reason: None,
                 })
         });
         Some(crate::app::api::HqpSettingOptions {
@@ -971,6 +1098,8 @@ fn DspSettings(
                 .map(|choice| crate::app::api::HqpOption {
                     value: choice.name.clone(),
                     label: Some(choice.name.clone()),
+                    disabled: false,
+                    reason: None,
                 })
                 .collect(),
             selected,
@@ -985,12 +1114,16 @@ fn DspSettings(
                     .map(|(value, label)| crate::app::api::HqpOption {
                         value: (*value).to_string(),
                         label: Some((*label).to_string()),
+                        disabled: false,
+                        reason: None,
                     })
                     .collect(),
                 selected: choices.get(usize::from(selected)).map(|(value, label)| {
                     crate::app::api::HqpOption {
                         value: (*value).to_string(),
                         label: Some((*label).to_string()),
+                        disabled: false,
+                        reason: None,
                     }
                 }),
             }
@@ -1002,21 +1135,9 @@ fn DspSettings(
         .and_then(|advanced| advanced.adaptive_volume);
     let random = matrix.as_ref().and_then(|advanced| advanced.random);
 
-    // Dynamic shaper label based on mode
-    // SDM/DSD mode = "Modulator", PCM mode = "Shaper" (not "Dither")
-    let shaper_label = mode_opts
-        .as_ref()
-        .and_then(|m| m.selected.as_ref())
-        .and_then(|s| s.label.as_ref())
-        .map(|label| {
-            let lower = label.to_lowercase();
-            if lower.contains("sdm") || lower.contains("dsd") {
-                "Modulator"
-            } else {
-                "Shaper" // PCM mode uses noise shaping, not dithering
-            }
-        })
-        .unwrap_or("Shaper");
+    let shaper_label = settings
+        .and_then(|settings| settings.shaper_label.clone())
+        .unwrap_or_else(|| "Dither / modulator".to_string());
 
     rsx! {
         div { class: "card p-6",
@@ -1032,10 +1153,10 @@ fn DspSettings(
                     h3 { class: "text-sm font-semibold mb-3", "Live engine state" }
                     dl { class: "grid grid-cols-2 gap-x-4 gap-y-3 sm:grid-cols-3 lg:grid-cols-5",
                         HqpReadout { label: "Engine", value: status.state.clone().unwrap_or_else(|| "Unknown".to_string()) }
-                        HqpReadout { label: "Mode", value: status.active_mode.clone().or_else(|| status.mode.clone()).unwrap_or_else(|| "—".to_string()) }
+                        HqpReadout { label: "Mode", value: hqp_live_mode_readout(status) }
                         HqpReadout { label: "Filter", value: status.active_filter.clone().unwrap_or_else(|| "—".to_string()) }
-                        HqpReadout { label: "Modulator / shaper", value: status.active_shaper.clone().unwrap_or_else(|| "—".to_string()) }
-                        HqpReadout { label: "Output", value: status.active_rate.map(format_hqp_rate).unwrap_or_else(|| "—".to_string()) }
+                        HqpReadout { label: "Dither / modulator", value: status.active_shaper.clone().unwrap_or_else(|| "—".to_string()) }
+                        HqpReadout { label: "Output", value: hqp_live_output_readout(status) }
                     }
                 }
             }
@@ -1090,6 +1211,8 @@ fn DspSettings(
                     label: "Filter (1x)",
                     setting: "filter1x",
                     options: filter1x_opts,
+                    searchable: true,
+                    hint: "Base-rate sources below 50 kHz. Search by family or suffix, such as gauss, hires, -lp, -mp, or -ip.",
                     disabled: loading,
                     on_change: on_set_pipeline,
                 }
@@ -1098,6 +1221,8 @@ fn DspSettings(
                     label: "Filter (Nx)",
                     setting: "filterNx",
                     options: filter_nx_opts,
+                    searchable: true,
+                    hint: "Sources at 2× and above. Search by family or suffix, such as gauss, hires, -lp, -mp, or -ip.",
                     disabled: loading,
                     on_change: on_set_pipeline,
                 }
@@ -1106,6 +1231,8 @@ fn DspSettings(
                     label: shaper_label,
                     setting: "shaper",
                     options: shaper_opts,
+                    searchable: true,
+                    hint: "PCM uses dither/noise shaping; SDM uses a sigma-delta modulator. Names ending 256+fs or 512+fs require those output-rate tiers.",
                     disabled: loading,
                     on_change: on_set_pipeline,
                 }
@@ -1184,13 +1311,48 @@ fn HqpReadout(label: &'static str, value: String) -> Element {
 }
 
 fn format_hqp_rate(rate: u64) -> String {
-    if rate >= 1_000_000 && rate.is_multiple_of(1_000_000) {
-        format!("{} MHz", rate / 1_000_000)
-    } else if rate >= 1_000 && rate.is_multiple_of(1_000) {
-        format!("{} kHz", rate / 1_000)
+    let (scaled, unit, precision) = if rate >= 1_000_000 {
+        (rate as f64 / 1_000_000.0, "MHz", 4)
+    } else if rate >= 1_000 {
+        (rate as f64 / 1_000.0, "kHz", 3)
     } else {
-        format!("{rate} Hz")
+        return format!("{rate} Hz");
+    };
+    let mut number = format!("{scaled:.precision$}");
+    while number.contains('.') && number.ends_with('0') {
+        number.pop();
     }
+    if number.ends_with('.') {
+        number.pop();
+    }
+    format!("{number} {unit}")
+}
+
+fn hqp_engine_is_playing(status: &crate::app::api::HqpPipelineStatus) -> bool {
+    status.state.as_deref() == Some("Playing")
+}
+
+fn hqp_live_mode_readout(status: &crate::app::api::HqpPipelineStatus) -> String {
+    if !hqp_engine_is_playing(status) {
+        return "—".to_string();
+    }
+    status
+        .active_mode
+        .as_deref()
+        .filter(|mode| !mode.trim().is_empty())
+        .unwrap_or("—")
+        .to_string()
+}
+
+fn hqp_live_output_readout(status: &crate::app::api::HqpPipelineStatus) -> String {
+    if !hqp_engine_is_playing(status) {
+        return "—".to_string();
+    }
+    status
+        .active_rate
+        .filter(|rate| *rate > 0)
+        .map(format_hqp_rate)
+        .unwrap_or_else(|| "—".to_string())
 }
 
 #[component]
@@ -1225,9 +1387,11 @@ fn HqpToggle(
 #[component]
 fn HqpSelect(
     id: &'static str,
-    label: &'static str,
+    label: String,
     setting: &'static str,
     options: Option<crate::app::api::HqpSettingOptions>,
+    #[props(default = false)] searchable: bool,
+    #[props(default)] hint: Option<&'static str>,
     #[props(default = false)] disabled: bool,
     on_change: EventHandler<(String, String)>,
 ) -> Element {
@@ -1240,11 +1404,29 @@ fn HqpSelect(
         .and_then(|o| o.selected.as_ref())
         .map(|s| s.value.clone())
         .unwrap_or_default();
+    let mut query = use_signal(String::new);
+    let visible_options = if searchable {
+        filter_hqp_options(&opts_list, &query(), &selected)
+    } else {
+        opts_list.clone()
+    };
+    let total_options = opts_list.len();
     let setting_name = setting.to_string();
 
     rsx! {
         label {
             span { class: "block text-sm font-medium mb-1", "{label}" }
+            if searchable {
+                input {
+                    r#type: "search",
+                    class: "input mb-2",
+                    value: "{query}",
+                    placeholder: "Search {total_options} choices…",
+                    disabled: disabled,
+                    aria_label: "Search {label}",
+                    oninput: move |evt| query.set(evt.value()),
+                }
+            }
             select {
                 id: "{id}",
                 class: "input",
@@ -1253,16 +1435,85 @@ fn HqpSelect(
                     let value = evt.value();
                     on_change.call((setting_name.clone(), value));
                 },
-                for opt in opts_list {
+                for opt in visible_options {
                     option {
                         value: "{opt.value}",
                         selected: opt.value == selected,
-                        "{opt.label.as_deref().unwrap_or(&opt.value)}"
+                        disabled: opt.disabled,
+                        if let Some(reason) = opt.reason.as_deref() {
+                            "{opt.label.as_deref().unwrap_or(&opt.value)} — {reason}"
+                        } else {
+                            "{opt.label.as_deref().unwrap_or(&opt.value)}"
+                        }
                     }
                 }
             }
+            if let Some(hint) = hint {
+                span { class: "block text-xs text-muted mt-1", "{hint}" }
+            }
         }
     }
+}
+
+fn filter_hqp_options(
+    options: &[crate::app::api::HqpOption],
+    query: &str,
+    selected: &str,
+) -> Vec<crate::app::api::HqpOption> {
+    let needle = query.trim().to_lowercase();
+    if needle.is_empty() {
+        return options.to_vec();
+    }
+    options
+        .iter()
+        .filter(|option| {
+            option.value == selected
+                || option.value.to_lowercase().contains(&needle)
+                || option
+                    .label
+                    .as_deref()
+                    .is_some_and(|label| label.to_lowercase().contains(&needle))
+        })
+        .cloned()
+        .collect()
+}
+
+fn hqp_shaper_minimum_rate_hz(name: &str) -> Option<u32> {
+    // HQPTuner's 1.7.0 metadata keeps these choices visible and applies the documented family
+    // floors. The native shaper enumeration has names but no constraint attributes, so match only
+    // the explicit rate-bearing families and leave every unknown future choice available.
+    if name.starts_with("AHM") {
+        Some(40_960_000)
+    } else if name.starts_with("AMSDM") && name.contains("512+fs") {
+        Some(20_480_000)
+    } else if name.contains("512+fs") {
+        Some(22_579_200)
+    } else if name.contains("256+fs") {
+        Some(10_240_000)
+    } else {
+        None
+    }
+}
+
+fn apply_hqp_shaper_rate_guidance(
+    mut options: crate::app::api::HqpSettingOptions,
+    selected_rate: u32,
+) -> crate::app::api::HqpSettingOptions {
+    if selected_rate == 0 {
+        return options;
+    }
+    for option in &mut options.options {
+        if let Some(minimum) = hqp_shaper_minimum_rate_hz(&option.value) {
+            if selected_rate < minimum {
+                option.disabled = true;
+                option.reason = Some(format!(
+                    "needs at least {}",
+                    format_hqp_rate(u64::from(minimum))
+                ));
+            }
+        }
+    }
+    options
 }
 
 /// Zone link selector component - simplified single dropdown

--- a/src/app/pages/hqplayer.rs
+++ b/src/app/pages/hqplayer.rs
@@ -60,6 +60,13 @@ struct ZoneUnlinkRequest {
     zone_id: String,
 }
 
+#[derive(Clone, Debug, PartialEq)]
+enum ZoneMatchFeedback {
+    Saved,
+    Removed,
+    Error(String),
+}
+
 /// Control request body
 #[derive(Clone, serde::Serialize)]
 struct ControlRequest {
@@ -157,6 +164,8 @@ pub fn HqPlayer() -> Element {
     // HQP state
     let mut hqp_loading = use_signal(|| false);
     let mut hqp_error = use_signal(|| None::<String>);
+    let mut zone_match_busy = use_signal(|| false);
+    let mut zone_match_feedback = use_signal(|| None::<ZoneMatchFeedback>);
 
     // Now playing for linked zones
     let mut now_playing_map = use_signal(std::collections::HashMap::<String, NowPlaying>::new);
@@ -202,6 +211,29 @@ pub fn HqPlayer() -> Element {
         api::fetch_json::<InstancesResponse>("/hqp/instances")
             .await
             .ok()
+    });
+    let mut zones_loaded_once = use_signal(|| false);
+    let mut zone_links_loaded_once = use_signal(|| false);
+    let mut instances_loaded_once = use_signal(|| false);
+
+    let zones_state = zones.state();
+    use_effect(move || {
+        if !zones_loaded_once() && matches!(*zones_state.read(), UseResourceState::Ready) {
+            zones_loaded_once.set(true);
+        }
+    });
+    let zone_links_state = zone_links.state();
+    use_effect(move || {
+        if !zone_links_loaded_once() && matches!(*zone_links_state.read(), UseResourceState::Ready)
+        {
+            zone_links_loaded_once.set(true);
+        }
+    });
+    let instances_state = instances.state();
+    use_effect(move || {
+        if !instances_loaded_once() && matches!(*instances_state.read(), UseResourceState::Ready) {
+            instances_loaded_once.set(true);
+        }
     });
 
     // Sync config to form when loaded
@@ -418,19 +450,45 @@ pub fn HqPlayer() -> Element {
 
     // Zone link handler
     let link_zone = move |(zone_id, instance): (String, String)| {
+        zone_match_busy.set(true);
+        zone_match_feedback.set(None);
         spawn(async move {
             let req = ZoneLinkRequest { zone_id, instance };
-            let _ = api::post_json_no_response("/hqp/zones/link", &req).await;
-            zone_links.restart();
+            match api::post_json_no_response("/hqp/zones/link", &req).await {
+                Ok(()) => {
+                    zone_match_feedback.set(Some(ZoneMatchFeedback::Saved));
+                    zone_links.restart();
+                    zones.restart();
+                }
+                Err(error) => {
+                    zone_match_feedback.set(Some(ZoneMatchFeedback::Error(format!(
+                        "Could not save the zone match: {error}"
+                    ))));
+                }
+            }
+            zone_match_busy.set(false);
         });
     };
 
     // Zone unlink handler
     let unlink_zone = move |zone_id: String| {
+        zone_match_busy.set(true);
+        zone_match_feedback.set(None);
         spawn(async move {
             let req = ZoneUnlinkRequest { zone_id };
-            let _ = api::post_json_no_response("/hqp/zones/unlink", &req).await;
-            zone_links.restart();
+            match api::post_json_no_response("/hqp/zones/unlink", &req).await {
+                Ok(()) => {
+                    zone_match_feedback.set(Some(ZoneMatchFeedback::Removed));
+                    zone_links.restart();
+                    zones.restart();
+                }
+                Err(error) => {
+                    zone_match_feedback.set(Some(ZoneMatchFeedback::Error(format!(
+                        "Could not remove the zone match: {error}"
+                    ))));
+                }
+            }
+            zone_match_busy.set(false);
         });
     };
 
@@ -441,12 +499,20 @@ pub fn HqPlayer() -> Element {
     let matrix_data = matrix.read().clone();
     let zones_list = zones_list_signal();
     let links_list = links_signal();
+    let mut zone_match_key_parts = links_list
+        .iter()
+        .map(|link| format!("{}={}", link.zone_id, link.instance))
+        .collect::<Vec<_>>();
+    zone_match_key_parts.sort();
+    let zone_match_key = zone_match_key_parts.join("|");
     let instances_list = instances
         .read()
         .clone()
         .flatten()
         .map(|r| r.instances)
         .unwrap_or_default();
+    let zone_match_resources_loaded =
+        zones_loaded_once() && zone_links_loaded_once() && instances_loaded_once();
     let np_map = now_playing_map();
 
     let controlled_zones = controlled_zones_signal();
@@ -552,14 +618,23 @@ pub fn HqPlayer() -> Element {
                 }
             }
 
-            // Zone Linking section
+            // Zone matching section
             section { id: "hqp-zone-links", class: "mb-8",
-                h2 { class: "text-lg font-semibold mb-4", "Zone Linking" }
-                div { class: "card p-6",
+                div { class: "mb-4 max-w-3xl",
+                    h2 { class: "text-lg font-semibold", "Zone matching" }
+                    p { class: "mt-1 text-sm text-muted",
+                        "Match a playback zone that already sends audio through HQPlayer. This combines playback and DSP controls; it does not change audio routing."
+                    }
+                }
+                div { class: "card overflow-hidden",
                     ZoneLinkTable {
+                        key: "{zone_match_key}",
                         zones: zones_list,
                         links: links_list,
                         instances: instances_list,
+                        resources_loaded: zone_match_resources_loaded,
+                        busy: zone_match_busy(),
+                        feedback: zone_match_feedback(),
                         on_link: link_zone,
                         on_unlink: unlink_zone,
                     }
@@ -573,7 +648,9 @@ pub fn HqPlayer() -> Element {
 mod tests {
     use super::{
         filter_hqp_options, format_hqp_rate, hqp_live_mode_readout, hqp_live_output_readout,
-        hqp_shaper_minimum_rate_hz, hqplayer_mute_control, CoalescingRefresh,
+        hqp_shaper_minimum_rate_hz, hqplayer_mute_control, is_zone_match_candidate,
+        normalized_match_selection, zone_match_availability, CoalescingRefresh,
+        ZoneMatchAvailability,
     };
     use crate::app::api::{HqpOption, HqpPipelineStatus, HqpSettingOptions};
 
@@ -728,6 +805,44 @@ mod tests {
         assert_eq!(
             guided.options[1].reason.as_deref(),
             Some("needs at least 22.5792 MHz")
+        );
+    }
+
+    #[test]
+    fn zone_matching_distinguishes_loading_from_an_empty_system() {
+        assert_eq!(
+            zone_match_availability(false, 0, 0),
+            ZoneMatchAvailability::Loading,
+            "pending zone, link, and instance reads are not an empty system"
+        );
+    }
+
+    #[test]
+    fn zone_matching_only_offers_unmatched_playback_zones() {
+        assert!(is_zone_match_candidate(
+            "roon:hqplayer-dsp",
+            Some("roon"),
+            false
+        ));
+        assert!(!is_zone_match_candidate(
+            "hqplayer:default",
+            Some("hqplayer"),
+            false
+        ));
+        assert!(!is_zone_match_candidate(
+            "roon:already-matched",
+            Some("roon"),
+            true
+        ));
+    }
+
+    #[test]
+    fn zone_matching_moves_selection_after_the_selected_zone_is_saved() {
+        let choices = vec!["roon:bedroom".to_string(), "roon:patio".to_string()];
+        assert_eq!(
+            normalized_match_selection("roon:just-saved", &choices),
+            "roon:bedroom",
+            "a saved zone disappears from the candidate list, so the form must select a valid next choice"
         );
     }
 }
@@ -1516,131 +1631,272 @@ fn apply_hqp_shaper_rate_guidance(
     options
 }
 
-/// Zone link selector component - simplified single dropdown
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ZoneMatchAvailability {
+    Loading,
+    Ready,
+    NoPlaybackZones,
+    NoInstances,
+}
+
+fn zone_match_availability(
+    resources_loaded: bool,
+    candidate_count: usize,
+    instance_count: usize,
+) -> ZoneMatchAvailability {
+    if !resources_loaded {
+        ZoneMatchAvailability::Loading
+    } else if instance_count == 0 {
+        ZoneMatchAvailability::NoInstances
+    } else if candidate_count == 0 {
+        ZoneMatchAvailability::NoPlaybackZones
+    } else {
+        ZoneMatchAvailability::Ready
+    }
+}
+
+fn is_zone_match_candidate(zone_id: &str, source: Option<&str>, already_linked: bool) -> bool {
+    !already_linked && source != Some("hqplayer") && !zone_id.starts_with("hqplayer:")
+}
+
+fn normalized_match_selection(current: &str, choices: &[String]) -> String {
+    if choices.iter().any(|choice| choice == current) {
+        current.to_string()
+    } else {
+        choices.first().cloned().unwrap_or_default()
+    }
+}
+
+fn playback_source_label(source: Option<&str>) -> String {
+    match source {
+        Some("roon") => "Roon".to_string(),
+        Some("lms") => "LMS".to_string(),
+        Some("openhome") => "OpenHome".to_string(),
+        Some("upnp") => "UPnP".to_string(),
+        Some(other) => other.to_string(),
+        None => "Playback zone".to_string(),
+    }
+}
+
+/// Shows every persisted source-zone match and lets the user add another one.
 #[component]
 fn ZoneLinkTable(
     zones: Vec<Zone>,
     links: Vec<ZoneLink>,
     instances: Vec<HqpInstance>,
+    resources_loaded: bool,
+    busy: bool,
+    feedback: Option<ZoneMatchFeedback>,
     on_link: EventHandler<(String, String)>,
     on_unlink: EventHandler<String>,
 ) -> Element {
-    if zones.is_empty() {
-        return rsx! {
-            p { class: "text-muted", "No audio zones available." }
-        };
-    }
+    let mut current_links = links.clone();
+    current_links.sort_by(|left, right| left.zone_id.cmp(&right.zone_id));
 
-    // Find currently linked zone (if any)
-    let linked_zone = links.first().cloned();
-    let _linked_zone_id = linked_zone.as_ref().map(|l| l.zone_id.clone());
-    let linked_instance = linked_zone.as_ref().map(|l| l.instance.clone());
+    let mut candidates = zones
+        .iter()
+        .filter(|zone| {
+            let already_linked = links.iter().any(|link| link.zone_id == zone.zone_id);
+            is_zone_match_candidate(&zone.zone_id, zone.source.as_deref(), already_linked)
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    candidates.sort_by(|left, right| left.zone_name.cmp(&right.zone_name));
+    let candidate_ids = candidates
+        .iter()
+        .map(|zone| zone.zone_id.clone())
+        .collect::<Vec<_>>();
 
-    // Default instance for new links (empty string if none configured)
     let default_instance = instances
         .first()
         .map(|i| i.name.clone())
         .unwrap_or_default();
-
-    // First zone ID (computed each render from props)
-    let first_zone_id = zones.first().map(|z| z.zone_id.clone()).unwrap_or_default();
-
-    // Selected zone - initialize to first zone if available
+    let first_zone_id = candidates
+        .first()
+        .map(|zone| zone.zone_id.clone())
+        .unwrap_or_default();
     let mut selected_zone = use_signal(|| first_zone_id.clone());
-    let mut selected_instance =
-        use_signal(|| linked_instance.clone().unwrap_or(default_instance.clone()));
-
-    // Clone for onclick closure
-    let first_zone_for_click = first_zone_id.clone();
+    let mut selected_instance = use_signal(|| default_instance.clone());
+    let candidate_ids_for_click = candidate_ids.clone();
     let default_instance_for_click = default_instance.clone();
-
-    let has_multiple_instances = instances.len() > 1;
+    let availability = zone_match_availability(resources_loaded, candidates.len(), instances.len());
+    let feedback_copy = feedback.as_ref().map(|state| match state {
+        ZoneMatchFeedback::Saved => (
+            false,
+            "Zone match saved. It will remain after restarts.".to_string(),
+        ),
+        ZoneMatchFeedback::Removed => (false, "Zone match removed.".to_string()),
+        ZoneMatchFeedback::Error(message) => (true, message.clone()),
+    });
 
     rsx! {
-        if let Some(ref link) = linked_zone {
-            // Currently linked - show linked zone with unlink option
+        div { class: "px-5 py-5 sm:px-6",
+            if current_links.is_empty()
+                && matches!(
+                    availability,
+                    ZoneMatchAvailability::Ready | ZoneMatchAvailability::NoPlaybackZones
+                )
             {
+                div { class: "mb-5",
+                    h3 { class: "font-semibold", "No saved matches" }
+                    p { class: "mt-1 text-sm text-muted",
+                        "Choose the playback zone that already uses this HQPlayer."
+                    }
+                }
+            }
+
+            if !current_links.is_empty() {
+                div { class: "mb-6",
+                    h3 { class: "font-semibold", "Saved matches" }
+                    p { class: "mt-1 text-sm text-muted",
+                        "These matches are stored by Unified Hi-Fi Control and remain after restarts."
+                    }
+                    div { class: "mt-4 divide-y divide-[var(--border-default)]",
+                        for link in current_links.iter() {
+                            {
                 let zone_name = zones
                     .iter()
                     .find(|z| z.zone_id == link.zone_id)
                     .map(|z| z.zone_name.clone())
                     .unwrap_or_else(|| link.zone_id.clone());
+                                let source = zones
+                                    .iter()
+                                    .find(|z| z.zone_id == link.zone_id)
+                                    .and_then(|z| z.source.as_deref());
+                                let source_label = playback_source_label(source);
+                                let instance_detail = instances
+                                    .iter()
+                                    .find(|instance| instance.name == link.instance)
+                                    .and_then(|instance| instance.host.as_deref())
+                                    .map(|host| format!("{} at {}", link.instance, host))
+                                    .unwrap_or_else(|| link.instance.clone());
                 let zone_id = link.zone_id.clone();
                 rsx! {
-                    div { class: "flex items-center gap-4 flex-wrap",
-                        div { class: "flex items-center gap-2",
-                            span { class: "text-muted", "Linked to" }
-                            span { class: "font-semibold", "{zone_name}" }
-                            if has_multiple_instances {
-                                span { class: "text-muted", "on" }
-                                span { class: "font-semibold", "{link.instance}" }
+                                    div { class: "flex flex-col gap-3 py-4 first:pt-0 last:pb-0 sm:flex-row sm:items-center sm:justify-between",
+                                        div { class: "min-w-0",
+                                            div { class: "flex flex-wrap items-center gap-2",
+                                                span { class: "font-semibold", "{zone_name}" }
+                                                span { class: "badge badge-secondary", "{source_label}" }
+                                            }
+                                            p { class: "mt-1 text-sm text-muted",
+                                                "Uses HQPlayer {instance_detail}"
+                                            }
+                                        }
+                                        button {
+                                            r#type: "button",
+                                            class: "btn btn-outline btn-sm shrink-0",
+                                            disabled: busy,
+                                            aria_label: "Remove match for {zone_name}",
+                                            onclick: move |_| on_unlink.call(zone_id.clone()),
+                                            if busy { "Updating…" } else { "Remove match" }
+                                        }
+                                    }
+                                }
                             }
-                        }
-                        button {
-                            class: "btn btn-outline btn-sm",
-                            onclick: move |_| on_unlink.call(zone_id.clone()),
-                            "Unlink"
                         }
                     }
                 }
             }
-        } else {
-            // Not linked - show zone dropdown and link button
-            div { class: "flex items-center gap-3 flex-wrap",
-                select {
-                    class: "input",
-                    "aria-label": "Select zone to link",
-                    value: "{selected_zone}",
-                    onchange: move |evt| selected_zone.set(evt.value()),
-                    for zone in zones.iter() {
-                        option {
-                            value: "{zone.zone_id}",
-                            selected: zone.zone_id == selected_zone(),
-                            "{zone.zone_name}"
-                        }
-                    }
-                }
-                if has_multiple_instances {
-                    select {
-                        class: "input",
-                        "aria-label": "Select HQPlayer instance",
-                        value: "{selected_instance}",
-                        onchange: move |evt| selected_instance.set(evt.value()),
-                        for inst in instances.iter() {
-                            option {
-                                value: "{inst.name}",
-                                selected: inst.name == selected_instance(),
-                                "{inst.name}"
-                            }
-                        }
-                    }
-                }
-                button {
-                    class: "btn btn-primary",
-                    onclick: move |_| {
-                        // Use selected zone, or fall back to first zone if signal wasn't synced
-                        let zone_id = {
-                            let sel = selected_zone();
-                            if sel.is_empty() {
-                                first_zone_for_click.clone()
-                            } else {
-                                sel
-                            }
-                        };
-                        // Use selected instance, or fall back to default if signal wasn't synced
-                        let instance = {
-                            let sel = selected_instance();
-                            if sel.is_empty() {
-                                default_instance_for_click.clone()
-                            } else {
-                                sel
-                            }
-                        };
-                        if !zone_id.is_empty() {
-                            on_link.call((zone_id, instance));
+
+            div { class: if current_links.is_empty() { "" } else { "border-t border-default pt-5" },
+                match availability {
+                    ZoneMatchAvailability::Loading => rsx! {
+                        p { class: "text-sm text-muted", aria_live: "polite",
+                            "Loading playback zones and saved matches…"
                         }
                     },
-                    "Link Zone"
+                    ZoneMatchAvailability::NoInstances => rsx! {
+                        h3 { class: "font-semibold", "Connect HQPlayer first" }
+                        p { class: "mt-1 text-sm text-muted",
+                            "Save an HQPlayer connection before matching it to a playback zone."
+                        }
+                    },
+                    ZoneMatchAvailability::NoPlaybackZones => rsx! {
+                        h3 { class: "font-semibold", "No unmatched playback zones" }
+                        p { class: "mt-1 text-sm text-muted",
+                            "Every available playback zone is already matched, or no playback provider is connected."
+                        }
+                    },
+                    ZoneMatchAvailability::Ready => rsx! {
+                        h3 { class: "font-semibold",
+                            if current_links.is_empty() { "Match a playback zone" } else { "Match another zone" }
+                        }
+                        div { class: "mt-4 grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] lg:items-end",
+                            div {
+                                label { class: "mb-2 block text-sm font-medium", r#for: "zone-match-playback", "Playback zone" }
+                                select {
+                                    id: "zone-match-playback",
+                                    class: "input",
+                                    value: "{selected_zone}",
+                                    disabled: busy,
+                                    onchange: move |evt| selected_zone.set(evt.value()),
+                                    for zone in candidates.iter() {
+                                        option {
+                                            value: "{zone.zone_id}",
+                                            selected: zone.zone_id == selected_zone(),
+                                            "{zone.zone_name} ({playback_source_label(zone.source.as_deref())})"
+                                        }
+                                    }
+                                }
+                            }
+                            div {
+                                label { class: "mb-2 block text-sm font-medium", r#for: "zone-match-instance", "HQPlayer" }
+                                select {
+                                    id: "zone-match-instance",
+                                    class: "input",
+                                    value: "{selected_instance}",
+                                    disabled: busy,
+                                    onchange: move |evt| selected_instance.set(evt.value()),
+                                    for instance in instances.iter() {
+                                        option {
+                                            value: "{instance.name}",
+                                            selected: instance.name == selected_instance(),
+                                            if let Some(ref host) = instance.host {
+                                                "{instance.name} ({host})"
+                                            } else {
+                                                "{instance.name}"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            button {
+                                r#type: "button",
+                                class: "btn btn-primary w-full lg:w-auto",
+                                disabled: busy,
+                                onclick: move |_| {
+                                    let zone_id = {
+                                        let selected = selected_zone();
+                                        normalized_match_selection(&selected, &candidate_ids_for_click)
+                                    };
+                                    let instance = {
+                                        let selected = selected_instance();
+                                        if selected.is_empty() {
+                                            default_instance_for_click.clone()
+                                        } else {
+                                            selected
+                                        }
+                                    };
+                                    if !zone_id.is_empty() && !instance.is_empty() {
+                                        on_link.call((zone_id, instance));
+                                    }
+                                },
+                                if busy { "Saving match…" } else { "Save match" }
+                            }
+                        }
+                        p { class: "mt-3 max-w-3xl text-xs text-muted",
+                            "Only match zones that are already configured to play through this HQPlayer. Saving a match does not reroute audio."
+                        }
+                    },
+                }
+            }
+
+            if let Some((is_error, message)) = feedback_copy {
+                p {
+                    class: if is_error { "mt-4 text-sm text-red-400" } else { "mt-4 text-sm status-ok" },
+                    role: if is_error { "alert" } else { "status" },
+                    aria_live: "polite",
+                    "{message}"
                 }
             }
         }

--- a/src/app/pages/hqplayer.rs
+++ b/src/app/pages/hqplayer.rs
@@ -381,7 +381,7 @@ pub fn HqPlayer() -> Element {
                 value,
             };
             if let Err(error) = api::post_json_no_response("/control", &req).await {
-                hqp_error.set(Some(format!("Playback control failed: {error}")));
+                hqp_error.set(Some(playback_control_error(&error.to_string())));
             }
         });
     };
@@ -731,8 +731,8 @@ mod tests {
     use super::{
         filter_hqp_options, format_hqp_rate, hqp_live_mode_readout, hqp_live_output_readout,
         hqp_shaper_minimum_rate_hz, hqplayer_mute_control, is_zone_match_candidate,
-        normalized_match_selection, playback_path_label, zone_match_availability,
-        CoalescingRefresh, ZoneMatchAvailability,
+        normalized_match_selection, playback_control_error, playback_path_label,
+        zone_match_availability, CoalescingRefresh, ZoneMatchAvailability,
     };
     use crate::app::api::{HqpOption, HqpPipelineStatus, HqpSettingOptions};
 
@@ -774,6 +774,18 @@ mod tests {
         let floored = hqplayer_mute_control(Some(-60.0), Some(-60.0));
         assert_eq!(floored.label, "At minimum volume");
         assert!(floored.disabled);
+    }
+
+    #[test]
+    fn rejected_queue_skip_explains_the_linked_transport_fallback() {
+        assert_eq!(
+            playback_control_error("HTTP 500: HQPlayer rejected Next (no reason given)"),
+            "HQPlayer has no usable native queue for next track. Use the linked playback zone's transport controls."
+        );
+        assert_eq!(
+            playback_control_error("HTTP 500: HQPlayer rejected Previous: empty playlist"),
+            "HQPlayer has no usable native queue for previous track. Use the linked playback zone's transport controls."
+        );
     }
 
     #[test]
@@ -1795,6 +1807,17 @@ fn playback_source_label(source: Option<&str>) -> String {
         Some(other) => other.to_string(),
         None => "Playback zone".to_string(),
     }
+}
+
+fn playback_control_error(error: &str) -> String {
+    for (element, action) in [("Next", "next track"), ("Previous", "previous track")] {
+        if error.contains(&format!("HQPlayer rejected {element}")) {
+            return format!(
+                "HQPlayer has no usable native queue for {action}. Use the linked playback zone's transport controls."
+            );
+        }
+    }
+    format!("Playback control failed: {error}")
 }
 
 fn playback_path_label(source: Option<&str>) -> String {

--- a/src/app/pages/hqplayer.rs
+++ b/src/app/pages/hqplayer.rs
@@ -332,7 +332,7 @@ pub fn HqPlayer() -> Element {
         let u = username();
         let pw = password();
 
-        config_status.set(Some("Saving...".to_string()));
+        config_status.set(Some("Testing connection…".to_string()));
 
         spawn(async move {
             let req = HqpConfigureRequest {
@@ -350,9 +350,12 @@ pub fn HqPlayer() -> Element {
                         .and_then(|v| v.as_bool())
                         .unwrap_or(false);
                     if connected {
-                        config_status.set(Some("Connected!".to_string()));
+                        config_status.set(Some("Connected and verified.".to_string()));
                     } else {
-                        config_status.set(Some("Saved but not connected".to_string()));
+                        config_status.set(Some(
+                            "Saved, but HQPlayer did not answer. Check the host and control port."
+                                .to_string(),
+                        ));
                     }
                     status.restart();
                     pipeline.restart();
@@ -360,7 +363,9 @@ pub fn HqPlayer() -> Element {
                     refresh_advanced_projection(matrix, matrix_refresh, false);
                 }
                 Err(e) => {
-                    config_status.set(Some(format!("Error: {}", e)));
+                    config_status.set(Some(format!(
+                        "Connection failed: {e}. Check the address, ports, and web credentials."
+                    )));
                 }
             }
         });
@@ -462,7 +467,7 @@ pub fn HqPlayer() -> Element {
                 }
                 Err(error) => {
                     zone_match_feedback.set(Some(ZoneMatchFeedback::Error(format!(
-                        "Could not save the zone match: {error}"
+                        "Could not pair this playback path: {error}"
                     ))));
                 }
             }
@@ -484,7 +489,7 @@ pub fn HqPlayer() -> Element {
                 }
                 Err(error) => {
                     zone_match_feedback.set(Some(ZoneMatchFeedback::Error(format!(
-                        "Could not remove the zone match: {error}"
+                        "Could not remove this pairing: {error}"
                     ))));
                 }
             }
@@ -513,6 +518,7 @@ pub fn HqPlayer() -> Element {
         .unwrap_or_default();
     let zone_match_resources_loaded =
         zones_loaded_once() && zone_links_loaded_once() && instances_loaded_once();
+    let controlled_zones_loaded = zones_loaded_once() && zone_links_loaded_once();
     let np_map = now_playing_map();
 
     let controlled_zones = controlled_zones_signal();
@@ -527,7 +533,12 @@ pub fn HqPlayer() -> Element {
             title: "HQPlayer".to_string(),
             nav_active: "hqplayer".to_string(),
 
-            h1 { class: "text-2xl font-bold mb-6", "HQPlayer" }
+            div { class: "hqp-page-heading",
+                h1 { class: "text-2xl font-bold", "HQPlayer" }
+                p { class: "mt-2 max-w-2xl text-sm text-muted sm:text-base",
+                    "Start playback in the app you already use, then see and shape HQPlayer's live output here."
+                }
+            }
 
             // Error display
             if let Some(ref error) = hqp_error() {
@@ -540,7 +551,35 @@ pub fn HqPlayer() -> Element {
             if !is_connected {
                 section { id: "hqp-config", class: "mb-8",
                     div { class: "card p-6",
-                        h2 { class: "text-lg font-semibold mb-4", "Connection" }
+                        div { class: "mb-5 max-w-2xl",
+                            h2 { class: "text-lg font-semibold", "Connect HQPlayer" }
+                            p { class: "mt-1 text-sm text-muted",
+                                "Add HQPlayer Embedded once. Unified Hi-Fi Control will verify the native engine and its web artwork endpoint."
+                            }
+                        }
+                        ol { class: "hqp-onboarding-path mb-6",
+                            li {
+                                span { "1" }
+                                div {
+                                    strong { "Connect" }
+                                    small { "Verify the engine" }
+                                }
+                            }
+                            li {
+                                span { "2" }
+                                div {
+                                    strong { "Pair" }
+                                    small { "Name the playback path" }
+                                }
+                            }
+                            li {
+                                span { "3" }
+                                div {
+                                    strong { "Listen & tune" }
+                                    small { "Control live DSP" }
+                                }
+                            }
+                        }
                         ConfigForm {
                             host: host,
                             port: port,
@@ -557,12 +596,22 @@ pub fn HqPlayer() -> Element {
 
             // Connected: show status bar with collapsible settings
             if is_connected {
-                div { class: "flex items-center justify-between mb-6",
-                    span { class: "status-ok", "✓ Connected to {current_status.as_ref().and_then(|s| s.host.as_deref()).unwrap_or(\"HQPlayer\")}" }
+                div { class: "hqp-connection-bar mb-8",
+                    div { class: "flex min-w-0 items-center gap-3",
+                        span { class: "hqp-signal", aria_hidden: "true" }
+                        div { class: "min-w-0",
+                            p { class: "font-semibold truncate",
+                                "Connected to {current_status.as_ref().and_then(|s| s.host.as_deref()).unwrap_or(\"HQPlayer\")}"
+                            }
+                            p { class: "mt-0.5 text-xs text-muted sm:text-sm",
+                                "Live engine reads and DSP changes are verified with HQPlayer."
+                            }
+                        }
+                    }
                     button {
                         class: "btn btn-ghost btn-sm",
                         onclick: move |_| show_config.toggle(),
-                        if show_config() { "Hide Settings" } else { "Settings" }
+                        if show_config() { "Close connection settings" } else { "Connection settings" }
                     }
                 }
 
@@ -588,7 +637,12 @@ pub fn HqPlayer() -> Element {
             // Every direct or linked HQPlayer zone uses the same aggregator-backed control path.
             if is_connected && !controlled_zones.is_empty() {
                 section { id: "hqp-zones", class: "mb-8",
-                    h2 { class: "text-lg font-semibold mb-4", "HQPlayer Zones" }
+                    div { class: "mb-4 max-w-3xl",
+                        h2 { class: "text-lg font-semibold", "Now playing through HQPlayer" }
+                        p { class: "mt-1 text-sm text-muted",
+                            "Transport comes from the playback zone; sound shaping comes from HQPlayer. Paired zones keep both together."
+                        }
+                    }
                     div { class: "grid gap-4 grid-cols-1",
                         for zone in controlled_zones.iter() {
                             LinkedZoneCard {
@@ -602,10 +656,35 @@ pub fn HqPlayer() -> Element {
                 }
             }
 
+            if is_connected && controlled_zones_loaded && controlled_zones.is_empty() {
+                section { id: "hqp-zones-empty", class: "hqp-empty-path mb-8",
+                    span { aria_hidden: "true",
+                        svg { view_box: "0 0 48 24",
+                            circle { cx: "8", cy: "12", r: "5" }
+                            path { d: "M14 12h18" }
+                            path { d: "m27 7 5 5-5 5" }
+                            circle { cx: "40", cy: "12", r: "5" }
+                        }
+                    }
+                    div { class: "min-w-0 flex-1",
+                        h2 { class: "font-semibold", "Bring your playback zone into view" }
+                        p { class: "mt-1 max-w-2xl text-sm text-muted",
+                            "If Roon, JPLAY, or another controller already sends this zone through HQPlayer, pair their names below. Audio routing stays exactly as configured."
+                        }
+                    }
+                    a { class: "btn btn-primary shrink-0", href: "#hqp-zone-links", "Pair a playback zone" }
+                }
+            }
+
             // DSP Settings (only if connected)
             if is_connected {
                 section { id: "hqp-dsp", class: "mb-8",
-                    h2 { class: "text-lg font-semibold mb-4", "DSP Settings" }
+                    div { class: "mb-4 max-w-3xl",
+                        h2 { class: "text-lg font-semibold", "Shape the sound" }
+                        p { class: "mt-1 text-sm text-muted",
+                            "Playing now is measured from HQPlayer's engine. The controls below set the pipeline and confirm what HQPlayer accepted."
+                        }
+                    }
                     DspSettings {
                         pipeline: current_pipeline,
                         profiles: profiles_list,
@@ -618,25 +697,28 @@ pub fn HqPlayer() -> Element {
                 }
             }
 
-            // Zone matching section
-            section { id: "hqp-zone-links", class: "mb-8",
-                div { class: "mb-4 max-w-3xl",
-                    h2 { class: "text-lg font-semibold", "Zone matching" }
-                    p { class: "mt-1 text-sm text-muted",
-                        "Match a playback zone that already sends audio through HQPlayer. This combines playback and DSP controls; it does not change audio routing."
+            // Pairing is useful only after HQPlayer itself is connected. Keeping it hidden during
+            // first-run setup preserves the connect → pair → listen progression above.
+            if is_connected {
+                section { id: "hqp-zone-links", class: "mb-8",
+                    div { class: "mb-4 max-w-3xl",
+                        h2 { class: "text-lg font-semibold", "Pair a playback zone" }
+                        p { class: "mt-1 text-sm text-muted",
+                            "Tell Unified Hi-Fi Control which playback-zone name and HQPlayer instance describe the same existing signal path."
+                        }
                     }
-                }
-                div { class: "card overflow-hidden",
-                    ZoneLinkTable {
-                        key: "{zone_match_key}",
-                        zones: zones_list,
-                        links: links_list,
-                        instances: instances_list,
-                        resources_loaded: zone_match_resources_loaded,
-                        busy: zone_match_busy(),
-                        feedback: zone_match_feedback(),
-                        on_link: link_zone,
-                        on_unlink: unlink_zone,
+                    div { class: "card overflow-hidden",
+                        ZoneLinkTable {
+                            key: "{zone_match_key}",
+                            zones: zones_list,
+                            links: links_list,
+                            instances: instances_list,
+                            resources_loaded: zone_match_resources_loaded,
+                            busy: zone_match_busy(),
+                            feedback: zone_match_feedback(),
+                            on_link: link_zone,
+                            on_unlink: unlink_zone,
+                        }
                     }
                 }
             }
@@ -649,8 +731,8 @@ mod tests {
     use super::{
         filter_hqp_options, format_hqp_rate, hqp_live_mode_readout, hqp_live_output_readout,
         hqp_shaper_minimum_rate_hz, hqplayer_mute_control, is_zone_match_candidate,
-        normalized_match_selection, zone_match_availability, CoalescingRefresh,
-        ZoneMatchAvailability,
+        normalized_match_selection, playback_path_label, zone_match_availability,
+        CoalescingRefresh, ZoneMatchAvailability,
     };
     use crate::app::api::{HqpOption, HqpPipelineStatus, HqpSettingOptions};
 
@@ -845,6 +927,13 @@ mod tests {
             "a saved zone disappears from the candidate list, so the form must select a valid next choice"
         );
     }
+
+    #[test]
+    fn playback_paths_name_direct_and_paired_control_without_implying_routing() {
+        assert_eq!(playback_path_label(Some("hqplayer")), "Direct HQPlayer");
+        assert_eq!(playback_path_label(Some("roon")), "Roon + HQPlayer DSP");
+        assert_eq!(playback_path_label(None), "Playback + HQPlayer DSP");
+    }
 }
 
 /// Linked zone card with playback controls
@@ -933,6 +1022,7 @@ fn LinkedZoneCard(
             }
         })
         .unwrap_or_default();
+    let path_label = playback_path_label(zone.source.as_deref());
 
     rsx! {
         article { class: "card p-4 sm:p-5",
@@ -942,7 +1032,7 @@ fn LinkedZoneCard(
                     img {
                         src: "{image_url}",
                         alt: "Album art",
-                        class: "w-20 h-20 sm:w-24 sm:h-24 object-cover rounded-lg bg-elevated flex-shrink-0"
+                        class: "hqp-album-art w-20 h-20 sm:w-24 sm:h-24 object-cover rounded-lg bg-elevated flex-shrink-0"
                     }
                 } else {
                     div { class: "w-20 h-20 sm:w-24 sm:h-24 rounded-lg bg-elevated flex items-center justify-center text-muted text-2xl flex-shrink-0",
@@ -952,7 +1042,10 @@ fn LinkedZoneCard(
 
                 // Info + controls
                 div { class: "flex-1 min-w-0",
-                    h3 { class: "text-base font-semibold truncate mb-1", "{zone.zone_name}" }
+                    div { class: "mb-2 flex flex-wrap items-center gap-2",
+                        h3 { class: "text-base font-semibold truncate", "{zone.zone_name}" }
+                        span { class: "badge badge-secondary", "{path_label}" }
+                    }
 
                     if !track.is_empty() {
                         p { class: "text-sm truncate mb-0.5", "{track}" }
@@ -1075,19 +1168,22 @@ fn ConfigForm(
     rsx! {
         div { class: "space-y-4",
             div {
-                label { class: "block text-sm font-medium mb-1", "Host" }
+                label { class: "block text-sm font-medium mb-1", r#for: "hqp-host", "HQPlayer host" }
                 input {
+                    id: "hqp-host",
                     class: "input",
                     r#type: "text",
                     placeholder: "192.168.1.100",
                     value: "{host}",
                     oninput: move |evt| host.set(evt.value())
                 }
+                p { class: "mt-1 text-xs text-muted", "The hostname or LAN address running HQPlayer Embedded." }
             }
             div { class: "grid grid-cols-1 sm:grid-cols-2 gap-4",
                 div {
-                    label { class: "block text-sm font-medium mb-1", "Native Port" }
+                    label { class: "block text-sm font-medium mb-1", r#for: "hqp-native-port", "Engine control port" }
                     input {
+                        id: "hqp-native-port",
                         class: "input",
                         r#type: "number",
                         value: "{port}",
@@ -1097,10 +1193,12 @@ fn ConfigForm(
                             }
                         }
                     }
+                    p { class: "mt-1 text-xs text-muted", "Usually 4321. Used for playback and DSP control." }
                 }
                 div {
-                    label { class: "block text-sm font-medium mb-1", "Web Port" }
+                    label { class: "block text-sm font-medium mb-1", r#for: "hqp-web-port", "Web and artwork port" }
                     input {
+                        id: "hqp-web-port",
                         class: "input",
                         r#type: "number",
                         value: "{web_port}",
@@ -1110,12 +1208,18 @@ fn ConfigForm(
                             }
                         }
                     }
+                    p { class: "mt-1 text-xs text-muted", "Usually 8088. Used for profiles and current cover art." }
                 }
+            }
+            div { class: "pt-1",
+                p { class: "text-sm font-medium", "Web sign-in" }
+                p { class: "mt-1 text-xs text-muted", "Optional. Leave blank unless HQPlayer's web interface requires credentials." }
             }
             div { class: "grid grid-cols-1 sm:grid-cols-2 gap-4",
                 div {
-                    label { class: "block text-sm font-medium mb-1", "Username" }
+                    label { class: "block text-sm font-medium mb-1", r#for: "hqp-username", "Username" }
                     input {
+                        id: "hqp-username",
                         class: "input",
                         r#type: "text",
                         placeholder: if has_credentials { "(saved)" } else { "admin" },
@@ -1124,8 +1228,9 @@ fn ConfigForm(
                     }
                 }
                 div {
-                    label { class: "block text-sm font-medium mb-1", "Password" }
+                    label { class: "block text-sm font-medium mb-1", r#for: "hqp-password", "Password" }
                     input {
+                        id: "hqp-password",
                         class: "input",
                         r#type: "password",
                         placeholder: if has_credentials { "(saved)" } else { "password" },
@@ -1134,10 +1239,10 @@ fn ConfigForm(
                     }
                 }
             }
-            div { class: "flex items-center gap-4",
-                button { class: "btn btn-primary", onclick: move |_| on_save.call(()), "Save" }
+            div { class: "flex flex-wrap items-center gap-4 pt-1",
+                button { class: "btn btn-primary", onclick: move |_| on_save.call(()), "Save and test connection" }
                 if let Some(ref msg) = config_status {
-                    span { class: if msg.contains("Connected") { "status-ok" } else if msg.starts_with("Error") { "status-err" } else { "text-muted" },
+                    span { class: if msg.contains("Connected") { "status-ok" } else if msg.contains("failed") || msg.starts_with("Saved, but") { "status-err" } else { "text-muted" },
                         "{msg}"
                     }
                 }
@@ -1265,7 +1370,10 @@ fn DspSettings(
 
             if let Some(status) = pipe.status.as_ref() {
                 div { class: "mb-6 pb-6 border-b border-subtle",
-                    h3 { class: "text-sm font-semibold mb-3", "Live engine state" }
+                    div { class: "mb-3 flex flex-wrap items-baseline justify-between gap-2",
+                        h3 { class: "text-sm font-semibold", "Playing now" }
+                        p { class: "text-xs text-muted", "Live engine readback" }
+                    }
                     dl { class: "grid grid-cols-2 gap-x-4 gap-y-3 sm:grid-cols-3 lg:grid-cols-5",
                         HqpReadout { label: "Engine", value: status.state.clone().unwrap_or_else(|| "Unknown".to_string()) }
                         HqpReadout { label: "Mode", value: hqp_live_mode_readout(status) }
@@ -1278,7 +1386,12 @@ fn DspSettings(
 
             // Profile selectors
             if !profiles.is_empty() || has_matrix {
-                div { class: "grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6",
+                div { class: "mb-6",
+                    div { class: "mb-3",
+                        h3 { class: "text-sm font-semibold", "Recall a saved setup" }
+                        p { class: "mt-1 text-xs text-muted", "Loading a profile can change several pipeline controls at once." }
+                    }
+                    div { class: "grid grid-cols-1 sm:grid-cols-2 gap-4",
                     if !profiles.is_empty() {
                         label { class: "block",
                             span { class: "block text-sm font-medium mb-1", "Profile" }
@@ -1300,10 +1413,16 @@ fn DspSettings(
                             }
                         }
                     }
+                    }
                 }
             }
 
-            h3 { class: "text-sm font-semibold mb-3", "Core pipeline" }
+            div { class: "mb-3",
+                h3 { class: "text-sm font-semibold", "Output pipeline" }
+                p { class: "mt-1 text-xs text-muted",
+                    "Mode and rate work as a pair. When you return to PCM or SDM, your last verified rate for that mode is restored."
+                }
+            }
             div { class: "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4",
                 HqpSelect {
                     id: "hqp-mode",
@@ -1678,6 +1797,14 @@ fn playback_source_label(source: Option<&str>) -> String {
     }
 }
 
+fn playback_path_label(source: Option<&str>) -> String {
+    match source {
+        Some("hqplayer") => "Direct HQPlayer".to_string(),
+        None => "Playback + HQPlayer DSP".to_string(),
+        _ => format!("{} + HQPlayer DSP", playback_source_label(source)),
+    }
+}
+
 /// Shows every persisted source-zone match and lets the user add another one.
 #[component]
 fn ZoneLinkTable(
@@ -1723,14 +1850,38 @@ fn ZoneLinkTable(
     let feedback_copy = feedback.as_ref().map(|state| match state {
         ZoneMatchFeedback::Saved => (
             false,
-            "Zone match saved. It will remain after restarts.".to_string(),
+            "Paired. Playback and DSP now share one control card.".to_string(),
         ),
-        ZoneMatchFeedback::Removed => (false, "Zone match removed.".to_string()),
+        ZoneMatchFeedback::Removed => (
+            false,
+            "Pairing removed. Audio routing was not changed.".to_string(),
+        ),
         ZoneMatchFeedback::Error(message) => (true, message.clone()),
     });
 
     rsx! {
         div { class: "px-5 py-5 sm:px-6",
+            div { class: "hqp-pairing-explainer mb-6",
+                div { class: "hqp-path-node",
+                    span { "Playback zone" }
+                    small { "Roon, JPLAY, LMS…" }
+                }
+                span { aria_hidden: "true",
+                    svg { view_box: "0 0 40 16",
+                        path { d: "M2 8h32" }
+                        path { d: "m29 3 5 5-5 5" }
+                    }
+                }
+                div { class: "hqp-path-node",
+                    span { "HQPlayer" }
+                    small { "DSP and output" }
+                }
+            }
+            p { class: "mb-6 max-w-3xl text-sm text-muted",
+                strong { class: "text-primary", "Pairing only changes this screen. " }
+                "It does not route audio, group rooms, or change either app's configuration."
+            }
+
             if current_links.is_empty()
                 && matches!(
                     availability,
@@ -1738,18 +1889,18 @@ fn ZoneLinkTable(
                 )
             {
                 div { class: "mb-5",
-                    h3 { class: "font-semibold", "No saved matches" }
+                    h3 { class: "font-semibold", "Nothing paired yet" }
                     p { class: "mt-1 text-sm text-muted",
-                        "Choose the playback zone that already uses this HQPlayer."
+                        "Choose the zone where you start playback and the HQPlayer instance it already feeds."
                     }
                 }
             }
 
             if !current_links.is_empty() {
                 div { class: "mb-6",
-                    h3 { class: "font-semibold", "Saved matches" }
+                    h3 { class: "font-semibold", "Paired playback paths" }
                     p { class: "mt-1 text-sm text-muted",
-                        "These matches are stored by Unified Hi-Fi Control and remain after restarts."
+                        "These pairings are stored by Unified Hi-Fi Control and remain after restarts."
                     }
                     div { class: "mt-4 divide-y divide-[var(--border-default)]",
                         for link in current_links.iter() {
@@ -1772,23 +1923,30 @@ fn ZoneLinkTable(
                                     .unwrap_or_else(|| link.instance.clone());
                 let zone_id = link.zone_id.clone();
                 rsx! {
-                                    div { class: "flex flex-col gap-3 py-4 first:pt-0 last:pb-0 sm:flex-row sm:items-center sm:justify-between",
-                                        div { class: "min-w-0",
-                                            div { class: "flex flex-wrap items-center gap-2",
-                                                span { class: "font-semibold", "{zone_name}" }
-                                                span { class: "badge badge-secondary", "{source_label}" }
+                                    div { class: "flex flex-col gap-3 py-4 first:pt-0 last:pb-0 lg:flex-row lg:items-center lg:justify-between",
+                                        div { class: "hqp-saved-path min-w-0 flex-1",
+                                            div { class: "min-w-0",
+                                                span { class: "badge badge-secondary mb-1", "{source_label}" }
+                                                p { class: "font-semibold truncate", title: "{zone_name}", "{zone_name}" }
                                             }
-                                            p { class: "mt-1 text-sm text-muted",
-                                                "Uses HQPlayer {instance_detail}"
+                                            span { aria_hidden: "true",
+                                                svg { view_box: "0 0 40 16",
+                                                    path { d: "M2 8h32" }
+                                                    path { d: "m29 3 5 5-5 5" }
+                                                }
+                                            }
+                                            div { class: "min-w-0",
+                                                span { class: "badge badge-secondary mb-1", "HQPlayer" }
+                                                p { class: "font-semibold truncate", title: "{instance_detail}", "{instance_detail}" }
                                             }
                                         }
                                         button {
                                             r#type: "button",
                                             class: "btn btn-outline btn-sm shrink-0",
                                             disabled: busy,
-                                            aria_label: "Remove match for {zone_name}",
+                                            aria_label: "Remove pairing for {zone_name}",
                                             onclick: move |_| on_unlink.call(zone_id.clone()),
-                                            if busy { "Updating…" } else { "Remove match" }
+                                            if busy { "Updating…" } else { "Remove pairing" }
                                         }
                                     }
                                 }
@@ -1802,7 +1960,7 @@ fn ZoneLinkTable(
                 match availability {
                     ZoneMatchAvailability::Loading => rsx! {
                         p { class: "text-sm text-muted", aria_live: "polite",
-                            "Loading playback zones and saved matches…"
+                            "Finding playback zones and saved pairings…"
                         }
                     },
                     ZoneMatchAvailability::NoInstances => rsx! {
@@ -1812,18 +1970,18 @@ fn ZoneLinkTable(
                         }
                     },
                     ZoneMatchAvailability::NoPlaybackZones => rsx! {
-                        h3 { class: "font-semibold", "No unmatched playback zones" }
+                        h3 { class: "font-semibold", "No playback zones available to pair" }
                         p { class: "mt-1 text-sm text-muted",
-                            "Every available playback zone is already matched, or no playback provider is connected."
+                            "Every available zone is already paired, or no playback provider is connected yet."
                         }
                     },
                     ZoneMatchAvailability::Ready => rsx! {
                         h3 { class: "font-semibold",
-                            if current_links.is_empty() { "Match a playback zone" } else { "Match another zone" }
+                            if current_links.is_empty() { "Pair this signal path" } else { "Pair another signal path" }
                         }
                         div { class: "mt-4 grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] lg:items-end",
                             div {
-                                label { class: "mb-2 block text-sm font-medium", r#for: "zone-match-playback", "Playback zone" }
+                                label { class: "mb-2 block text-sm font-medium", r#for: "zone-match-playback", "Zone where playback starts" }
                                 select {
                                     id: "zone-match-playback",
                                     class: "input",
@@ -1840,7 +1998,7 @@ fn ZoneLinkTable(
                                 }
                             }
                             div {
-                                label { class: "mb-2 block text-sm font-medium", r#for: "zone-match-instance", "HQPlayer" }
+                                label { class: "mb-2 block text-sm font-medium", r#for: "zone-match-instance", "HQPlayer it already feeds" }
                                 select {
                                     id: "zone-match-instance",
                                     class: "input",
@@ -1881,11 +2039,11 @@ fn ZoneLinkTable(
                                         on_link.call((zone_id, instance));
                                     }
                                 },
-                                if busy { "Saving match…" } else { "Save match" }
+                                if busy { "Pairing…" } else { "Pair zone" }
                             }
                         }
                         p { class: "mt-3 max-w-3xl text-xs text-muted",
-                            "Only match zones that are already configured to play through this HQPlayer. Saving a match does not reroute audio."
+                            "Not sure? Start a track in your playback app and confirm that this HQPlayer begins playing before you pair them."
                         }
                     },
                 }

--- a/src/app/pages/zones.rs
+++ b/src/app/pages/zones.rs
@@ -195,25 +195,35 @@ pub fn Zones() -> Element {
                 profile: String,
             }
             let req = ProfileRequest { profile };
-            if let Err(e) = crate::app::api::post_json_no_response("/hqplayer/profile", &req).await
-            {
-                hqp_error.set(Some(format!("Profile load failed: {e}")));
+            match crate::app::api::post_json_no_response("/hqplayer/profile", &req).await {
+                Ok(()) => {
+                    if let Ok(profiles) =
+                        crate::app::api::fetch_json::<Vec<HqpProfile>>("/hqplayer/profiles").await
+                    {
+                        hqp_profiles.set(profiles);
+                    }
+                }
+                Err(e) => {
+                    hqp_error.set(Some(format!("Profile load failed: {e}")));
+                }
             }
         });
     };
 
     // Set matrix profile handler
-    let set_matrix = move |profile_idx: u32| {
+    let set_matrix = move |profile_name: String| {
         hqp_error.set(None);
         spawn(async move {
             #[derive(serde::Serialize)]
             struct MatrixRequest {
-                profile: u32,
+                setting: &'static str,
+                value: String,
             }
             let req = MatrixRequest {
-                profile: profile_idx,
+                setting: "matrix_profile",
+                value: profile_name,
             };
-            match crate::app::api::post_json_no_response("/hqplayer/matrix/profile", &req).await {
+            match crate::app::api::post_json_no_response("/hqp/pipeline", &req).await {
                 Ok(_) => {
                     // Refresh matrix after change
                     if let Ok(matrix) = crate::app::api::fetch_json::<HqpMatrixProfilesResponse>(
@@ -333,7 +343,7 @@ fn ZoneCard(
     hqp_matrix: Option<HqpMatrixProfilesResponse>,
     on_control: EventHandler<(String, String)>,
     on_load_profile: EventHandler<String>,
-    on_set_matrix: EventHandler<u32>,
+    on_set_matrix: EventHandler<String>,
 ) -> Element {
     let zone_id = zone.zone_id.clone();
     let zone_id_prev = zone_id.clone();
@@ -386,17 +396,14 @@ fn ZoneCard(
         .unwrap_or_default();
 
     // HQP matrix info
-    let has_matrix = hqp_matrix
-        .as_ref()
-        .map(|m| !m.profiles.is_empty())
-        .unwrap_or(false);
+    let has_matrix = hqp_matrix.is_some();
     let matrix_profiles = hqp_matrix
         .as_ref()
         .map(|m| m.profiles.clone())
         .unwrap_or_default();
     let matrix_current = hqp_matrix
         .as_ref()
-        .and_then(|m| m.current.as_ref().map(|profile| profile.index));
+        .and_then(|m| m.current.as_ref().map(|profile| profile.name.clone()));
 
     rsx! {
         article { class: "zone-card",
@@ -440,6 +447,7 @@ fn ZoneCard(
                 HqpControlsCompact {
                     profiles: hqp_profiles,
                     matrix_profiles: matrix_profiles,
+                    matrix_available: has_matrix,
                     active_matrix: matrix_current,
                     on_profile_select: on_load_profile,
                     on_matrix_select: on_set_matrix,

--- a/src/bus/events.rs
+++ b/src/bus/events.rs
@@ -292,6 +292,14 @@ pub struct ImageData {
     pub data: Vec<u8>,
 }
 
+/// Narrow provider boundary for HQPlayer's current-cover resource.
+///
+/// HTTP surfaces depend on this capability rather than reaching into the concrete instance manager.
+#[async_trait::async_trait]
+pub trait HqpImageSource: Send + Sync {
+    async fn get_current_cover(&self, instance: &str) -> anyhow::Result<ImageData>;
+}
+
 /// Zone update payload for partial updates.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ZoneUpdate {

--- a/src/input.css
+++ b/src/input.css
@@ -277,4 +277,143 @@
   .hqp-seek:disabled {
     @apply cursor-not-allowed opacity-45;
   }
+
+  .hqp-page-heading {
+    @apply mb-7;
+  }
+
+  .hqp-connection-bar {
+    @apply flex flex-col gap-3 rounded-xl px-4 py-3 sm:flex-row sm:items-center sm:justify-between;
+    background: var(--surface-elevated);
+    border: 1px solid var(--border-default);
+  }
+
+  .hqp-signal {
+    @apply relative block size-2.5 shrink-0 rounded-full;
+    background: var(--secondary-success-color);
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--secondary-success-color) 35%, transparent);
+    animation: hqp-signal 2.8s cubic-bezier(0.16, 1, 0.3, 1) infinite;
+  }
+
+  .hqp-onboarding-path {
+    @apply grid grid-cols-1 gap-0 border-y sm:grid-cols-3;
+    border-color: var(--border-subtle);
+  }
+
+  .hqp-onboarding-path li {
+    @apply flex items-center gap-3 py-3 sm:px-4;
+  }
+
+  .hqp-onboarding-path li:first-child {
+    @apply sm:pl-0;
+  }
+
+  .hqp-onboarding-path li + li {
+    @apply border-t sm:border-l sm:border-t-0;
+    border-color: var(--border-subtle);
+  }
+
+  .hqp-onboarding-path li > span {
+    @apply flex size-7 shrink-0 items-center justify-center rounded-full text-xs font-semibold;
+    background: var(--surface-hover);
+    color: var(--text-primary);
+  }
+
+  .hqp-onboarding-path strong,
+  .hqp-onboarding-path small {
+    @apply block;
+  }
+
+  .hqp-onboarding-path strong {
+    @apply text-sm;
+  }
+
+  .hqp-onboarding-path small {
+    @apply mt-0.5 text-xs;
+    color: var(--text-muted);
+  }
+
+  .hqp-empty-path {
+    @apply flex flex-col gap-4 rounded-xl p-5 sm:flex-row sm:items-center;
+    background: var(--surface-elevated);
+    border: 1px dashed var(--border-default);
+  }
+
+  .hqp-empty-path > span {
+    @apply h-10 w-20 shrink-0;
+  }
+
+  .hqp-empty-path > span > svg {
+    @apply size-full;
+    fill: none;
+    stroke: var(--accent-color);
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-width: 2;
+  }
+
+  .hqp-album-art {
+    box-shadow: 0 8px 20px color-mix(in srgb, black 22%, transparent);
+  }
+
+  .hqp-pairing-explainer {
+    @apply grid grid-cols-[minmax(0,1fr)_2.5rem_minmax(0,1fr)] items-center gap-2 rounded-xl px-3 py-4 sm:px-5;
+    background: var(--surface-base);
+  }
+
+  .hqp-pairing-explainer > span,
+  .hqp-saved-path > span {
+    @apply h-4 w-10;
+  }
+
+  .hqp-pairing-explainer > span > svg,
+  .hqp-saved-path > span > svg {
+    @apply size-full;
+    fill: none;
+    stroke: var(--accent-color);
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-width: 2;
+  }
+
+  .hqp-path-node {
+    @apply min-w-0;
+  }
+
+  .hqp-path-node:last-child {
+    @apply text-right;
+  }
+
+  .hqp-path-node span,
+  .hqp-path-node small {
+    @apply block;
+  }
+
+  .hqp-path-node span {
+    @apply text-sm font-semibold;
+  }
+
+  .hqp-path-node small {
+    @apply mt-0.5 truncate text-xs;
+    color: var(--text-muted);
+  }
+
+  .hqp-saved-path {
+    @apply grid grid-cols-[minmax(0,1fr)_2.5rem_minmax(0,1fr)] items-center gap-3;
+  }
+}
+
+@keyframes hqp-signal {
+  0%, 55% {
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--secondary-success-color) 35%, transparent);
+  }
+  100% {
+    box-shadow: 0 0 0 8px transparent;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hqp-signal {
+    animation: none;
+  }
 }

--- a/src/mcp/tools/hqplayer.rs
+++ b/src/mcp/tools/hqplayer.rs
@@ -249,16 +249,26 @@ fn hqp_status_payload_from_snapshot(
                         .map(|item| item.name)
                         .collect(),
                 },
-                matrix_profile: McpHqpSelection {
-                    current: snapshot
+                matrix_profile: {
+                    let current = snapshot
                         .current_matrix_profile
                         .map(|profile| profile.name)
-                        .unwrap_or_default(),
-                    choices: snapshot
-                        .matrix_profiles
-                        .into_iter()
-                        .map(|profile| profile.name)
-                        .collect(),
+                        .or_else(|| {
+                            (!state.matrix_profile.is_empty()).then(|| state.matrix_profile.clone())
+                        })
+                        .unwrap_or_else(|| "[Default]".to_string());
+                    let mut choices = std::iter::once("[Default]".to_string())
+                        .chain(
+                            snapshot
+                                .matrix_profiles
+                                .into_iter()
+                                .map(|profile| profile.name),
+                        )
+                        .collect::<Vec<_>>();
+                    if !choices.contains(&current) {
+                        choices.push(current.clone());
+                    }
+                    McpHqpSelection { current, choices }
                 },
                 convolution: state.convolution,
                 adaptive_volume: state.adaptive,
@@ -279,8 +289,10 @@ fn hqp_status_payload_from_snapshot(
     McpHqpStatus {
         connected: status.connected,
         host: status.host,
+        active_profile: snapshot.observation.active_profile.clone(),
         pipeline: pipeline.map(|p| McpPipelineStatus {
             state: p.status.state,
+            mode: p.status.active_mode,
             filter: p.status.active_filter,
             shaper: p.status.active_shaper,
             rate: p.status.active_rate,
@@ -300,6 +312,7 @@ async fn hqp_status_payload_for_adapter(state: &AppState, instance: &str) -> Mcp
         return McpHqpStatus {
             connected: false,
             host: None,
+            active_profile: None,
             pipeline: None,
             options: None,
             options_unavailable_reason: None,
@@ -406,13 +419,14 @@ pub async fn handle_load_profile(
     )
     .await
     {
-        Ok(()) => {
-            let env = match hqp_mutation_payload(state, &instance).await {
-                Some(payload) => env.data(&payload),
-                None => env,
-            };
-            Ok(env.text_result(format!("Loaded profile: {}", args.profile)))
-        }
+        Ok(()) => match hqp_mutation_payload(state, &instance).await {
+            Some(payload) => Ok(env
+                .data(&payload)
+                .text_result(format!("Loaded profile: {}", args.profile))),
+            None => env.failed(
+                "HQPlayer verified the profile load, but its canonical readback is unavailable",
+            ),
+        },
         Err(e) => env.failed(format!("Failed to load profile: {}", e.message())),
     }
 }
@@ -441,7 +455,14 @@ pub async fn handle_set_pipeline(
     let normalized = match args.setting.as_str() {
         // Accepts a name like "PCM", "DSD", "[source]".
         "mode" | "filter1x" | "filter_1x" | "filterNx" | "filter_nx" | "filternx" | "shaper"
-        | "dither" | "junk" | "junk_filter" | "matrix" | "matrix_profile" => args.value.clone(),
+        | "dither" | "junk" | "junk_filter" => args.value.clone(),
+        "matrix" | "matrix_profile" => {
+            if args.value.eq_ignore_ascii_case("[default]") {
+                String::new()
+            } else {
+                args.value.clone()
+            }
+        }
         "convolution" => match parse_bool(&args.value) {
             Some(value) => value.to_string(),
             None => {
@@ -553,13 +574,15 @@ pub async fn handle_set_pipeline(
     )
     .await
     {
-        Ok(()) => {
-            let env = match hqp_mutation_payload(state, &instance).await {
-                Some(payload) => env.data(&payload),
-                None => env,
-            };
-            Ok(env.text_result(format!("Set {} to {}", args.setting, args.value)))
-        }
+        Ok(()) => match hqp_mutation_payload(state, &instance).await {
+            Some(payload) => Ok(env
+                .data(&payload)
+                .text_result(format!("Set {} to {}", args.setting, args.value))),
+            None => env.failed(format!(
+                "HQPlayer verified {}, but its canonical readback is unavailable",
+                args.setting
+            )),
+        },
         Err(e) => env.failed(format!("Failed to set {}: {}", args.setting, e.message())),
     }
 }

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -93,6 +93,8 @@ pub struct McpPlayResult {
 pub struct McpHqpStatus {
     pub connected: bool,
     pub host: Option<String>,
+    /// Active named HQPlayer configuration; `None` means the unnamed base configuration.
+    pub active_profile: Option<String>,
     pub pipeline: Option<McpPipelineStatus>,
     pub options: Option<McpHqpOptions>,
     pub options_unavailable_reason: Option<String>,
@@ -101,6 +103,8 @@ pub struct McpHqpStatus {
 #[derive(Debug, Serialize)]
 pub struct McpPipelineStatus {
     pub state: String,
+    /// The mode the running HQPlayer engine reports, distinct from `options.mode.current`.
+    pub mode: String,
     pub filter: String,
     pub shaper: String,
     pub rate: u32,

--- a/src/producers/hqplayer.rs
+++ b/src/producers/hqplayer.rs
@@ -3053,6 +3053,7 @@ mod tests {
                 info: None,
             },
             pipeline: crate::adapters::hqplayer::PipelineStatus::default(),
+            active_profile: Some("Zen".to_string()),
             transport: HqpNativeTransportState::Playing,
             metadata: HqpNativeMetadata {
                 track_id: Some("track-42".to_string()),

--- a/src/producers/hqplayer.rs
+++ b/src/producers/hqplayer.rs
@@ -384,26 +384,31 @@ pub(super) fn project_native(
             CONTROL_TRANSPORT_PLAY,
             "control.transport.play",
             CONTROL_TRANSPORT_STATE,
+            true,
         ),
         transport_action_control(
             CONTROL_TRANSPORT_PAUSE,
             "control.transport.pause",
             CONTROL_TRANSPORT_STATE,
+            true,
         ),
         transport_action_control(
             CONTROL_TRANSPORT_STOP,
             "control.transport.stop",
             CONTROL_TRANSPORT_STATE,
+            true,
         ),
         transport_action_control(
             CONTROL_TRANSPORT_PREVIOUS,
             "control.transport.previous",
             CONTROL_METADATA_TRACK_ID,
+            observation.zone.is_previous_allowed,
         ),
         transport_action_control(
             CONTROL_TRANSPORT_NEXT,
             "control.transport.next",
             CONTROL_METADATA_TRACK_ID,
+            observation.zone.is_next_allowed,
         ),
         transport_state_control(observation),
         metadata_control(
@@ -696,7 +701,12 @@ fn transport_state_control(observation: &HqpNativeObservation) -> Control {
     )
 }
 
-fn transport_action_control(id: &str, label_key: &str, verify_via: &str) -> Control {
+fn transport_action_control(
+    id: &str,
+    label_key: &str,
+    verify_via: &str,
+    available: bool,
+) -> Control {
     control(
         id,
         ControlKind::Action,
@@ -705,7 +715,15 @@ fn transport_action_control(id: &str, label_key: &str, verify_via: &str) -> Cont
         Vec::new(),
         None,
         None,
-        Availability::available(),
+        if available {
+            Availability::available()
+        } else {
+            unavailable(
+                ReasonCode::NotSupported,
+                ReasonScope::Observed,
+                "reason.transport.queue_owned_by_source",
+            )
+        },
         Some(ApplySemantics {
             lane: ApplyLane::Immediate,
             effect: ApplyEffect::VerifiedPending,

--- a/tests/client_harness.rs
+++ b/tests/client_harness.rs
@@ -1580,7 +1580,7 @@ mod hqplayer_setting_route_contract {
     #[tokio::test]
     async fn advanced_state_and_choices_round_trip_through_the_web_routes() {
         let model = Arc::new(DaemonModel::with_profile(VERIFIED_PROFILE));
-        let server = WireServer::start(model, WirePolicy::default()).await;
+        let server = WireServer::start(model.clone(), WirePolicy::default()).await;
         let (app, state) = create_test_app_with_state().await;
         state
             .hqplayer
@@ -1642,6 +1642,7 @@ mod hqplayer_setting_route_contract {
             ("repeat", "all"),
             ("random", "true"),
         ] {
+            let choices_before = model.request_count("GetJunkFilters");
             let (status, body) = post_json(
                 &app,
                 "/hqp/pipeline",
@@ -1649,6 +1650,15 @@ mod hqplayer_setting_route_contract {
             )
             .await;
             assert_eq!(status, StatusCode::OK, "{setting}: {body}");
+            let returned = assert_json("canonical pipeline write response", &body);
+            assert!(
+                returned["settings"].is_object(),
+                "a successful pipeline write returns canonical pipeline state, never an unqualified {{\"ok\":true}} fallback: {body}"
+            );
+            assert!(
+                model.request_count("GetJunkFilters") - choices_before <= 3,
+                "the reliable command path's verified publication owns the post-write reads; a fourth GetJunkFilters means the HTTP route issued the redundant refresh that caused live writes to fall back to unqualified success"
+            );
         }
 
         let (status, body) = get_request(&app, "/hqplayer/matrix/profiles").await;

--- a/tests/hqplayer_conformance.rs
+++ b/tests/hqplayer_conformance.rs
@@ -7107,6 +7107,52 @@ async fn a_performed_mode_write_reports_the_cleared_rate_pin_honestly() {
     h.stop();
 }
 
+/// HQPlayer keeps one rate pin and clears it on every real mode change. Like HQPTuner, the client
+/// must remember a verified pin per output family and restore the entered family's pin after the
+/// mode-dependent rate list has been re-enumerated.
+#[tokio::test]
+async fn switching_modes_restores_each_familys_last_verified_rate_pin() {
+    let h = Harness::verified().await;
+    h.adapter
+        .set_rate(352_800)
+        .await
+        .applied()
+        .expect("remember a PCM pin");
+    h.adapter
+        .set_mode("SDM (DSD)")
+        .await
+        .applied()
+        .expect("enter SDM");
+    h.adapter
+        .set_rate(5_644_800)
+        .await
+        .applied()
+        .expect("remember an SDM pin");
+
+    h.adapter
+        .set_mode("PCM")
+        .await
+        .applied()
+        .expect("return to PCM");
+    assert_eq!(
+        h.model.state().rate_index,
+        7,
+        "PCM 352.8 kHz must be restored"
+    );
+
+    h.adapter
+        .set_mode("SDM (DSD)")
+        .await
+        .applied()
+        .expect("return to SDM");
+    assert_eq!(
+        h.model.state().rate_index,
+        3,
+        "SDM 5.6448 MHz must be restored"
+    );
+    h.stop();
+}
+
 /// The daemon names the DSD mode `"SDM (DSD)"`, so a caller asking for `"DSD"` or `"SDM"` must reach
 /// it by **semantic alias**, never by assuming a list position (HQP-C-013's device fixture is why
 /// position is unsafe).

--- a/tests/hqplayer_conformance.rs
+++ b/tests/hqplayer_conformance.rs
@@ -7153,6 +7153,91 @@ async fn switching_modes_restores_each_familys_last_verified_rate_pin() {
     h.stop();
 }
 
+/// `Auto` is not a usable return target on every NAA path. When HQPlayer has resolved Auto to an
+/// exact live output rate, that verified output is the only safe family-specific value available
+/// to retain before `SetMode` clears the pin.
+#[tokio::test]
+async fn an_auto_pin_learns_the_live_pcm_rate_before_a_round_trip_through_sdm() {
+    let h = Harness::verified().await;
+    h.model.external_change(|state| {
+        state.playback = 2;
+        state.mode_index = 1;
+        state.loaded_chain = LoadedChain::Pcm;
+        state.rate_index = 0;
+        state.active_rate_hz = 352_800;
+    });
+
+    let observed = h
+        .adapter
+        .get_pipeline_status()
+        .await
+        .expect("live PCM state");
+    assert_eq!(observed.settings.samplerate.selected.value, "0");
+    assert_eq!(observed.status.active_rate, 352_800);
+
+    h.adapter
+        .set_mode("SDM (DSD)")
+        .await
+        .applied()
+        .expect("enter SDM");
+    h.adapter
+        .set_rate(5_644_800)
+        .await
+        .applied()
+        .expect("pin SDM");
+    h.adapter
+        .set_mode("PCM")
+        .await
+        .applied()
+        .expect("return to PCM");
+
+    assert_eq!(
+        h.model.state().rate_index,
+        7,
+        "the exact 352.8 kHz output observed under Auto must become PCM's safe return rate"
+    );
+    h.stop();
+}
+
+#[tokio::test]
+async fn an_auto_output_absent_from_the_fresh_rate_list_is_never_invented_as_a_pin() {
+    let h = Harness::verified().await;
+    h.model.external_change(|state| {
+        state.playback = 2;
+        state.mode_index = 1;
+        state.loaded_chain = LoadedChain::Pcm;
+        state.rate_index = 0;
+        state.active_rate_hz = 123_456;
+    });
+
+    h.adapter
+        .get_pipeline_status()
+        .await
+        .expect("observe an unpinnable live rate");
+    h.adapter
+        .set_mode("SDM (DSD)")
+        .await
+        .applied()
+        .expect("enter SDM");
+    h.adapter
+        .set_rate(5_644_800)
+        .await
+        .applied()
+        .expect("pin SDM");
+    h.adapter
+        .set_mode("PCM")
+        .await
+        .applied()
+        .expect("return to PCM");
+
+    assert_eq!(
+        h.model.state().rate_index,
+        0,
+        "a live number the PCM enumeration cannot pin must leave Auto truthful"
+    );
+    h.stop();
+}
+
 /// The daemon names the DSD mode `"SDM (DSD)"`, so a caller asking for `"DSD"` or `"SDM"` must reach
 /// it by **semantic alias**, never by assuming a list position (HQP-C-013's device fixture is why
 /// position is unsafe).

--- a/tests/hqplayer_conformance.rs
+++ b/tests/hqplayer_conformance.rs
@@ -946,6 +946,11 @@ async fn filters_list_is_parsed_in_full_from_a_multiline_container() {
         expected,
         "every FiltersItem in the container must be parsed, not just the first"
     );
+    assert_eq!(
+        filters.first().and_then(|filter| filter.description.as_deref()),
+        Some("(text not reproduced)"),
+        "the daemon's compact filter description is authoritative selector metadata and must not be discarded"
+    );
     h.stop();
 }
 
@@ -1636,6 +1641,53 @@ fn the_persistent_config_form_separates_the_unnamed_base_from_named_profiles() {
          ones, and the distinction matters: loading a NAMED profile restarts the daemon and empties \
          /backup/settings.zip, while `[default]` does not. Found {offered:?}"
     );
+}
+
+/// The native public getter exposes only a named active profile. HQPlayer's empty base
+/// configuration is an implementation detail and must remain a neutral `None`, not a selectable
+/// `[default]` profile.
+#[tokio::test]
+async fn the_active_profile_getter_hides_the_unnamed_base_and_reports_a_named_profile() {
+    let h = Harness::verified().await;
+
+    assert_eq!(
+        h.adapter
+            .get_active_profile()
+            .await
+            .expect("read unnamed active configuration"),
+        None
+    );
+
+    h.model
+        .external_change(|state| state.active_configuration = "Zen".to_string());
+    assert_eq!(
+        h.adapter
+            .get_active_profile()
+            .await
+            .expect("read named active configuration")
+            .as_deref(),
+        Some("Zen")
+    );
+    h.stop();
+}
+
+/// HQPTuner treats Status mode/rate as playback evidence: once the engine is stopped, their last
+/// values no longer describe an active output. Filter/shaper remain useful configured context.
+#[tokio::test]
+async fn a_stopped_engine_suppresses_stale_active_mode_and_rate() {
+    let h = Harness::verified().await;
+    h.model.external_change(|state| {
+        state.playback = 0;
+        state.active_rate_hz = 5_644_800;
+    });
+
+    let pipeline = h.adapter.get_pipeline_status().await.expect("pipeline");
+    assert_eq!(pipeline.status.state, "Stopped");
+    assert_eq!(pipeline.status.active_mode, "");
+    assert_eq!(pipeline.status.active_rate, 0);
+    assert!(!pipeline.status.active_filter.is_empty());
+    assert!(!pipeline.status.active_shaper.is_empty());
+    h.stop();
 }
 
 /// Verified rule for the persistent WRITE lane: "the 200 response body is the HTML restore page —
@@ -3806,9 +3858,59 @@ const CONFIG_PAGE_RAW_LANE: &str = r#"<html><body><form>
 
 const PROFILE_PAGE_SEMANTIC_LANE: &str = r#"<html><body><form>
     <select name="profile">
+      <option value="[default]">[default]</option>
+      <option value="Default">Default</option>
       <option value="semantic-z">Semantic Lane Z</option>
     </select>
 </form></body></html>"#;
+
+/// The browser inventory and native active getter are one user-facing fact. The unnamed HQPlayer
+/// base remains absent, while a named native configuration marks exactly its matching selector.
+#[tokio::test]
+async fn profile_inventory_marks_the_active_named_profile_without_exposing_the_base() {
+    let web = FakeConfigWeb::start(CONFIG_PAGE_RAW_LANE, PROFILE_PAGE_SEMANTIC_LANE).await;
+    let h = Harness::start(VERIFIED_PROFILE, WirePolicy::default(), fast_timeouts()).await;
+    h.adapter.connect().await.expect("connect to fake daemon");
+    configure_without_persisting(
+        &h.adapter,
+        "127.0.0.1",
+        h.server.port(),
+        web.port,
+        "conformance",
+        "conformance",
+    )
+    .await;
+
+    let unnamed = h.adapter.fetch_profiles().await.expect("unnamed inventory");
+    assert_eq!(unnamed.len(), 2);
+    assert!(
+        unnamed.iter().any(|profile| profile.value == "Default"),
+        "a saved profile literally named Default is not HQPlayer's bracketed unnamed [default] base"
+    );
+    assert!(
+        unnamed.iter().all(|profile| profile.value != "[default]"),
+        "the bracketed unnamed base must not become a user-facing profile"
+    );
+    assert!(
+        unnamed.iter().all(|profile| !profile.active),
+        "the unnamed base is not a named profile"
+    );
+
+    h.model
+        .external_change(|state| state.active_configuration = "semantic-z".to_string());
+    let named = h.adapter.fetch_profiles().await.expect("named inventory");
+    assert_eq!(named.len(), 2);
+    assert!(
+        named
+            .iter()
+            .find(|profile| profile.value == "semantic-z")
+            .is_some_and(|profile| profile.active),
+        "the matching named profile must be selected"
+    );
+
+    h.stop();
+    web.stop();
+}
 
 #[tokio::test]
 async fn an_about_redirect_is_not_reported_as_an_empty_profile_or_config_page() {
@@ -7541,6 +7643,31 @@ async fn an_external_matrix_switch_is_visible_and_an_empty_profile_is_no_selecti
             .is_none(),
         "an empty profile field is the default/no-selection identity, not index 0"
     );
+    h.stop();
+}
+
+/// `[Default]` is the user-facing name for the unnamed matrix, while `Default` can be a distinct
+/// saved profile. The Rust client accepts the friendly sentinel and sends the daemon's empty value.
+#[tokio::test]
+async fn the_friendly_matrix_default_sends_an_empty_native_name() {
+    let h = Harness::verified().await;
+    h.adapter
+        .set_matrix_profile_named("[Default]")
+        .await
+        .applied()
+        .expect("select unnamed matrix default");
+
+    assert_eq!(
+        request_attr(
+            &h.model
+                .last_request("MatrixSetProfile")
+                .expect("MatrixSetProfile sent"),
+            "value"
+        )
+        .as_deref(),
+        Some(""),
+    );
+    assert_eq!(h.model.state().matrix_profile, "");
     h.stop();
 }
 

--- a/tests/hqplayer_direct_zone.rs
+++ b/tests/hqplayer_direct_zone.rs
@@ -26,6 +26,7 @@ use std::time::{Duration, Instant};
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
+use axum::response::Redirect;
 use axum::routing::{get, post};
 use axum::Router;
 use serde_json::{json, Value};
@@ -588,9 +589,63 @@ async fn a_loaded_playing_zone_advertises_the_transport_it_really_has() {
         .expect("a loaded track publishes now_playing");
     assert_eq!(np.duration, Some(215.0));
     assert_eq!(np.seek_position, Some(42.0));
+    assert!(
+        np.image_key
+            .as_deref()
+            .is_some_and(|key| key.starts_with("hqplayer:")),
+        "a loaded HQPlayer track must carry a stable artwork identity"
+    );
 
     rig.shutdown().await;
     server.stop();
+}
+
+/// **Client expectation.** HQPlayer Embedded's own page displays `/cover/current`, which may
+/// redirect to a streaming service CDN. UHC's existing artwork proxy must return those bytes for a
+/// direct HQPlayer zone instead of its generic "No Image" placeholder.
+#[tokio::test]
+async fn hqplayer_current_cover_reaches_the_unified_image_interface() {
+    const JPEG: &[u8] = b"\xff\xd8\xff\xe0hqplayer-cover\xff\xd9";
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind cover server");
+    let web_port = listener.local_addr().expect("cover address").port();
+    let cover_server = tokio::spawn(async move {
+        let app = Router::new()
+            .route(
+                "/cover/current",
+                get(|| async { Redirect::temporary("/art.jpg") }),
+            )
+            .route(
+                "/art.jpg",
+                get(|| async { ([("content-type", "image/jpeg")], JPEG) }),
+            );
+        axum::serve(listener, app).await.expect("serve cover");
+    });
+
+    let rig = Rig::new().await;
+    rig.manager
+        .add_instance(
+            "cover".to_string(),
+            "127.0.0.1".to_string(),
+            Some(9),
+            Some(web_port),
+            None,
+            None,
+        )
+        .await;
+
+    let image = rig
+        .state
+        .get_image("hqplayer:cover", "hqplayer:test-track", None, None, None)
+        .await
+        .expect("fetch the current HQPlayer cover through the unified image interface");
+    assert_eq!(image.content_type, "image/jpeg");
+    assert_eq!(image.data, JPEG);
+
+    rig.shutdown().await;
+    cover_server.abort();
 }
 
 /// **Client expectation.** A seek on a zone the server told the client was not seekable is refused

--- a/tests/hqplayer_direct_zone.rs
+++ b/tests/hqplayer_direct_zone.rs
@@ -371,19 +371,14 @@ async fn transport_reaches_the_selected_hqplayer_instance_and_not_roon() {
 /// **RED before #328:** all of them reached Roon. `stop` and `seek` additionally had no route at
 /// all — `control_roon` maps `stop`, but `seek` is not in any adapter's action vocabulary.
 #[tokio::test]
-async fn stop_next_previous_and_seek_all_route_to_the_daemon() {
+async fn stop_and_seek_route_while_queue_skips_are_refused() {
     let model = playing_daemon();
     let server = start_daemon(&model).await;
     let rig = Rig::new().await;
     rig.attach(&server).await;
     rig.zone_when(|z| z.state == PlaybackState::Playing).await;
 
-    for (action, element, value) in [
-        ("next", "Next", None),
-        ("previous", "Previous", None),
-        ("seek", "Seek", Some(json!(90))),
-        ("stop", "Stop", None),
-    ] {
+    for (action, element, value) in [("seek", "Seek", Some(json!(90))), ("stop", "Stop", None)] {
         let before = model.request_count(element);
         let mut body = json!({"zone_id":"hqplayer:rig","action":action});
         if let Some(v) = value {
@@ -399,6 +394,23 @@ async fn stop_next_previous_and_seek_all_route_to_the_daemon() {
             model.request_count(element),
             before + 1,
             "action `{action}` must send exactly one `{element}`"
+        );
+    }
+
+    for (action, element) in [("next", "Next"), ("previous", "Previous")] {
+        let before = model.request_count(element);
+        let (status, response) = rig
+            .post_control(json!({"zone_id":"hqplayer:rig","action":action}))
+            .await;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "{action} must be refused: {response}"
+        );
+        assert_eq!(
+            model.request_count(element),
+            before,
+            "{action} must not reach HQPlayer"
         );
     }
 
@@ -578,8 +590,11 @@ async fn a_loaded_playing_zone_advertises_the_transport_it_really_has() {
     let zone = rig.zone_when(|z| z.state == PlaybackState::Playing).await;
 
     assert!(zone.is_seekable, "a 215 s track is seekable");
-    assert!(zone.is_next_allowed);
-    assert!(zone.is_previous_allowed);
+    // HQPlayer is the DSP endpoint here, not the playback queue owner. Its native
+    // Next/Previous commands are not a reliable transport capability for tracks
+    // supplied by Roon/JPLAY, even while metadata is present.
+    assert!(!zone.is_next_allowed);
+    assert!(!zone.is_previous_allowed);
     assert!(zone.is_pause_allowed);
     assert!(!zone.is_play_allowed, "already playing");
     assert!(zone.is_controllable);
@@ -928,7 +943,8 @@ async fn stopping_clears_the_track_and_the_capabilities_that_depended_on_it() {
     let rig = Rig::new().await;
     rig.attach(&server).await;
     let playing = rig.zone_when(|z| z.state == PlaybackState::Playing).await;
-    assert!(playing.is_seekable && playing.is_next_allowed);
+    assert!(playing.is_seekable);
+    assert!(!playing.is_next_allowed);
 
     model.external_change(|s| {
         s.playback = 0;

--- a/tests/hqplayer_direct_zone.rs
+++ b/tests/hqplayer_direct_zone.rs
@@ -46,7 +46,7 @@ use unified_hifi_control::adapters::roon::RoonAdapter;
 use unified_hifi_control::adapters::upnp::UPnPAdapter;
 use unified_hifi_control::adapters::Startable;
 use unified_hifi_control::aggregator::ZoneAggregator;
-use unified_hifi_control::api::AppState;
+use unified_hifi_control::api::{self, AppState};
 use unified_hifi_control::bus::runtime::build_runtime;
 use unified_hifi_control::bus::{create_bus, BusEvent, PlaybackState, SharedBus, Zone};
 use unified_hifi_control::coordinator::AdapterCoordinator;
@@ -107,6 +107,7 @@ fn fast_recovery() -> HqpRecoveryConfig {
 /// route the client does not use.
 fn client_router(state: AppState) -> Router {
     Router::new()
+        .route("/hqplayer/configure", post(api::hqp_configure_handler))
         .route("/control", post(knobs::knob_control_handler))
         .route("/knob/control", post(knobs::knob_control_handler))
         .route("/knob/now_playing", get(knobs::knob_now_playing_handler))
@@ -259,6 +260,32 @@ impl Rig {
             .oneshot(request)
             .await
             .expect("get response");
+        let status = response.status();
+        let bytes = axum::body::to_bytes(response.into_body(), 512 * 1024)
+            .await
+            .expect("read body");
+        let value = serde_json::from_slice(&bytes).unwrap_or_else(|e| {
+            panic!(
+                "{uri} response was not JSON ({e}): {}",
+                String::from_utf8_lossy(&bytes)
+            )
+        });
+        (status, value)
+    }
+
+    async fn post_json(&self, uri: &str, body: Value) -> (StatusCode, Value) {
+        let request = Request::builder()
+            .method("POST")
+            .uri(uri)
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .expect("build post request");
+        let response = self
+            .app
+            .clone()
+            .oneshot(request)
+            .await
+            .expect("post response");
         let status = response.status();
         let bytes = axum::body::to_bytes(response.into_body(), 512 * 1024)
             .await
@@ -1474,6 +1501,55 @@ async fn a_linked_roon_zone_keeps_its_dsp_enrichment() {
     assert_eq!(linked["dsp"]["instance"], "rig");
 
     rig.state.hqp_zone_links.unlink_zone("roon:living").await;
+    rig.shutdown().await;
+    server.stop();
+}
+
+/// **Client expectation.** Reconnecting or re-saving an HQPlayer endpoint must not forget which
+/// source zone the user linked to that instance. The link is user configuration keyed by the
+/// stable instance name; connection settings are implementation details of that same instance.
+///
+/// **RED before #498 follow-up:** `POST /hqplayer/configure` unconditionally removed every link to
+/// `default`, including when saving the same endpoint after a daemon or host reboot.
+#[tokio::test]
+async fn configuring_the_default_instance_preserves_its_zone_link() {
+    let model = playing_daemon();
+    let server = start_daemon(&model).await;
+    let rig = Rig::new().await;
+
+    rig.state
+        .hqp_zone_links
+        .link_zone("roon:hqplayer-dsp".to_string(), "default".to_string())
+        .await
+        .expect("link source zone to the default HQPlayer instance");
+
+    let (status, body) = rig
+        .post_json(
+            "/hqplayer/configure",
+            json!({
+                "host": "127.0.0.1",
+                "port": server.port(),
+                "web_port": 1,
+                "username": null,
+                "password": null
+            }),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "configure failed: {body}");
+    assert_eq!(
+        rig.state
+            .hqp_zone_links
+            .get_instance_for_zone("roon:hqplayer-dsp")
+            .await
+            .as_deref(),
+        Some("default"),
+        "reconfiguring an existing instance must preserve its user-owned zone link"
+    );
+
+    rig.state
+        .hqp_zone_links
+        .unlink_zone("roon:hqplayer-dsp")
+        .await;
     rig.shutdown().await;
     server.stop();
 }

--- a/tests/hqplayer_direct_zone.rs
+++ b/tests/hqplayer_direct_zone.rs
@@ -38,8 +38,8 @@ use mock_servers::hqplayer::model::{DaemonModel, Metadata};
 use mock_servers::hqplayer::wire::{WirePolicy, WireServer};
 
 use unified_hifi_control::adapters::hqplayer::{
-    HqpAdapter, HqpInstanceManager, HqpRecoveryConfig, HqpStatus, HqpTimeouts, HqpZoneLinkService,
-    VolumeRange,
+    HqpAdapter, HqpInfo, HqpInstanceManager, HqpRecoveryConfig, HqpStatus, HqpTimeouts,
+    HqpZoneLinkService, VolumeRange,
 };
 use unified_hifi_control::adapters::lms::LmsAdapter;
 use unified_hifi_control::adapters::openhome::OpenHomeAdapter;
@@ -985,6 +985,25 @@ async fn a_loaded_source_track_without_a_native_queue_refuses_queue_skips() {
             .await;
         assert_eq!(status, StatusCode::BAD_REQUEST, "{action}: {response}");
     }
+}
+
+#[test]
+fn a_single_item_native_queue_does_not_advertise_skip_controls() {
+    let status = HqpAdapter::parse_status_for_test(
+        r#"<Status state="2" track="1" tracks_total="1" track_id="queued-track" position="4" length="215" volume="-18" samplerate="44100"/>"#,
+    );
+    let zone = HqpAdapter::project_direct_zone(
+        "hqplayer.test",
+        Some("rig"),
+        &HqpInfo::default(),
+        &status,
+        &VolumeRange::default(),
+    );
+
+    assert!(
+        !zone.is_next_allowed && !zone.is_previous_allowed,
+        "a one-item native queue must not advertise skips that HQPlayer will reject"
+    );
 }
 
 /// **Client expectation.** A transient failure to read the volume capability must not tell the

--- a/tests/hqplayer_direct_zone.rs
+++ b/tests/hqplayer_direct_zone.rs
@@ -308,7 +308,8 @@ impl Rig {
     }
 }
 
-/// A daemon mid-playback with a loaded, seekable track and a working decimal-dB control.
+/// A daemon mid-playback with a native playlist cursor, a loaded seekable track, and a working
+/// decimal-dB control.
 fn playing_daemon() -> DaemonModel {
     let model = DaemonModel::with_profile(VERIFIED_PROFILE);
     model.external_change(|s| {
@@ -371,14 +372,19 @@ async fn transport_reaches_the_selected_hqplayer_instance_and_not_roon() {
 /// **RED before #328:** all of them reached Roon. `stop` and `seek` additionally had no route at
 /// all — `control_roon` maps `stop`, but `seek` is not in any adapter's action vocabulary.
 #[tokio::test]
-async fn stop_and_seek_route_while_queue_skips_are_refused() {
+async fn transport_actions_route_to_the_daemon_when_its_native_queue_is_loaded() {
     let model = playing_daemon();
     let server = start_daemon(&model).await;
     let rig = Rig::new().await;
     rig.attach(&server).await;
     rig.zone_when(|z| z.state == PlaybackState::Playing).await;
 
-    for (action, element, value) in [("seek", "Seek", Some(json!(90))), ("stop", "Stop", None)] {
+    for (action, element, value) in [
+        ("next", "Next", None),
+        ("previous", "Previous", None),
+        ("seek", "Seek", Some(json!(90))),
+        ("stop", "Stop", None),
+    ] {
         let before = model.request_count(element);
         let mut body = json!({"zone_id":"hqplayer:rig","action":action});
         if let Some(v) = value {
@@ -394,23 +400,6 @@ async fn stop_and_seek_route_while_queue_skips_are_refused() {
             model.request_count(element),
             before + 1,
             "action `{action}` must send exactly one `{element}`"
-        );
-    }
-
-    for (action, element) in [("next", "Next"), ("previous", "Previous")] {
-        let before = model.request_count(element);
-        let (status, response) = rig
-            .post_control(json!({"zone_id":"hqplayer:rig","action":action}))
-            .await;
-        assert_eq!(
-            status,
-            StatusCode::BAD_REQUEST,
-            "{action} must be refused: {response}"
-        );
-        assert_eq!(
-            model.request_count(element),
-            before,
-            "{action} must not reach HQPlayer"
         );
     }
 
@@ -590,11 +579,14 @@ async fn a_loaded_playing_zone_advertises_the_transport_it_really_has() {
     let zone = rig.zone_when(|z| z.state == PlaybackState::Playing).await;
 
     assert!(zone.is_seekable, "a 215 s track is seekable");
-    // HQPlayer is the DSP endpoint here, not the playback queue owner. Its native
-    // Next/Previous commands are not a reliable transport capability for tracks
-    // supplied by Roon/JPLAY, even while metadata is present.
-    assert!(!zone.is_next_allowed);
-    assert!(!zone.is_previous_allowed);
+    assert!(
+        zone.is_next_allowed,
+        "a native HQPlayer track cursor enables Next"
+    );
+    assert!(
+        zone.is_previous_allowed,
+        "a native HQPlayer track cursor enables Previous"
+    );
     assert!(zone.is_pause_allowed);
     assert!(!zone.is_play_allowed, "already playing");
     assert!(zone.is_controllable);
@@ -944,7 +936,7 @@ async fn stopping_clears_the_track_and_the_capabilities_that_depended_on_it() {
     rig.attach(&server).await;
     let playing = rig.zone_when(|z| z.state == PlaybackState::Playing).await;
     assert!(playing.is_seekable);
-    assert!(!playing.is_next_allowed);
+    assert!(playing.is_next_allowed);
 
     model.external_change(|s| {
         s.playback = 0;
@@ -966,6 +958,33 @@ async fn stopping_clears_the_track_and_the_capabilities_that_depended_on_it() {
 
     rig.shutdown().await;
     server.stop();
+}
+
+#[tokio::test]
+async fn a_loaded_source_track_without_a_native_queue_refuses_queue_skips() {
+    let model = DaemonModel::with_profile(VERIFIED_PROFILE);
+    model.external_change(|s| {
+        s.playback = 2;
+        s.track = 0;
+        s.track_id = "source-track".to_string();
+        s.position = 42;
+        s.length = 215;
+        s.metadata = Some(Metadata::sample());
+    });
+    let server = start_daemon(&model).await;
+    let rig = Rig::new().await;
+    rig.attach(&server).await;
+    let zone = rig.zone_when(|z| z.state == PlaybackState::Playing).await;
+
+    assert!(!zone.is_next_allowed);
+    assert!(!zone.is_previous_allowed);
+
+    for action in ["next", "previous"] {
+        let (status, response) = rig
+            .post_control(json!({"zone_id":"hqplayer:rig","action":action}))
+            .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{action}: {response}");
+    }
 }
 
 /// **Client expectation.** A transient failure to read the volume capability must not tell the

--- a/tests/mcp_contract.rs
+++ b/tests/mcp_contract.rs
@@ -1237,6 +1237,7 @@ async fn hifi_hqplayer_status_shape_is_pinned() {
         json!({
             "connected": false,
             "host": null,
+            "active_profile": null,
             "pipeline": null,
             "options": null,
             "options_unavailable_reason": null
@@ -2192,6 +2193,10 @@ const FIELD_ROLES: &[(&str, FieldRole)] = &[
         DisplayOnly("hifi_status grouping key, not a value a client passes anywhere"),
     ),
     (
+        "active_profile",
+        DisplayOnly("active named HQPlayer configuration; None is the unnamed base configuration"),
+    ),
+    (
         "pipeline",
         DisplayOnly("hifi_hqplayer_status grouping key wrapping the pipeline readout"),
     ),
@@ -2589,6 +2594,7 @@ async fn no_tool_returns_an_unclassified_field() {
     collect_keys(
         &serde_json::to_value(McpPipelineStatus {
             state: String::new(),
+            mode: String::new(),
             filter: String::new(),
             shaper: String::new(),
             rate: 0,
@@ -2946,7 +2952,7 @@ const TEXT_CORRECTIONS: &[(&str, &str, &str)] = &[
     (
         "hifi_hqplayer_status/disconnected",
         "{\n  \"connected\": false,\n  \"host\": null,\n  \"pipeline\": null\n}",
-        "{\n  \"connected\": false,\n  \"host\": null,\n  \"pipeline\": null,\n  \"options\": null,\n  \"options_unavailable_reason\": null\n}",
+        "{\n  \"connected\": false,\n  \"host\": null,\n  \"active_profile\": null,\n  \"pipeline\": null,\n  \"options\": null,\n  \"options_unavailable_reason\": null\n}",
     ),
 ];
 

--- a/tests/mcp_hqplayer_control.rs
+++ b/tests/mcp_hqplayer_control.rs
@@ -488,8 +488,8 @@ async fn mcp_hqplayer_refusals_set_the_call_tool_error_flag() {
 }
 
 /// **Client expectation.** Every transport verb the direct zone advertises routes through MCP, not
-/// just play/pause. HQPlayer is not the queue owner, so Next/Previous are refused before native
-/// I/O; linked source zones own those operations.
+/// just play/pause. A native HQPlayer queue owns Next/Previous when its cursor is present; linked
+/// source zones continue to use their source transport.
 ///
 /// **RED:** `stop`, `seek` are not recognized `hifi_control` action values at all (they fall into
 /// the generic pass-through and are sent as an unknown action to Roon); `next`/`previous` fall
@@ -502,7 +502,12 @@ async fn mcp_stop_next_previous_and_seek_all_route_to_the_hqplayer_daemon() {
     rig.attach(&server).await;
     rig.zone_when(|z| z.state == PlaybackState::Playing).await;
 
-    for (action, element, value) in [("seek", "Seek", Some(90.0)), ("stop", "Stop", None)] {
+    for (action, element, value) in [
+        ("next", "Next", None),
+        ("previous", "Previous", None),
+        ("seek", "Seek", Some(90.0)),
+        ("stop", "Stop", None),
+    ] {
         let before = model.request_count(element);
         let mut args = json!({"zone_id": "hqplayer:rig", "action": action});
         if let Some(v) = value {
@@ -518,30 +523,6 @@ async fn mcp_stop_next_previous_and_seek_all_route_to_the_hqplayer_daemon() {
             model.request_count(element),
             before + 1,
             "action `{action}` must send exactly one `{element}`"
-        );
-    }
-
-    for (action, element) in [("next", "Next"), ("previous", "Previous")] {
-        let before = model.request_count(element);
-        let result = rig
-            .call_tool(
-                "hifi_control",
-                json!({"zone_id": "hqplayer:rig", "action": action}),
-            )
-            .await;
-        let text = text_of(&result);
-        assert!(
-            result.is_error == Some(true),
-            "{action} must be refused: {text}"
-        );
-        assert!(
-            text.contains("not available"),
-            "{action} refusal must be actionable: {text}"
-        );
-        assert_eq!(
-            model.request_count(element),
-            before,
-            "{action} must not reach HQPlayer"
         );
     }
 

--- a/tests/mcp_hqplayer_control.rs
+++ b/tests/mcp_hqplayer_control.rs
@@ -793,6 +793,7 @@ async fn mcp_status_does_not_publish_adapter_private_connection_state() {
 #[tokio::test]
 async fn mcp_hqplayer_status_profiles_and_pipeline_tools_reach_the_default_instance() {
     let model = playing_daemon();
+    model.external_change(|state| state.active_configuration = "Zen".to_string());
     let server = start_daemon(&model).await;
     let rig = Rig::new().await;
     rig.attach_default(&server).await;
@@ -808,6 +809,14 @@ async fn mcp_hqplayer_status_profiles_and_pipeline_tools_reach_the_default_insta
     let status = rig.call_tool("hifi_hqplayer_status", json!({})).await;
     let status_json: Value = serde_json::from_str(&text_of(&status)).expect("status JSON");
     assert_eq!(status_json["connected"], true, "status={status_json}");
+    assert_eq!(
+        status_json["active_profile"], "Zen",
+        "ConfigurationGet must reach MCP as the optional active named profile: {status_json}"
+    );
+    assert!(
+        status_json["pipeline"]["mode"].is_string(),
+        "MCP must expose the live engine mode separately from options.mode.current: {status_json}"
+    );
 
     let profiles = rig.call_tool("hifi_hqplayer_profiles", json!({})).await;
     let profiles_text = text_of(&profiles);
@@ -848,7 +857,10 @@ async fn mcp_advanced_hqplayer_tools_target_the_named_instance_not_default() {
     let default_model = playing_daemon();
     default_model.external_change(|s| s.filter_nx_index = 0);
     let rig_model = playing_daemon();
-    rig_model.external_change(|s| s.filter_nx_index = 1);
+    rig_model.external_change(|s| {
+        s.filter_nx_index = 1;
+        s.matrix_profile.clear();
+    });
     let default_server = start_daemon(&default_model).await;
     let rig_server = start_daemon(&rig_model).await;
     let rig = Rig::new().await;
@@ -898,6 +910,18 @@ async fn mcp_advanced_hqplayer_tools_target_the_named_instance_not_default() {
     assert!(
         options["repeat"].is_string(),
         "status must expose repeat as off/one/all: {options}"
+    );
+    assert_eq!(
+        options["matrix_profile"]["current"], "[Default]",
+        "the unnamed matrix must use HQPTuner's friendly identity: {options}"
+    );
+    assert!(
+        options["matrix_profile"]["choices"]
+            .as_array()
+            .is_some_and(|choices| {
+                choices.contains(&json!("[Default]")) && choices.contains(&json!("Default"))
+            }),
+        "the unnamed [Default] matrix and a saved profile literally named Default are distinct choices: {options}"
     );
 
     let default_before = default_model.request_count("SetFilter");

--- a/tests/mcp_hqplayer_control.rs
+++ b/tests/mcp_hqplayer_control.rs
@@ -488,7 +488,8 @@ async fn mcp_hqplayer_refusals_set_the_call_tool_error_flag() {
 }
 
 /// **Client expectation.** Every transport verb the direct zone advertises routes through MCP, not
-/// just play/pause.
+/// just play/pause. HQPlayer is not the queue owner, so Next/Previous are refused before native
+/// I/O; linked source zones own those operations.
 ///
 /// **RED:** `stop`, `seek` are not recognized `hifi_control` action values at all (they fall into
 /// the generic pass-through and are sent as an unknown action to Roon); `next`/`previous` fall
@@ -501,12 +502,7 @@ async fn mcp_stop_next_previous_and_seek_all_route_to_the_hqplayer_daemon() {
     rig.attach(&server).await;
     rig.zone_when(|z| z.state == PlaybackState::Playing).await;
 
-    for (action, element, value) in [
-        ("next", "Next", None),
-        ("previous", "Previous", None),
-        ("seek", "Seek", Some(90.0)),
-        ("stop", "Stop", None),
-    ] {
+    for (action, element, value) in [("seek", "Seek", Some(90.0)), ("stop", "Stop", None)] {
         let before = model.request_count(element);
         let mut args = json!({"zone_id": "hqplayer:rig", "action": action});
         if let Some(v) = value {
@@ -522,6 +518,30 @@ async fn mcp_stop_next_previous_and_seek_all_route_to_the_hqplayer_daemon() {
             model.request_count(element),
             before + 1,
             "action `{action}` must send exactly one `{element}`"
+        );
+    }
+
+    for (action, element) in [("next", "Next"), ("previous", "Previous")] {
+        let before = model.request_count(element);
+        let result = rig
+            .call_tool(
+                "hifi_control",
+                json!({"zone_id": "hqplayer:rig", "action": action}),
+            )
+            .await;
+        let text = text_of(&result);
+        assert!(
+            result.is_error == Some(true),
+            "{action} must be refused: {text}"
+        );
+        assert!(
+            text.contains("not available"),
+            "{action} refusal must be actionable: {text}"
+        );
+        assert_eq!(
+            model.request_count(element),
+            before,
+            "{action} must not reach HQPlayer"
         );
     }
 

--- a/tests/mock_servers/hqplayer.rs
+++ b/tests/mock_servers/hqplayer.rs
@@ -181,6 +181,11 @@ async fn process_command(command: &str, state: &Arc<RwLock<MockHqpState>>) -> St
         "VolumeRange" => {
             "<?xml version=\"1.0\"?>\n<VolumeRange min=\"-60\" max=\"0\" step=\"1\" enabled=\"1\" adaptive=\"0\"/>\n".to_string()
         }
+        "ConfigurationGet" => {
+            // Empty is HQPlayer's unnamed base configuration. It must reach the
+            // public model as no active named profile, not as a profile called Default.
+            "<?xml version=\"1.0\"?>\n<ConfigurationGet value=\"\"/>\n".to_string()
+        }
         "GetModes" => {
             "<?xml version=\"1.0\"?>\n<GetModes><ModesItem index=\"0\" name=\"PCM\" value=\"0\"/><ModesItem index=\"1\" name=\"SDM\" value=\"1\"/></GetModes>\n".to_string()
         }

--- a/tests/mock_servers/hqplayer/model.rs
+++ b/tests/mock_servers/hqplayer/model.rs
@@ -1001,10 +1001,15 @@ impl Responder for DaemonModel {
 
             "MatrixSetProfile" => {
                 let name = request_attr(request, "value").unwrap_or_default();
-                let known =
-                    corpus::enum_entries(&inner.enumeration("MatrixListProfiles"), "MatrixProfile")
-                        .into_iter()
-                        .any(|e| e.name == name);
+                // HQPlayer's unnamed matrix is selected with an empty value. It is deliberately
+                // absent from MatrixListProfiles and is rendered as `[Default]` by friendly UIs.
+                let known = name.is_empty()
+                    || corpus::enum_entries(
+                        &inner.enumeration("MatrixListProfiles"),
+                        "MatrixProfile",
+                    )
+                    .into_iter()
+                    .any(|e| e.name == name);
                 if known {
                     inner.apply(
                         "MatrixSetProfile",

--- a/tests/qnap_service_contract.rs
+++ b/tests/qnap_service_contract.rs
@@ -2,6 +2,15 @@
 
 const SERVICE: &str = include_str!("../build/qnap/shared/unified-hifi-control.sh");
 const UNINSTALL: &str = include_str!("../build/qnap/shared/uninstall.sh");
+const QPKG_CONFIG: &str = include_str!("../build/qnap/qpkg.cfg");
+
+#[test]
+fn qpkg_allows_install_volume_selection_and_migration() {
+    assert!(
+        QPKG_CONFIG.contains("QPKG_VOLUME_SELECT=3"),
+        "QNAP must allow selecting and migrating the package volume instead of forcing the system volume"
+    );
+}
 
 #[test]
 fn qnap_service_keeps_credentials_private_and_stops_only_its_recorded_process() {

--- a/tests/qnap_service_contract.rs
+++ b/tests/qnap_service_contract.rs
@@ -1,14 +1,38 @@
-//! Safety contract for the privileged QNAP service wrapper.
+//! Safety and packaging contract for the privileged QNAP service wrapper.
 
 const SERVICE: &str = include_str!("../build/qnap/shared/unified-hifi-control.sh");
 const UNINSTALL: &str = include_str!("../build/qnap/shared/uninstall.sh");
 const QPKG_CONFIG: &str = include_str!("../build/qnap/qpkg.cfg");
+const BUILD_WORKFLOW: &str = include_str!("../.github/workflows/build.yml");
 
 #[test]
 fn qpkg_allows_install_volume_selection_and_migration() {
     assert!(
         QPKG_CONFIG.contains("QPKG_VOLUME_SELECT=3"),
         "QNAP must allow selecting and migrating the package volume instead of forcing the system volume"
+    );
+}
+
+#[test]
+fn qnap_jobs_pin_qdk_architecture_to_the_binary_they_package() {
+    let x64_job = BUILD_WORKFLOW
+        .split("build-qnap-x64:")
+        .nth(1)
+        .and_then(|tail| tail.split("build-qnap-arm:").next())
+        .expect("x64 QNAP job exists");
+    let arm_job = BUILD_WORKFLOW
+        .split("build-qnap-arm:")
+        .nth(1)
+        .and_then(|tail| tail.split("build-docker-x64:").next())
+        .expect("ARM QNAP job exists");
+
+    assert!(
+        x64_job.contains("qbuild --build-dir /src/build --build-arch x86_64"),
+        "the x64 package must be built for x86_64 explicitly"
+    );
+    assert!(
+        arm_job.contains("qbuild --build-dir /src/build --build-arch arm_64"),
+        "the ARM package must be built for arm_64 explicitly"
     );
 }
 

--- a/tests/qnap_service_contract.rs
+++ b/tests/qnap_service_contract.rs
@@ -4,6 +4,7 @@ const SERVICE: &str = include_str!("../build/qnap/shared/unified-hifi-control.sh
 const UNINSTALL: &str = include_str!("../build/qnap/shared/uninstall.sh");
 const QPKG_CONFIG: &str = include_str!("../build/qnap/qpkg.cfg");
 const BUILD_WORKFLOW: &str = include_str!("../.github/workflows/build.yml");
+const QNAP_DOCKERFILE: &str = include_str!("../build/qnap/Dockerfile");
 
 #[test]
 fn qpkg_allows_install_volume_selection_and_migration() {
@@ -33,6 +34,44 @@ fn qnap_jobs_pin_qdk_architecture_to_the_binary_they_package() {
     assert!(
         arm_job.contains("qbuild --build-dir /src/build --build-arch arm_64"),
         "the ARM package must be built for arm_64 explicitly"
+    );
+}
+
+#[test]
+fn qnap_jobs_use_the_pinned_first_party_qdk_builder() {
+    assert!(
+        !BUILD_WORKFLOW.contains("owncloudci/qnap-qpkg-builder"),
+        "QNAP builds must not depend on the unowned third-party builder image"
+    );
+    assert!(
+        BUILD_WORKFLOW
+            .matches("--file build/qnap/Dockerfile")
+            .count()
+            >= 2,
+        "each QNAP architecture job must build the repository-owned QDK image"
+    );
+    assert!(
+        BUILD_WORKFLOW.matches("qnap-qdk:2.5.3").count() >= 4,
+        "both QNAP jobs must use the pinned QDK image tag for build and run"
+    );
+    assert!(
+        QNAP_DOCKERFILE.contains("FROM ubuntu:20.04@sha256:"),
+        "the QDK builder base image must be digest-pinned"
+    );
+    assert!(
+        QNAP_DOCKERFILE.contains(
+            "qnap-dev/QDK/releases/download/v${QDK_VERSION}/qdk_${QDK_VERSION}_amd64.deb"
+        ),
+        "the builder must download QDK from the official qnap-dev release"
+    );
+    assert!(
+        QNAP_DOCKERFILE
+            .contains("17b3841b7d4590a4ee025844ba583304b5e3c497d9fa8934d5175131d3908022"),
+        "the official QDK 2.5.3 artifact must be checksum-pinned"
+    );
+    assert!(
+        BUILD_WORKFLOW.contains("/usr/share/QDK/bin/qbuild"),
+        "the workflow must invoke the path shipped by official QDK 2.5.3"
     );
 }
 


### PR DESCRIPTION
Fixes #498

## What changed

- Makes configured mode come from HQPlayer `State.mode` and live mode/rate come from `Status.active_mode` / `active_rate`, including source-following PCM/SDM behavior.
- Carries the native active profile through the Rust client, adapter, aggregator, UI, and MCP.
- Makes immediate DSP mutations return verified canonical readback instead of bare success.
- Re-enumerates the mode-specific rates, filters, and dither/modulator options after PCM/SDM changes.
- Preserves saved profile `Default` while omitting HQPlayer's special `[default]` entry; treats the unnamed matrix default separately.
- Adds user-friendly labels/search and HQPTuner-aligned rate guidance.
- Adds conformance, client, MCP, route-contract, and mock-daemon coverage.
- Records the HQPTuner comparison and salvage/audit evidence.

## Live validation

Validated against the same live HQPlayer daemon through UHC and HQPTuner:

- PCM inventory: 67 filters, 10 dithers, 13 rates — exact value/order parity.
- SDM inventory: 77 filters, 36 modulators, 6 rates — exact value/order parity.
- PCM readback: 705600 Hz, `poly-sinc-gauss-short`, `poly-sinc-gauss-hires-mp`, `TPDF`.
- SDM readback: DSD128 and DSD256; filters and `ASDM7EC-fast` / `DSD7 256+fs` changes independently confirmed in HQPTuner.
- Native profile `Zen` list/load/active readback confirmed.
- Junk filter, adaptive volume, random, repeat, convolution rejection, and HQPlayer digital volume readback checked.
- Never selected above DSD256.

Restored final state: profile `Zen`, SDM, DSD256, `poly-sinc-gauss-long`, `poly-sinc-gauss-hires-lp`, `ASDM7EC-fast`, -3 dB, optional controls off, stopped.

Sustained playback could not be qualified: Roon supplied an HTTP source URL that returned 404. Pipeline mutation and live native/HQPTuner readback were still exercised while the transport was active.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo test --all-targets --features server`
- `git diff --check`

The `build:qnap` label will request the QNAP x86_64 package for local installation.